### PR TITLE
fix(hooks): branch-guard must ask what is OPEN, not only what once merged

### DIFF
--- a/.agents/backlog/HARNESS-054-progress-quantification-scan-cannot-be-cleared.md
+++ b/.agents/backlog/HARNESS-054-progress-quantification-scan-cannot-be-cleared.md
@@ -1,0 +1,67 @@
+---
+id: HARNESS-054
+title: 'HARNESS-054: the progress-quantification scan skips in CI and its local red can never be cleared'
+status: todo
+priority: medium
+urgency: soon
+type: INFRA
+area: scripts/harness
+created: 2026-07-26
+depends_on: [HARNESS-052]
+---
+
+## Problem
+
+`scan-progress-report-quantification` is registered in `run-all-scans.mjs`, so it is nominally part
+of the CI scan suite. It is not. Its subject is the agent session transcript under
+`~/.claude/projects`, which no CI runner has, so on every CI run it prints an explicit SKIP and
+exits 0. Measured 2026-07-26:
+
+```
+$ HOME=/tmp/nohome node scripts/harness/scan-progress-report-quantification.mjs
+progress-report quantification scan skipped: no session transcript for this workspace …
+exit=0
+```
+
+The SKIP is honest and deliberate — it is not a silent pass. The defect is structural: **the only
+environment where this scan can ever fail is a developer's own machine**, and there its red state is
+**permanent**. A transcript is append-only history; a finding cannot be edited away. Once the scan
+fires, `pnpm harness:scan` is red on that host forever, for every unrelated change.
+
+That is the shape lesson 3 of `.agents/memory/check-validity-two-axes.md` names directly: a guard
+that fires and cannot be cleared gets suppressed, and a suppressed guard costs more than what it
+catches. The only existing escape is `enforceSinceIso` in `.agents/harness.config.json`, which is
+global — moving it to clear one finding disables enforcement for every session before that date.
+
+Observed live: the line `**5 → 6/7 병행 전환 완료.**` (TypeScript 5 → 6/7 side-by-side) was flagged
+as `ratio 6/7 reported without a percentage`. The operands are version numbers. The policy already
+declares versions a non-count class (`v|version` appear in `identifierNounPattern`), but the noun
+must sit inside the 24-character window before the match; here the subject was named earlier in the
+sentence. Whether that specific line is judged a false positive or genuinely ambiguous prose is
+secondary — either verdict leaves the scan red with no path back to green.
+
+## Proposed direction
+
+Two separable pieces; the first is the one with teeth.
+
+1. **A per-finding acknowledgment path.** A finding is identified by its transcript file + line +
+   ratio; record acknowledged findings in a checked-in ledger with a reason, the way other scans
+   carry allowlists with anti-rot. Anti-rot must apply: an entry whose finding no longer appears is
+   itself a failure, so the ledger cannot silently accumulate. This gives the scan a way back to
+   green without disarming it, and makes each waiver a reviewable artifact rather than a config
+   ratchet nudge.
+2. **Widen the version-reference suppression to sentence scope** for the nouns already declared in
+   `identifierNounPattern`, instead of the fixed 24-character lookbehind — and add fixtures for the
+   `X → Y/Z` migration form.
+
+Do not treat this as a reason to weaken the completion-keyword vocabulary. The rule it enforces is
+sound; what is missing is a clearing mechanism.
+
+## Done when
+
+- A finding can be acknowledged with a recorded reason, and the scan then exits 0.
+- An acknowledgment whose finding no longer exists fails the scan (anti-rot proven RED).
+- The `X → Y/Z` version-migration form is covered by a fixture, with the verdict — suppressed or
+  flagged — stated deliberately rather than falling out of a lookbehind width.
+- The CI-vacuity is stated in the scan's own header, so a reader of `run-all-scans` output is not
+  led to believe this scan gates anything in CI.

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -125,14 +125,19 @@ while the guardrails below keep it safe.
 
 **Confirm the merge landed BEFORE deleting the remote branch. Zero exceptions.** A remote branch deleted
 while its PR is still open CLOSES/orphans that PR. So a remote-branch deletion is allowed only once
-`gh pr view <n> --json state` reports `MERGED` (equivalently, `gh pr list --head <branch> --state merged`
-is non-empty). Never run `gh pr merge` and the deletion in one blind sequence — the merge can fail (e.g.
-`mergeStateStatus: DIRTY`) while the deletion still fires. **Enforced** by `.claude/hooks/branch-guard.sh`,
-which blocks `gh api -X DELETE .../git/refs/heads/<name>`, `git push <remote> --delete <name>`, and
-`git push <remote> :<name>` unless the branch has a merged PR (override for an intentional abandon:
-`BRANCH_GUARD_ALLOW_DELETE=1`).
+`gh pr view <n> --json state` reports `MERGED` **and** no PR is open on the branch right now
+(`gh pr list --head <branch> --state open` is empty). Those are two questions, not one: a merged PR in
+the branch's history is not evidence that nothing is open on it — a reused branch name accumulates
+merged PRs from earlier rounds, and the open one hides behind that count. Never run `gh pr merge` and
+the deletion in one blind sequence — the merge can fail (e.g. `mergeStateStatus: DIRTY`) while the
+deletion still fires. **Enforced** by `.claude/hooks/branch-guard.sh`, which blocks
+`gh api -X DELETE .../git/refs/heads/<name>`, `git push <remote> --delete <name>`, and
+`git push <remote> :<name>` unless both hold, and fails closed when either query cannot answer.
+Override for an intentional abandon: `BRANCH_GUARD_ALLOW_DELETE=1` **inline in the same command**
+(`BRANCH_GUARD_ALLOW_DELETE=1 git push origin --delete <name>`) — the guard reads the command string,
+so an `export` in an earlier statement does not reach it.
 
-**Why:** `--delete-branch` once deleted the `develop` integration branch, and a blind delete after a _failed_ merge once closed an unmerged PR (cherry-pick recovery). Deletion is safe only after the merge is confirmed, never for integration branches. Note the two hazards differ in cost: a deleted `develop` is **recoverable** (re-cut it from `main`), whereas a branch deleted while its PR is unmerged **orphans work**. That asymmetry is why the ban targets the blind, automatic form — not deletion itself, which the agent should do routinely once a merge is confirmed.
+**Why:** `--delete-branch` once deleted the `develop` integration branch, and a blind delete after a _failed_ merge once closed an unmerged PR (cherry-pick recovery). The merged-PR half alone was not enough: `fix/d4-scope-calculator` carried two merged PRs from earlier reuses of the name, so the count read `2` and the deletion proceeded while #1483 was open and `DIRTY` — GitHub closed it. Deletion is safe only after the merge is confirmed, never for integration branches. Note the two hazards differ in cost: a deleted `develop` is **recoverable** (re-cut it from `main`), whereas a branch deleted while its PR is unmerged **orphans work**. That asymmetry is why the ban targets the blind, automatic form — not deletion itself, which the agent should do routinely once a merge is confirmed.
 
 ### Branch Policy
 

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -117,7 +117,33 @@ if [[ -n "$DELETE_BRANCH_NAME" && "${BRANCH_GUARD_ALLOW_DELETE:-0}" != "1" ]]; t
     echo "[branch-guard] Intentional abandon of an unmerged branch? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
     exit 2
   fi
-  # MERGED_COUNT >= 1 → the PR merged; deletion is safe. Fall through.
+
+  # A merged PR in the branch's history is NOT proof that nothing is open on it NOW.
+  #
+  # Measured 2026-07-26: `fix/d4-scope-calculator` carried two merged PRs (#1484, #1485) from earlier
+  # reuses of the same branch name. #1483 was open and CONFLICTING at the time — never merged. The
+  # merged-count check saw `2`, allowed the deletion, and GitHub closed #1483 as a result. The exact
+  # outcome this guard exists to prevent, waved through by the guard itself.
+  #
+  # So ask the question that actually matters: is anything OPEN on this branch right now?
+  OPEN_COUNT=""
+  if command -v gh >/dev/null 2>&1; then
+    OPEN_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null || echo "")
+  fi
+  if [[ -z "$OPEN_COUNT" ]]; then
+    echo "[branch-guard] Blocked: cannot confirm whether an OPEN PR exists for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
+    echo "[branch-guard] Unable to determine is not the same as safe. Check by hand, then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+    exit 2
+  fi
+  if [[ "$OPEN_COUNT" != "0" ]]; then
+    OPEN_LIST=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number,mergeStateStatus \
+      --jq '[.[] | "#\(.number) (\(.mergeStateStatus))"] | join(", ")' 2>/dev/null || echo "")
+    echo "[branch-guard] Blocked: '$DELETE_BRANCH_NAME' still has an OPEN PR — $OPEN_LIST." >&2
+    echo "[branch-guard] Deleting it now CLOSES that PR. A merged PR earlier in this branch's history does not make deletion safe." >&2
+    echo "[branch-guard] Merge or close it deliberately first. Intentional abandon? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+    exit 2
+  fi
+  # A merged PR exists AND nothing is open on the branch → deletion is safe. Fall through.
 fi
 
 if [[ "$IS_COMMIT" == "false" && "$IS_PUSH" == "false" && "$IS_MERGE" == "false" && "$IS_BRANCH_CREATE" == "false" ]]; then


### PR DESCRIPTION
## What went wrong

I deleted `fix/d4-scope-calculator` while PR #1483 was open and CONFLICTING. GitHub closed the PR — the exact outcome this guard exists to prevent. The guard did not stop me.

## Root cause

The guard asked one question: *does this branch have a merged PR?* It got `2`, because the branch name had been reused and #1484/#1485 had merged earlier in its history. #1483 was open and unmerged at that moment, and the check never looked at it.

```
$ gh pr list --head fix/d4-scope-calculator --state all
#1485 MERGED   #1484 MERGED   #1483 CLOSED (never merged)
merged count: 2   ← the guard saw this and allowed the deletion
```

A merged PR in a branch's history is not evidence that nothing is open on it now.

## The fix

Also query open PRs, block naming their numbers and merge states, and fail closed when the query cannot answer — *unable to determine* is not *safe*.

## Falsification

Proven three ways with a stubbed `gh`, because no branch currently has an open PR to reproduce against:

| Case | Stub | Result |
| --- | --- | --- |
| The incident (2 merged + 1 open) | merged=2, open=1 | **blocked**, naming `#1483 (DIRTY)` |
| Normal cleanup (merged, none open) | merged=1, open=0 | passes — routine cleanup unaffected |
| Query fails | `gh` exits 1 | blocked, fail-closed |

The middle row matters as much as the first: a guard that blocks correct deletions gets suppressed.

## Also in this PR

`HARNESS-054` — found by running the scan suite for this change. `scan-progress-report-quantification` skips in CI and its local red can never be cleared, because transcripts are append-only. Filed rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z