### PR TITLE
chore(release): promote develop to main

### DIFF
--- a/.agents/backlog/HARNESS-051-dead-code-satisfies-architecture-gate.md
+++ b/.agents/backlog/HARNESS-051-dead-code-satisfies-architecture-gate.md
@@ -1,11 +1,33 @@
 ---
 id: HARNESS-051
 title: An architecture gate is satisfied vacuously by dead code, and the linter was blind to the code that hid it
-status: todo
+status: in-progress
 priority: medium
 type: INFRA
 created: 2026-07-26
 ---
+
+## Progress (2026-07-26)
+
+Findings 1 (the gate) and 3 (`verify-change.mjs`) are resolved. Finding 2 (the test-file
+`no-unused-vars` exemption) is untouched — it needs a measured alert count before and after, and it
+belongs to the ESLint configuration owner, not to the harness scans.
+
+- `scripts/harness/check-agent-server-boundary.mjs` — a required import now counts only when the
+  importing module is **reachable from a declared entry point** and the **imported binding is
+  actually referenced** there. Falsified rather than trusted green: against the pre-fix checker both
+  vacuous shapes (unreachable module, imports-only module) return no finding; against the repaired
+  one both are reported, and the genuinely wired `agent-web → @robota-sdk/agent-playground/client`
+  seam stays clean, including when reached transitively.
+- The `agent-playground → agent-remote-client` requirement (dependency **and** import) is
+  **withdrawn**, with the reason recorded in the checker. The composition does not exist: the
+  package reaches the server through its own `robota-executor/sse-client`, and the remote client has
+  no reachable importer anywhere in the repo. The forbidden-direction rules are untouched.
+- `verify-change.mjs` no longer reports a `passed` field that could only be written `true`.
+
+**This unblocks the playground dead chain** (`agent-session.ts`, `remote-providers.ts` and the
+`orphan-exports` cascade behind them): the gate that made deleting them a CI failure no longer
+requires them. The deletion itself stays with SEC-005 / the package owner.
 
 ## Problem
 
@@ -67,11 +89,13 @@ elsewhere. Fix it or remove it — a value that cannot vary should not be report
 
 ## Acceptance
 
-- [ ] The `agent-server-boundary` gate either verifies a wired seam or its requirement is restated to
-      match what it can actually check — with the playground's dead chain removed either way.
+- [x] The `agent-server-boundary` gate either verifies a wired seam or its requirement is restated to
+      match what it can actually check — the gate now verifies a wired seam, and the requirement the
+      dead chain was propping up is withdrawn. The dead chain is now deletable and its removal is
+      tracked in SEC-005 (it needs the `orphan-exports` cascade resolved inside the package).
 - [ ] The test-file `no-unused-vars` exemption is justified in place or narrowed, and the alert count
       in tests is measured after the change.
-- [ ] `verify-change.mjs`'s `passed` field varies with the outcome, or is gone.
+- [x] `verify-change.mjs`'s `passed` field varies with the outcome, or is gone — gone.
 
 ## References
 

--- a/.agents/backlog/HARNESS-053-stale-dist-phantom-red.md
+++ b/.agents/backlog/HARNESS-053-stale-dist-phantom-red.md
@@ -1,7 +1,7 @@
 ---
 id: HARNESS-053
 title: 'HARNESS-053: a stale dist makes `pnpm typecheck` report a phantom breakage of a healthy branch'
-status: todo
+status: in-progress
 priority: medium
 urgency: soon
 type: INFRA
@@ -70,9 +70,204 @@ Each must be proven RED before the fix per `check-regression-red-proof` — a gu
 bug that was never demonstrated to detect staleness is the HARNESS-052 defect recurring inside its
 own remedy.
 
+## What was built
+
+Point 1 only, done properly. Points 2 and 3 are **not implemented** and the reason is ownership,
+not judgement — see [Not implemented](#not-implemented-and-why).
+
+`scripts/harness/scan-dist-freshness.mjs` now performs a genuine freshness comparison alongside the
+presence gate it already was. Per buildable package: the newest **emitted-source** file under `src/`
+versus the newest artefact under `dist/`. Tests, mocks, fixtures and non-source extensions are
+excluded — `tsconfig.build.json` keeps them out of the build, so they move no declaration and a
+stale verdict drawn from one would be a false alarm.
+
+The rule is decomposed into four separately-testable pieces (`isEmittedSourceFile`, `walkTree`,
+`freshnessVerdict`, `presenceResults`) precisely because HARNESS-052's own guard shipped three
+defects of which **two masked each other** — a defect pair only reachable when rules are exercised
+together and never alone.
+
+### mtime, deliberately
+
+The item asked for a considered answer rather than a default, so: **mtime is the oracle, it is
+evidence and not proof, and each caveat was traced to which direction it cuts.**
+
+| Situation                                                    | Effect on this rule                              | Verdict                                                                                          |
+| ------------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| fresh clone / cold checkout                                  | no `dist` at all ⇒ nothing to compare            | **silent** — pinned by a test                                                                    |
+| `git checkout` / rebase / stash pop                          | touched sources newer than the other tree's dist | **true positive** — that dist _is_ stale                                                         |
+| restored build cache / CI artefact download                  | `dist` arrives with a new mtime ⇒ reads fresh    | **false negative** — as silent as the presence-only check already was; it never fabricates a red |
+| source reverted to the exact content its dist was built from | newer mtime, identical content                   | **false positive** — the only realistic one, and the reason the rule is advisory                 |
+
+Only the last row produces a wrong red, and only advisorily. The sound alternative — a **content
+hash of the emitted-source set stamped into the build output** at build time and compared here —
+removes every row above. It is not implemented because stamping requires changing the build
+pipeline (`tsdown` config, package `build` scripts, or the root `build` script), all outside this
+item's ownership. Recorded as the upgrade path; **not** judged unnecessary.
+
+### Blocking vs advisory
+
+**Advisory. Staleness never changes the exit code**, and that decision is itself pinned by a test
+(`reports staleness but EXITS 0`) so it cannot drift silently. Four reasons, in descending weight:
+
+1. **It can fire on correct state.** The reverted-file row above is a real false positive. The
+   item's own instruction is that a check firing on correct state is not an acceptable outcome.
+2. **The suppression path is already wired.** `ci.yml` carries a `--skip dist` argument. A gate that
+   reddens on a legitimately-cold or legitimately-reverted tree would be routed through it within a
+   week, and then neither half of the scan runs.
+3. **The blocking enforcement already exists and is sound.** `verify-like-ci`'s `build` stage
+   rebuilds rather than trusting this scan — it does not need a second, weaker gate beside it.
+4. **Precedent.** The same reasoning is recorded in this repo for `review-gate`'s severity split and
+   for the slug-equality rule that would have fired on 34 of 111 correct pairs.
+
+The presence half stays blocking, unchanged.
+
+### Two HARNESS-052 findings in the same file, repaired alongside
+
+- **The operator-precedence bug** (`scan-dist-freshness:59` in HARNESS-052's notes) that downgraded
+  a genuine missing-dist ERROR to a non-blocking warning for a `main`-only package. Blast radius
+  **measured**: 3 packages change classification (`apps/action`, `apps/agent-app`,
+  `apps/agent-server`), all `private: true` and short-circuited before that branch, so no live
+  verdict moves.
+- **The banner's universal claim.** `All 86 buildable packages have dist/` was measured to assert
+  presence for **31**; the other 55 produce no presence result at all. Same shape as HARNESS-052's
+  G1. It now states the count it actually covered.
+
+### The audited defect, found live inside this item's own remedy
+
+Registering the finder in `scan-guard-scope-fail-closed` **by measurement** — as instructed, and as
+HARNESS-052's guard was caught not doing — went in three steps, and the third one paid:
+
+1. `measureFinder` on `collectDistFreshnessResults` against a bare root: still `fail-closed`, so the
+   existing ledger entry is accurate and unchanged.
+2. But **incidentally** so: `finder(bare)` supplies one argument, `scopes` is undefined, and
+   `scopes.filter` throws. A missing-argument crash, not a governed-tree check. This finder has no
+   tree of its own — its subject is the package set the _caller_ enumerates. It therefore stays in
+   `PENDING_CLASSIFICATION` rather than being promoted to `MANDATORY_TREE_GUARDS`, where it would
+   certify a property it does not hold. The ledger now records that reasoning instead of the bare
+   verdict.
+3. The gap step 2 leaves was **measured rather than asserted**: the CLI's `main()` _does_ enumerate,
+   via `listWorkspaceScopes()`. Run against a `pnpm-workspace.yaml` resolving to zero packages, it
+   printed `dist/ present on all 0 package(s)` and **exited 0** — a green pass over a scan that
+   measured nothing, which is exactly the class HARNESS-052 audits. Now an exit 1, pinned by a test.
+   (A root with no manifest at all already threw out of `listWorkspaceScopes` — also measured, not
+   assumed.)
+
+## Falsification record
+
+### 1. The HIDING direction — proven
+
+The dangerous, symptomless direction. Constructed with the repo's own toolchain (`tsc` to emit,
+`tsgo` to check), reproducible via the fixture script recorded in this item's PR discussion.
+
+| Step | State                                                                         | `typecheck`                                           |
+| ---- | ----------------------------------------------------------------------------- | ----------------------------------------------------- |
+| 1    | producer built from v1 `export function greet(): string`                      | —                                                     |
+| 2    | src → v2 `export function greet(name: string): string`; **dist not rebuilt**  | —                                                     |
+| 3    | consumer `greet()` — genuinely broken against v2 — checked against stale dist | **exit 0**                                            |
+| 5    | producer rebuilt, **identical consumer source** re-checked                    | **exit 1**: `TS2554: Expected 1 arguments, but got 0` |
+
+The stale dist silently hid a real cross-package type error. At step 4 the new rule reported
+`@fx/producer: dist/ may be STALE — src/index.ts is 1s newer than the newest artefact
+dist/index.d.ts`, tally `{measured:1, fresh:0, stale:1, unmeasurable:0}`; at step 6, after the
+rebuild, it was silent with `{measured:1, fresh:1, stale:0, unmeasurable:0}`.
+
+### 2. The PHANTOM direction — proven
+
+| Step | State                                                       | `typecheck`                                                                     |
+| ---- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 1    | producer built from v1 (exports `greet`)                    | —                                                                               |
+| 2    | src adds `export function farewell()`; **dist not rebuilt** | —                                                                               |
+| 3    | consumer imports `farewell` — **correct** source            | **exit 1**: `TS2305: Module '"@fx/producer"' has no exported member 'farewell'` |
+| 5    | producer rebuilt, identical consumer source                 | **exit 0** — the breakage was never real                                        |
+
+Same error family (`TS2305`) as two of the three failures in the incident table above. Again the
+rule reported the staleness at step 4 and went silent at step 6.
+
+### 2b. The same falsification HARNESS-052 recorded, replayed on the real repo
+
+`touch packages/agent-core/src/index.ts` on a freshly-built tree:
+
+- **old scan** (`origin/develop`): `All 86 buildable packages have dist/`, **exit 0** — and
+  `✅ @robota-sdk/agent-core: dist/ present` printed for the stale package itself.
+- **new scan**: `🕒 @robota-sdk/agent-core: dist/ may be STALE — src/index.ts is 5m 35s newer than
+the newest artefact dist/node/index-Bcx57CtY.d.ts`, `freshness: 1 stale / 75 compared`,
+  **exit 0** (advisory).
+
+### 3. No regression — proven, both halves
+
+- **Genuinely fresh tree.** Immediately after a green `pnpm build`, on the real workspace:
+  `freshness: 0 stale / 75 compared (11 not comparable: no src/ or no dist/)`. **Zero false
+  positives on correct state.** No timing tolerance was needed; the 11 not-comparable scopes are
+  ten `apps/*` that `pnpm build` does not build plus `packages/agent-cli-web` — every package under
+  `packages/**` that has a dist is compared.
+- **Genuinely cold checkout, no `dist` at all.** Reported `unmeasurable`, not stale — the presence
+  rule still owns the missing dist and freshness adds no second verdict on top. This is the case
+  that separates a freshness check from the presence check it replaces, and it is pinned twice
+  (unit + integration).
+
+### Per-rule mutation testing, and the one it caught
+
+Seven single-rule mutations were applied to the shipped scan and the suite re-run against each.
+Six failed 1–9 tests. **The seventh — reinstating the banner overclaim — failed ZERO**, because the
+CLI fixture had one package, so `presenceAsserted === buildableCount` and the mutation was
+invisible. A test with the two counts deliberately different was added and the mutation re-run
+until it went red.
+
+That is the item's own warning landing: a rule was shipped, reviewed and green with no test
+underneath it, and only mutation found it. It was found by **measuring**, not by reading.
+
+| Mutation                                    | Tests failed                               |
+| ------------------------------------------- | ------------------------------------------ |
+| freshness comparison removed (always fresh) | 4                                          |
+| cold-checkout guard removed                 | 2                                          |
+| test/mock/fixture exclusion removed         | 9                                          |
+| extension allowlist removed                 | 3                                          |
+| freshness made blocking                     | 1                                          |
+| presence precedence bug reinstated          | 2                                          |
+| banner overclaim reinstated                 | **0 → 1** after the missing test was added |
+
+## Not implemented, and why
+
+Stated plainly rather than quietly dropped:
+
+- **Point 2 — `pnpm typecheck` failing fast and explanatorily.** Requires editing the root
+  `package.json` `typecheck` script, outside this item's ownership. The diagnostic text it would
+  have carried is instead emitted by this scan when staleness is found.
+- **Point 3 — routing the diagnostic instruction into the rules/skills tree.** `.agents/rules/**`
+  and `.agents/skills/**` are outside this item's ownership. The instruction ("a cross-package type
+  error seen only in a whole-workspace typecheck should be re-checked after `pnpm build` before it
+  is treated as a branch defect") is emitted verbatim by the scan when it finds staleness, so it is
+  at least reachable at the moment of confusion.
+- **The content-hash oracle.** See [mtime, deliberately](#mtime-deliberately). Blocked on
+  build-pipeline ownership, not on judgement. This is the one upgrade that would make a **blocking**
+  freshness gate defensible.
+
+## Known ceilings
+
+- **`run-all-scans` discards a passing scan's output.** Under `pnpm harness:scan` the freshness
+  advisory is counted in this scan's own summary but its per-package lines are not displayed. That
+  is HARNESS-052's still-open "`run-all-scans` distinguishes ran-and-found-nothing from
+  ran-and-measured-nothing" item and cannot be fixed from inside this file. Run the scan directly —
+  the diagnostic moment it exists for — to see the packages named.
+- **A restored cache or downloaded artefact reads fresh.** False negative, unchanged from the
+  presence-only behaviour.
+- **The rule compares timestamps, not content.** It cannot see a `dist` that is byte-identical to
+  what the current source would emit, nor one whose staleness is confined to a file the newest-mtime
+  comparison does not reach.
+
 ## Acceptance
 
-- Falsification recorded: with a deliberately stale `dist`, the new check goes red/warns; with a
-  fresh one it is silent.
-- `scan-dist-freshness`'s name and behaviour agree, or the divergence note is updated to point here.
-- No new blocking check that can fire on a correct tree.
+- [x] Falsification recorded: with a deliberately stale `dist` the new check warns; with a fresh one
+      it is silent. Both directions (hiding **and** phantom) proven, plus the real-repo replay.
+- [x] `scan-dist-freshness`'s name and behaviour agree — it now measures freshness, so HARNESS-052's
+      open "rename it to match what it checks" line is moot rather than pending. The `--skip dist`
+      argument in `ci.yml` needs no change.
+- [x] No new blocking check that can fire on a correct tree: freshness never changes the exit code,
+      measured at 0 stale / 75 compared on a freshly-built workspace.
+- [x] Each rule of the check tested separately, and the one rule that had no test found by mutation.
+- [x] Registered in `guard-scope-fail-closed` by measurement — which surfaced and fixed a live
+      pass-over-nothing in this scan's own CLI.
+- [ ] Content-hash build stamp replaces mtime, making a blocking freshness gate defensible
+      (needs build-pipeline ownership).
+- [ ] `pnpm typecheck` fails fast with the staleness explanation (needs root `package.json`).
+- [ ] The diagnostic is routed into the rules/skills tree (needs `.agents/rules|skills` ownership).

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -82,15 +82,19 @@ jobs:
             2. `gh pr diff <PR NUMBER>` 로 diff 본문을 한 번에 읽는다. 출력이 잘리면 다시 시도하지
                말고, 1의 목록에서 중요한 파일만 골라 Read 로 확인한다 — PR 브랜치는 이미 작업
                디렉터리에 체크아웃되어 있다.
-            3. 발견은 `mcp__github_inline_comment__create_inline_comment` 로 해당 라인에 남긴다.
-            4. 마지막에 `gh pr comment <PR NUMBER> --body "..."` 로 3줄 이내 요약을 남긴다. 이 요약은
-               반드시 남긴다 — 지적할 것이 없으면 없다고 쓴다. 아무것도 남기지 않은 실행은 리뷰하지
+            3. diff 를 다 읽었으면, 인라인 코멘트를 남기기 **전에** 먼저
+               `gh pr comment <PR NUMBER> --body "..."` 로 요약을 남긴다. 요약에는 발견한 것을
+               심각도 순으로 한 줄씩 적는다(없으면 없다고 쓴다). 이 순서는 의도된 것이다 —
+               예산이 끊기더라도 요약은 이미 남아 있다. 아무것도 남기지 않은 실행은 리뷰하지
                않은 실행과 구분되지 않는다.
+            4. 그다음 `mcp__github_inline_comment__create_inline_comment` 로 심각도가 높은 순서대로
+               해당 라인에 코멘트를 남긴다. 여기서 예산이 끝나도 3의 요약이 이미 있으므로,
+               잃는 것은 세부 위치뿐이다.
 
-            예산 규칙: 턴 예산은 25이고 인라인 코멘트 1건이 1턴을 쓴다. 심각도가 높은 순으로 최대
-            10건까지만 인라인으로 남기고 나머지는 요약에 한 줄씩 적는다. 남은 턴이 5 이하라고 판단되면
-            인라인 코멘트를 그만 남기고 4의 요약부터 먼저 처리한다 — 요약 없이 예산이 끝나는 것이
-            최악의 결과다. 빌드·타입체크·테스트 실행이나 전체 트리 탐색은 하지 않는다.
+            예산 규칙: 인라인 코멘트는 1건이 1턴을 쓰므로 최대 10건까지만 남기고 나머지는 3의
+            요약에 적는다. 이 10건은 스스로 셀 수 있는 수이므로 지킬 수 있다 — 남은 턴 수는
+            액션이 알려주지 않으니 그것을 기준으로 판단하려 하지 마라. 빌드·타입체크·테스트
+            실행이나 전체 트리 탐색은 하지 않는다.
 
             이 레포가 특히 강조하는 규율: strict TypeScript(`any`/`unknown` 금지), no-fallback(오류를
             기본값으로 삼켜 감추지 말 것), SSOT 타입, 일방향 패키지 의존성(순환·pass-through
@@ -112,14 +116,30 @@ jobs:
           # Bash, and no network fetch; --disallowedTools states that rather than leaving it to the
           # default permission behaviour.
           #
-          # --max-turns: 25 is kept deliberately, not by default. Re-measured against a large
-          # multi-area PR with the grant above, a full review — diff, context reads, inline
-          # findings, summary — lands inside it. What the cap really bounds is the number of
-          # FINDINGS (one inline comment costs one turn), which is why the prompt caps inline
-          # comments at 10 instead of asking for a bigger budget: a budget that has to grow with
-          # every large PR is not a fix.
+          # --max-turns counts the agent's back-and-forth exchanges inside ONE run. It is not a
+          # retry count: a run that exhausts it stops at `error_max_turns` and the job goes red.
+          #
+          # 25 was set on the claim that a full review lands inside it. Measured over the 40 most
+          # recent runs of this workflow, that claim was false: 7 failed (17.5%), ALL of them
+          # `error_max_turns` at exactly `num_turns: 26`. Successful runs used 10-22 turns
+          # (median ~16), so the cap sat three turns above the observed maximum and cut the tail
+          # off. Worse, a run that died there had often spent its whole budget and posted NOTHING.
+          #
+          # Two things were wrong, and raising the number alone fixes neither:
+          #
+          #   1. The prompt ordered the summary LAST while saying a missing summary is the worst
+          #      outcome. Exhaustion therefore destroyed the one artifact that always has value.
+          #      The summary now goes FIRST and inline comments follow, so running out costs only
+          #      the line-level detail.
+          #   2. The budget rule was unobservable. "stop when fewer than 5 turns remain" cannot be
+          #      followed, because the action never tells the agent how many it has used. It is now
+          #      a count of its own inline comments, which the agent can actually keep.
+          #
+          # 45 gives the measured tail (22) real headroom rather than three turns of it. The point
+          # is not that bigger is better — with the summary landing first, an exhausted run now
+          # degrades instead of vanishing, and the cap is what stops a runaway.
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob"
             --disallowedTools "Write,Edit,NotebookEdit,WebFetch,WebSearch"
-            --max-turns 25
+            --max-turns 45
             --model claude-sonnet-5

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -433,4 +433,21 @@ describe('classifySpecifierUsage', () => {
     expect(classifySpecifierUsage("import 'pkg';", 'pkg')).toBe('used');
     expect(classifySpecifierUsage("export { a } from 'pkg';", 'pkg')).toBe('used');
   });
+
+  // Two sequential strip passes cannot be ordered correctly — each order corrupts real code in the
+  // other's case. Block-first (the version this replaced) let a `/*` inside a LINE comment open a
+  // block scan and delete everything to the next terminator: measured, the `require` line vanished
+  // and a genuinely wired seam read as absent. Line-first instead breaks a block's terminator.
+  it('does not let a comment marker inside another comment swallow real code', () => {
+    const lineCommentContainingBlockOpen = "// see /* note\nconst w = require('pkg');\n/* real */";
+    expect(classifySpecifierUsage(lineCommentContainingBlockOpen, 'pkg')).toBe('used');
+
+    const blockCommentContainingLineMarker = "/* a // b */\nconst w = require('pkg');";
+    expect(classifySpecifierUsage(blockCommentContainingLineMarker, 'pkg')).toBe('used');
+  });
+
+  // The `[^:]` guard: without it every `https://…` reads as a comment and deletes the rest of its line.
+  it('does not mistake a URL for a line comment', () => {
+    expect(classifySpecifierUsage("const u = 'https://x'; require('pkg');", 'pkg')).toBe('used');
+  });
 });

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -5,7 +5,10 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { findAgentServerBoundaryFindings } from '../check-agent-server-boundary.mjs';
+import {
+  classifySpecifierUsage,
+  findAgentServerBoundaryFindings,
+} from '../check-agent-server-boundary.mjs';
 
 async function createFixture(files) {
   const root = await mkdtemp(path.join(tmpdir(), 'robota-agent-server-boundary-'));
@@ -66,8 +69,13 @@ const requiredSources = {
     'void import("@robota-sdk/agent-playground/client");\n',
   'apps/agent-server/src/app.ts':
     'import { OpenAIProvider } from "@robota-sdk/agent-provider-openai";\n',
-  'packages/agent-playground/src/remote-providers.ts':
-    'import { RemoteExecutor } from "@robota-sdk/agent-remote-client";\n',
+  // Wired seam: an entry source imports the specifier and actually uses the binding.
+  'packages/agent-playground/src/index.ts': [
+    'import { RemoteExecutor } from "@robota-sdk/agent-remote-client";',
+    'export function createExecutor() {',
+    '  return new RemoteExecutor();',
+    '}',
+  ].join('\n'),
   'packages/agent-remote-client/src/index.ts':
     'import type { IExecutor } from "@robota-sdk/agent-core";\n',
 };
@@ -196,5 +204,131 @@ describe('findAgentServerBoundaryFindings', () => {
           'agent-server SPEC must state that provider semantics, session policy, and Playground UI state are not server-owned.',
       },
     ]);
+  });
+});
+
+// HARNESS-051: the required-import rule used to pass on any file containing the token, so a
+// never-called module satisfied a boundary the code did not implement. These cases pin the
+// difference between an import statement and a wired seam.
+describe('required imports must be wired, not merely present', () => {
+  it('flags a required import held only by a module no entry point reaches', async () => {
+    const root = await createFixture(
+      validFixture({
+        'apps/agent-web/src/app/playground/page.tsx':
+          'export default function Page() {\n  return null;\n}\n',
+        'apps/agent-web/src/lib/legacy-remote.ts': [
+          'import { PlaygroundApp } from "@robota-sdk/agent-playground/client";',
+          'export function renderLegacy() {',
+          '  return PlaygroundApp;',
+          '}',
+        ].join('\n'),
+      }),
+    );
+
+    const findings = await findAgentServerBoundaryFindings(root);
+
+    expect(findings).toEqual([
+      {
+        file: 'apps/agent-web/src/lib/legacy-remote.ts',
+        type: 'agent-web-unwired-browser-safe-playground-import',
+        detail: expect.stringContaining(
+          'apps/agent-web/src/lib/legacy-remote.ts is not reachable from an entry point',
+        ),
+      },
+    ]);
+  });
+
+  it('flags a required import whose binding the importing module never references', async () => {
+    const root = await createFixture(
+      validFixture({
+        'apps/agent-web/src/app/playground/page.tsx':
+          'import { PlaygroundApp } from "@robota-sdk/agent-playground/client";\n',
+      }),
+    );
+
+    const findings = await findAgentServerBoundaryFindings(root);
+
+    expect(findings).toEqual([
+      {
+        file: 'apps/agent-web/src/app/playground/page.tsx',
+        type: 'agent-web-unwired-browser-safe-playground-import',
+        detail: expect.stringContaining(
+          'apps/agent-web/src/app/playground/page.tsx imports it without referencing the binding',
+        ),
+      },
+    ]);
+  });
+
+  it('accepts a required import reached transitively from an entry point', async () => {
+    const root = await createFixture(
+      validFixture({
+        'apps/agent-web/src/app/playground/page.tsx': [
+          'import { PlaygroundHost } from "../../components/playground-host";',
+          'export default function Page() {',
+          '  return PlaygroundHost();',
+          '}',
+        ].join('\n'),
+        'apps/agent-web/src/components/playground-host.tsx': [
+          'import { PlaygroundApp } from "@robota-sdk/agent-playground/client";',
+          'export function PlaygroundHost() {',
+          '  return PlaygroundApp;',
+          '}',
+        ].join('\n'),
+      }),
+    );
+
+    const findings = await findAgentServerBoundaryFindings(root);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('still reports a required import that is absent everywhere', async () => {
+    const root = await createFixture(
+      validFixture({
+        'apps/agent-web/src/app/playground/page.tsx':
+          'export default function Page() {\n  return null;\n}\n',
+      }),
+    );
+
+    const findings = await findAgentServerBoundaryFindings(root);
+
+    expect(findings).toEqual([
+      {
+        file: 'apps/agent-web/src',
+        type: 'agent-web-missing-browser-safe-playground-import',
+        detail:
+          'agent-web should render Playground through the browser-safe @robota-sdk/agent-playground/client entry.',
+      },
+    ]);
+  });
+});
+
+describe('classifySpecifierUsage', () => {
+  it('reads the bound names of the matching import only', () => {
+    const content = [
+      "import type { IAIProvider } from '@robota-sdk/agent-core';",
+      "import { RemoteExecutor } from '@robota-sdk/agent-remote-client';",
+      'export function make() {',
+      '  return new RemoteExecutor();',
+      '}',
+    ].join('\n');
+
+    expect(classifySpecifierUsage(content, '@robota-sdk/agent-remote-client')).toBe('used');
+    expect(classifySpecifierUsage(content, '@robota-sdk/agent-core')).toBe('imported-unused');
+  });
+
+  it('treats evaluated and forwarding forms as used', () => {
+    expect(classifySpecifierUsage("void import('pkg');", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export { A } from 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("import 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("const a = require('pkg');", 'pkg')).toBe('used');
+  });
+
+  it('reports an absent specifier and an aliased binding', () => {
+    expect(classifySpecifierUsage("import { A } from 'other';", 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage("import { A as B } from 'pkg';\nB();", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("import { A as B } from 'pkg';\nA();", 'pkg')).toBe(
+      'imported-unused',
+    );
   });
 });

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -256,6 +256,29 @@ describe('required imports must be wired, not merely present', () => {
     ]);
   });
 
+  it('follows a tsconfig path alias when computing reachability', async () => {
+    const root = await createFixture(
+      validFixture({
+        'apps/agent-web/src/app/playground/page.tsx': [
+          'import { PlaygroundHost } from "@/components/playground-host";',
+          'export default function Page() {',
+          '  return PlaygroundHost();',
+          '}',
+        ].join('\n'),
+        'apps/agent-web/src/components/playground-host.tsx': [
+          'import { PlaygroundApp } from "@robota-sdk/agent-playground/client";',
+          'export function PlaygroundHost() {',
+          '  return PlaygroundApp;',
+          '}',
+        ].join('\n'),
+      }),
+    );
+
+    const findings = await findAgentServerBoundaryFindings(root);
+
+    expect(findings).toEqual([]);
+  });
+
   it('accepts a required import reached transitively from an entry point', async () => {
     const root = await createFixture(
       validFixture({

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   classifySpecifierUsage,
+  collectReachableModules,
   findAgentServerBoundaryFindings,
 } from '../check-agent-server-boundary.mjs';
 
@@ -487,5 +488,15 @@ describe('classifySpecifierUsage', () => {
     expect(classifySpecifierUsage("export { type A, B } from 'pkg';", 'pkg')).toBe('used');
     expect(classifySpecifierUsage("export * from 'pkg';", 'pkg')).toBe('used');
     expect(classifySpecifierUsage("export * as ns from 'pkg';", 'pkg')).toBe('used');
+  });
+
+  // A check added later without an entryPattern would have crashed on `undefined.test` and taken
+  // the whole scan down. A guard that dies is a guard that gets skipped, so it fails closed with
+  // the reason instead. There is no safe default: entry points are declared per check, never inferred.
+  it('fails closed when a check declares no entry pattern', () => {
+    const contents = new Map([['a.ts', '']]);
+    expect(() => collectReachableModules(contents, undefined)).toThrow(/requires an entryPattern/);
+    expect(() => collectReachableModules(contents, 'src/')).toThrow(/requires an entryPattern/);
+    expect(collectReachableModules(contents, /a\.ts/).size).toBe(1);
   });
 });

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -450,4 +450,27 @@ describe('classifySpecifierUsage', () => {
   it('does not mistake a URL for a line comment', () => {
     expect(classifySpecifierUsage("const u = 'https://x'; require('pkg');", 'pkg')).toBe('used');
   });
+
+  // A file containing `const example = "await import('pkg')"` classified as a wired seam — a token
+  // appearing somewhere in the file, which is the class this gate exists to reject. Blanking every
+  // string literal is not the fix either: each pattern matches the QUOTED specifier, so the search
+  // target would vanish and every import would read absent. Only literals whose content IS the
+  // specifier survive.
+  it('does not treat an import written inside a string literal as wiring', () => {
+    expect(classifySpecifierUsage(`const ex = "await import('pkg')";`, 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage(`const ex = "require('pkg')";`, 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage(`const doc = "import { A } from 'pkg'";`, 'pkg')).toBe('absent');
+  });
+
+  it('leaves a bare specifier-valued constant unwired', () => {
+    expect(classifySpecifierUsage("const name = 'pkg';", 'pkg')).toBe('absent');
+  });
+
+  it('still classifies every real wiring form as used', () => {
+    expect(classifySpecifierUsage("await import('pkg');", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("require('pkg');", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("import 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export { a } from 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("import { A } from 'pkg';\nA();", 'pkg')).toBe('used');
+  });
 });

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -473,4 +473,19 @@ describe('classifySpecifierUsage', () => {
     expect(classifySpecifierUsage("export { a } from 'pkg';", 'pkg')).toBe('used');
     expect(classifySpecifierUsage("import { A } from 'pkg';\nA();", 'pkg')).toBe('used');
   });
+
+  // Same rule as the import side, one review round later on the branch that had not been given it:
+  // `export type { X } from 'pkg'` is erased by the compiler and forwards nothing at runtime.
+  it('does not treat a type-only re-export as wiring', () => {
+    expect(classifySpecifierUsage("export type { X } from 'pkg';", 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage("export { type X } from 'pkg';", 'pkg')).toBe('absent');
+  });
+
+  it('treats every runtime re-export form as wiring', () => {
+    expect(classifySpecifierUsage("export { A } from 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export { A as B } from 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export { type A, B } from 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export * from 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export * as ns from 'pkg';", 'pkg')).toBe('used');
+  });
 });

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -69,13 +69,10 @@ const requiredSources = {
     'void import("@robota-sdk/agent-playground/client");\n',
   'apps/agent-server/src/app.ts':
     'import { OpenAIProvider } from "@robota-sdk/agent-provider-openai";\n',
-  // Wired seam: an entry source imports the specifier and actually uses the binding.
-  'packages/agent-playground/src/index.ts': [
-    'import { RemoteExecutor } from "@robota-sdk/agent-remote-client";',
-    'export function createExecutor() {',
-    '  return new RemoteExecutor();',
-    '}',
-  ].join('\n'),
+  'packages/agent-playground/src/index.ts':
+    'export { PlaygroundExecutor } from "./lib/playground-executor";\n',
+  'packages/agent-playground/src/lib/playground-executor.ts':
+    'export class PlaygroundExecutor {}\n',
   'packages/agent-remote-client/src/index.ts':
     'import type { IExecutor } from "@robota-sdk/agent-core";\n',
 };
@@ -274,6 +271,22 @@ describe('required imports must be wired, not merely present', () => {
           '  return PlaygroundApp;',
           '}',
         ].join('\n'),
+      }),
+    );
+
+    const findings = await findAgentServerBoundaryFindings(root);
+
+    expect(findings).toEqual([]);
+  });
+
+  // The withdrawn requirement (HARNESS-051): agent-playground is no longer required to compose
+  // agent-remote-client, because nothing in the repo does. The forbidden directions still hold.
+  it('does not require agent-playground to import agent-remote-client', async () => {
+    const root = await createFixture(
+      validFixture({
+        'packages/agent-playground/package.json': packageJson('@robota-sdk/agent-playground', {
+          '@robota-sdk/agent-core': 'workspace:*',
+        }),
       }),
     );
 

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -360,6 +360,27 @@ describe('classifySpecifierUsage', () => {
     expect(classifySpecifierUsage("const a = require('pkg');", 'pkg')).toBe('used');
   });
 
+  it('does not count a mention in a comment or a string literal as a use', () => {
+    expect(classifySpecifierUsage("import { A } from 'pkg';\n// A() is coming soon\n", 'pkg')).toBe(
+      'imported-unused',
+    );
+    expect(classifySpecifierUsage("import { A } from 'pkg';\n/* renders A */\n", 'pkg')).toBe(
+      'imported-unused',
+    );
+    expect(classifySpecifierUsage('import { A } from \'pkg\';\nconst label = "A";\n', 'pkg')).toBe(
+      'imported-unused',
+    );
+  });
+
+  it('counts a template-literal reference and survives a URL in a string', () => {
+    expect(classifySpecifierUsage("import { A } from 'pkg';\nconst x = `${A}`;\n", 'pkg')).toBe(
+      'used',
+    );
+    expect(
+      classifySpecifierUsage('import { A } from \'pkg\';\nconst u = "https://x";\nA();\n', 'pkg'),
+    ).toBe('used');
+  });
+
   it('reports an absent specifier and an aliased binding', () => {
     expect(classifySpecifierUsage("import { A } from 'other';", 'pkg')).toBe('absent');
     expect(classifySpecifierUsage("import { A as B } from 'pkg';\nB();", 'pkg')).toBe('used');

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -388,4 +388,27 @@ describe('classifySpecifierUsage', () => {
       'imported-unused',
     );
   });
+
+  // A type-only import is erased by the compiler, so the emitted module never touches the seam.
+  // Counting it as wiring would let a purely type-level reference satisfy a gate that exists to
+  // prove runtime reachability — the same defect class this item is closing. Found in review.
+  it('does not treat a type-only import as wiring', () => {
+    expect(classifySpecifierUsage("import type { A } from 'pkg';\nconst x: A = 1;", 'pkg')).toBe(
+      'imported-unused',
+    );
+    expect(classifySpecifierUsage("import { type A } from 'pkg';\nconst x: A = 1;", 'pkg')).toBe(
+      'imported-unused',
+    );
+    expect(
+      classifySpecifierUsage("import type * as ns from 'pkg';\nlet x: ns.A;", 'pkg'),
+    ).toBe('imported-unused');
+  });
+
+  // A mixed clause binds only its value specifiers.
+  it('counts the value half of a mixed type/value import', () => {
+    expect(classifySpecifierUsage("import { type A, B } from 'pkg';\nB();", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("import { type A, B } from 'pkg';\nconst x: A = 1;", 'pkg')).toBe(
+      'imported-unused',
+    );
+  });
 });

--- a/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
+++ b/scripts/harness/__tests__/check-agent-server-boundary.test.mjs
@@ -399,9 +399,9 @@ describe('classifySpecifierUsage', () => {
     expect(classifySpecifierUsage("import { type A } from 'pkg';\nconst x: A = 1;", 'pkg')).toBe(
       'imported-unused',
     );
-    expect(
-      classifySpecifierUsage("import type * as ns from 'pkg';\nlet x: ns.A;", 'pkg'),
-    ).toBe('imported-unused');
+    expect(classifySpecifierUsage("import type * as ns from 'pkg';\nlet x: ns.A;", 'pkg')).toBe(
+      'imported-unused',
+    );
   });
 
   // A mixed clause binds only its value specifiers.
@@ -410,5 +410,27 @@ describe('classifySpecifierUsage', () => {
     expect(classifySpecifierUsage("import { type A, B } from 'pkg';\nconst x: A = 1;", 'pkg')).toBe(
       'imported-unused',
     );
+  });
+
+  // The `used` branch returned before looking at anything else, and it tested RAW content — so a
+  // commented-out `import('pkg')` classified as a wired seam. Found in review; same mention-instead-
+  // of-wiring shape this item exists to close. Comments are stripped before any import is matched,
+  // but string literals are NOT: every pattern matches the quoted specifier, so blanking strings
+  // would delete what is being searched for and every import would read as absent.
+  it('does not treat a commented-out evaluated import as wiring', () => {
+    expect(classifySpecifierUsage("// await import('pkg');\nconst x = 1;", 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage("/* await import('pkg'); */\nconst x = 1;", 'pkg')).toBe(
+      'absent',
+    );
+    expect(classifySpecifierUsage("// require('pkg');", 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage("// import 'pkg';", 'pkg')).toBe('absent');
+    expect(classifySpecifierUsage("// import { A } from 'pkg';\nA();", 'pkg')).toBe('absent');
+  });
+
+  it('still classifies real evaluated imports as wiring', () => {
+    expect(classifySpecifierUsage("await import('pkg');", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("require('pkg');", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("import 'pkg';", 'pkg')).toBe('used');
+    expect(classifySpecifierUsage("export { a } from 'pkg';", 'pkg')).toBe('used');
   });
 });

--- a/scripts/harness/__tests__/run-all-scans.test.mjs
+++ b/scripts/harness/__tests__/run-all-scans.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseSkips, runScans } from '../run-all-scans.mjs';
+import { ADVISORY_MARKER, extractAdvisories, parseSkips, runScans } from '../run-all-scans.mjs';
 
 function stubScan(name, exitCode) {
   return {
@@ -86,6 +86,146 @@ describe('run-all-scans', () => {
     );
     expect(exitCode).toBe(1);
     expect(lines.join('\n')).toContain('2 of 3 scans failed');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// HARNESS-053 — the ADVISORY channel. Rules pinned one at a time.
+//
+// The gap, MEASURED on the real path before this existed: `touch packages/agent-core/src/index.ts
+// && pnpm harness:scan | grep -i stale` printed NOTHING. The `dist` scan had detected the staleness
+// and the runner threw the output away, because captured output is surfaced only for a non-zero
+// exit. A finding nobody sees is not a finding.
+// ---------------------------------------------------------------------------------------------
+
+describe('extractAdvisories', () => {
+  it('extracts the text after the marker', () => {
+    expect(extractAdvisories(`${ADVISORY_MARKER} dist is stale\n`)).toEqual(['dist is stale']);
+  });
+
+  it('ignores unmarked lines, so ordinary passing output stays suppressed', () => {
+    const output = `quiet pass\n${ADVISORY_MARKER} the one thing worth saying\nmore chatter\n`;
+    expect(extractAdvisories(output)).toEqual(['the one thing worth saying']);
+  });
+
+  it('strips the emitting scan’s ANSI colouring', () => {
+    // Exactly what scan-dist-freshness prints: yellow open, glyph, marker, text, reset.
+    const line = '\x1b[33m\u{1F552} ' + ADVISORY_MARKER + ' coloured advisory\x1b[0m';
+    expect(extractAdvisories(line)).toEqual(['coloured advisory']);
+  });
+
+  it('does NOT strip bracketed digits that are not an ANSI escape', () => {
+    // Pins the ESC in the pattern. Written as `/\[[0-9;]*m/` it matched any `[<digits>m`, so this
+    // advisory would have been silently corrupted into "see frame  of the trace".
+    expect(extractAdvisories(`${ADVISORY_MARKER} see frame [12m of the trace`)).toEqual([
+      'see frame [12m of the trace',
+    ]);
+  });
+
+  it('drops a marked line with no text after the marker', () => {
+    // An advisory channel able to print a contentless bullet is a way to look like it reported
+    // something while reporting nothing — the class this whole item exists to close.
+    expect(extractAdvisories(`${ADVISORY_MARKER}\n${ADVISORY_MARKER}   \n`)).toEqual([]);
+  });
+
+  it('returns nothing for empty or absent output', () => {
+    expect(extractAdvisories('')).toEqual([]);
+    expect(extractAdvisories(undefined)).toEqual([]);
+  });
+
+  it('preserves order and collects several', () => {
+    expect(extractAdvisories(`${ADVISORY_MARKER} first\n${ADVISORY_MARKER} second\n`)).toEqual([
+      'first',
+      'second',
+    ]);
+  });
+});
+
+describe('runScans — advisory surfacing', () => {
+  it('surfaces an advisory from a PASSING scan while still suppressing its other output', async () => {
+    const scans = [
+      {
+        name: 'dist',
+        run: () =>
+          Promise.resolve({
+            code: 0,
+            output: `quiet pass\n${ADVISORY_MARKER} @pkg/a: dist/ may be STALE\n`,
+          }),
+      },
+    ];
+    const lines = [];
+    const exitCode = await runScans(scans, (line) => lines.push(line));
+    const out = lines.join('\n');
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain('⚑ dist: @pkg/a: dist/ may be STALE');
+    expect(out).not.toContain('quiet pass'); // the pre-existing suppression is unchanged
+  });
+
+  it('does NOT turn the suite red — an advisory-only run still exits 0 and reports all-pass', async () => {
+    const scans = [
+      { name: 'a', run: () => Promise.resolve({ code: 0, output: `${ADVISORY_MARKER} noted\n` }) },
+      { name: 'b', run: () => Promise.resolve(0) },
+    ];
+    const lines = [];
+    const exitCode = await runScans(scans, (line) => lines.push(line));
+    const out = lines.join('\n');
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain('✓ a'); // the emitting scan is still a PASS in the summary
+    expect(out).toContain('all 2 scans passed');
+    expect(out).toContain('NOT failures');
+  });
+
+  it('leaves the verdict as the LAST line, so a green run still ends green', async () => {
+    const scans = [
+      { name: 'a', run: () => Promise.resolve({ code: 0, output: `${ADVISORY_MARKER} noted\n` }) },
+    ];
+    const lines = [];
+    await runScans(scans, (line) => lines.push(line));
+    expect(lines.filter((line) => line !== '').at(-1)).toBe('all 1 scans passed');
+  });
+
+  it('prints no advisory block at all when there are none', async () => {
+    const lines = [];
+    await runScans([stubScan('a', 0), stubScan('b', 0)], (line) => lines.push(line));
+    const out = lines.join('\n');
+    expect(out).not.toContain('⚑');
+    expect(out).not.toContain('advisory');
+  });
+
+  it('is general, not a dist special case — a FAILING scan’s advisory is surfaced too', async () => {
+    const scans = [
+      {
+        name: 'other',
+        run: () =>
+          Promise.resolve({
+            code: 1,
+            output: `ERROR: boom\n${ADVISORY_MARKER} also worth noting\n`,
+          }),
+      },
+    ];
+    const lines = [];
+    const exitCode = await runScans(scans, (line) => lines.push(line));
+    const out = lines.join('\n');
+
+    expect(exitCode).toBe(1);
+    expect(out).toContain('ERROR: boom');
+    expect(out).toContain('⚑ other: also worth noting');
+    expect(out).toContain('1 of 1 scans failed');
+  });
+
+  it('attributes each advisory to the scan that emitted it', async () => {
+    const scans = [
+      { name: 'a', run: () => Promise.resolve({ code: 0, output: `${ADVISORY_MARKER} from-a\n` }) },
+      { name: 'b', run: () => Promise.resolve({ code: 0, output: `${ADVISORY_MARKER} from-b\n` }) },
+    ];
+    const lines = [];
+    await runScans(scans, (line) => lines.push(line));
+    const out = lines.join('\n');
+    expect(out).toContain('⚑ a: from-a');
+    expect(out).toContain('⚑ b: from-b');
+    expect(out).toContain('2 advisory finding(s)');
   });
 });
 

--- a/scripts/harness/__tests__/scan-dist-freshness.test.mjs
+++ b/scripts/harness/__tests__/scan-dist-freshness.test.mjs
@@ -25,7 +25,11 @@ function writeFiles(root, files) {
   }
 }
 
-function scope(relativeDir, workspaceName, scripts = { build: 'tsc' }) {
+// `build:js` is in the default because freshness is only compared for packages the ROOT build
+// rebuilds — `pnpm --filter "./packages/**" build:js`. Presence checks apply to every buildable
+// scope, so `build` alone still exercises those; the freshness half needs both halves of that
+// filter, which is why fixtures asserting freshness live under `packages/`.
+function scope(relativeDir, workspaceName, scripts = { build: 'tsc', 'build:js': 'tsdown' }) {
   return { relativeDir, workspaceName, scripts };
 }
 
@@ -177,7 +181,9 @@ describe('scan-dist-freshness CLI', () => {
       'packages/pkg-a/package.json': JSON.stringify({
         name: '@fixture/pkg-a',
         exports: { '.': './dist/index.js' },
-        scripts: { build: 'tsc' },
+        // `build:js` under `packages/` is what the root build actually rebuilds, and freshness is
+        // only claimed for those. Without it this fixture is correctly reported unmeasurable.
+        scripts: { build: 'tsc', 'build:js': 'tsdown' },
       }),
       'packages/pkg-a/dist/index.js': 'export {};\n',
     };
@@ -441,6 +447,29 @@ describe('collectDistFreshnessResults — freshness integration', () => {
 
   it('assesses freshness for a private package too, when it has both src and dist', async () => {
     const root = await createRoot({
+      'packages/pkg-private/package.json': JSON.stringify({
+        name: '@fixture/pkg-private',
+        private: true,
+      }),
+      'packages/pkg-private/src/index.ts': 'export const a = 1;\n',
+      'packages/pkg-private/dist/index.js': 'export const a = 1;\n',
+    });
+    setMtime(path.join(root, 'packages/pkg-private/dist/index.js'), 1000);
+    setMtime(path.join(root, 'packages/pkg-private/src/index.ts'), 5000);
+
+    const { freshness } = await collectDistFreshnessResults(root, [
+      scope('packages/pkg-private', '@fixture/pkg-private'),
+    ]);
+    expect(freshness.stale).toBe(1);
+  });
+
+  // Freshness is only claimed for what the ROOT build rebuilds — `pnpm --filter "./packages/**"
+  // build:js`. Measured immediately after a clean `pnpm build`, three workspaces still reported
+  // stale by 167-383 hours, and running the command the advisory recommends would never have
+  // cleared any of them. An advisory that survives the action it advises trains people to ignore
+  // the channel.
+  it('does not claim staleness for an app, which the root build never rebuilds', async () => {
+    const root = await createRoot({
       'apps/app-a/package.json': JSON.stringify({ name: '@fixture/app-a', private: true }),
       'apps/app-a/src/index.ts': 'export const a = 1;\n',
       'apps/app-a/dist/index.js': 'export const a = 1;\n',
@@ -448,10 +477,29 @@ describe('collectDistFreshnessResults — freshness integration', () => {
     setMtime(path.join(root, 'apps/app-a/dist/index.js'), 1000);
     setMtime(path.join(root, 'apps/app-a/src/index.ts'), 5000);
 
+    // Declaring `build:js` is not enough — `apps/remote-signaling` declares it and is still outside
+    // the `./packages/**` filter, which is the case that survived the first version of this rule.
     const { freshness } = await collectDistFreshnessResults(root, [
-      scope('apps/app-a', '@fixture/app-a'),
+      scope('apps/app-a', '@fixture/app-a', { build: 'tsdown', 'build:js': 'tsdown' }),
     ]);
-    expect(freshness.stale).toBe(1);
+    expect(freshness.stale).toBe(0);
+    expect(freshness.unmeasurable).toBe(1);
+  });
+
+  it('does not claim staleness for a package the root build skips (no build:js)', async () => {
+    const root = await createRoot({
+      'packages/pkg-vite/package.json': JSON.stringify({ name: '@fixture/pkg-vite' }),
+      'packages/pkg-vite/src/main.tsx': 'export const a = 1;\n',
+      'packages/pkg-vite/dist/index.html': '<html></html>\n',
+    });
+    setMtime(path.join(root, 'packages/pkg-vite/dist/index.html'), 1000);
+    setMtime(path.join(root, 'packages/pkg-vite/src/main.tsx'), 5000);
+
+    const { freshness } = await collectDistFreshnessResults(root, [
+      scope('packages/pkg-vite', '@fixture/pkg-vite', { build: 'vite build' }),
+    ]);
+    expect(freshness.stale).toBe(0);
+    expect(freshness.unmeasurable).toBe(1);
   });
 });
 
@@ -462,7 +510,9 @@ describe('scan-dist-freshness CLI — freshness severity', () => {
       'packages/pkg-a/package.json': JSON.stringify({
         name: '@fixture/pkg-a',
         exports: { '.': './dist/index.js' },
-        scripts: { build: 'tsc' },
+        // `build:js` under `packages/` is what the root build actually rebuilds, and freshness is
+        // only claimed for those. Without it this fixture is correctly reported unmeasurable.
+        scripts: { build: 'tsc', 'build:js': 'tsdown' },
       }),
       'packages/pkg-a/src/index.ts': 'export const a = 1;\n',
       'packages/pkg-a/dist/index.d.ts': 'export declare const a: number;\n',

--- a/scripts/harness/__tests__/scan-dist-freshness.test.mjs
+++ b/scripts/harness/__tests__/scan-dist-freshness.test.mjs
@@ -252,6 +252,11 @@ describe('isEmittedSourceFile', () => {
     'robota.test.ts',
     'nested/robota.test.tsx',
     'parser.spec.ts',
+    // `.json` IS an emitted source extension, so a JS/TS-only test pattern let a test fixture count
+    // as a source and touching it marked the package stale. Found in review; measured before the
+    // fix — `isEmittedSourceFile('src/a.test.json')` returned true.
+    'payload.test.json',
+    'payload.spec.json',
     '__tests__/helper.ts',
     '__mocks__/provider.ts',
     '__fixtures__/payload.json',

--- a/scripts/harness/__tests__/scan-dist-freshness.test.mjs
+++ b/scripts/harness/__tests__/scan-dist-freshness.test.mjs
@@ -532,6 +532,17 @@ describe('scan-dist-freshness CLI — freshness severity', () => {
     expect(result.stdout).not.toContain('all 2 package(s) required');
   });
 
+  it('exits 1 when the workspace enumerates ZERO buildable packages (fail closed)', async () => {
+    // MEASURED before the guard existed: this fixture printed "dist/ present on all 0 package(s)"
+    // and exited 0. That is HARNESS-052's audited defect — a pass over work never done — found
+    // live inside HARNESS-053, the item written to fix an instance of it.
+    const root = await createRoot({ 'pnpm-workspace.yaml': "packages:\n  - 'packages/*'\n" });
+
+    const result = run(root);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('measured nothing');
+  });
+
   it('still exits 1 for a missing dist even while a sibling is stale', async () => {
     const root = await createRoot({
       ...staleFixtureFiles(),

--- a/scripts/harness/__tests__/scan-dist-freshness.test.mjs
+++ b/scripts/harness/__tests__/scan-dist-freshness.test.mjs
@@ -1,5 +1,5 @@
-import { execFileSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -7,7 +7,13 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { collectDistFreshnessResults } from '../scan-dist-freshness.mjs';
+import {
+  collectDistFreshnessResults,
+  freshnessVerdict,
+  isEmittedSourceFile,
+  presenceResults,
+  walkTree,
+} from '../scan-dist-freshness.mjs';
 
 const SCAN_SCRIPT = fileURLToPath(new URL('../scan-dist-freshness.mjs', import.meta.url));
 
@@ -109,12 +115,36 @@ describe('collectDistFreshnessResults', () => {
     ]);
   });
 
-  it('warns (not errors) for an internal package with no dist exports and no bin', async () => {
+  it('errors for a package whose `main` points at dist with no exports block', async () => {
+    // HARNESS-052 recorded this line as an operator-precedence bug: `pkg.main?.includes('dist') ||
+    // pkg.exports ? JSON.stringify(pkg.exports ?? {}).includes('dist') : false` parses as
+    // `(a || b) ? c : false`, so a `main`-only package took the `exports` branch, stringified an
+    // EMPTY object, and had its genuine missing-dist ERROR downgraded to a non-blocking warning.
+    // A package that publishes `main: dist/index.js` and ships no dist is broken, not internal.
+    // Measured on this repo: 3 packages change classification, all `private: true` and therefore
+    // short-circuited before this branch — the repair alters no live verdict here.
     const root = await createRoot({
       'packages/internal/package.json': JSON.stringify({
         name: '@fixture/internal',
-        main: 'dist/index.js', // main alone does not mark a package dist-exporting (see pkgJson note)
+        main: 'dist/index.js',
       }),
+    });
+
+    const { results } = await collectDistFreshnessResults(root, [
+      scope('packages/internal', '@fixture/internal'),
+    ]);
+    expect(results).toEqual([
+      {
+        kind: 'error',
+        message:
+          '@fixture/internal (packages/internal): dist/ is missing or empty — run pnpm build first',
+      },
+    ]);
+  });
+
+  it('warns (not errors) for an internal package with neither dist exports nor bin', async () => {
+    const root = await createRoot({
+      'packages/internal/package.json': JSON.stringify({ name: '@fixture/internal' }),
     });
 
     const { results } = await collectDistFreshnessResults(root, [
@@ -169,7 +199,10 @@ describe('scan-dist-freshness CLI', () => {
   it('exits 0 on a workspace whose buildable package has dist/', async () => {
     const root = await createRoot(cliFixtureFiles());
     const result = runScan(root);
-    expect(result.stdout).toContain('All 1 buildable packages have dist/.');
+    // The banner states the count it ACTUALLY asserted, not the buildable total: a private or
+    // non-dist-exporting package that has a dist produces no presence result at all, so
+    // "All 86 buildable packages have dist/" was a universal claim over 43 of them (HARNESS-053).
+    expect(result.stdout).toContain('dist/ present on all 1 package(s) required to have one');
     expect(result.status).toBe(0);
   });
 
@@ -180,5 +213,339 @@ describe('scan-dist-freshness CLI', () => {
     const result = runScan(root);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('dist/ is missing or empty — run pnpm build first');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// HARNESS-053 — the FRESHNESS rule. Each rule is tested SEPARATELY, because HARNESS-052's own
+// guard shipped three defects of which two masked each other, and only per-rule falsification
+// would have separated them.
+// ---------------------------------------------------------------------------------------------
+
+/** Stamp an absolute mtime (seconds since epoch) so fixtures never depend on wall-clock ordering. */
+function setMtime(absolutePath, epochSeconds) {
+  utimesSync(absolutePath, epochSeconds, epochSeconds);
+}
+
+describe('isEmittedSourceFile', () => {
+  it.each(['index.ts', 'nested/deep/foo.tsx', 'schema.json', 'legacy.mjs', 'types/index.d.ts'])(
+    'accepts %s — it can move the emitted type surface',
+    (relativePath) => {
+      expect(isEmittedSourceFile(relativePath)).toBe(true);
+    },
+  );
+
+  it.each(['README.md', 'notes.txt', 'logo.svg'])(
+    'rejects %s — a non-source file beside the code emits no declaration',
+    (relativePath) => {
+      expect(isEmittedSourceFile(relativePath)).toBe(false);
+    },
+  );
+
+  it.each([
+    'robota.test.ts',
+    'nested/robota.test.tsx',
+    'parser.spec.ts',
+    '__tests__/helper.ts',
+    '__mocks__/provider.ts',
+    '__fixtures__/payload.json',
+    '__snapshots__/render.ts',
+  ])('rejects %s — tsconfig.build.json keeps it out of the build', (relativePath) => {
+    expect(isEmittedSourceFile(relativePath)).toBe(false);
+  });
+
+  it('rejects an empty path rather than treating it as source', () => {
+    expect(isEmittedSourceFile('')).toBe(false);
+    expect(isEmittedSourceFile(undefined)).toBe(false);
+  });
+});
+
+describe('walkTree', () => {
+  it('reports nothing for a directory that does not exist', async () => {
+    const root = await createRoot({});
+    expect(walkTree(path.join(root, 'nope'))).toEqual({ fileCount: 0, newest: null });
+  });
+
+  it('finds the newest file across nested directories', async () => {
+    const root = await createRoot({
+      'tree/a.ts': 'a',
+      'tree/deep/b.ts': 'b',
+      'tree/deep/deeper/c.ts': 'c',
+    });
+    setMtime(path.join(root, 'tree/a.ts'), 1000);
+    setMtime(path.join(root, 'tree/deep/b.ts'), 3000);
+    setMtime(path.join(root, 'tree/deep/deeper/c.ts'), 2000);
+
+    const walk = walkTree(path.join(root, 'tree'));
+    expect(walk.fileCount).toBe(3);
+    expect(walk.newest.path.split(path.sep).join('/')).toBe('deep/b.ts');
+    expect(walk.newest.mtimeMs).toBe(3_000_000);
+  });
+
+  it('never lets a rejected file become the newest (RED without the filter)', async () => {
+    const root = await createRoot({ 'tree/a.ts': 'a', 'tree/a.test.ts': 'test' });
+    setMtime(path.join(root, 'tree/a.ts'), 1000);
+    setMtime(path.join(root, 'tree/a.test.ts'), 9000);
+
+    const filtered = walkTree(path.join(root, 'tree'), isEmittedSourceFile);
+    expect(filtered.fileCount).toBe(1);
+    expect(filtered.newest.mtimeMs).toBe(1_000_000);
+
+    // Without the filter the very same tree answers with the test file — this is the rule the
+    // assertion above depends on, pinned rather than assumed.
+    expect(walkTree(path.join(root, 'tree')).newest.mtimeMs).toBe(9_000_000);
+  });
+});
+
+describe('freshnessVerdict', () => {
+  const src = (mtimeMs) => ({ path: 'index.ts', mtimeMs });
+  const dist = (mtimeMs) => ({ path: 'index.d.ts', mtimeMs });
+
+  it('is unmeasurable — never "fresh" — when there is no source to compare', () => {
+    expect(freshnessVerdict(null, dist(10)).state).toBe('unmeasurable');
+  });
+
+  it('is unmeasurable — never "stale" — on a cold checkout with no dist at all', () => {
+    // The case that separates a freshness check from the presence check it replaces. A fresh clone
+    // has every source stamped at checkout time and no dist; reporting that as stale would redden
+    // correct state, which is the one outcome this item forbids.
+    expect(freshnessVerdict(src(10), null)).toEqual({
+      state: 'unmeasurable',
+      reason: 'no artefacts under dist/',
+    });
+  });
+
+  it('reports STALE when the newest source is newer than the newest artefact', () => {
+    const verdict = freshnessVerdict(src(5_000), dist(2_000));
+    expect(verdict.state).toBe('stale');
+    expect(verdict.lagMs).toBe(3_000);
+  });
+
+  it('reports FRESH when the newest artefact is newer than the newest source', () => {
+    expect(freshnessVerdict(src(2_000), dist(5_000)).state).toBe('fresh');
+  });
+
+  it('reports FRESH — not stale — on an exact mtime tie', () => {
+    // A build reads src then writes dist, so equal stamps mean the artefact is not older. Strict
+    // `>` keeps a same-millisecond tie out of the advisory.
+    expect(freshnessVerdict(src(4_000), dist(4_000)).state).toBe('fresh');
+  });
+});
+
+describe('presenceResults (pure branch table)', () => {
+  const scopeA = scope('packages/pkg-a', '@fixture/pkg-a');
+
+  it('asserts presence for a dist-exporting package that has one', () => {
+    const pkg = { exports: { '.': './dist/index.js' } };
+    expect(presenceResults(scopeA, pkg, true)).toEqual([
+      { kind: 'ok', message: '@fixture/pkg-a: dist/ present' },
+    ]);
+  });
+
+  it('errors for a dist-exporting package that has none', () => {
+    const pkg = { exports: { '.': './dist/index.js' } };
+    expect(presenceResults(scopeA, pkg, false)[0].kind).toBe('error');
+  });
+
+  it('errors for a `main`-only package with no exports block (precedence, HARNESS-052)', () => {
+    // The original expression was `pkg.main?.includes('dist') || pkg.exports ? … : false`, which
+    // downgraded this genuine missing-dist ERROR to a non-blocking warning.
+    expect(presenceResults(scopeA, { main: 'dist/index.js' }, false)[0].kind).toBe('error');
+  });
+
+  it('errors for a bin-only package with no dist', () => {
+    expect(presenceResults(scopeA, { bin: { fx: 'dist/cli.js' } }, false)[0].kind).toBe('error');
+  });
+
+  it('warns, not errors, for a private package with no dist', () => {
+    expect(presenceResults(scopeA, { private: true }, false)[0].kind).toBe('warn');
+  });
+
+  it('asserts nothing for a private package that has a dist', () => {
+    expect(presenceResults(scopeA, { private: true }, true)).toEqual([]);
+  });
+});
+
+describe('collectDistFreshnessResults — freshness integration', () => {
+  function distExportingPackage(name) {
+    return JSON.stringify({ name, exports: { '.': './dist/index.js' } });
+  }
+
+  it('reports STALE when src is newer than dist (RED)', async () => {
+    const root = await createRoot({
+      'packages/pkg-a/package.json': distExportingPackage('@fixture/pkg-a'),
+      'packages/pkg-a/src/index.ts': 'export const a = 1;\n',
+      'packages/pkg-a/dist/index.d.ts': 'export declare const a: number;\n',
+    });
+    setMtime(path.join(root, 'packages/pkg-a/dist/index.d.ts'), 1000);
+    setMtime(path.join(root, 'packages/pkg-a/src/index.ts'), 5000);
+
+    const { results, freshness } = await collectDistFreshnessResults(root, [
+      scope('packages/pkg-a', '@fixture/pkg-a'),
+    ]);
+    expect(freshness).toEqual({ measured: 1, fresh: 0, stale: 1, unmeasurable: 0 });
+    const stale = results.find((r) => r.kind === 'stale');
+    expect(stale.message).toContain('@fixture/pkg-a: dist/ may be STALE');
+    expect(stale.message).toContain('src/index.ts');
+    expect(stale.message).toContain('dist/index.d.ts');
+  });
+
+  it('is silent on a genuinely fresh tree (no regression)', async () => {
+    const root = await createRoot({
+      'packages/pkg-a/package.json': distExportingPackage('@fixture/pkg-a'),
+      'packages/pkg-a/src/index.ts': 'export const a = 1;\n',
+      'packages/pkg-a/dist/index.d.ts': 'export declare const a: number;\n',
+    });
+    setMtime(path.join(root, 'packages/pkg-a/src/index.ts'), 1000);
+    setMtime(path.join(root, 'packages/pkg-a/dist/index.d.ts'), 5000);
+
+    const { results, freshness } = await collectDistFreshnessResults(root, [
+      scope('packages/pkg-a', '@fixture/pkg-a'),
+    ]);
+    expect(freshness).toEqual({ measured: 1, fresh: 1, stale: 0, unmeasurable: 0 });
+    expect(results.some((r) => r.kind === 'stale')).toBe(false);
+  });
+
+  it('is silent on a cold checkout with no dist at all (no regression)', async () => {
+    const root = await createRoot({
+      'packages/pkg-a/package.json': distExportingPackage('@fixture/pkg-a'),
+      'packages/pkg-a/src/index.ts': 'export const a = 1;\n',
+    });
+
+    const { results, freshness } = await collectDistFreshnessResults(root, [
+      scope('packages/pkg-a', '@fixture/pkg-a'),
+    ]);
+    expect(freshness).toEqual({ measured: 0, fresh: 0, stale: 0, unmeasurable: 1 });
+    expect(results.some((r) => r.kind === 'stale')).toBe(false);
+    // The presence rule still owns the missing dist — freshness adds no second verdict on top.
+    expect(results.map((r) => r.kind)).toEqual(['error']);
+  });
+
+  it('does not report STALE when only a test file is newer than dist', async () => {
+    const root = await createRoot({
+      'packages/pkg-a/package.json': distExportingPackage('@fixture/pkg-a'),
+      'packages/pkg-a/src/index.ts': 'export const a = 1;\n',
+      'packages/pkg-a/src/index.test.ts': 'it("x", () => {});\n',
+      'packages/pkg-a/dist/index.d.ts': 'export declare const a: number;\n',
+    });
+    setMtime(path.join(root, 'packages/pkg-a/src/index.ts'), 1000);
+    setMtime(path.join(root, 'packages/pkg-a/dist/index.d.ts'), 5000);
+    setMtime(path.join(root, 'packages/pkg-a/src/index.test.ts'), 9000);
+
+    const { freshness } = await collectDistFreshnessResults(root, [
+      scope('packages/pkg-a', '@fixture/pkg-a'),
+    ]);
+    expect(freshness.stale).toBe(0);
+    expect(freshness.fresh).toBe(1);
+  });
+
+  it('assesses freshness for a private package too, when it has both src and dist', async () => {
+    const root = await createRoot({
+      'apps/app-a/package.json': JSON.stringify({ name: '@fixture/app-a', private: true }),
+      'apps/app-a/src/index.ts': 'export const a = 1;\n',
+      'apps/app-a/dist/index.js': 'export const a = 1;\n',
+    });
+    setMtime(path.join(root, 'apps/app-a/dist/index.js'), 1000);
+    setMtime(path.join(root, 'apps/app-a/src/index.ts'), 5000);
+
+    const { freshness } = await collectDistFreshnessResults(root, [
+      scope('apps/app-a', '@fixture/app-a'),
+    ]);
+    expect(freshness.stale).toBe(1);
+  });
+});
+
+describe('scan-dist-freshness CLI — freshness severity', () => {
+  function staleFixtureFiles() {
+    return {
+      'pnpm-workspace.yaml': "packages:\n  - 'packages/*'\n",
+      'packages/pkg-a/package.json': JSON.stringify({
+        name: '@fixture/pkg-a',
+        exports: { '.': './dist/index.js' },
+        scripts: { build: 'tsc' },
+      }),
+      'packages/pkg-a/src/index.ts': 'export const a = 1;\n',
+      'packages/pkg-a/dist/index.d.ts': 'export declare const a: number;\n',
+    };
+  }
+
+  // spawnSync, not execFileSync: the advisory goes to stderr via console.warn, and execFileSync's
+  // SUCCESS path returns stdout only — a helper that cannot see the advisory would make the
+  // severity assertion below unfalsifiable, which is this item's own subject.
+  function run(cwd) {
+    const result = spawnSync(process.execPath, [SCAN_SCRIPT], { cwd, encoding: 'utf8' });
+    return {
+      status: result.status,
+      stdout: `${result.stdout ?? ''}`,
+      stderr: `${result.stderr ?? ''}`,
+    };
+  }
+
+  it('reports staleness but EXITS 0 — the freshness rule is advisory, never blocking', async () => {
+    const root = await createRoot(staleFixtureFiles());
+    setMtime(path.join(root, 'packages/pkg-a/dist/index.d.ts'), 1000);
+    setMtime(path.join(root, 'packages/pkg-a/src/index.ts'), 5000);
+
+    const result = run(root);
+    // This assertion IS the severity decision. mtime is evidence, not proof: a source reverted to
+    // the exact content its dist was built from is fresh in content and stale in mtime. A blocking
+    // gate that reddens on correct state gets `--skip`-ed, and ci.yml already carries `--skip dist`.
+    expect(result.status).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain('dist/ may be STALE');
+    expect(result.stdout).toContain('freshness: 1 stale / 1 compared');
+  });
+
+  it('reports the freshness tally even when nothing is stale', async () => {
+    const root = await createRoot(staleFixtureFiles());
+    setMtime(path.join(root, 'packages/pkg-a/src/index.ts'), 1000);
+    setMtime(path.join(root, 'packages/pkg-a/dist/index.d.ts'), 5000);
+
+    const result = run(root);
+    expect(result.status).toBe(0);
+    // "ran and measured nothing" must not render as "ran and found nothing" (HARNESS-052).
+    expect(result.stdout).toContain('freshness: 0 stale / 1 compared');
+    expect(result.stdout).not.toContain('may be STALE');
+  });
+
+  it('states the count it ASSERTED, not the buildable total', async () => {
+    // Pinned with the two numbers DIFFERENT on purpose. The first version of this suite exercised
+    // only a 1-package fixture, where `presenceAsserted === buildableCount` — so reinstating the
+    // "All N buildable packages have dist/" overclaim failed ZERO tests. Measured, not assumed:
+    // that mutation was run and came back green, which is why this case exists.
+    const root = await createRoot({
+      ...staleFixtureFiles(),
+      // Buildable and has a dist, but private — so it produces no presence result and the
+      // universal claim must not count it.
+      'packages/pkg-private/package.json': JSON.stringify({
+        name: '@fixture/pkg-private',
+        private: true,
+        scripts: { build: 'tsc' },
+      }),
+      'packages/pkg-private/dist/index.js': 'export {};\n',
+    });
+
+    const result = run(root);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      'dist/ present on all 1 package(s) required to have one (of 2 buildable',
+    );
+    expect(result.stdout).not.toContain('all 2 package(s) required');
+  });
+
+  it('still exits 1 for a missing dist even while a sibling is stale', async () => {
+    const root = await createRoot({
+      ...staleFixtureFiles(),
+      'packages/pkg-b/package.json': JSON.stringify({
+        name: '@fixture/pkg-b',
+        exports: { '.': './dist/index.js' },
+        scripts: { build: 'tsc' },
+      }),
+    });
+    setMtime(path.join(root, 'packages/pkg-a/dist/index.d.ts'), 1000);
+    setMtime(path.join(root, 'packages/pkg-a/src/index.ts'), 5000);
+
+    const result = run(root);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('dist/ is missing or empty');
   });
 });

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -2,6 +2,27 @@
 
 /**
  * Check the browser/server/playground/remote-client boundary for remote execution.
+ *
+ * Required-import checks verify a WIRED SEAM, not a token.
+ *
+ * Lesson source (HARNESS-051, 2026-07-26): this gate's required-import rule was satisfied
+ * by `packages/agent-playground/src/lib/playground/robota-executor/remote-providers.ts` — a
+ * module nothing in the package imports, holding a function nobody calls. The gate ran, could
+ * fail, and still certified a seam that did not exist: it checked that a token appeared in some
+ * file. Deleting provably dead code turned the gate red, which is the inverse of what a boundary
+ * gate is for.
+ *
+ * A required import now counts only when BOTH hold:
+ * 1. the importing module is reachable from a declared entry point of its own tree, and
+ * 2. the imported binding is actually referenced in that module (a side-effect import, a
+ *    re-export, and a dynamic `import()` expression each count as referenced, since each one
+ *    evaluates or forwards the specifier).
+ *
+ * Deliberate scope limits, so the rule fires zero times on correct code:
+ * - Reachability is computed over relative imports inside the scanned tree only. Test files are
+ *   outside the graph, so a module only tests import is not "wired" — which is the intent.
+ * - Entry points are declared per check (`entryPattern`), never inferred. Framework route files
+ *   (Next.js `page`/`layout`/...) have no in-repo importer and must be declared as entries.
  */
 
 import { promises as fs } from 'node:fs';
@@ -136,15 +157,22 @@ const SOURCE_IMPORT_CHECKS = [
 const REQUIRED_SOURCE_IMPORTS = [
   {
     dir: 'apps/agent-web/src',
+    // Next.js App Router: route files are framework entry points — nothing in the repo imports them.
+    entryPattern:
+      /(^|\/)(page|layout|template|default|route|middleware|error|not-found)\.[cm]?[jt]sx?$/,
     importSpecifier: '@robota-sdk/agent-playground/client',
     type: 'agent-web-missing-browser-safe-playground-import',
+    unwiredType: 'agent-web-unwired-browser-safe-playground-import',
     detail:
       'agent-web should render Playground through the browser-safe @robota-sdk/agent-playground/client entry.',
   },
   {
     dir: 'packages/agent-playground/src',
+    // Package entry sources behind the `.` and `./client` export conditions.
+    entryPattern: /\/src\/(index|client)\.[cm]?[jt]sx?$/,
     importSpecifier: '@robota-sdk/agent-remote-client',
     type: 'agent-playground-missing-remote-client-import',
+    unwiredType: 'agent-playground-unwired-remote-client-import',
     detail:
       'agent-playground should keep reusable remote execution behavior in the package, backed by agent-remote-client.',
   },
@@ -342,25 +370,174 @@ async function findSourceImportFindings(root) {
   return findings;
 }
 
+function toPosixPath(value) {
+  return value.split(path.sep).join('/');
+}
+
+const RESOLUTION_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs'];
+
+/** Resolve a relative import to a file inside the scanned set, or undefined. */
+export function resolveRelativeImport(fileSet, fromFile, specifier) {
+  if (!specifier.startsWith('.')) {
+    return undefined;
+  }
+  const base = path.posix.normalize(
+    path.posix.join(path.posix.dirname(toPosixPath(fromFile)), specifier),
+  );
+  const candidates = [base, ...RESOLUTION_EXTENSIONS.map((extension) => `${base}${extension}`)];
+  for (const extension of RESOLUTION_EXTENSIONS) {
+    candidates.push(`${base}/index${extension}`);
+  }
+  return candidates.find((candidate) => fileSet.has(candidate));
+}
+
+/**
+ * Modules reachable from the declared entry points, following relative imports only.
+ * A module outside this set ships no behavior: nothing loads it.
+ */
+export function collectReachableModules(contentsByFile, entryPattern) {
+  const fileSet = new Set(contentsByFile.keys());
+  const reachable = new Set();
+  const queue = [...fileSet].filter((file) => entryPattern.test(file));
+
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (reachable.has(current)) {
+      continue;
+    }
+    reachable.add(current);
+    for (const specifier of extractImports(contentsByFile.get(current) ?? '')) {
+      const resolved = resolveRelativeImport(fileSet, current, specifier);
+      if (resolved !== undefined && !reachable.has(resolved)) {
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return reachable;
+}
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Classify how a module references a specifier.
+ *
+ * Returns `'absent'`, `'imported-unused'` (the specifier is imported but no bound name is
+ * referenced anywhere else in the module — an import statement, not a wired seam), or `'used'`.
+ */
+export function classifySpecifierUsage(content, specifier) {
+  const quoted = `['"]${escapeForRegExp(specifier)}['"]`;
+  const evaluatedPattern = new RegExp(
+    `(?:import\\s*\\(\\s*${quoted}\\s*\\)|require\\s*\\(\\s*${quoted}\\s*\\)|import\\s+${quoted}|export\\s+[^;]*?from\\s*${quoted})`,
+  );
+  if (evaluatedPattern.test(content)) {
+    // Dynamic import, require, side-effect import, and re-export all evaluate or forward the
+    // specifier — the module wires it by existing.
+    return 'used';
+  }
+
+  // The clause may span lines but never contains `;` or a quote, so the match cannot swallow a
+  // preceding import statement (which would then mis-read that statement's bound names).
+  const staticPattern = new RegExp(`import\\s+([^;'"]*?)\\s*from\\s*${quoted}`, 'g');
+  const boundNames = new Set();
+  let masked = content;
+  let matchedStaticImport = false;
+  let match;
+  while ((match = staticPattern.exec(content)) !== null) {
+    matchedStaticImport = true;
+    masked = masked.replace(match[0], ' '.repeat(match[0].length));
+    for (const name of extractBoundNames(match[1])) {
+      boundNames.add(name);
+    }
+  }
+
+  if (!matchedStaticImport) {
+    return 'absent';
+  }
+
+  for (const name of boundNames) {
+    if (new RegExp(`\\b${escapeForRegExp(name)}\\b`).test(masked)) {
+      return 'used';
+    }
+  }
+  return 'imported-unused';
+}
+
+/** Local binding names introduced by an import clause (`X`, `* as ns`, `{ a, b as c }`). */
+function extractBoundNames(clause) {
+  const names = [];
+  const withoutTypeKeyword = clause.replace(/^\s*type\s+/, '');
+  const namedMatch = withoutTypeKeyword.match(/\{([^}]*)\}/);
+  if (namedMatch) {
+    for (const entry of namedMatch[1].split(',')) {
+      const parts = entry
+        .trim()
+        .replace(/^type\s+/, '')
+        .split(/\s+as\s+/);
+      const local = (parts[1] ?? parts[0] ?? '').trim();
+      if (/^[A-Za-z_$][\w$]*$/.test(local)) {
+        names.push(local);
+      }
+    }
+  }
+  const namespaceMatch = withoutTypeKeyword.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+  if (namespaceMatch) {
+    names.push(namespaceMatch[1]);
+  }
+  const defaultMatch = withoutTypeKeyword.match(/^\s*([A-Za-z_$][\w$]*)\s*(?:,|$)/);
+  if (defaultMatch) {
+    names.push(defaultMatch[1]);
+  }
+  return names;
+}
+
 async function findRequiredSourceImportFindings(root) {
   const findings = [];
 
   for (const check of REQUIRED_SOURCE_IMPORTS) {
-    let found = false;
+    const contentsByFile = new Map();
     for (const file of await walkFiles(root, check.dir)) {
-      const content = await fs.readFile(path.join(root, file), 'utf8');
-      if (extractImports(content).includes(check.importSpecifier)) {
-        found = true;
+      contentsByFile.set(toPosixPath(file), await fs.readFile(path.join(root, file), 'utf8'));
+    }
+
+    const reachable = collectReachableModules(contentsByFile, check.entryPattern);
+    const importingFiles = [];
+    let wiredFile;
+    let unwiredFile;
+
+    for (const [file, content] of contentsByFile) {
+      const usage = classifySpecifierUsage(content, check.importSpecifier);
+      if (usage === 'absent') {
+        continue;
+      }
+      importingFiles.push(file);
+      if (usage === 'used' && reachable.has(file)) {
+        wiredFile = file;
         break;
       }
+      unwiredFile ??= { file, usage };
     }
-    if (!found) {
-      findings.push({
-        file: check.dir,
-        type: check.type,
-        detail: check.detail,
-      });
+
+    if (wiredFile !== undefined) {
+      continue;
     }
+
+    if (importingFiles.length === 0) {
+      findings.push({ file: check.dir, type: check.type, detail: check.detail });
+      continue;
+    }
+
+    const reason =
+      unwiredFile.usage === 'imported-unused'
+        ? `${unwiredFile.file} imports it without referencing the binding`
+        : `${unwiredFile.file} is not reachable from an entry point`;
+    findings.push({
+      file: unwiredFile.file,
+      type: check.unwiredType,
+      detail: `${check.detail} ${check.importSpecifier} is imported but not wired: ${reason}. An import statement that nothing loads or calls does not satisfy this boundary.`,
+    });
   }
 
   return findings;

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -455,8 +455,26 @@ function stripCommentsAndStringLiterals(content) {
  * `'used'` without looking at anything else. Comments out, strings in.
  */
 function stripComments(content) {
-  return content.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  return content.replace(COMMENT_PATTERN, (_match, lineCommentPrefix) =>
+    lineCommentPrefix === undefined ? ' ' : lineCommentPrefix,
+  );
 }
+
+/**
+ * One alternation, not two sequential passes — whichever comment STARTS first wins.
+ *
+ * Two passes cannot be ordered correctly, because each order corrupts real code in the other's
+ * case. Block-first, which this was: `// see /* note` opens a block scan inside a LINE comment, so
+ * everything up to the next `*​/` is deleted. Measured on
+ * `// see /* note\nconst wired = require('pkg');\n/* real block *​/` — the `require` line was gone,
+ * so a genuinely wired seam would have read as absent. Line-first is no better: `/* a // b *​/`
+ * loses its terminator and the block is then never closed.
+ *
+ * A single left-to-right scan has no ordering to get wrong. The `[^:]` guard on the line-comment
+ * arm stays — without it every `https://…` in the file reads as a comment and deletes the rest of
+ * its line.
+ */
+const COMMENT_PATTERN = /\/\*[\s\S]*?\*\/|(^|[^:])\/\/[^\n]*/g;
 
 /**
  * Classify how a module references a specifier.

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -167,6 +167,9 @@ const REQUIRED_SOURCE_IMPORTS = [
     // Next.js App Router: route files are framework entry points — nothing in the repo imports them.
     entryPattern:
       /(^|\/)(page|layout|template|default|route|middleware|error|not-found)\.[cm]?[jt]sx?$/,
+    // apps/agent-web/tsconfig.json maps "@/*" to "./src/*"; an unresolved alias edge would make a
+    // live module look unreachable.
+    moduleAliases: [{ prefix: '@/', target: 'apps/agent-web/src/' }],
     importSpecifier: '@robota-sdk/agent-playground/client',
     type: 'agent-web-missing-browser-safe-playground-import',
     unwiredType: 'agent-web-unwired-browser-safe-playground-import',
@@ -375,14 +378,22 @@ function toPosixPath(value) {
 
 const RESOLUTION_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs'];
 
-/** Resolve a relative import to a file inside the scanned set, or undefined. */
-export function resolveRelativeImport(fileSet, fromFile, specifier) {
-  if (!specifier.startsWith('.')) {
-    return undefined;
+/** Resolve a relative or aliased import to a file inside the scanned set, or undefined. */
+export function resolveRelativeImport(fileSet, fromFile, specifier, moduleAliases = []) {
+  let base;
+  if (specifier.startsWith('.')) {
+    base = path.posix.normalize(
+      path.posix.join(path.posix.dirname(toPosixPath(fromFile)), specifier),
+    );
+  } else {
+    // A tsconfig path alias is an in-tree edge too; missing one would make a live module look
+    // unreachable, and a check that fires on correct code gets suppressed.
+    const alias = moduleAliases.find(({ prefix }) => specifier.startsWith(prefix));
+    if (!alias) {
+      return undefined;
+    }
+    base = path.posix.normalize(`${alias.target}${specifier.slice(alias.prefix.length)}`);
   }
-  const base = path.posix.normalize(
-    path.posix.join(path.posix.dirname(toPosixPath(fromFile)), specifier),
-  );
   const candidates = [base, ...RESOLUTION_EXTENSIONS.map((extension) => `${base}${extension}`)];
   for (const extension of RESOLUTION_EXTENSIONS) {
     candidates.push(`${base}/index${extension}`);
@@ -394,7 +405,7 @@ export function resolveRelativeImport(fileSet, fromFile, specifier) {
  * Modules reachable from the declared entry points, following relative imports only.
  * A module outside this set ships no behavior: nothing loads it.
  */
-export function collectReachableModules(contentsByFile, entryPattern) {
+export function collectReachableModules(contentsByFile, entryPattern, moduleAliases = []) {
   const fileSet = new Set(contentsByFile.keys());
   const reachable = new Set();
   const queue = [...fileSet].filter((file) => entryPattern.test(file));
@@ -406,7 +417,7 @@ export function collectReachableModules(contentsByFile, entryPattern) {
     }
     reachable.add(current);
     for (const specifier of extractImports(contentsByFile.get(current) ?? '')) {
-      const resolved = resolveRelativeImport(fileSet, current, specifier);
+      const resolved = resolveRelativeImport(fileSet, current, specifier, moduleAliases);
       if (resolved !== undefined && !reachable.has(resolved)) {
         queue.push(resolved);
       }
@@ -501,7 +512,11 @@ async function findRequiredSourceImportFindings(root) {
       contentsByFile.set(toPosixPath(file), await fs.readFile(path.join(root, file), 'utf8'));
     }
 
-    const reachable = collectReachableModules(contentsByFile, check.entryPattern);
+    const reachable = collectReachableModules(
+      contentsByFile,
+      check.entryPattern,
+      check.moduleAliases ?? [],
+    );
     const importingFiles = [];
     let wiredFile;
     let unwiredFile;

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -69,19 +69,26 @@ const PACKAGE_CHECKS = [
   },
 ];
 
+/**
+ * Withdrawn requirement (HARNESS-051, 2026-07-26):
+ * `agent-playground` was required to depend on and import `@robota-sdk/agent-remote-client`.
+ * Measured against the tree, that architecture is not the one implemented: the package reaches the
+ * server through its own `robota-executor/sse-client`, and `@robota-sdk/agent-remote-client` has no
+ * reachable importer anywhere in the repo — the single import lives in a module nothing loads.
+ * Under the wired-seam rule above the requirement can only ever be red, and a gate asserting an
+ * unimplemented design is what made deleting dead code a CI failure in the first place.
+ *
+ * The forbidden-direction rules (no host, CLI, or provider may reach into a remote client, and the
+ * remote client may not reach back into UI) are unaffected — those hold whether or not the seam is
+ * composed. Re-add a required-seam rule when the composition actually exists; do not re-add it as
+ * an aspiration.
+ */
 const REQUIRED_PACKAGE_DEPENDENCIES = [
   {
     file: 'apps/agent-server/package.json',
     dependencyPattern: /^@robota-sdk\/agent-provider(?:-|$)/,
     type: 'agent-server-missing-provider-composition',
     detail: 'agent-server should remain the provider-side composition root for remote execution.',
-  },
-  {
-    file: 'packages/agent-playground/package.json',
-    dependencyPattern: /^@robota-sdk\/agent-remote-client$/,
-    type: 'agent-playground-missing-remote-client-dependency',
-    detail:
-      'agent-playground should compose reusable browser execution through agent-remote-client.',
   },
 ];
 
@@ -166,16 +173,8 @@ const REQUIRED_SOURCE_IMPORTS = [
     detail:
       'agent-web should render Playground through the browser-safe @robota-sdk/agent-playground/client entry.',
   },
-  {
-    dir: 'packages/agent-playground/src',
-    // Package entry sources behind the `.` and `./client` export conditions.
-    entryPattern: /\/src\/(index|client)\.[cm]?[jt]sx?$/,
-    importSpecifier: '@robota-sdk/agent-remote-client',
-    type: 'agent-playground-missing-remote-client-import',
-    unwiredType: 'agent-playground-unwired-remote-client-import',
-    detail:
-      'agent-playground should keep reusable remote execution behavior in the package, backed by agent-remote-client.',
-  },
+  // The agent-playground -> agent-remote-client required import is withdrawn; see the note above
+  // REQUIRED_PACKAGE_DEPENDENCIES.
 ];
 
 const SERVER_FORBIDDEN_OWNERSHIP_PATTERNS = [

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -165,8 +165,12 @@ const REQUIRED_SOURCE_IMPORTS = [
   {
     dir: 'apps/agent-web/src',
     // Next.js App Router: route files are framework entry points — nothing in the repo imports them.
+    // The full App Router special-file set. `loading` and `global-error` were missing, and a module
+    // reachable only from one of those would have read as unreachable — the gate would then call a
+    // genuinely wired seam dead. Under-listing entry points fails in the direction that produces
+    // false findings, which is the direction that gets a gate disabled.
     entryPattern:
-      /(^|\/)(page|layout|template|default|route|middleware|error|not-found)\.[cm]?[jt]sx?$/,
+      /(^|\/)(page|layout|template|default|route|middleware|error|global-error|not-found|loading)\.[cm]?[jt]sx?$/,
     // apps/agent-web/tsconfig.json maps "@/*" to "./src/*"; an unresolved alias edge would make a
     // live module look unreachable.
     moduleAliases: [{ prefix: '@/', target: 'apps/agent-web/src/' }],

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -493,28 +493,42 @@ export function classifySpecifierUsage(content, specifier) {
   return 'imported-unused';
 }
 
-/** Local binding names introduced by an import clause (`X`, `* as ns`, `{ a, b as c }`). */
+/**
+ * RUNTIME binding names introduced by an import clause (`X`, `* as ns`, `{ a, b as c }`).
+ *
+ * Type-only imports bind nothing. `import type { X }` and `import { type X }` are erased by the
+ * compiler, so the emitted module never references them — the seam is not wired, whatever the
+ * source looks like. An earlier version stripped the `type` keyword and counted them as bindings,
+ * which would let a purely type-level reference satisfy a gate whose whole purpose is to prove a
+ * seam is actually reachable at runtime. That is the exact defect class HARNESS-051 is closing, so
+ * counting them here would have reintroduced it inside the fix.
+ *
+ * Returns `[]` for a wholly type-only clause; drops individually `type`-marked specifiers from a
+ * mixed one (`import { type A, B }` binds only `B`).
+ */
 function extractBoundNames(clause) {
+  // `import type …` — the entire clause is erased. Nothing is bound at runtime.
+  if (/^\s*type\s+/.test(clause)) return [];
+
   const names = [];
-  const withoutTypeKeyword = clause.replace(/^\s*type\s+/, '');
-  const namedMatch = withoutTypeKeyword.match(/\{([^}]*)\}/);
+  const namedMatch = clause.match(/\{([^}]*)\}/);
   if (namedMatch) {
     for (const entry of namedMatch[1].split(',')) {
-      const parts = entry
-        .trim()
-        .replace(/^type\s+/, '')
-        .split(/\s+as\s+/);
+      const trimmed = entry.trim();
+      // `{ type A }` / `{ type A as B }` — an inline type specifier, erased like the clause form.
+      if (/^type\s+/.test(trimmed)) continue;
+      const parts = trimmed.split(/\s+as\s+/);
       const local = (parts[1] ?? parts[0] ?? '').trim();
       if (/^[A-Za-z_$][\w$]*$/.test(local)) {
         names.push(local);
       }
     }
   }
-  const namespaceMatch = withoutTypeKeyword.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
+  const namespaceMatch = clause.match(/\*\s+as\s+([A-Za-z_$][\w$]*)/);
   if (namespaceMatch) {
     names.push(namespaceMatch[1]);
   }
-  const defaultMatch = withoutTypeKeyword.match(/^\s*([A-Za-z_$][\w$]*)\s*(?:,|$)/);
+  const defaultMatch = clause.match(/^\s*([A-Za-z_$][\w$]*)\s*(?:,|$)/);
   if (defaultMatch) {
     names.push(defaultMatch[1]);
   }

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -476,6 +476,14 @@ function stripComments(content) {
  */
 const COMMENT_PATTERN = /\/\*[\s\S]*?\*\/|(^|[^:])\/\/[^\n]*/g;
 
+/** Every string literal blanked except those whose content is exactly `specifier`. */
+function stripStringLiteralsExcept(content, specifier) {
+  return content.replace(/'(?:\\.|[^'\\\n])*'|"(?:\\.|[^"\\\n])*"/g, (literal) => {
+    const quote = literal[0];
+    return literal.slice(1, -1) === specifier ? literal : `${quote}${quote}`;
+  });
+}
+
 /**
  * Classify how a module references a specifier.
  *
@@ -484,9 +492,17 @@ const COMMENT_PATTERN = /\/\*[\s\S]*?\*\/|(^|[^:])\/\/[^\n]*/g;
  * `'used'`.
  */
 export function classifySpecifierUsage(rawContent, specifier) {
-  // Comments stripped before ANY import is matched — a commented-out import wires nothing. String
-  // literals are kept, because the patterns below match the quoted specifier itself.
-  const content = stripComments(rawContent);
+  // Comments out, and every string literal blanked EXCEPT the specifier itself.
+  //
+  // Neither half alone is enough. Keeping strings let a file containing
+  // `const example = "await import('pkg')"` classify as a wired seam — token-appears-somewhere, the
+  // exact class this gate exists to reject. Blanking all strings is worse: every import pattern
+  // matches the QUOTED specifier, so the thing being searched for disappears and every import reads
+  // as absent. Preserving only literals whose content IS the specifier resolves it: the outer string
+  // above is blanked (its content is not `pkg`), while `import('pkg')` keeps its argument. A bare
+  // `const name = 'pkg'` survives too and is harmless — the patterns all require `import(`,
+  // `require(`, `import ` or `from ` in front of it.
+  const content = stripStringLiteralsExcept(stripComments(rawContent), specifier);
   const quoted = `['"]${escapeForRegExp(specifier)}['"]`;
   const evaluatedPattern = new RegExp(
     `(?:import\\s*\\(\\s*${quoted}\\s*\\)|require\\s*\\(\\s*${quoted}\\s*\\)|import\\s+${quoted}|export\\s+[^;]*?from\\s*${quoted})`,

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -406,6 +406,16 @@ export function resolveRelativeImport(fileSet, fromFile, specifier, moduleAliase
  * A module outside this set ships no behavior: nothing loads it.
  */
 export function collectReachableModules(contentsByFile, entryPattern, moduleAliases = []) {
+  // Fail closed on a missing entry pattern rather than crashing on `undefined.test`. A check added
+  // later without one would otherwise take the whole scan down with a TypeError, and a guard that
+  // dies is a guard that gets skipped. Saying which declaration is incomplete beats a stack trace.
+  if (!(entryPattern instanceof RegExp)) {
+    throw new TypeError(
+      'collectReachableModules requires an entryPattern RegExp — the check declaring it is incomplete. ' +
+        'Entry points are declared per check and never inferred, so there is no safe default to fall back to.',
+    );
+  }
+
   const fileSet = new Set(contentsByFile.keys());
   const reachable = new Set();
   const queue = [...fileSet].filter((file) => entryPattern.test(file));

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -440,11 +440,22 @@ function escapeForRegExp(value) {
  * inside surviving text is not mistaken for a line comment.
  */
 function stripCommentsAndStringLiterals(content) {
-  return content
+  return stripComments(content)
     .replace(/'(?:\\.|[^'\\\n])*'/g, "''")
-    .replace(/"(?:\\.|[^"\\\n])*"/g, '""')
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+    .replace(/"(?:\\.|[^"\\\n])*"/g, '""');
+}
+
+/**
+ * Remove comments only, keeping string literals intact.
+ *
+ * Import detection cannot use the full strip: every import pattern matches a QUOTED specifier, so
+ * blanking string literals deletes the very thing being searched for and every import would read as
+ * absent. But the raw content must not be searched either — a commented-out `import('pkg')` would
+ * then classify as `used`, letting a mention stand in for a wiring in the branch that returns
+ * `'used'` without looking at anything else. Comments out, strings in.
+ */
+function stripComments(content) {
+  return content.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
 }
 
 /**
@@ -454,7 +465,10 @@ function stripCommentsAndStringLiterals(content) {
  * referenced in the module's executable text — an import statement, not a wired seam), or
  * `'used'`.
  */
-export function classifySpecifierUsage(content, specifier) {
+export function classifySpecifierUsage(rawContent, specifier) {
+  // Comments stripped before ANY import is matched — a commented-out import wires nothing. String
+  // literals are kept, because the patterns below match the quoted specifier itself.
+  const content = stripComments(rawContent);
   const quoted = `['"]${escapeForRegExp(specifier)}['"]`;
   const evaluatedPattern = new RegExp(
     `(?:import\\s*\\(\\s*${quoted}\\s*\\)|require\\s*\\(\\s*${quoted}\\s*\\)|import\\s+${quoted}|export\\s+[^;]*?from\\s*${quoted})`,

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -432,10 +432,27 @@ function escapeForRegExp(value) {
 }
 
 /**
+ * Drop the parts of a module that cannot reference a binding: comments and quoted string
+ * literals. Otherwise a name merely MENTIONED in a comment would count as a use — the same
+ * vacuous satisfaction this check exists to reject, one level down.
+ *
+ * Template literals are left intact: `${name}` is a real reference. `://` is preserved so a URL
+ * inside surviving text is not mistaken for a line comment.
+ */
+function stripCommentsAndStringLiterals(content) {
+  return content
+    .replace(/'(?:\\.|[^'\\\n])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\\n])*"/g, '""')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/**
  * Classify how a module references a specifier.
  *
  * Returns `'absent'`, `'imported-unused'` (the specifier is imported but no bound name is
- * referenced anywhere else in the module — an import statement, not a wired seam), or `'used'`.
+ * referenced in the module's executable text — an import statement, not a wired seam), or
+ * `'used'`.
  */
 export function classifySpecifierUsage(content, specifier) {
   const quoted = `['"]${escapeForRegExp(specifier)}['"]`;
@@ -467,8 +484,9 @@ export function classifySpecifierUsage(content, specifier) {
     return 'absent';
   }
 
+  const executable = stripCommentsAndStringLiterals(masked);
   for (const name of boundNames) {
-    if (new RegExp(`\\b${escapeForRegExp(name)}\\b`).test(masked)) {
+    if (new RegExp(`\\b${escapeForRegExp(name)}\\b`).test(executable)) {
       return 'used';
     }
   }

--- a/scripts/harness/check-agent-server-boundary.mjs
+++ b/scripts/harness/check-agent-server-boundary.mjs
@@ -504,11 +504,23 @@ export function classifySpecifierUsage(rawContent, specifier) {
   // `require(`, `import ` or `from ` in front of it.
   const content = stripStringLiteralsExcept(stripComments(rawContent), specifier);
   const quoted = `['"]${escapeForRegExp(specifier)}['"]`;
+  // Re-exports are matched separately from the other evaluated forms, because a type-only one is
+  // erased exactly like `import type` — `export type { X } from 'pkg'` forwards nothing at runtime,
+  // and the single combined pattern counted it as wiring. Same finding as the import side, one
+  // review round later, on the branch that had not been given the same rule.
+  const reExportPattern = new RegExp(`export\\s+([^;]*?)\\s*from\\s*${quoted}`, 'g');
+  for (const reExport of content.matchAll(reExportPattern)) {
+    const clause = reExport[1];
+    // `export *` / `export * as ns` is a namespace forward: always live at runtime.
+    if (/^\s*\*/.test(clause)) return 'used';
+    if (extractBoundNames(clause).length > 0) return 'used';
+  }
+
   const evaluatedPattern = new RegExp(
-    `(?:import\\s*\\(\\s*${quoted}\\s*\\)|require\\s*\\(\\s*${quoted}\\s*\\)|import\\s+${quoted}|export\\s+[^;]*?from\\s*${quoted})`,
+    `(?:import\\s*\\(\\s*${quoted}\\s*\\)|require\\s*\\(\\s*${quoted}\\s*\\)|import\\s+${quoted})`,
   );
   if (evaluatedPattern.test(content)) {
-    // Dynamic import, require, side-effect import, and re-export all evaluate or forward the
+    // Dynamic import, require, and side-effect import all evaluate the
     // specifier — the module wires it by existing.
     return 'used';
   }

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -19,6 +19,58 @@ import path from 'node:path';
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 /**
+ * Sentinel a scan prints to mark ONE line as an ADVISORY finding (HARNESS-053).
+ *
+ * THE GAP THIS CLOSES, measured. Passing scans' output is discarded — `expect(out).not.toContain
+ * ('quiet pass')` is a pinned property of this runner, and a correct one: 78 scans printing their
+ * successes is noise nobody reads. But it left no third channel, so a scan that measured something
+ * worth saying while still passing had nowhere to say it. Measured on the real path:
+ * `touch packages/agent-core/src/index.ts && pnpm harness:scan | grep -i stale` printed NOTHING,
+ * while the `dist` scan had detected and reported the staleness. A finding nobody sees is not a
+ * finding, and this is the exact sequence that cost a misdiagnosis cycle: run `harness:scan`, see
+ * green, conclude the branch is healthy, then blame missing barrel exports for a stale `dist`.
+ *
+ * WHY A LINE MARKER RATHER THAN AN EXIT CODE. Advisories must not be able to change a scan's
+ * verdict — a second non-zero code would eventually be treated as failure by something downstream,
+ * and then "advisory" becomes blocking by accident. A marker is opt-in per LINE, so a scan chooses
+ * exactly which of its output reaches the summary and the rest stays suppressed as before.
+ *
+ * GENERAL, not a special case for one scan: any scan may print it, and several in this repo have
+ * advisory output currently thrown away (e.g. `scan-file-size`'s ratchet-tighten notices).
+ */
+export const ADVISORY_MARKER = '::advisory::';
+
+/**
+ * SGR colour sequences, stripped so a scan's own colouring does not leak into the summary.
+ *
+ * The ESC is written `\x1b`, not as a raw control byte, and it is part of the pattern deliberately:
+ * without it the regex is `/\[[0-9;]*m/`, which matches any bracketed digits ending in `m`, so an
+ * advisory whose text happened to mention `[12m` would have had it silently deleted. A sanitiser
+ * that corrupts the message it is sanitising is worse than none. Both properties are pinned below.
+ */
+const ANSI_SGR_PATTERN = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Advisory texts a scan emitted, in the order printed. Pure, so the rule is testable without
+ * spawning anything.
+ *
+ * A marked line with no text after the marker is DROPPED rather than surfaced as an empty bullet —
+ * an advisory channel that can print a contentless line is a way to look like it reported
+ * something while reporting nothing, which is the class this whole item exists to close.
+ */
+export function extractAdvisories(output) {
+  const advisories = [];
+  for (const rawLine of String(output ?? '').split('\n')) {
+    const line = rawLine.replace(ANSI_SGR_PATTERN, '');
+    const markerAt = line.indexOf(ADVISORY_MARKER);
+    if (markerAt === -1) continue;
+    const text = line.slice(markerAt + ADVISORY_MARKER.length).trim();
+    if (text.length > 0) advisories.push(text);
+  }
+  return advisories;
+}
+
+/**
  * Default scan concurrency (INFRA-037). Each scan is an independent, read-only subprocess, so they run
  * concurrently under a bounded pool instead of one-at-a-time. Cap leaves one core for the parent.
  */
@@ -276,6 +328,11 @@ function spawnScan(command) {
  * Each scan is `{ name, run: () => Promise<{code, output}> | Promise<number> }`. Output is CAPTURED per
  * scan and printed only for FAILURES (passes stay a one-line ✓), so parallel runs do not interleave.
  * Returns the aggregate exit code (0 = all passed). The summary + exit code are order-independent.
+ *
+ * THREE output channels, not two (HARNESS-053): failures print in full, `ADVISORY_MARKER` lines
+ * print from every scan regardless of verdict, and everything else from a passing scan stays
+ * suppressed. Advisories never touch the return value — `runScans` returns 0 for a suite whose only
+ * findings are advisory, and that is pinned by a test.
  */
 export async function runScans(
   scans,
@@ -311,6 +368,21 @@ export async function runScans(
   write('harness scan summary:');
   for (const result of results) {
     write(`${result.code === 0 ? '✓' : '✗'} ${result.name}`);
+  }
+
+  // ADVISORIES from EVERY scan, passing or failing (HARNESS-053). Deliberately placed after the
+  // ✓/✗ list and before the verdict: high enough to be read, low enough that the verdict is still
+  // the last line, so a green run still ENDS in green and the advisory cannot be mistaken for one.
+  const advisories = results.flatMap((result) =>
+    extractAdvisories(result.output).map((text) => ({ name: result.name, text })),
+  );
+  if (advisories.length > 0) {
+    write('');
+    write(
+      `⚑ ${advisories.length} advisory finding(s) — NOT failures. The verdict below is unaffected.`,
+    );
+    for (const advisory of advisories) write(`⚑ ${advisory.name}: ${advisory.text}`);
+    write('');
   }
 
   const failed = results.filter((result) => result.code !== 0);

--- a/scripts/harness/scan-dist-freshness.mjs
+++ b/scripts/harness/scan-dist-freshness.mjs
@@ -95,7 +95,10 @@ const EMITTED_SOURCE_EXTENSIONS = new Set([
   '.json',
 ]);
 
-const TEST_FILE_PATTERN = /\.(test|spec)\.[cm]?[jt]sx?$/;
+// Any extension, not just JS/TS. `.json` is an emitted source extension, so the JS/TS-only version
+// let `src/a.test.json` count as a source: touching a test fixture marked its package stale.
+// Measured before the fix — `isEmittedSourceFile('src/a.test.json')` returned true.
+const TEST_FILE_PATTERN = /\.(test|spec)\.[A-Za-z0-9]+$/;
 const NON_EMITTED_DIR_PATTERN = /(^|\/)(__tests__|__mocks__|__fixtures__|__snapshots__)(\/|$)/;
 
 /**

--- a/scripts/harness/scan-dist-freshness.mjs
+++ b/scripts/harness/scan-dist-freshness.mjs
@@ -58,11 +58,13 @@
  * REBUILDS rather than trusting this scan. This check's job is a legible message at the moment of
  * confusion, not a second gate.
  *
- * VISIBILITY CEILING: `run-all-scans.mjs` discards a PASSING scan's output, so under
- * `pnpm harness:scan` a freshness advisory is counted in this scan's own summary but its per-package
- * lines are not displayed. That is HARNESS-052's open "`run-all-scans` distinguishes ran-and-found-
- * nothing from ran-and-measured-nothing" item, not something this file can fix from inside. Run this
- * scan DIRECTLY — the diagnostic moment it exists for — to see the packages named.
+ * VISIBILITY: staleness lines carry `ADVISORY_MARKER`, so they reach `pnpm harness:scan`'s summary
+ * even though this scan exits 0. That marker is load-bearing, not decoration. MEASURED before it
+ * existed: `touch packages/agent-core/src/index.ts && pnpm harness:scan | grep -i stale` printed
+ * NOTHING, because `run-all-scans` surfaces captured output only for scans with a non-zero exit. The
+ * finding was made and discarded, so the misdiagnosis sequence — run `harness:scan`, see green,
+ * conclude the branch is healthy — was completely unchanged by detecting the staleness. A finding
+ * nobody sees is not a finding.
  *
  * Run: node scripts/harness/scan-dist-freshness.mjs
  */
@@ -70,6 +72,7 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { extname, join, relative, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 import { listWorkspaceScopes, readJson } from './shared.mjs';
 
 const ROOT = process.cwd();
@@ -252,15 +255,14 @@ export async function collectDistFreshnessResults(root, scopes) {
       continue;
     }
     freshness.stale++;
+    // Kept to ONE compact line per package. It is surfaced through the runner's advisory channel,
+    // where it sits beside up to 77 other scans' output — the full explanation belongs in the
+    // single footer line below, not repeated per package until people stop reading it.
     results.push({
       kind: 'stale',
       message:
         `${scope.workspaceName}: dist/ may be STALE — src/${verdict.srcNewest.path} is ` +
-        `${formatLag(verdict.lagMs)} newer than the newest artefact dist/${verdict.distNewest.path}. ` +
-        'Cross-package `pnpm typecheck` resolves this package to dist/*.d.ts, so a consumer is being ' +
-        'compared against an OLD type surface — it can report a phantom error on correct code, and it ' +
-        'can hide a real one. Run `pnpm build` before trusting a typecheck verdict. ADVISORY: mtime ' +
-        'is evidence, not proof (see header).',
+        `${formatLag(verdict.lagMs)} newer than dist/${verdict.distNewest.path}`,
     });
   }
 
@@ -297,7 +299,12 @@ export async function main() {
       console.error(`\x1b[31m❌ ${result.message}\x1b[0m`);
       errors++;
     } else if (result.kind === 'stale') {
-      console.warn(`\x1b[33m🕒 ${result.message}\x1b[0m`);
+      // ADVISORY_MARKER makes this line reach `pnpm harness:scan`'s summary even though this scan
+      // exits 0. Without it the finding existed and nobody saw it: `touch
+      // packages/agent-core/src/index.ts && pnpm harness:scan | grep -i stale` printed NOTHING,
+      // because the runner discards a passing scan's output. That silence is the whole reason the
+      // stale dist was misdiagnosed as a branch breakage in the first place.
+      console.warn(`\x1b[33m🕒 ${ADVISORY_MARKER} ${result.message}\x1b[0m`);
     } else if (result.kind === 'warn') {
       console.warn(`\x1b[33m⚠️  ${result.message}\x1b[0m`);
       warnings++;
@@ -314,11 +321,14 @@ export async function main() {
       `(${freshness.unmeasurable} not comparable: no src/ or no dist/). ADVISORY — never blocking.`,
   );
   if (freshness.stale > 0) {
+    // The diagnostic instruction, carried on the same advisory channel so it arrives WITH the
+    // package list rather than only on a direct run. This is the routing the item asked for in its
+    // point 3; the rules/skills tree that would otherwise host it is outside this item's ownership.
     console.warn(
-      `\x1b[33m${freshness.stale} package(s) have a dist/ older than their src/. ` +
-        'A cross-package type error seen only in a whole-workspace typecheck should be re-checked ' +
-        'after `pnpm build` (or `pnpm harness:verify-like-ci`, which rebuilds) before it is treated ' +
-        'as a branch defect.\x1b[0m',
+      `\x1b[33m${ADVISORY_MARKER} ${freshness.stale} package(s) have a dist/ older than their ` +
+        'src/. A cross-package type error seen only in a whole-workspace typecheck should be ' +
+        're-checked after `pnpm build` (or `pnpm harness:verify-like-ci`, which rebuilds) before ' +
+        'it is treated as a branch defect.\x1b[0m',
     );
   }
 

--- a/scripts/harness/scan-dist-freshness.mjs
+++ b/scripts/harness/scan-dist-freshness.mjs
@@ -243,6 +243,27 @@ export async function collectDistFreshnessResults(root, scopes) {
 
     results.push(...presenceResults(scope, pkg, distWalk.fileCount > 0));
 
+    // Freshness is only compared for packages the STANDARD build rebuilds. Root `pnpm build` is
+    // `pnpm --filter "./packages/**" build:js`, so `apps/**` and any package without a `build:js`
+    // script are never refreshed by it. Measured on a tree immediately after a clean `pnpm build`:
+    // agent-app (312h), remote-signaling (383h) and agent-cli-web (167h) still reported stale, and
+    // no amount of running the command the advisory recommends would ever clear them.
+    //
+    // An advisory that cannot be cleared by the action it advises is the shape that trains people
+    // to ignore the channel — the same defect HARNESS-054 records for a scan whose red has no path
+    // back to green. Their dist genuinely is old; it is just not this scan's claim to make, because
+    // the claim it exists to support is "your cross-package typecheck is reading a stale dist,
+    // rebuild", and rebuilding does not apply to them.
+    // BOTH halves of the filter matter. `apps/remote-signaling` declares `build:js` and is still
+    // never rebuilt, because the filter is `./packages/**` — the script's presence says nothing
+    // about whether the root build reaches it.
+    const rebuiltByRootBuild =
+      scope.relativeDir.startsWith('packages/') && Boolean(scope.scripts['build:js']);
+    if (!rebuiltByRootBuild) {
+      freshness.unmeasurable++;
+      continue;
+    }
+
     const srcWalk = walkTree(join(scopeDir, 'src'), isEmittedSourceFile);
     const verdict = freshnessVerdict(srcWalk.newest, distWalk.newest);
     if (verdict.state === 'unmeasurable') {

--- a/scripts/harness/scan-dist-freshness.mjs
+++ b/scripts/harness/scan-dist-freshness.mjs
@@ -271,6 +271,20 @@ export async function main() {
   const scopes = await listWorkspaceScopes();
   const { results, buildableCount, freshness } = await collectDistFreshnessResults(ROOT, scopes);
 
+  // FAIL CLOSED on an empty subject. MEASURED, not assumed: before this guard, a
+  // `pnpm-workspace.yaml` resolving to zero packages printed "dist/ present on all 0 package(s)"
+  // and exited 0 — the exact "reports success over work it did not do" shape HARNESS-052 audits,
+  // found live inside its own remedy. A dist scan that enumerated no buildable package has not
+  // found them all built; it has found nothing. (A root with no manifest at all already throws
+  // out of `listWorkspaceScopes`.)
+  if (buildableCount === 0) {
+    console.error(
+      '\x1b[31mNo buildable workspace package was enumerated, so this scan measured nothing. ' +
+        'That is an error, not a pass — check the workspace manifest and the cwd.\x1b[0m',
+    );
+    process.exit(1);
+  }
+
   let errors = 0;
   let warnings = 0;
   // Packages whose dist presence was actually ASSERTED — i.e. that produced an `ok` or `error`.

--- a/scripts/harness/scan-dist-freshness.mjs
+++ b/scripts/harness/scan-dist-freshness.mjs
@@ -1,112 +1,289 @@
 /**
- * Harness check: dist PRESENCE gate.
+ * Harness check: dist PRESENCE (blocking) + dist FRESHNESS (advisory).
  *
- * Verifies that every workspace package with a build script has a non-empty dist/ directory.
- * Catches "CI will fail on typecheck because dist is missing" before the code reaches remote CI.
+ * WHY BOTH LIVE HERE (HARNESS-053). `pnpm typecheck` resolves a cross-package import to the
+ * PRODUCING package's built `dist/*.d.ts`, never to its source. So the dist of every package is a
+ * type-surface that the rest of the workspace is compiled against, and its state has two failure
+ * directions:
  *
- * WHAT IT DOES NOT CHECK, said plainly because the filename says otherwise (HARNESS-052). This is
- * named `scan-dist-freshness` and it does not measure freshness: it never compares dist against the
- * sources that produced it. Falsified 2026-07-26 — `touch packages/agent-core/src/index.ts` makes
- * the source 28 minutes newer than its dist, and this scan still exits 0 and reports "All 86
- * buildable packages have dist/". A STALE dist is indistinguishable from a fresh one here.
+ *   MISSING dist → `TS7016: Could not find a declaration file`. Loud, obvious, already blocking here.
+ *   STALE   dist → new consumer source compared against an OLD producer type surface. Silent.
  *
- * That gap is load-bearing elsewhere and is handled there rather than hidden: `verify-like-ci`'s
- * `build` stage exists precisely because "locally a STALE dist passes the presence-only freshness
- * scan", and it rebuilds instead of trusting this result. The name is the defect, not the behaviour
- * — the check is a correct presence gate wearing a temporal claim. Renaming it is deferred only
- * because the registered scan name `dist` appears in a `--skip dist` argument inside ci.yml, which
- * is outside this item's ownership; see HARNESS-052.
+ * The stale direction is symmetric and the quiet half is the dangerous one:
+ *
+ *   PHANTOM RED  — a healthy branch reported broken. Measured 2026-07-26: `origin/develop` was
+ *                  reported to have three `TS2305`/`TS2559` failures. All three were a `dist` built
+ *                  07-25 23:44 judged against source from 07-26 07:19; every symbol was in fact
+ *                  exported and every signature in fact compatible. `pnpm harness:scan` was GREEN on
+ *                  precisely the tree that made `pnpm typecheck` RED, and an agent was dispatched to
+ *                  fix code that was already correct.
+ *   HIDDEN GREEN — the same staleness makes a consumer that SHOULD fail typecheck pass, because the
+ *                  old `.d.ts` still declares the surface the consumer was written against. This
+ *                  direction produces no symptom at all. It is what the check is actually for.
+ *
+ * WHAT THIS FILE USED TO BE, said plainly because HARNESS-052 recorded it: it was named
+ * `scan-dist-freshness` and measured only PRESENCE — `touch packages/agent-core/src/index.ts` left
+ * the source newer than its dist and the scan still exited 0 reporting "All 86 buildable packages
+ * have dist/". The freshness rule below is the repair; the name and the behaviour now agree.
+ *
+ * THE ORACLE, and its limits — stated rather than implied, because a guard that oversells what it
+ * measured is the defect this file was written to close:
+ *
+ *   Freshness is decided by MTIME: the newest emitted-source file under `src/` versus the newest
+ *   artefact under `dist/`. mtime is EVIDENCE, not proof. It is sound in the directions that matter
+ *   here and unsound in one that does not:
+ *
+ *     - fresh clone / cold checkout → git stamps every file at checkout time and `dist` does not
+ *       exist at all, so there is nothing to compare and NO staleness is reported. This is the case
+ *       that separates a freshness check from the presence check it replaces, and it is pinned by a
+ *       test.
+ *     - `git checkout <branch>` / rebase / stash pop → the touched sources become newer than a dist
+ *       built from the other tree. That dist IS stale. TRUE positive.
+ *     - a restored build cache or a downloaded CI artefact → `dist` arrives with a NEW mtime, so a
+ *       genuinely stale dist reads as fresh. FALSE NEGATIVE, i.e. this check is silent exactly where
+ *       the presence-only check was already silent. It never fabricates a red from it.
+ *     - reverting a source file to the exact content its dist was built from → newer mtime, identical
+ *       content. FALSE POSITIVE, and the only realistic one. It is why this rule is ADVISORY.
+ *
+ *   The sound alternative is a CONTENT HASH of the emitted-source set stamped into the build output
+ *   at build time and compared here, which removes every mtime caveat above. It is not implemented
+ *   because stamping requires changing the build pipeline (`tsdown` config / package build scripts /
+ *   the root `build` script), which is outside this item's ownership — not because mtime was judged
+ *   sufficient. HARNESS-053 records it as the upgrade path.
+ *
+ * SEVERITY: presence is an ERROR, freshness is an ADVISORY that never changes the exit code. A
+ * freshness rule that hard-failed would redden a legitimately-reverted file, and `ci.yml` already
+ * carries a `--skip dist`, so the suppression path for a noisy gate here is literally pre-wired. The
+ * blocking enforcement for staleness already exists and is sound: `verify-like-ci`'s `build` stage
+ * REBUILDS rather than trusting this scan. This check's job is a legible message at the moment of
+ * confusion, not a second gate.
+ *
+ * VISIBILITY CEILING: `run-all-scans.mjs` discards a PASSING scan's output, so under
+ * `pnpm harness:scan` a freshness advisory is counted in this scan's own summary but its per-package
+ * lines are not displayed. That is HARNESS-052's open "`run-all-scans` distinguishes ran-and-found-
+ * nothing from ran-and-measured-nothing" item, not something this file can fix from inside. Run this
+ * scan DIRECTLY — the diagnostic moment it exists for — to see the packages named.
  *
  * Run: node scripts/harness/scan-dist-freshness.mjs
  */
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { extname, join, relative, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { listWorkspaceScopes, readJson } from './shared.mjs';
 
 const ROOT = process.cwd();
 
-function isNonEmptyDir(dirPath) {
-  if (!existsSync(dirPath)) return false;
-  try {
-    const entries = readdirSync(dirPath, { recursive: true });
-    return entries.some((e) => {
-      const full = join(dirPath, e);
-      return statSync(full).isFile();
-    });
-  } catch {
-    return false;
-  }
+/**
+ * Extensions that can contribute to what a build emits, and therefore to the type surface a
+ * consumer is compiled against. Deliberately an ALLOWLIST: a `README.md` or a `__snapshots__` blob
+ * beside the code moves no declaration, and treating it as source would make the rule fire on a tree
+ * whose emitted surface is unchanged — an over-firing advisory is one that gets ignored.
+ */
+const EMITTED_SOURCE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.json',
+]);
+
+const TEST_FILE_PATTERN = /\.(test|spec)\.[cm]?[jt]sx?$/;
+const NON_EMITTED_DIR_PATTERN = /(^|\/)(__tests__|__mocks__|__fixtures__|__snapshots__)(\/|$)/;
+
+/**
+ * Does this `src/`-relative path contribute to the package's emitted output?
+ *
+ * Tests are excluded on purpose: `tsconfig.build.json` keeps them out of the build, so a touched
+ * `*.test.ts` changes no `.d.ts` and a stale verdict drawn from it would be a false alarm.
+ */
+export function isEmittedSourceFile(relativePath) {
+  const normalized = String(relativePath ?? '')
+    .split(sep)
+    .join('/');
+  if (normalized === '') return false;
+  const basename = normalized.slice(normalized.lastIndexOf('/') + 1);
+  if (!EMITTED_SOURCE_EXTENSIONS.has(extname(basename))) return false;
+  if (TEST_FILE_PATTERN.test(basename)) return false;
+  if (NON_EMITTED_DIR_PATTERN.test(normalized)) return false;
+  return true;
 }
 
 /**
- * Pure finding collector: classifies each buildable scope's dist state.
- * Returns ordered results ({ kind: 'ok' | 'warn' | 'error', message }) plus the
- * buildable count, so the CLI wrapper can print identically to the original.
+ * Walk `dirPath` recursively, counting accepted files and remembering the newest one.
+ *
+ * Returns `{ fileCount, newest }` where `newest` is `{ path, mtimeMs }` relative to `dirPath`, or
+ * `null` when nothing was accepted. A missing or unreadable directory yields `fileCount: 0` — the
+ * CALLERS decide what that means, because for `dist/` it is a presence error and for `src/` it is
+ * simply not measurable.
+ */
+export function walkTree(dirPath, accept = () => true) {
+  if (!existsSync(dirPath)) return { fileCount: 0, newest: null };
+  let entries;
+  try {
+    entries = readdirSync(dirPath, { recursive: true, withFileTypes: true });
+  } catch {
+    return { fileCount: 0, newest: null };
+  }
+
+  let fileCount = 0;
+  let newest = null;
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const fullPath = join(entry.parentPath ?? entry.path, entry.name);
+    const relativePath = relative(dirPath, fullPath);
+    if (!accept(relativePath)) continue;
+    fileCount++;
+    let mtimeMs;
+    try {
+      mtimeMs = statSync(fullPath).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (newest === null || mtimeMs > newest.mtimeMs) newest = { path: relativePath, mtimeMs };
+  }
+  return { fileCount, newest };
+}
+
+/**
+ * Compare the newest emitted source against the newest emitted artefact.
+ *
+ * `unmeasurable` is a first-class third state, not a pass: "there was nothing to compare" and "the
+ * comparison came out clean" are different answers and this scan reports them differently.
+ */
+export function freshnessVerdict(srcNewest, distNewest) {
+  if (!srcNewest) return { state: 'unmeasurable', reason: 'no emitted source files under src/' };
+  if (!distNewest) return { state: 'unmeasurable', reason: 'no artefacts under dist/' };
+  if (srcNewest.mtimeMs > distNewest.mtimeMs) {
+    return { state: 'stale', srcNewest, distNewest, lagMs: srcNewest.mtimeMs - distNewest.mtimeMs };
+  }
+  return { state: 'fresh', srcNewest, distNewest };
+}
+
+function formatLag(lagMs) {
+  const seconds = Math.round(lagMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+/**
+ * Presence verdict for one scope — pure, so the branching is testable without a filesystem.
+ *
+ * Returns zero or one result. Note the parenthesised `hasDistExport`: without it, `main` pointing at
+ * `dist/` with no `exports` block downgraded a genuine missing-dist ERROR to a non-blocking warning
+ * (HARNESS-052 recorded the precedence bug).
+ */
+export function presenceResults(scope, pkg, hasDist) {
+  // Private packages are never published, so their dist presence is a dev concern, not a
+  // release/publish gate — but a private package can still carry dist-based `exports`/`main`
+  // (e.g. a private server app), so the skip keys on `private`, not on the absence of dist exports.
+  if (pkg.private === true) {
+    return hasDist
+      ? []
+      : [
+          {
+            kind: 'warn',
+            message: `${scope.workspaceName}: no dist/ (private, not published — not blocking)`,
+          },
+        ];
+  }
+
+  const hasDistExport = Boolean(
+    pkg.main?.includes('dist') || (pkg.exports && JSON.stringify(pkg.exports).includes('dist')),
+  );
+
+  if (!hasDistExport && !pkg.bin) {
+    // App or internal package with no dist-based exports — warn but don't error
+    return hasDist
+      ? []
+      : [
+          {
+            kind: 'warn',
+            message: `${scope.workspaceName}: no dist/ (app/internal, not blocking)`,
+          },
+        ];
+  }
+
+  if (!hasDist) {
+    return [
+      {
+        kind: 'error',
+        message: `${scope.workspaceName} (${scope.relativeDir}): dist/ is missing or empty — run pnpm build first`,
+      },
+    ];
+  }
+  return [{ kind: 'ok', message: `${scope.workspaceName}: dist/ present` }];
+}
+
+/**
+ * Finding collector: classifies each buildable scope's dist state.
+ *
+ * Returns ordered results (`{ kind: 'ok' | 'warn' | 'error' | 'stale', message }`), the buildable
+ * count, and a `freshness` tally so the CLI can report what it MEASURED alongside what it found.
  */
 export async function collectDistFreshnessResults(root, scopes) {
   const buildable = scopes.filter((s) => s.scripts.build);
   const results = [];
+  const freshness = { measured: 0, fresh: 0, stale: 0, unmeasurable: 0 };
 
   for (const scope of buildable) {
-    const distPath = join(root, scope.relativeDir, 'dist');
-    const pkg = await readJson(join(root, scope.relativeDir, 'package.json'));
+    const scopeDir = join(root, scope.relativeDir);
+    const distWalk = walkTree(join(scopeDir, 'dist'));
+    const pkg = await readJson(join(scopeDir, 'package.json'));
 
-    // Private packages are never published, so their dist freshness is a dev concern, not a
-    // release/publish gate. This is what "apps that don't publish" below intends — but a private
-    // package can still carry dist-based `exports`/`main` (e.g. a private server app), so key the
-    // skip on `private`, not just the absence of dist exports.
-    if (pkg.private === true) {
-      if (!isNonEmptyDir(distPath)) {
-        results.push({
-          kind: 'warn',
-          message: `${scope.workspaceName}: no dist/ (private, not published — not blocking)`,
-        });
-      }
+    results.push(...presenceResults(scope, pkg, distWalk.fileCount > 0));
+
+    const srcWalk = walkTree(join(scopeDir, 'src'), isEmittedSourceFile);
+    const verdict = freshnessVerdict(srcWalk.newest, distWalk.newest);
+    if (verdict.state === 'unmeasurable') {
+      freshness.unmeasurable++;
       continue;
     }
-
-    // Skip packages with no exports pointing to dist (e.g. apps that don't publish)
-    const hasDistExport =
-      pkg.main?.includes('dist') || pkg.exports
-        ? JSON.stringify(pkg.exports ?? {}).includes('dist')
-        : false;
-
-    if (!hasDistExport && !pkg.bin) {
-      // App or internal package with no dist-based exports — warn but don't error
-      if (!isNonEmptyDir(distPath)) {
-        results.push({
-          kind: 'warn',
-          message: `${scope.workspaceName}: no dist/ (app/internal, not blocking)`,
-        });
-      }
+    freshness.measured++;
+    if (verdict.state === 'fresh') {
+      freshness.fresh++;
       continue;
     }
-
-    if (!isNonEmptyDir(distPath)) {
-      results.push({
-        kind: 'error',
-        message: `${scope.workspaceName} (${scope.relativeDir}): dist/ is missing or empty — run pnpm build first`,
-      });
-    } else {
-      results.push({ kind: 'ok', message: `${scope.workspaceName}: dist/ present` });
-    }
+    freshness.stale++;
+    results.push({
+      kind: 'stale',
+      message:
+        `${scope.workspaceName}: dist/ may be STALE — src/${verdict.srcNewest.path} is ` +
+        `${formatLag(verdict.lagMs)} newer than the newest artefact dist/${verdict.distNewest.path}. ` +
+        'Cross-package `pnpm typecheck` resolves this package to dist/*.d.ts, so a consumer is being ' +
+        'compared against an OLD type surface — it can report a phantom error on correct code, and it ' +
+        'can hide a real one. Run `pnpm build` before trusting a typecheck verdict. ADVISORY: mtime ' +
+        'is evidence, not proof (see header).',
+    });
   }
 
-  return { results, buildableCount: buildable.length };
+  return { results, buildableCount: buildable.length, freshness };
 }
 
 export async function main() {
   const scopes = await listWorkspaceScopes();
-  const { results, buildableCount } = await collectDistFreshnessResults(ROOT, scopes);
+  const { results, buildableCount, freshness } = await collectDistFreshnessResults(ROOT, scopes);
 
   let errors = 0;
   let warnings = 0;
+  // Packages whose dist presence was actually ASSERTED — i.e. that produced an `ok` or `error`.
+  // A private or non-dist-exporting package that HAS a dist produces no presence result at all, so
+  // the old banner's "All 86 buildable packages have dist/" was a universal claim over 43 of them
+  // (measured 2026-07-26). Same shape as HARNESS-052's G1; corrected rather than left standing.
+  const presenceAsserted = results.filter((r) => r.kind === 'ok' || r.kind === 'error').length;
   for (const result of results) {
     if (result.kind === 'error') {
       console.error(`\x1b[31m❌ ${result.message}\x1b[0m`);
       errors++;
+    } else if (result.kind === 'stale') {
+      console.warn(`\x1b[33m🕒 ${result.message}\x1b[0m`);
     } else if (result.kind === 'warn') {
       console.warn(`\x1b[33m⚠️  ${result.message}\x1b[0m`);
       warnings++;
@@ -116,6 +293,21 @@ export async function main() {
   }
 
   console.log('');
+  // Reported unconditionally, pass or fail: "ran and measured nothing" must not render the same as
+  // "ran and found nothing" (HARNESS-052).
+  console.log(
+    `freshness: ${freshness.stale} stale / ${freshness.measured} compared ` +
+      `(${freshness.unmeasurable} not comparable: no src/ or no dist/). ADVISORY — never blocking.`,
+  );
+  if (freshness.stale > 0) {
+    console.warn(
+      `\x1b[33m${freshness.stale} package(s) have a dist/ older than their src/. ` +
+        'A cross-package type error seen only in a whole-workspace typecheck should be re-checked ' +
+        'after `pnpm build` (or `pnpm harness:verify-like-ci`, which rebuilds) before it is treated ' +
+        'as a branch defect.\x1b[0m',
+    );
+  }
+
   if (errors > 0) {
     console.error(
       `\x1b[31m${errors} package(s) have missing dist/. Run \`pnpm build\` before pushing.\x1b[0m`,
@@ -123,7 +315,9 @@ export async function main() {
     process.exit(1);
   } else {
     console.log(
-      `\x1b[32mAll ${buildableCount} buildable packages have dist/. ${warnings > 0 ? `(${warnings} app/internal warnings)` : ''}\x1b[0m`,
+      `\x1b[32mdist/ present on all ${presenceAsserted} package(s) required to have one ` +
+        `(of ${buildableCount} buildable; the rest are private or export no dist). ` +
+        `${warnings > 0 ? `(${warnings} app/internal warnings)` : ''}\x1b[0m`,
     );
   }
 }

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -307,6 +307,19 @@ export const PENDING_CLASSIFICATION = [
     measured: 'vacuous',
   },
   {
+    // RE-MEASURED 2026-07-26 after HARNESS-053 replaced this scan's presence-only body with a real
+    // freshness comparison: still `fail-closed`, but INCIDENTALLY, so it stays here rather than
+    // being promoted. `finder(bare)` supplies one argument, `scopes` is undefined, and
+    // `scopes.filter` throws — a missing-argument crash, not a check on a governed tree. This
+    // finder has no tree of its own to be absent: its subject is the package set the CALLER
+    // enumerates. Pinning it in MANDATORY_TREE_GUARDS would certify a property it does not hold.
+    //
+    // The gap that reasoning leaves was measured separately rather than left implied, and it was
+    // real: the CLI's `main()` — which DOES enumerate, via `listWorkspaceScopes()` — printed
+    // "dist/ present on all 0 package(s)" and exited 0 for a `pnpm-workspace.yaml` resolving to
+    // zero packages. That pass-over-nothing is this scan's own subject, and it is now an exit 1
+    // pinned by a test in `__tests__/scan-dist-freshness.test.mjs`. A root with no manifest at all
+    // already threw out of `listWorkspaceScopes`.
     file: 'scan-dist-freshness.mjs',
     finder: 'collectDistFreshnessResults',
     measured: 'fail-closed',

--- a/scripts/harness/schemas/harness-report.schema.json
+++ b/scripts/harness/schemas/harness-report.schema.json
@@ -54,12 +54,12 @@
     },
     "VerifyReport": {
       "type": "object",
-      "required": ["type", "timestamp", "passed", "scopes"],
+      "description": "Written only on a fully successful run — every check failure throws before the report is produced, so there is no `passed` field to vary (HARNESS-051).",
+      "required": ["type", "timestamp", "scopes"],
       "additionalProperties": false,
       "properties": {
         "type": { "const": "verify" },
         "timestamp": { "type": "string", "format": "date-time" },
-        "passed": { "type": "boolean" },
         "scopes": {
           "type": "array",
           "items": { "$ref": "#/$defs/VerifyScopeResult" }

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -123,7 +123,6 @@ async function main() {
   }
 
   const summary = [];
-  let allPassed = true;
 
   for (const planScope of plan.scopes) {
     const scope = scopes.find((candidate) => candidate.relativeDir === planScope.scope);
@@ -168,7 +167,6 @@ async function main() {
         stepResults.test = 'pass';
       } catch (error) {
         stepResults.test = 'fail';
-        allPassed = false;
         throw error;
       }
     }
@@ -179,7 +177,6 @@ async function main() {
         stepResults.lint = 'pass';
       } catch (error) {
         stepResults.lint = 'fail';
-        allPassed = false;
         throw error;
       }
     }
@@ -199,7 +196,6 @@ async function main() {
         stepResults.typecheck = 'pass';
       } catch (error) {
         stepResults.typecheck = 'fail';
-        allPassed = false;
         throw error;
       }
     }
@@ -263,7 +259,6 @@ async function main() {
 
           if (execution.status !== 0) {
             stepResults.scenarios = 'fail';
-            allPassed = false;
             throw new Error(`Command failed: ${execution.rendered}`);
           }
 
@@ -297,7 +292,6 @@ async function main() {
             );
             if (differences.length > 0) {
               stepResults.scenarios = 'fail';
-              allPassed = false;
               throw new Error(
                 `Scenario record drift detected for ${scope.relativeDir} at ${relativePathFromRoot(artifactEntry.artifactPath)}: ${differences.join('; ')}. ` +
                   `Run \`pnpm harness:record -- --scope ${scope.relativeDir}\` if the change is intentional.`,
@@ -353,6 +347,11 @@ async function main() {
 
   if (options.reportFile) {
     const format = inferReportFormat(options.reportFile, options.reportFormat);
+    // No `passed` field (HARNESS-051): every check failure throws, so this report is written only
+    // on a fully successful run and its existence IS the outcome. The field it replaced could only
+    // ever be written `true`, which reads like a signal and becomes a fail-open the moment a
+    // consumer trusts it. If a report is ever wanted for failed runs, write it from the failure
+    // path first, then add a field that can actually vary.
     const reportPayload = {
       type: 'verify',
       timestamp: new Date().toISOString(),
@@ -365,7 +364,6 @@ async function main() {
         scenarios: item.scenarios,
         notes: item.notes,
       })),
-      passed: allPassed,
     };
 
     const targetPath = path.resolve(WORKSPACE_ROOT, options.reportFile);


### PR DESCRIPTION
Built by `scripts/harness/promote.mjs` — A1/A2/A3 ancestry gates hold, merge is clean, develop's tree promoted unchanged.

## What lands

**The review job stops running out of turns** (#1495). `max_turns` bounds the agent's exchanges inside one run — not retries. Measured over the 40 most recent runs: **7 failed (17.5%), all `error_max_turns` at exactly `num_turns: 26`**, while successful runs used 10–22 (median ~16). The cap sat three turns above the observed maximum, and an exhausted run often posted **nothing**.

Two defects, neither fixed by a bigger number alone: the prompt ordered the summary **last** while declaring a missing summary the worst outcome, and its budget rule ("stop when fewer than 5 turns remain") was **unobservable** — the action never reports turns used. The summary now goes first, the rule counts the agent's own inline comments, and the cap is 45. This PR's own review ran `success` in **5 turns**.

**HARNESS-053 — dist freshness is now visible and honest** (#1491). `run-all-scans` discarded passing scans' output, so a detected stale dist reached nobody: `touch packages/agent-core/src/index.ts && pnpm harness:scan | grep -i stale` printed nothing. A third output channel surfaces advisories without touching any verdict. The rule was then narrowed to what the root build actually rebuilds — three workspaces reported stale by 167–383h straight after a clean `pnpm build`, and no amount of running the recommended command would have cleared them.

**HARNESS-051 — the boundary gate no longer accepts a mention for a wiring** (#1492). Across review rounds it stopped counting type-only imports and type-only re-exports (erased at compile time, wire nothing), commented-out imports, and imports written inside string literals. The comment stripper was also rebuilt as a single left-to-right scan after the two-pass version was measured deleting real code.

## Note

Every one of the defects above was found by the review job — the same job this promotion also repairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z