### PR TITLE
fix(harness): INFRA-060 D4 — build tooling resolves to the full workspace, not zero scopes

### DIFF
--- a/.agents/backlog/INFRA-060-ci-yml-job-by-job-audit.md
+++ b/.agents/backlog/INFRA-060-ci-yml-job-by-job-audit.md
@@ -34,8 +34,8 @@ with stubbed inputs, or its command run directly, the way INFRA-048 and INFRA-05
 | 1   | `main-pr-source-guard` (`main PR source guard`)       | main     | A PR to `main` comes from develop/release/hotfix in THIS repo                                           | matches                                                      | **yes** — 6 cases run under `bash -e`: develop✓, feature✗, fork-named-develop✗, release/*✓, empty head_ref✗                     | PASS                                  |
 | 2   | `promotion-ancestry` (`promotion ancestry`)           | main     | The promotion carries `main`'s ancestry (INFRA-051 A1/A3)                                               | matches                                                      | **yes** — ran the scan with `GITHUB_BASE_REF=main` + a non-promotion head; exit 1 on A1                                         | PASS                                  |
 | 3   | `changes`                                             | **no**   | Classifies the PR code vs docs-only                                                                     | matches                                                      | **yes** — probe PR #1476 forced the job to fail and the consequence was measured (see D3)                                       | PASS, but see D3                      |
-| 4   | `build`                                               | develop  | The monorepo builds                                                                                     | **checks the wrong thing**                                   | **yes** — see D4                                                                                                                | DEFECT (filed)                        |
-| 5   | `quality`                                             | develop  | The affected scopes' build/test/lint/typecheck pass                                                     | **checks the wrong thing** on one PR shape                   | **yes** — see D4                                                                                                                | DEFECT (filed)                        |
+| 4   | `build`                                               | develop  | The monorepo builds                                                                                     | matches after D4                                             | **yes** — see D4                                                                                                                | **DEFECT — FIXED**                    |
+| 5   | `quality`                                             | develop  | The affected scopes' build/test/lint/typecheck pass                                                     | matches after D4                                             | **yes** — see D4                                                                                                                | **DEFECT — FIXED**                    |
 | 6   | `scans`                                               | develop  | The harness suite + full dist-independent scan suite pass                                               | matches                                                      | **yes** — run in verification, 70 scans + 1153 harness tests                                                                    | PASS, but see D6                      |
 | 7   | `security-audit` (`security audit`)                   | develop  | _Reads as:_ the PR was audited for security. _Is:_ an OSV dependency scan, only when a manifest changed | **over-claims in the name**                                  | **yes** — step extracted; unresolvable base ref correctly forces `changed=true`; regex verified on nested/lock/code-only inputs | ENFORCEMENT PASS, fidelity filed (D5) |
 | 8   | `release-grade-verify` (`release-grade verification`) | main     | The FULL build/scan/test/typecheck/lint sweep                                                           | **over-claims** — `pnpm test` is `-r --if-present`           | partly — measured the 5 silently-skipped workspaces                                                                             | ENFORCEMENT PASS, fidelity filed (D7) |
@@ -136,10 +136,10 @@ release-grade verification    skipping   (control)
 This is the property the whole fix rests on, and it is now the measured half of #1424: that
 incident recorded the three contexts reporting `skipping`; this records the same three running.
 
-### D4 — `build` and `quality` both green having done nothing, on a build-tooling PR — **FILED**
+### D4 — `build` and `quality` both green having done nothing, on a build-tooling PR — **FIXED**
 
-A one-line change to `scripts/build-types-ordered.mjs` — the second half of root `pnpm build` —
-resolves to `scopes: []`:
+**Reproduced first.** A one-line change to `scripts/build-types-ordered.mjs` — the second half of
+root `pnpm build` — resolved to `scopes: []`:
 
 ```
 $ pnpm harness:plan -- --base-ref origin/develop
@@ -153,18 +153,97 @@ No package or app scope detected from changed files.
 $ echo $?  →  0
 ```
 
-So `build` never runs `pnpm build`; `quality` verifies zero scopes, skips the binary e2e (gated on
-`package_dist_required`) and runs `build-contracts` against no restored dist. Two REQUIRED checks,
-both vacuous, on a PR that changes the build tooling itself.
+So `build` never ran `pnpm build`; `quality` verified zero scopes, skipped the binary e2e (gated on
+`package_dist_required`) and ran `build-contracts` against no restored dist. Two REQUIRED checks,
+both vacuous, on a PR that changes the build tooling itself. Real build coverage did exist — but it
+was delivered by jobs named `tui-e2e` and `examples-typecheck`, which is the fidelity half.
 
-Real build coverage does exist — `tui-e2e` and `examples-typecheck` both run `pnpm build:deps`, and
-`changes` classifies this file as CODE — so a broken build IS caught. It is caught by jobs named
-`tui-e2e` and `examples-typecheck`. That is the fidelity defect: `build`'s guarantee is delivered
-elsewhere, and its own green means only "no scope asked for dist".
+**The fix is in the calculator, not in the gate.** "Fail when scopes is empty" was rejected: a
+docs-only PR legitimately resolves to zero scopes, and reddening it is precisely why `review-gate`
+was rolled back the day it was armed. The defect is that a PR changing the build tooling does not
+affect zero packages — it affects **all** of them, and the calculator could not see that
+dependency. `scripts/harness/check-plan.mjs` now declares
+`WORKSPACE_WIDE_BUILD_TOOLING_PATHS`, and a change to any of them selects the FULL workspace with
+`forceFullVerification`.
 
-Not fixed here: the candidate fixes (require build whenever `changes.code == 'true'`; treat
-build-relevant unmapped files as requiring dist) each change which PRs run a multi-minute build,
-i.e. what gates a merge and what CI costs. Owner call.
+The membership rule, so the list can be extended without re-deriving it: **a repo-root path belongs
+there when changing it changes the OUTCOME of `build` / `typecheck` / `lint` / `test` for scopes
+that did not themselves change.** Eight entries, each with the evidence rather than the intuition:
+
+| Path                              | Why every scope                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `scripts/build-types-ordered.mjs` | root `build` is `pnpm --filter "./packages/**" build:js && node scripts/build-types-ordered.mjs`                   |
+| `package.json` (root)             | owns `build`/`typecheck`/`lint`/`test`, the toolchain `devDependencies`, `pnpm.overrides`, `engines`               |
+| `pnpm-workspace.yaml`             | decides which directories ARE workspace packages at all                                                            |
+| `tsconfig.base.json`              | extended by **80 of the 86** in-scope tsconfigs (counted, not assumed)                                             |
+| `tsconfig.json`                   | root project references; `tsconfig.eslint.json` extends it                                                         |
+| `tsconfig.eslint.json`            | extended by each package's own `tsconfig.eslint.json`, which its `.eslintrc.json` names as `parserOptions.project` |
+| `.eslintrc.json`, `.eslintignore` | root `lint` is `eslint packages apps`; every package's config resolves through the root                            |
+
+**After the fix**, the same branch:
+
+```
+$ pnpm harness:plan -- --base-ref origin/develop
+Changed files: 1
+Scope coverage: 86 of 86 workspace scopes (workspace-wide build tooling changed: scripts/build-types-ordered.mjs).
+Scopes:
+- apps/action: build, test, typecheck
+… 86 rows …
+$ node <the build job's Detect-build-requirement step>  →  required=true
+```
+
+**The docs-only path is unchanged, and that was checked, not assumed** — the over-correction is the
+other failure mode, and a slow gate gets bypassed:
+
+```
+$ pnpm harness:plan -- --changed-file README.md
+Scope coverage: 0 of 86 workspace scopes — this plan verifies NO package or app.
+Scopes:
+- none
+$ echo $?  →  0     # still a PASS, as it must be
+```
+
+An ordinary package change is also untouched: `packages/agent-core/src/index.ts` still resolves to
+55 of 86 (its owner plus its dependents), not 86.
+
+**Second half — an empty scope set is now visible.** Zero scopes stays a pass, but it no longer
+reads like a full one. Every plan states its coverage as a count, on stdout and in the GitHub **job
+summary** (`$GITHUB_STEP_SUMMARY`, appended by the harness itself — no workflow change needed, so
+this required no edit to `ci.yml`):
+
+```
+Scope coverage: 0 of 86 workspace scopes — this plan verifies NO package or app.
+Scope coverage: 86 of 86 workspace scopes (workspace-wide build tooling changed: …).
+```
+
+`verify-change.mjs` prints and posts the same line BEFORE any check runs, including on its
+zero-scope early return. A `neutral` conclusion was not attempted: it would require changing job
+definitions in `ci.yml`, which this branch does not own.
+
+**The sweep — is the class larger than the one instance?** Every path in the repo outside
+`packages/` and `apps/` was classified through the calculator's own `classifyRepositoryChecks`
+(1882 files land in `repository-review`, which has no executable check at all — that is D6's
+territory, not a scope-selection defect). The candidates that could plausibly govern every scope
+were then measured against 400 `develop` commits, and each was decided on the number:
+
+| Candidate                                                                                           | Touched (of 371 commits with files) | Verdict                                                                                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/build-types-ordered.mjs`                                                                   | 0                                   | **added** — the audit's instance; never changed in 400 commits, so its cost is ~0                                                                                                                                                                                                                 |
+| `package.json` (root)                                                                               | 23 (17 with no scope)               | **added**, unconditionally. A key-precise variant (only `devDependencies`/`pnpm`/`engines`/build scripts) would fire 14 rather than 23 — rejected: that key list is itself a rot surface, and 9 extra full verifications per 371 commits is the cheap direction of the error                      |
+| `pnpm-workspace.yaml`, `tsconfig.base.json`, `tsconfig.json`, `.eslintrc.json`                      | 0, 1, 2, 2                          | **added** — ~1.3% of commits combined                                                                                                                                                                                                                                                             |
+| `tsconfig.eslint.json`, `.eslintignore`                                                             | 0, 0                                | **added** for closure with the two above                                                                                                                                                                                                                                                          |
+| `pnpm-lock.yaml`                                                                                    | 41 (7 with no scope)                | **excluded, measured.** All 7 of the no-scope commits ALSO touched root `package.json`, so it adds no detection the list does not have; adding it would move the other 34 from partial to full verification for nothing                                                                           |
+| `vitest.config.ts` (root)                                                                           | —                                   | **excluded, verified.** It does not govern a scope's `pnpm test` — vitest resolves config from the cwd and never searches upward. `packages/agent-tools` has no local vitest config and still collected 26 test files, which the root `include` (`packages/**/src/**`) cannot match from that cwd |
+| `.prettierrc.json`, `commitlint.config.js`, `stryker.conf.mjs`, `.dependency-cruiser.cjs`, `.nvmrc` | —                                   | **excluded** — none is read by a scope's `build`/`test`/`lint`/`typecheck`                                                                                                                                                                                                                        |
+
+So the class was larger than the one instance the audit found (8 paths, not 1), but it is bounded
+and small: the added paths fire on roughly **5% of commits**, and 3 of the 8 have never been
+touched in 400 commits. Two more candidates were measured and deliberately left out with the number
+behind the decision, which is the part that will still be checkable in six months.
+
+**Not swept, and named as such.** This looked only at paths that resolve to ZERO scopes when they
+should resolve to many. The converse — a path that resolves to SOME scopes when it should resolve
+to more — was not audited, and `mapFilesToScopes`'s prefix rule makes it plausible.
 
 ### D5 — `security audit` claims more than it checks — **FILED**
 
@@ -252,6 +331,33 @@ registered in `pnpm harness:scan`.
   an `if:`-excluded dependency.
 - `test-selection-tolerance` — a workflow step that NARROWS a test run must not route it through a
   script containing `--passWithNoTests`. Reverting D1 reports both windows-shell steps.
+- `build-tooling-scope` (D4) — four rules, each red-proven against its own live defect and green
+  after. **R1** every declared path still exists. **R2** the calculator, EXECUTED, resolves each
+  declared path to the full workspace — reverting the fix in place reports all 8 as
+  `resolves to 0 of 86 workspace scopes`, which is the pre-fix `scopes: []` exactly. **R3** every
+  file root `package.json`'s build-defining scripts invoke is declared — adding
+  `node scripts/migrate-session-history.mjs` to root `build` reports it, which is the recurrence
+  this class produces. **R4** a docs-only change still resolves to ZERO scopes and still passes —
+  declaring `README.md` as build tooling reports it, pinning the over-correction shut.
+
+  R2 **executes** rather than reads. HARNESS-052's own guard derived its ledger by regex over
+  source text and therefore measured spelling, not behaviour, in three separate places; a rule
+  about a calculator's OUTPUT must run the calculator. The scan refuses to print a pass when it
+  enumerated zero declared paths, zero workspace scopes or zero root build scripts.
+
+**Where this guard's own ceiling is, stated rather than implied.** It cannot decide whether a path
+IS build tooling. That judgement lives in the constant's membership rule, and a wrong judgement
+there passes every rule above — the same ceiling this item's closing section already states for
+every other structural guard. What the guard does catch is the part that actually rots: a declared
+path going stale, the calculator silently ceasing to honour the list, a new build script joining
+root `build` without joining it, and over-correction into docs.
+
+**Inherited red, fixed in passing.** `guard-scope-fail-closed` rule 1 was already failing on
+`origin/develop` — INFRA-058 registered `scan-required-check-needs` and
+`scan-test-selection-tolerance` without classifying their finders (reproduced on a clean checkout
+of `origin/develop`). Both were measured by EXECUTING them against a bare root — `fail-closed` and
+`vacuous` respectively — and recorded in `PENDING_CLASSIFICATION`. This item's own scan measures
+`fail-closed` and is pinned in `MANDATORY_TREE_GUARDS` with its governed tree named.
 
 Both fail loudly on ZERO edges / ZERO invocations examined, so a broken parser cannot report a
 clean pass over nothing. Each rule's two halves are unit-tested separately, because
@@ -287,11 +393,14 @@ This audit is not, and cannot be, complete. What no pattern can reach:
 
 ## Test Plan
 
-- `pnpm harness:scan` — 70/70 with `--skip dist --skip build-contracts` (the CI form); the local
-  full run's only failure is `dist`, which needs a built tree and is skipped in CI by design.
-- `pnpm harness:test` — 90 files / 1153 tests.
-- `pnpm harness:verify-like-ci`.
-- Each new guard run RED against the reverted defect and GREEN against the fix.
+- `pnpm harness:scan` — **76/76** on a built tree (the local full run's only failure without one is
+  `dist`, which needs built output and is skipped in CI by design).
+- `pnpm harness:test` — **94 files / 1244 tests**.
+- `pnpm harness:verify-like-ci` — **PASS, all 11 stages**.
+- `pnpm build` and `pnpm typecheck` — both exit 0.
+- Each new guard run RED against the reverted defect and GREEN against the fix. For D4 the revert
+  was made IN PLACE (the workspace-wide branch short-circuited while the declared list stayed
+  exported), so the proof is against the live pre-fix behaviour rather than a description of it.
 - YAML parse of `ci.yml` (`yaml.parse`, 14 jobs enumerated) and `bash -n` on every touched `run:`.
 
 ## User Execution Test Scenarios

--- a/scripts/harness/__tests__/check-plan.test.mjs
+++ b/scripts/harness/__tests__/check-plan.test.mjs
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { createVerificationPlan, parsePlanArgs, renderPlanSummary } from '../check-plan.mjs';
+import {
+  WORKSPACE_WIDE_BUILD_TOOLING_PATHS,
+  createVerificationPlan,
+  listWorkspaceWideTriggers,
+  parsePlanArgs,
+  renderPlanSummary,
+  renderScopeCoverageLine,
+} from '../check-plan.mjs';
 
 const scopes = [
   {
@@ -218,7 +225,122 @@ describe('createVerificationPlan', () => {
   });
 });
 
+// INFRA-060 D4. Each half is asserted separately: the calculator's selection, and the coverage
+// line CI's readers see. The pre-fix defect is pinned in both directions — build tooling must
+// select everything, and a docs-only change must still select nothing WITHOUT failing.
+describe('workspace-wide build tooling (INFRA-060 D4)', () => {
+  it('selects EVERY scope in full for the ordered-types builder — the measured defect', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['scripts/build-types-ordered.mjs'],
+      scopeTokens: [],
+    });
+
+    // Pre-fix this was `[]`, which made CI's `build` job skip `pnpm build` and its `quality`
+    // job verify zero scopes — two REQUIRED checks, both green, on a build-tooling PR.
+    expect(plan.scopes.map((item) => item.scope)).toEqual(scopes.map((item) => item.relativeDir));
+    for (const item of plan.scopes) {
+      expect(item.checks).toEqual(['build', 'test', 'lint', 'typecheck']);
+      expect(item.notes).toContain('workspace-wide:scripts/build-types-ordered.mjs');
+    }
+    expect(plan.workspaceWideTriggers).toEqual(['scripts/build-types-ordered.mjs']);
+  });
+
+  it('selects every scope for each declared path, one at a time', () => {
+    expect(WORKSPACE_WIDE_BUILD_TOOLING_PATHS.length).toBeGreaterThan(0);
+
+    for (const declaredPath of WORKSPACE_WIDE_BUILD_TOOLING_PATHS) {
+      const plan = createVerificationPlan({ scopes, changedFiles: [declaredPath] });
+      expect(plan.scopes.length, `${declaredPath} must select the full workspace`).toBe(
+        scopes.length,
+      );
+    }
+  });
+
+  it('leaves a docs-only change at zero scopes — over-correction is the other failure', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['README.md', 'docs/plans/example.md', '.agents/backlog/EXAMPLE-1.md'],
+      scopeTokens: [],
+    });
+
+    expect(plan.scopes).toEqual([]);
+    expect(plan.workspaceWideTriggers).toEqual([]);
+  });
+
+  it('leaves an ordinary package change scoped to its owner', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['packages/agent-core/src/agent.ts'],
+    });
+
+    expect(plan.scopes.map((item) => item.scope)).toEqual(['packages/agent-core']);
+    expect(plan.workspaceWideTriggers).toEqual([]);
+  });
+
+  it('does not widen an explicitly requested scope', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['package.json'],
+      scopeTokens: ['packages/agent-core'],
+    });
+
+    expect(plan.scopes.map((item) => item.scope)).toEqual(['packages/agent-core']);
+    expect(plan.workspaceWideTriggers).toEqual([]);
+  });
+
+  it('matches build tooling by exact path, not by prefix', () => {
+    expect(listWorkspaceWideTriggers(['package.json'])).toEqual(['package.json']);
+    expect(listWorkspaceWideTriggers(['packages/agent-core/package.json'])).toEqual([]);
+    expect(listWorkspaceWideTriggers(['scripts/build-types-ordered.mjs.bak'])).toEqual([]);
+    expect(listWorkspaceWideTriggers([])).toEqual([]);
+  });
+});
+
+describe('renderScopeCoverageLine (INFRA-060 D4)', () => {
+  it('says in words that nothing was verified when the plan is empty', () => {
+    const plan = createVerificationPlan({ scopes, changedFiles: ['README.md'] });
+
+    expect(renderScopeCoverageLine(plan)).toBe(
+      `Scope coverage: 0 of ${scopes.length} workspace scopes — this plan verifies NO package or app.`,
+    );
+  });
+
+  it('states the count and the reason when the whole workspace is selected', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['scripts/build-types-ordered.mjs'],
+    });
+
+    expect(renderScopeCoverageLine(plan)).toBe(
+      `Scope coverage: ${scopes.length} of ${scopes.length} workspace scopes ` +
+        '(workspace-wide build tooling changed: scripts/build-types-ordered.mjs).',
+    );
+  });
+
+  it('distinguishes a partial plan from an empty one', () => {
+    const plan = createVerificationPlan({
+      scopes,
+      changedFiles: ['packages/agent-core/src/agent.ts'],
+    });
+
+    expect(renderScopeCoverageLine(plan)).toBe(
+      `Scope coverage: 1 of ${scopes.length} workspace scopes.`,
+    );
+  });
+});
+
 describe('renderPlanSummary', () => {
+  it('always states the scope coverage, empty or not', () => {
+    const empty = createVerificationPlan({ scopes, changedFiles: ['README.md'] });
+    const full = createVerificationPlan({ scopes, changedFiles: ['tsconfig.base.json'] });
+
+    expect(renderPlanSummary(empty)).toContain('this plan verifies NO package or app.');
+    expect(renderPlanSummary(full)).toContain(
+      `Scope coverage: ${scopes.length} of ${scopes.length} workspace scopes`,
+    );
+  });
+
   it('renders selected scope checks and unmapped files', () => {
     const plan = createVerificationPlan({
       scopes,

--- a/scripts/harness/__tests__/scan-build-tooling-scope.test.mjs
+++ b/scripts/harness/__tests__/scan-build-tooling-scope.test.mjs
@@ -1,0 +1,229 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as plan from '../check-plan.mjs';
+import {
+  BUILD_DEFINING_ROOT_SCRIPTS,
+  extractScriptFileReferences,
+  findBuildToolingScopeFindings,
+  main,
+} from '../scan-build-tooling-scope.mjs';
+
+/**
+ * INFRA-060 D4 — the guard's own tests.
+ *
+ * Each rule is exercised SEPARATELY against a live defect, because HARNESS-052's own guard shipped
+ * with three instances of the shape it audited: two of its defects masked each other exactly, and
+ * a suite that only ever asserted the aggregate verdict would not have separated them.
+ */
+
+const DECLARED = [...plan.WORKSPACE_WIDE_BUILD_TOOLING_PATHS];
+
+afterEach(() => {
+  plan.WORKSPACE_WIDE_BUILD_TOOLING_PATHS.length = 0;
+  plan.WORKSPACE_WIDE_BUILD_TOOLING_PATHS.push(...DECLARED);
+});
+
+const temporaryRoots = [];
+afterEach(() => {
+  while (temporaryRoots.length > 0) {
+    rmSync(temporaryRoots.pop(), { recursive: true, force: true });
+  }
+});
+
+/** A miniature workspace: two packages, a root manifest, and the declared tooling files. */
+function makeRoot({ buildScript, files = DECLARED } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'build-tooling-scope-'));
+  temporaryRoots.push(root);
+
+  writeFileSync(path.join(root, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+  mkdirSync(path.join(root, 'packages', 'alpha'), { recursive: true });
+  mkdirSync(path.join(root, 'packages', 'beta'), { recursive: true });
+  for (const name of ['alpha', 'beta']) {
+    writeFileSync(
+      path.join(root, 'packages', name, 'package.json'),
+      JSON.stringify({ name: `@x/${name}`, scripts: { build: 'tsdown', test: 'vitest run' } }),
+    );
+  }
+
+  for (const file of files) {
+    const target = path.join(root, file);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, '{}\n');
+  }
+
+  // Last, so it survives a declared list that (correctly) contains `package.json` itself.
+  writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'root',
+      scripts: { build: buildScript ?? 'node scripts/build-types-ordered.mjs' },
+    }),
+  );
+
+  return root;
+}
+
+/** Two fixture scopes, standing in for the 86 real ones. */
+const FIXTURE_SCOPES = ['alpha', 'beta'].map((name) => ({
+  kind: 'package',
+  relativeDir: `packages/${name}`,
+  shortName: name,
+  workspaceName: `@x/${name}`,
+  scripts: { build: 'tsdown', test: 'vitest run', lint: 'eslint src' },
+  hasTsconfig: true,
+  workspaceDependencies: [],
+}));
+
+const listFixtureScopes = async () => FIXTURE_SCOPES;
+
+function rules(findings) {
+  return findings.map((finding) => finding.rule.split(' ')[0]).sort();
+}
+
+describe('extractScriptFileReferences', () => {
+  it('finds a repo-root file the root build invokes', () => {
+    const root = makeRoot();
+    expect(
+      extractScriptFileReferences('pnpm -r build:js && node scripts/build-types-ordered.mjs', root),
+    ).toEqual(['scripts/build-types-ordered.mjs']);
+  });
+
+  it('ignores globs, flag values and package-local paths', () => {
+    const root = makeRoot();
+    mkdirSync(path.join(root, 'packages', 'alpha'), { recursive: true });
+    writeFileSync(path.join(root, 'packages', 'alpha', 'tsdown.config.ts'), '');
+
+    expect(
+      extractScriptFileReferences(
+        'pnpm --filter "./packages/**" build:js --ext .ts,.tsx --config packages/alpha/tsdown.config.ts',
+        root,
+      ),
+    ).toEqual([]);
+  });
+
+  it('ignores a token that names no file on disk', () => {
+    const root = makeRoot();
+    expect(extractScriptFileReferences('node scripts/does-not-exist.mjs', root)).toEqual([]);
+  });
+
+  it('governs the verbs a scope is verified by', () => {
+    for (const verb of ['build', 'typecheck', 'lint', 'test']) {
+      expect(BUILD_DEFINING_ROOT_SCRIPTS).toContain(verb);
+    }
+  });
+});
+
+describe('findBuildToolingScopeFindings', () => {
+  it('passes on a workspace whose declared tooling is live and wired', async () => {
+    const result = await findBuildToolingScopeFindings(makeRoot(), {
+      listScopes: listFixtureScopes,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(result.scopeCount).toBe(2);
+    expect(result.declaredCount).toBe(DECLARED.length);
+    expect(result.referencesExamined).toBe(1);
+  });
+
+  it('R1: reports a declared path that no longer exists', async () => {
+    const root = makeRoot();
+    plan.WORKSPACE_WIDE_BUILD_TOOLING_PATHS.push('scripts/build-types-renamed.mjs');
+
+    const result = await findBuildToolingScopeFindings(root, { listScopes: listFixtureScopes });
+
+    expect(rules(result.findings)).toEqual(['R1']);
+    expect(result.findings[0].detail).toContain('scripts/build-types-renamed.mjs');
+  });
+
+  it('R2: fires against a calculator that has stopped honouring the declared list', async () => {
+    const root = makeRoot();
+    // The pre-fix calculator exactly: path-prefix mapping only, no workspace-wide branch. It is
+    // the shape the live red proof used (INFRA-060 D4), reproduced here per-rule.
+    const preFixPlanner = ({ scopes, changedFiles }) => ({
+      scopes: scopes.filter((scope) =>
+        changedFiles.some((file) => file.startsWith(`${scope.relativeDir}/`)),
+      ),
+    });
+
+    const result = await findBuildToolingScopeFindings(root, {
+      planner: preFixPlanner,
+      listScopes: listFixtureScopes,
+    });
+
+    expect(new Set(rules(result.findings))).toEqual(new Set(['R2']));
+    expect(result.findings).toHaveLength(DECLARED.length);
+    expect(result.findings[0].detail).toContain('resolves to 0 of 2 workspace scopes');
+  });
+
+  it('R2: passes on the real calculator for every declared path', async () => {
+    const result = await findBuildToolingScopeFindings(makeRoot(), {
+      listScopes: listFixtureScopes,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(result.declaredCount).toBe(DECLARED.length);
+  });
+
+  it('R3: reports a file joining root build without joining the declared list', async () => {
+    const root = makeRoot({
+      buildScript: 'node scripts/build-types-ordered.mjs && node scripts/build-next-thing.mjs',
+    });
+    mkdirSync(path.join(root, 'scripts'), { recursive: true });
+    writeFileSync(path.join(root, 'scripts', 'build-next-thing.mjs'), '');
+
+    const result = await findBuildToolingScopeFindings(root, { listScopes: listFixtureScopes });
+
+    expect(rules(result.findings)).toEqual(['R3']);
+    expect(result.findings[0].detail).toContain('scripts/build-next-thing.mjs');
+  });
+
+  it('R4: reports over-correction that would redden documentation PRs', async () => {
+    const root = makeRoot();
+    plan.WORKSPACE_WIDE_BUILD_TOOLING_PATHS.push('README.md');
+    writeFileSync(path.join(root, 'README.md'), '');
+
+    const result = await findBuildToolingScopeFindings(root, { listScopes: listFixtureScopes });
+
+    expect(rules(result.findings)).toEqual(['R4']);
+    expect(result.findings[0].detail).toContain('must stay a pass');
+  });
+
+  it('reports zero counts rather than a pass when its subject is missing', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'build-tooling-scope-bare-'));
+    temporaryRoots.push(root);
+    writeFileSync(path.join(root, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+    mkdirSync(path.join(root, 'packages'), { recursive: true });
+
+    const result = await findBuildToolingScopeFindings(root, { listScopes: async () => [] });
+
+    expect(result.scopeCount).toBe(0);
+    expect(result.buildScriptCount).toBe(0);
+    expect(result.referencesExamined).toBe(0);
+  });
+
+  it('main() refuses to print a pass when it enumerated nothing', async () => {
+    const written = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const originalExitCode = process.exitCode;
+    plan.WORKSPACE_WIDE_BUILD_TOOLING_PATHS.length = 0;
+
+    process.stdout.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+    try {
+      await main();
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    expect(written.join('')).toContain('ZERO declared workspace-wide paths');
+    expect(written.join('')).not.toContain('scan passed');
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/scripts/harness/check-plan.mjs
+++ b/scripts/harness/check-plan.mjs
@@ -12,6 +12,71 @@ import { classifyScopeChanges, mapFilesToScopes, resolveRequestedScopes } from '
  */
 export const PACKAGE_DIST_CHECKS = ['build', 'test', 'typecheck'];
 
+/**
+ * Root paths that change how EVERY workspace scope is built, typechecked or linted.
+ *
+ * INFRA-060 D4. The calculator maps a changed file to a scope by PATH PREFIX alone, so a file
+ * outside `packages/` and `apps/` resolved to zero scopes no matter what it governed. A one-line
+ * edit to `scripts/build-types-ordered.mjs` — the second half of root `pnpm build` — therefore
+ * planned `scopes: []`, which made CI's `build` job skip `pnpm build` and its `quality` job verify
+ * nothing, both REQUIRED and both green. The vacuous green was the symptom; the calculator not
+ * knowing that build tooling is a dependency of every package was the defect.
+ *
+ * A change to any path here selects the FULL workspace, because the honest answer to "which
+ * packages does this affect" is "all of them".
+ *
+ * MEMBERSHIP RULE, so this list can be extended without re-deriving it: a repo-root path belongs
+ * here when changing it changes the OUTCOME of `build` / `typecheck` / `lint` / `test` for scopes
+ * that did not themselves change. Measured, per entry:
+ *
+ * - `scripts/build-types-ordered.mjs` — root `build` is
+ *   `pnpm --filter "./packages/**" build:js && node scripts/build-types-ordered.mjs`; it builds
+ *   every package's `.d.ts` in topological order.
+ * - `package.json` — root; owns `build`, `typecheck`, `lint`, `test`, the shared toolchain in
+ *   `devDependencies` (typescript, tsdown, vitest, eslint), `pnpm.overrides` and `engines`.
+ * - `pnpm-workspace.yaml` — decides which directories ARE workspace packages at all.
+ * - `tsconfig.base.json` — extended by 80 of the 86 in-scope tsconfigs.
+ * - `tsconfig.json` — root project references; `tsconfig.eslint.json` extends it.
+ * - `tsconfig.eslint.json` — extended by the per-package `tsconfig.eslint.json` that each
+ *   package's `.eslintrc.json` names as its `parserOptions.project`.
+ * - `.eslintrc.json`, `.eslintignore` — root `lint` is `eslint packages apps`, and every package's
+ *   own `.eslintrc.json` resolves through the root config.
+ *
+ * DELIBERATELY EXCLUDED, with the measurement behind each — over the last 400 develop commits:
+ *
+ * - `pnpm-lock.yaml` (41 commits touched it). All 7 of the commits that touched it WITHOUT
+ *   touching any scope also touched root `package.json`, so it adds no detection this list does
+ *   not already have; adding it would move the other 34 from partial to full verification for
+ *   nothing. A per-scope dependency change already selects that scope and its dependents.
+ * - `vitest.config.ts` (root). It does not govern a scope's `pnpm test`: vitest resolves its
+ *   config from the cwd and does not search upward. Verified — `packages/agent-tools` has no local
+ *   vitest config and still collected 26 test files, which the root `include`
+ *   (`packages/** /src/**`) cannot match from that cwd.
+ * - `.prettierrc.json`, `commitlint.config.js`, `stryker.conf.mjs`, `.dependency-cruiser.cjs`,
+ *   `.nvmrc` — none is read by a scope's `build`/`test`/`lint`/`typecheck`.
+ *
+ * Guarded by `scan-build-tooling-scope` (`pnpm harness:scan`), which re-derives the root build
+ * script's file references, EXECUTES the calculator against each entry, and fails if any entry
+ * stops resolving to the full workspace — or if a new file joins root `build` without joining
+ * this list.
+ */
+export const WORKSPACE_WIDE_BUILD_TOOLING_PATHS = [
+  '.eslintignore',
+  '.eslintrc.json',
+  'package.json',
+  'pnpm-workspace.yaml',
+  'scripts/build-types-ordered.mjs',
+  'tsconfig.base.json',
+  'tsconfig.eslint.json',
+  'tsconfig.json',
+];
+
+/** The changed files that are workspace-wide build tooling, in the order given. */
+export function listWorkspaceWideTriggers(changedFiles) {
+  const declared = new Set(WORKSPACE_WIDE_BUILD_TOOLING_PATHS);
+  return (changedFiles ?? []).filter((file) => declared.has(file));
+}
+
 /** Whether a verification plan contains a scope whose checks need the monorepo build output. */
 export function planRequiresPackageDist(plan) {
   const dependent = new Set(PACKAGE_DIST_CHECKS);
@@ -199,24 +264,40 @@ export function createVerificationPlan({
   includeDependentScopes = true,
 }) {
   const scopeFiles = mapFilesToScopes(changedFiles, scopes);
-  const initialSelectedScopes =
-    scopeTokens.length > 0
-      ? resolveRequestedScopes(scopeTokens, scopes)
-      : scopes.filter((scope) => (scopeFiles.get(scope.relativeDir) ?? []).length > 0);
+  const explicitScopes = scopeTokens.length > 0;
+  const workspaceWideTriggers = explicitScopes ? [] : listWorkspaceWideTriggers(changedFiles);
+  const workspaceWide = workspaceWideTriggers.length > 0;
+  const forceFullVerification = explicitScopes || workspaceWide;
+
+  let initialSelectedScopes;
+  if (explicitScopes) {
+    initialSelectedScopes = resolveRequestedScopes(scopeTokens, scopes);
+  } else if (workspaceWide) {
+    // Build tooling changed: every scope is affected, so every scope is verified in full.
+    initialSelectedScopes = [...scopes];
+  } else {
+    initialSelectedScopes = scopes.filter(
+      (scope) => (scopeFiles.get(scope.relativeDir) ?? []).length > 0,
+    );
+  }
 
   const scopePlans = new Map();
 
   for (const scope of initialSelectedScopes) {
     const files = scopeFiles.get(scope.relativeDir) ?? [];
-    const classification = classifyScopeChanges(scope, files, scopeTokens.length > 0, {
+    const classification = classifyScopeChanges(scope, files, forceFullVerification, {
       manifestChange: manifestChangesByScope.get(scope.relativeDir) ?? null,
     });
+    const notes = listNotes(classification);
+    if (workspaceWide) {
+      notes.push(`workspace-wide:${workspaceWideTriggers.join(', ')}`);
+    }
     scopePlans.set(scope.relativeDir, {
       scope: scope.relativeDir,
       workspaceName: scope.workspaceName,
       files,
       checks: listChecks(scope, classification),
-      notes: listNotes(classification),
+      notes,
     });
 
     if (includeDependentScopes && needsDependentChecks(classification)) {
@@ -262,11 +343,41 @@ export function createVerificationPlan({
     scopes: planScopes,
     unmappedFiles,
     repositoryChecks,
+    workspaceWideTriggers,
+    workspaceScopeCount: scopes.length,
   };
 }
 
+/**
+ * One line stating how much of the workspace this plan covers.
+ *
+ * INFRA-060 D4, second half. A plan over zero scopes and a plan over every scope produced output a
+ * reader had to reconstruct from the absence of a list, and the CI check they feed reported the
+ * same word — `success` — either way. "Verified 0 scopes" and "verified 86 scopes" must not look
+ * identical from outside, so the count is stated explicitly, always, and the zero case says in
+ * words that no package or app was verified. Zero scopes is NOT an error: a docs-only change
+ * legitimately resolves to zero, and reddening it would redden every documentation PR.
+ */
+export function renderScopeCoverageLine(plan) {
+  const selected = plan?.scopes?.length ?? 0;
+  const total = plan?.workspaceScopeCount ?? 0;
+
+  if (selected === 0) {
+    return `Scope coverage: 0 of ${total} workspace scopes — this plan verifies NO package or app.`;
+  }
+
+  const triggers = plan?.workspaceWideTriggers ?? [];
+  const reason =
+    triggers.length > 0 ? ` (workspace-wide build tooling changed: ${triggers.join(', ')})` : '';
+  return `Scope coverage: ${selected} of ${total} workspace scopes${reason}.`;
+}
+
 export function renderPlanSummary(plan) {
-  const lines = ['Verification plan', `Changed files: ${plan.changedFiles.length}`];
+  const lines = [
+    'Verification plan',
+    `Changed files: ${plan.changedFiles.length}`,
+    renderScopeCoverageLine(plan),
+  ];
 
   lines.push('', 'Scopes:');
   if (plan.scopes.length === 0) {

--- a/scripts/harness/plan-change.mjs
+++ b/scripts/harness/plan-change.mjs
@@ -1,8 +1,14 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { createVerificationPlan, parsePlanArgs, renderPlanSummary } from './check-plan.mjs';
 import {
+  createVerificationPlan,
+  parsePlanArgs,
+  renderPlanSummary,
+  renderScopeCoverageLine,
+} from './check-plan.mjs';
+import {
+  appendJobSummary,
   collectPackageManifestChanges,
   detectChangedFiles,
   listWorkspaceScopes,
@@ -53,6 +59,7 @@ async function main() {
   });
 
   process.stdout.write(renderPlanSummary(plan));
+  appendJobSummary(`### Verification plan\n\n${renderScopeCoverageLine(plan)}\n`);
 
   if (options.reportFile) {
     await writeReport(

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -130,6 +130,13 @@ const SCAN_COMMANDS = [
     name: 'test-selection-tolerance',
     command: ['node', 'scripts/harness/scan-test-selection-tolerance.mjs'],
   },
+  {
+    // INFRA-060 D4 — the affected-scope calculator resolved build tooling to ZERO scopes, so a PR
+    // changing how every package is built left the REQUIRED `build` and `quality` checks green
+    // having verified nothing. Executes the calculator against each declared path.
+    name: 'build-tooling-scope',
+    command: ['node', 'scripts/harness/scan-build-tooling-scope.mjs'],
+  },
   { name: 'no-fallback', command: ['node', 'scripts/harness/scan-no-fallback.mjs'] },
   {
     name: 'release-verification-gate',

--- a/scripts/harness/scan-build-tooling-scope.mjs
+++ b/scripts/harness/scan-build-tooling-scope.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+/**
+ * Build-tooling scope-coverage guard (INFRA-060 D4).
+ *
+ * THE DEFECT THIS FENCES. The affected-scope calculator maps a changed file to a workspace scope
+ * by PATH PREFIX alone. Everything outside `packages/` and `apps/` therefore resolved to zero
+ * scopes no matter what it governed — including `scripts/build-types-ordered.mjs`, the second half
+ * of root `pnpm build`. Measured before the fix:
+ *
+ *     $ pnpm harness:plan -- --base-ref origin/develop     # one line changed in that file
+ *     Scopes:
+ *     - none
+ *     $ node <ci.yml's "Detect build requirement" step>  ->  required=false
+ *     $ pnpm harness:verify -- --base-ref origin/develop --skip-build --skip-record-check
+ *     No package or app scope detected from changed files.   ->  exit 0
+ *
+ * Two REQUIRED status checks, `build` and `quality`, both green having verified nothing, on a PR
+ * that changed how every package in the repo is built.
+ *
+ * WHAT A STRUCTURAL GUARD CAN AND CANNOT DO HERE. It cannot decide whether a path is build
+ * tooling — that is a judgement, and a calculator whose judgement is wrong passes every structural
+ * check (INFRA-060's own "mechanical ceiling" section says so). What it CAN do is the part that
+ * actually rots:
+ *
+ *   R1  every declared path still exists — a renamed or deleted entry can never match a diff again
+ *       and would sit in the list looking like coverage.
+ *   R2  the calculator, EXECUTED, still resolves each declared path to the FULL workspace. This is
+ *       the rule that is red against the pre-fix calculator, and the rule that catches a later
+ *       refactor quietly dropping the workspace-wide branch. It executes rather than reads: the
+ *       lesson from HARNESS-052's own guard is that a rule derived by regex from source text
+ *       measures spelling, not behaviour.
+ *   R3  every file that root `package.json`'s build-defining scripts invoke is declared. This is
+ *       the recurrence rule: adding `node scripts/build-next-thing.mjs` to root `build` without
+ *       adding it to the list reinstates the exact defect, and nothing else would notice.
+ *   R4  a docs-only change still resolves to ZERO scopes, and that stays a PASS. The fix's own
+ *       failure mode is over-correction — if every PR builds everything, a slow gate replaces a
+ *       silent one and gets bypassed instead. `review-gate` was rolled back the day it was armed
+ *       for reddening documentation PRs; this pins that it cannot happen here.
+ *
+ * ANTI-ROT: every rule is quantified over things this scan enumerated, and it fails loudly when
+ * any of those counts is zero — no declared paths, no workspace scopes, no root build script. A
+ * guard that examined nothing must not print a pass.
+ *
+ * Exit code 0 = the workspace-wide path class is declared, live, and behaving; 1 = otherwise.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { WORKSPACE_WIDE_BUILD_TOOLING_PATHS, createVerificationPlan } from './check-plan.mjs';
+import { listWorkspaceScopes } from './shared.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/**
+ * Root scripts whose behaviour IS the per-scope verification verbs. A file one of these invokes
+ * runs for every package, so changing it changes every package's result.
+ */
+export const BUILD_DEFINING_ROOT_SCRIPTS = [
+  'build',
+  'build:js',
+  'build:types',
+  'build:deps',
+  'build:all',
+  'typecheck',
+  'lint',
+  'test',
+];
+
+/** A token that names a file in the repo rather than a flag, a glob or a package filter. */
+const FILE_TOKEN = /^\.?[\w][\w./-]*\.(?:mjs|cjs|js|ts|mts|cts|sh|json|ya?ml)$/;
+
+/** Docs-only paths used to pin that zero scopes remains reachable and passing (R4). */
+export const DOCS_ONLY_CONTROL = [
+  'README.md',
+  '.agents/backlog/INFRA-060-ci-yml-job-by-job-audit.md',
+  'docs/plans/example.md',
+];
+
+/**
+ * The repo-root files that a root script invokes.
+ *
+ * Only tokens that resolve to an existing file OUTSIDE `packages/` and `apps/` count: a
+ * package-local build config is already selected by the ordinary path-prefix rule, and a token
+ * that names nothing on disk is a flag value, not a dependency.
+ */
+export function extractScriptFileReferences(command, root = WORKSPACE_ROOT) {
+  const found = [];
+  for (const raw of String(command ?? '').split(/\s+/)) {
+    const token = raw.replace(/^["']|["'],?$/g, '');
+    if (token.includes('*') || !FILE_TOKEN.test(token)) {
+      continue;
+    }
+    const normalized = token.replace(/^\.\//, '');
+    if (normalized.startsWith('packages/') || normalized.startsWith('apps/')) {
+      continue;
+    }
+    if (!existsSync(path.join(root, normalized))) {
+      continue;
+    }
+    if (!found.includes(normalized)) {
+      found.push(normalized);
+    }
+  }
+  return found;
+}
+
+/**
+ * Every rule, evaluated. Returns the findings plus the counts each rule was quantified over, so a
+ * caller can refuse to report a pass over nothing.
+ *
+ * `planner` and `listScopes` exist so R2 can be exercised against a calculator that has STOPPED
+ * honouring the declared list — the refactor R2 is there to catch — and against a workspace other
+ * than this one. `main()` always uses the real pair, so the seams cannot make the SHIPPED scan
+ * measure anything but the shipped calculator over the real workspace. (`listWorkspaceScopes`
+ * resolves the workspace from the process cwd captured at import, so `root` alone cannot redirect
+ * it; the seam is the only honest way to point the rules at a fixture.)
+ */
+export async function findBuildToolingScopeFindings(
+  root = WORKSPACE_ROOT,
+  { planner = createVerificationPlan, listScopes = listWorkspaceScopes } = {},
+) {
+  const findings = [];
+  const declared = [...WORKSPACE_WIDE_BUILD_TOOLING_PATHS];
+  const scopes = await listScopes();
+
+  const rootManifestPath = path.join(root, 'package.json');
+  const rootScripts = existsSync(rootManifestPath)
+    ? (JSON.parse(readFileSync(rootManifestPath, 'utf8')).scripts ?? {})
+    : {};
+  const buildScripts = BUILD_DEFINING_ROOT_SCRIPTS.filter(
+    (name) => typeof rootScripts[name] === 'string',
+  );
+
+  // R1 — every declared path still exists.
+  for (const declaredPath of declared) {
+    if (!existsSync(path.join(root, declaredPath))) {
+      findings.push({
+        rule: 'R1 declared-path-exists',
+        detail:
+          `\`${declaredPath}\` is declared workspace-wide build tooling but does not exist. A ` +
+          `renamed or deleted entry can never match a diff again, so it sits in the list looking ` +
+          `like coverage while contributing none. Update or remove it.`,
+      });
+    }
+  }
+
+  // R2 — the calculator, executed, resolves each declared path to the FULL workspace.
+  for (const declaredPath of declared) {
+    const plan = planner({ scopes, changedFiles: [declaredPath] });
+    if (plan.scopes.length !== scopes.length) {
+      findings.push({
+        rule: 'R2 resolves-to-full-workspace',
+        detail:
+          `changing \`${declaredPath}\` alone resolves to ${plan.scopes.length} of ` +
+          `${scopes.length} workspace scopes. It is declared as build tooling — a path that ` +
+          `changes how EVERY package is built, typechecked or linted — so anything short of the ` +
+          `full workspace means CI's \`build\` and \`quality\` checks can report green over ` +
+          `packages this change actually affects (INFRA-060 D4).`,
+      });
+    }
+  }
+
+  // R3 — every file the root build-defining scripts invoke is declared.
+  let referencesExamined = 0;
+  for (const name of buildScripts) {
+    for (const reference of extractScriptFileReferences(rootScripts[name], root)) {
+      referencesExamined += 1;
+      if (declared.includes(reference)) {
+        continue;
+      }
+      findings.push({
+        rule: 'R3 build-script-reference-declared',
+        detail:
+          `root \`package.json\`'s \`${name}\` script invokes \`${reference}\`, which is NOT in ` +
+          `WORKSPACE_WIDE_BUILD_TOOLING_PATHS. A file the root build runs affects every package, ` +
+          `so a change to it must select the full workspace; today it would select zero scopes ` +
+          `and leave \`build\` and \`quality\` green having verified nothing. Add it to the list ` +
+          `in scripts/harness/check-plan.mjs.`,
+      });
+    }
+  }
+
+  // R4 — a docs-only change still resolves to zero scopes.
+  const docsPlan = planner({ scopes, changedFiles: [...DOCS_ONLY_CONTROL] });
+  if (docsPlan.scopes.length !== 0) {
+    findings.push({
+      rule: 'R4 docs-only-stays-empty',
+      detail:
+        `a docs-only change (${DOCS_ONLY_CONTROL.join(', ')}) resolves to ` +
+        `${docsPlan.scopes.length} scopes, not zero. Zero scopes is the CORRECT answer for a ` +
+        `documentation PR, and it must stay a pass: widening the workspace-wide class until it ` +
+        `catches docs trades a silent gate for a slow one, and a slow gate gets bypassed.`,
+    });
+  }
+
+  return {
+    findings,
+    declaredCount: declared.length,
+    scopeCount: scopes.length,
+    buildScriptCount: buildScripts.length,
+    referencesExamined,
+  };
+}
+
+export async function main() {
+  const result = await findBuildToolingScopeFindings();
+
+  const vacuous = [
+    result.declaredCount === 0 ? 'ZERO declared workspace-wide paths' : null,
+    result.scopeCount === 0 ? 'ZERO workspace scopes enumerated' : null,
+    result.buildScriptCount === 0 ? 'ZERO build-defining root scripts found' : null,
+  ].filter(Boolean);
+
+  if (vacuous.length > 0) {
+    process.stdout.write(
+      `build-tooling-scope scan failed — ${vacuous.join('; ')}.\n` +
+        'Every rule here is quantified over things this scan enumerated, so finding none means the\n' +
+        'scan stopped reading its subject, not that the calculator is sound.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.findings.length > 0) {
+    process.stdout.write('build-tooling-scope scan failed (INFRA-060 D4):\n');
+    for (const finding of result.findings) {
+      process.stdout.write(`  - ${finding.rule}: ${finding.detail}\n`);
+    }
+    process.stdout.write(
+      "\nA scope calculator that resolves build tooling to zero scopes makes CI's `build` and\n" +
+        '`quality` checks report success over a monorepo they never built.\n',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(
+    `build-tooling-scope scan passed — ${result.declaredCount} declared path(s) each resolve to ` +
+      `all ${result.scopeCount} workspace scopes; ${result.referencesExamined} file reference(s) ` +
+      `across ${result.buildScriptCount} root build script(s) declared; docs-only still resolves ` +
+      `to zero scopes.\n`,
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isDirectExecution) {
+  await main();
+}

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -119,6 +119,12 @@ export const MANDATORY_TREE_GUARDS = [
     tree: 'packages, apps and scripts',
     why: 'merge debris in a tree that was never opened is the one thing a "conflict markers" gate must never report clean',
   },
+  {
+    file: 'scan-build-tooling-scope.mjs',
+    finder: 'findBuildToolingScopeFindings',
+    tree: 'the declared workspace-wide build tooling (root package.json, tsconfig.base.json, scripts/build-types-ordered.mjs and the rest)',
+    why: 'INFRA-060 D4 — this guard exists because build tooling resolving to zero scopes made two REQUIRED checks green over a monorepo they never built; a run that finds none of that tooling has measured nothing, and "no build tooling here" is exactly the answer the defect produced',
+  },
 ];
 
 /**
@@ -284,6 +290,23 @@ export const PENDING_CLASSIFICATION = [
     file: 'scan-unearned-done-claims.mjs',
     finder: 'findUnearnedDoneClaimFindings',
     measured: 'fail-closed',
+  },
+  // INFRA-058's two guards, unclassified when they were registered — which left rule 1 RED on
+  // `develop` (reproduced on a clean checkout of origin/develop, 2026-07-26). Measured here rather
+  // than assumed, and left in the ledger rather than pinned: naming their governed tree accurately
+  // is their own item's call, not this one's.
+  {
+    file: 'scan-required-check-needs.mjs',
+    finder: 'findRequiredCheckNeedsFindings',
+    measured: 'fail-closed',
+  },
+  {
+    // The FINDER is vacuous on an absent `.github/workflows` — it returns `{findings: [],
+    // invocations: 0}`. Its `main()` is not: it fails on `invocations === 0`. The ledger records
+    // what the finder does, because that is what this scan can execute.
+    file: 'scan-test-selection-tolerance.mjs',
+    finder: 'findTestSelectionFindings',
+    measured: 'vacuous',
   },
 ];
 

--- a/scripts/harness/shared.mjs
+++ b/scripts/harness/shared.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { promises as fs } from 'node:fs';
+import { appendFileSync, promises as fs } from 'node:fs';
 import path from 'node:path';
 
 export const WORKSPACE_ROOT = process.cwd();
@@ -304,6 +304,27 @@ export function parseScopeArgs(argv) {
  */
 export function envWithoutGitVars(base = process.env) {
   return Object.fromEntries(Object.entries(base).filter(([key]) => !key.startsWith('GIT_')));
+}
+
+/**
+ * Append markdown to the GitHub Actions JOB SUMMARY, so what a job actually covered is readable
+ * from the run page rather than only from the middle of a log.
+ *
+ * INFRA-060 D4. `build: success` and `quality: success` read identically whether the job verified
+ * every package or none of them; the fact that a PR verified NOTHING was recoverable only by
+ * opening the log. Writing to `$GITHUB_STEP_SUMMARY` needs no workflow change — any step's process
+ * can append to it — so the harness surfaces its own coverage instead of the workflow describing it.
+ *
+ * Returns false (and writes nothing) outside Actions, which is every local run.
+ */
+export function appendJobSummary(markdown) {
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (!target) {
+    return false;
+  }
+
+  appendFileSync(target, markdown.endsWith('\n') ? markdown : `${markdown}\n`, 'utf8');
+  return true;
 }
 
 export function runCommand(command, args, workdir, dryRun, envOverrides = {}) {

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { createVerificationPlan } from './check-plan.mjs';
+import { createVerificationPlan, renderScopeCoverageLine } from './check-plan.mjs';
 import {
   compareScenarioRecordArtifact,
   createScenarioRecordPayload,
@@ -15,6 +15,7 @@ import {
 import { resolveScenarioVerification } from './scenario-owner-map.mjs';
 import {
   WORKSPACE_ROOT,
+  appendJobSummary,
   classifyScopeChanges,
   collectPackageManifestChanges,
   detectChangedFiles,
@@ -92,6 +93,12 @@ async function main() {
     manifestChangesByScope,
     includeDependentScopes: !options.skipDependentScopes,
   });
+
+  // INFRA-060 D4: state the coverage BEFORE any check runs and again in the job summary, so a
+  // reader of the check list cannot mistake "verified nothing" for "verified everything, clean".
+  const coverageLine = renderScopeCoverageLine(plan);
+  process.stdout.write(`${coverageLine}\n`);
+  appendJobSummary(`### Affected-scope verification\n\n${coverageLine}\n`);
 
   if (plan.repositoryChecks.length > 0 && !options.skipRepositoryChecks) {
     process.stdout.write(`Repository checks: ${plan.repositoryChecks.join(', ')}\n`);


### PR DESCRIPTION
## INFRA-060 D4 — `build` and `quality` reported green having verified nothing

### Reproduced first

A one-line change to `scripts/build-types-ordered.mjs` — the second half of root `pnpm build`:

```
$ pnpm harness:plan -- --base-ref origin/develop
Changed files: 1
Scopes:
- none
$ node <ci.yml's "Detect build requirement" step>   →  required=false
$ pnpm harness:verify -- --base-ref origin/develop --skip-build --skip-record-check
No package or app scope detected from changed files.
$ echo $?  →  0
```

Two REQUIRED checks on `protect-develop`, both green, on a PR that changes how every package in the repo is built.

### The fix is the calculator, not the gate

"Fail when scopes is empty" was **rejected**: a docs-only PR legitimately resolves to zero scopes, and reddening it is exactly why `review-gate` was rolled back the day it was armed.

The real defect is that a build-tooling PR does not affect *zero* packages — it affects **all** of them, and the calculator could not see that dependency. `check-plan.mjs` now declares `WORKSPACE_WIDE_BUILD_TOOLING_PATHS` (8 root paths, each with the measurement behind it), and a change to any selects the full workspace.

**After:**

```
Scope coverage: 86 of 86 workspace scopes (workspace-wide build tooling changed: scripts/build-types-ordered.mjs).
$ node <the same detect step>   →  required=true
```

**Docs-only unchanged — checked, not assumed:**

```
$ pnpm harness:plan -- --changed-file README.md
Scope coverage: 0 of 86 workspace scopes — this plan verifies NO package or app.
$ echo $?  →  0      # still a PASS
```

`packages/agent-core/src/index.ts` still resolves to 55 of 86 (owner + dependents), not 86.

### Second half — an empty scope set is now visible

Zero scopes stays a pass, but no longer reads like a full one. Every plan states its coverage as a count, on stdout **and in the GitHub job summary** (`$GITHUB_STEP_SUMMARY`, appended by the harness itself — so **no `ci.yml` change was needed**). `verify-change.mjs` prints and posts the same line before any check runs, including on its zero-scope early return.

### The sweep

Every non-`packages`/`apps` path classified through the calculator; the plausible candidates measured over 400 `develop` commits. Two were **excluded with the number**, not by intuition:

- `pnpm-lock.yaml` — 41 commits touched it; all 7 that touched it *without* a scope also touched root `package.json`, so it adds no detection. Including it would move 34 commits from partial to full verification for nothing.
- root `vitest.config.ts` — verified not to govern a scope's `pnpm test`: `packages/agent-tools` has no local config and still collected 26 files, which the root `include` cannot match from that cwd.

Added paths fire on ~5% of commits; 3 of the 8 were never touched in 400 commits.

### Guard: `build-tooling-scope`

Registered in `run-all-scans`. Four rules, each **red-proven against its own live defect** and green after:

| Rule | Red proof |
| --- | --- |
| R1 declared-path-exists | a renamed entry is reported |
| R2 resolves-to-full-workspace | the fix reverted **in place** reports all 8 as `resolves to 0 of 86 workspace scopes` — the pre-fix `scopes: []` exactly |
| R3 build-script-reference-declared | adding `node scripts/migrate-session-history.mjs` to root `build` is reported |
| R4 docs-only-stays-empty | declaring `README.md` as build tooling is reported — over-correction pinned shut |

R2 **executes** the calculator rather than reading its source: HARNESS-052's own guard derived its ledger by regex and measured spelling, not behaviour, three times over. The scan refuses to print a pass when it enumerated zero declared paths, scopes or build scripts.

**Ceiling, stated:** it cannot decide whether a path *is* build tooling. That judgement lives in the membership rule, and a wrong judgement there passes every structural rule — the same ceiling INFRA-060 already records.

### Inherited red, fixed in passing

`guard-scope-fail-closed` rule 1 was **already failing on `origin/develop`** (reproduced on a clean checkout): INFRA-058 registered two scans without classifying their finders. Both measured by execution against a bare root and recorded.

### Verification

- `pnpm harness:scan` — **76/76** (built tree)
- `pnpm harness:test` — **94 files / 1244 tests**
- `pnpm harness:verify-like-ci` — **PASS, all 11 stages**
- `pnpm build`, `pnpm typecheck` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
