### PR TITLE
test(harness): pin the job-summary emitter behind INFRA-060 D4's visibility half

### DIFF
--- a/scripts/harness/__tests__/check-plan.test.mjs
+++ b/scripts/harness/__tests__/check-plan.test.mjs
@@ -1,3 +1,7 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -8,6 +12,7 @@ import {
   renderPlanSummary,
   renderScopeCoverageLine,
 } from '../check-plan.mjs';
+import { appendJobSummary } from '../shared.mjs';
 
 const scopes = [
   {
@@ -353,5 +358,33 @@ describe('renderPlanSummary', () => {
     );
     expect(renderPlanSummary(plan)).toContain('Files outside workspace scopes:');
     expect(renderPlanSummary(plan)).toContain('- .agents/tasks/example.md');
+  });
+});
+
+// INFRA-060 D4, the visibility half. `renderScopeCoverageLine` is what CI's readers see; this pins
+// the delivery path — a line the harness appends to `$GITHUB_STEP_SUMMARY` itself, which is why the
+// fix needed no `ci.yml` edit. Verified live on PR #1484: both `build` and `quality` printed
+// `Scope coverage: 0 of 86 workspace scopes — this plan verifies NO package or app.`
+describe('appendJobSummary (INFRA-060 D4)', () => {
+  it('appends inside Actions and writes nothing outside it', () => {
+    const target = path.join(mkdtempSync(path.join(tmpdir(), 'job-summary-')), 'summary.md');
+    const previous = process.env.GITHUB_STEP_SUMMARY;
+
+    try {
+      delete process.env.GITHUB_STEP_SUMMARY;
+      expect(appendJobSummary('nothing should be written')).toBe(false);
+      expect(existsSync(target)).toBe(false);
+
+      process.env.GITHUB_STEP_SUMMARY = target;
+      expect(appendJobSummary('### First')).toBe(true);
+      expect(appendJobSummary('### Second\n')).toBe(true);
+
+      // Appends, never replaces: `build` and `quality` each contribute their own line.
+      expect(readFileSync(target, 'utf8')).toBe('### First\n### Second\n');
+    } finally {
+      if (previous === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+      else process.env.GITHUB_STEP_SUMMARY = previous;
+      rmSync(path.dirname(target), { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #1484 (INFRA-060 D4). One test, no behaviour change.

D4's second half — making an empty scope set visible — shipped with `renderScopeCoverageLine` tested but its **delivery path** unpinned. `appendJobSummary` is what makes `build: success` over zero scopes distinguishable from one over 86: it appends to `$GITHUB_STEP_SUMMARY` from inside the harness, which is why the fix needed no `ci.yml` edit at all. An untested emitter could be silently reduced to a no-op and every symptom would look identical to the defect D4 closed.

**Red-proven, not assumed** — replacing the append with a bare `return true`:

```
× appendJobSummary (INFRA-060 D4) > appends inside Actions and writes nothing outside it
  Tests  1 failed | 22 passed (23)
```

Restored: 23 passed.

**Confirmed live on #1484's own CI run** (30197612557) — both required jobs printed it, and both correctly report zero scopes for a harness-only PR:

```
build    Show verification plan          Scope coverage: 0 of 86 workspace scopes — this plan verifies NO package or app.
quality  Verify affected quality checks  Scope coverage: 0 of 86 workspace scopes — this plan verifies NO package or app.
```

The test asserts three things: it returns `false` and writes nothing outside Actions; it returns `true` and writes inside; and it **appends** rather than replaces, so `build` and `quality` each contribute their own line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
