### PR TITLE
docs(backlog): reconcile status against what actually landed

### DIFF
--- a/.agents/backlog/HARNESS-052-vacuous-green-sweep.md
+++ b/.agents/backlog/HARNESS-052-vacuous-green-sweep.md
@@ -394,9 +394,12 @@ in `## Test Plan`.
 - [ ] The 30 vacuous finders in `PENDING_CLASSIFICATION` fail closed (re-measured every run).
 - [ ] `check-design-doc-completeness`' subject is decided — required somewhere, or declared optional.
 - [ ] The six depth-1 `packages/` walkers adopt `workspace-packages.mjs`.
-- [x] `run-all-scans` distinguishes "ran and found nothing" from "ran and measured nothing" — the
-      advisory channel landed in HARNESS-053 (#1491); a scan may mark a line and have it surfaced on
-      exit 0. The remaining half — a SKIPPED scan still renders as `✓` — is filed as `HARNESS-056`.
+- [x] `run-all-scans` has a third output channel: a scan may mark a line and have it surfaced even
+      on exit 0, so a finding made by a passing scan is no longer discarded. Landed in HARNESS-053
+      (#1491).
+- [ ] `run-all-scans` distinguishes "ran and found nothing" from "ran and measured nothing" — the
+      channel above exists, but nothing routes a SKIP through it: a scan that examined no subject
+      still renders `✓` and still counts toward `all N scans passed`. Owned by `HARNESS-056`.
 - [ ] `review-gate.yml` subscribes to `edited`; R7 is extended to `develop`'s required contexts.
 - [ ] `changes` is a required context, or the three jobs it gates stop depending on it.
 - [ ] `.claude/hooks/check-forbidden-patterns.sh` resolves worktree paths.

--- a/.agents/backlog/HARNESS-052-vacuous-green-sweep.md
+++ b/.agents/backlog/HARNESS-052-vacuous-green-sweep.md
@@ -394,7 +394,9 @@ in `## Test Plan`.
 - [ ] The 30 vacuous finders in `PENDING_CLASSIFICATION` fail closed (re-measured every run).
 - [ ] `check-design-doc-completeness`' subject is decided — required somewhere, or declared optional.
 - [ ] The six depth-1 `packages/` walkers adopt `workspace-packages.mjs`.
-- [ ] `run-all-scans` distinguishes "ran and found nothing" from "ran and measured nothing".
+- [x] `run-all-scans` distinguishes "ran and found nothing" from "ran and measured nothing" — the
+      advisory channel landed in HARNESS-053 (#1491); a scan may mark a line and have it surfaced on
+      exit 0. The remaining half — a SKIPPED scan still renders as `✓` — is filed as `HARNESS-056`.
 - [ ] `review-gate.yml` subscribes to `edited`; R7 is extended to `develop`'s required contexts.
 - [ ] `changes` is a required context, or the three jobs it gates stop depending on it.
 - [ ] `.claude/hooks/check-forbidden-patterns.sh` resolves worktree paths.

--- a/.agents/backlog/HARNESS-055-action-references-resolve-through-a-moving-pointer.md
+++ b/.agents/backlog/HARNESS-055-action-references-resolve-through-a-moving-pointer.md
@@ -1,0 +1,57 @@
+---
+id: HARNESS-055
+title: 'HARNESS-055: two workflow action references resolve through a branch head, not a tag'
+status: todo
+priority: low
+urgency: later
+type: INFRA
+area: .github/workflows
+created: 2026-07-27
+depends_on: [INFRA-059]
+---
+
+## Problem
+
+`scan-action-references --live` (INFRA-059) resolves every workflow `uses:` reference against the
+remote. Two of them resolve through a **branch head** rather than a tag:
+
+```
+note: 2 reference(s) resolve through a branch head, not a tag — a moving pointer that still
+resolves (HARNESS-055).
+```
+
+A branch head resolves today and points somewhere else tomorrow, with no change to this repository
+and no signal that anything moved. That is weaker than the tag references beside it, which at least
+move only when someone republishes the tag.
+
+INFRA-059 reports this as a **note, not a failure**, deliberately. The reference does resolve, the
+workflow does run, and failing on it would fire on correct configuration — a guard that flags
+working setups gets suppressed, and a suppressed guard costs more than what it catches.
+
+## Why it is filed rather than fixed
+
+Pinning is not free and the right target is not obvious from inside the scan:
+
+- Pinning to a tag keeps the reference readable but still moves when the tag is republished.
+- Pinning to a commit SHA is the only genuinely immovable form, and it makes every upgrade a manual
+  edit — which in practice means the pin rots and the action never gets updated.
+
+Which of those is right depends on how much the repository trusts each publisher, and that is a
+judgement, not a rule the scan can derive.
+
+## Proposed direction
+
+Decide per reference, and record the decision where the reference lives:
+
+- For actions published by an owner this repository already trusts with a token, a tag is enough —
+  say so in a comment beside the `uses:` line so the note stops reading as an unresolved question.
+- For anything else, pin to a SHA and pair it with whatever keeps pins current (Dependabot already
+  updates SHA-pinned actions).
+
+## Done when
+
+- Both branch-head references are either pinned or carry a stated reason for staying as they are.
+- `scan-action-references --live` emits no unexplained branch-head note — either because none
+  remain, or because the remaining ones are declared.
+- The declaration carries anti-rot: a declared exception whose reference no longer exists fails, so
+  the list cannot outlive what it excuses.

--- a/.agents/backlog/HARNESS-056-a-scan-that-skipped-renders-as-a-tick.md
+++ b/.agents/backlog/HARNESS-056-a-scan-that-skipped-renders-as-a-tick.md
@@ -1,0 +1,56 @@
+---
+id: HARNESS-056
+title: 'HARNESS-056: a scan that skipped renders as ✓, so the suite total overstates what ran'
+status: todo
+priority: medium
+urgency: soon
+type: INFRA
+area: scripts/harness
+created: 2026-07-27
+depends_on: [HARNESS-052]
+---
+
+## Problem
+
+INFRA-060's audit recorded this as **D6** and marked it FILED. Nothing was filed — this item is that
+filing, written after the audit's follow-ups were reconciled and D6 turned out to have no target.
+
+`run-all-scans` decides a scan's mark from its exit code. A scan that ran nothing and exited 0
+because it had no subject is indistinguishable from one that examined its whole subject and found it
+clean: both print `✓`, and both are counted in `all N scans passed`.
+
+Measured on this host: `scan-progress-report-quantification` prints
+
+```
+progress-report quantification scan skipped: no session transcript for this workspace …
+```
+
+and exits 0, so the suite shows `✓ progress-report-quantification` and counts it toward the total.
+On a CI runner that is EVERY run — the scan has no subject there and can never fail. The output is
+honest; the summary line above it is not.
+
+`"all 80 scans passed"` is therefore weaker than it reads, and it is the line people actually read.
+
+## What changed since the audit, and what did not
+
+HARNESS-053 (#1491) gave the runner a third output channel: a scan may mark a line
+`::advisory::` and it is surfaced even on exit 0, without touching the verdict. That is the
+mechanism this needs — a skip is exactly an advisory — but no scan uses it to declare a skip, and
+the `✓` mark and the count are unchanged. The channel exists; the skip is not routed through it.
+
+## Proposed direction
+
+- A scan that skipped says so through the advisory channel, and the runner renders it distinctly
+  (`↩` rather than `✓`).
+- The summary counts what RAN, and states skips separately: `78 passed, 2 skipped` rather than
+  `all 80 scans passed`.
+- Deliberately NOT a failure. Skipping is legitimate — a transcript-reading scan has nothing to read
+  in CI, and failing there would fire on correct configuration on every run, which is how a guard
+  gets disabled. The defect is the misreporting, not the skip.
+
+## Done when
+
+- A skipped scan is visually distinct from a passing one in `pnpm harness:scan` output.
+- The suite summary separates ran from skipped, proven by a run containing at least one of each.
+- A scan that exits 0 having examined nothing cannot report `✓` — proven RED by executing one
+  against an empty subject, not by reading the runner.

--- a/.agents/backlog/INFRA-064-windows-runner-reruns-a-pure-function.md
+++ b/.agents/backlog/INFRA-064-windows-runner-reruns-a-pure-function.md
@@ -1,0 +1,52 @@
+---
+id: INFRA-064
+title: 'INFRA-064: the windows-shell job pays for the most expensive runner to re-run a pure function'
+status: todo
+priority: low
+urgency: later
+type: INFRA
+area: .github/workflows
+created: 2026-07-27
+depends_on: [INFRA-060]
+---
+
+## Problem
+
+INFRA-060's audit recorded this as **D2** and marked it FILED. Nothing was filed — this item is that
+filing, written when the audit's follow-ups were reconciled and D2 turned out to have no target.
+
+`windows-shell` step 1 runs `packages/agent-core/src/utils/platform-shell.test.ts` on
+`windows-latest`. That test is a pure function test: `resolvePlatformShell(env, platform)` takes the
+platform as an ARGUMENT. It never reads `process.platform` and spawns nothing, so its verdict on
+Windows is identical to its verdict on Linux — proven by running it on Linux (8 passed).
+
+The job's stated reason — "these tests exercise the win32 path that the macOS/Linux jobs cannot" —
+is false for this half. It buys the matrix's most expensive runner to re-run something `quality`
+already covers.
+
+Step 2 (`agent-tools`) **does** spawn a real shell and is genuinely win32-only. It stays.
+
+## Why it was not changed in the audit
+
+`windows-shell` is a required check. Removing a step from it changes what gates a merge, which is
+the owner's call rather than an auditor's — the same reason the audit filed rather than executed
+several of its findings.
+
+## Proposed direction
+
+Drop step 1 and keep step 2, so the Windows runner is paid for only where the platform is actually
+the variable under test. State in the job that step 2 is the win32-specific half, so the next reader
+does not re-add a platform-independent test on the assumption that everything here needs Windows.
+
+Worth checking while there: whether any OTHER matrix step is platform-independent in the same way.
+One instance found by reading is unlikely to be the only one, and the cheap check is the same —
+does the test take the platform as an argument, or read it from the process?
+
+## Done when
+
+- The Windows job runs only tests whose behaviour actually depends on running on Windows, with each
+  remaining step's platform-dependence stated.
+- The saved runner time is measured and recorded, so the change is justified by a number rather than
+  by the argument above.
+- No coverage is lost: the removed test still runs somewhere on every PR, proven by pointing at the
+  job that runs it.

--- a/.agents/backlog/completed/HARNESS-051-dead-code-satisfies-architecture-gate.md
+++ b/.agents/backlog/completed/HARNESS-051-dead-code-satisfies-architecture-gate.md
@@ -1,9 +1,10 @@
 ---
 id: HARNESS-051
 title: An architecture gate is satisfied vacuously by dead code, and the linter was blind to the code that hid it
-status: in-progress
+status: done
 priority: medium
 type: INFRA
+completed: 2026-07-27
 created: 2026-07-26
 ---
 
@@ -101,3 +102,7 @@ elsewhere. Fix it or remove it — a value that cannot vary should not be report
 
 - `.agents/backlog/SEC-005-codeql-dead-code-backlog.md`
 - `scripts/harness/verify-change.mjs`, the `agent-server-boundary` and `orphan-exports` scans
+
+## Closed 2026-07-27
+
+Landed as PR #1492. Across review rounds the gate stopped accepting a MENTION for a wiring: type-only imports and type-only re-exports (erased at compile time), commented-out imports, and imports written inside string literals all classify unwired. The comment stripper was rebuilt as a single left-to-right scan after the two-pass version was measured deleting real code.

--- a/.agents/backlog/completed/HARNESS-053-stale-dist-phantom-red.md
+++ b/.agents/backlog/completed/HARNESS-053-stale-dist-phantom-red.md
@@ -1,11 +1,12 @@
 ---
 id: HARNESS-053
 title: 'HARNESS-053: a stale dist makes `pnpm typecheck` report a phantom breakage of a healthy branch'
-status: in-progress
+status: done
 priority: medium
 urgency: soon
 type: INFRA
 area: scripts/harness
+completed: 2026-07-27
 created: 2026-07-26
 depends_on: [HARNESS-052]
 ---
@@ -271,3 +272,7 @@ Stated plainly rather than quietly dropped:
       (needs build-pipeline ownership).
 - [ ] `pnpm typecheck` fails fast with the staleness explanation (needs root `package.json`).
 - [ ] The diagnostic is routed into the rules/skills tree (needs `.agents/rules|skills` ownership).
+
+## Closed 2026-07-27
+
+Landed as PR #1491. The freshness comparison is real (proven by hiding and phantom directions), and — the part that made it useful — `run-all-scans` gained an advisory channel so the finding reaches `pnpm harness:scan` instead of being discarded with every other passing scan's output. The rule was then narrowed to what the root build actually rebuilds, after three workspaces reported stale by 167-383h immediately after a clean `pnpm build`.

--- a/.agents/backlog/completed/INFRA-060-ci-yml-job-by-job-audit.md
+++ b/.agents/backlog/completed/INFRA-060-ci-yml-job-by-job-audit.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-060: ci.yml job-by-job audit — three fail-open paths closed, four fidelity gaps filed'
-status: in-progress
+status: done
+completed: 2026-07-27
 created: 2026-07-26
 priority: high
 urgency: now
@@ -486,3 +487,21 @@ This audit is not, and cannot be, complete. What no pattern can reach:
 
 Not applicable — CI workflow and harness-guard changes deliver no runnable user-facing surface. The
 enforcement evidence is the red/green proofs recorded above and the checks on this item's own PR.
+
+## Closed 2026-07-27 — every finding now has a real disposition
+
+The audit's ten findings were reconciled against the tree. Three of them said **FILED** with no
+target, which is the same defect the audit itself catalogues: a claim that reads as closed and
+closes nothing. Those are now real files.
+
+|                | Disposition                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------------- |
+| D1, D3, D4, D5 | FIXED and merged                                                                            |
+| D2             | filed as `INFRA-064` (was FILED with no target)                                             |
+| D6             | filed as `HARNESS-056` (was FILED with no target)                                           |
+| D7             | filed as `INFRA-063` — PR open                                                              |
+| D8             | already FIXED — `check-patch-coverage --detect` carries `FAIL-CLOSED (HARNESS-052)` in code |
+| D9             | FIXED — `scan-workflow-permissions` merged (#1481)                                          |
+| D10            | resolved by `INFRA-062`, now closed                                                         |
+
+Nothing from this audit is left holding an obligation of its own.

--- a/.agents/backlog/completed/INFRA-062-parity-guard-deadlock-retirement.md
+++ b/.agents/backlog/completed/INFRA-062-parity-guard-deadlock-retirement.md
@@ -1,9 +1,10 @@
 ---
 id: INFRA-062
 title: Two sound guards jointly made claude-code-review.yml unmodifiable — remove the condition, not the guard's teeth
-status: in-progress
+status: done
 priority: high
 type: INFRA
+completed: 2026-07-27
 created: 2026-07-26
 ---
 
@@ -195,3 +196,7 @@ The `MANDATORY_TREE_GUARDS` classification in `scan-guard-scope-fail-closed.mjs`
   INFRA-053 (the turn-budget/denial fix this unblocks), PRs #1472, #1473
 - `.github/workflows/claude-code-review.yml`, `scripts/harness/scan-review-token-supply.mjs`,
   `scripts/harness/__tests__/scan-review-token-supply.test.mjs`
+
+## Closed 2026-07-27
+
+All four acceptance criteria met and checked in the document. The parity deadlock is gone: the review workflow is modifiable, `scan-review-token-supply` replaces the retired parity scan, and no admin bypass was used anywhere.

--- a/.agents/backlog/completed/PERF-005-remove-legacy-typescript.md
+++ b/.agents/backlog/completed/PERF-005-remove-legacy-typescript.md
@@ -1,9 +1,10 @@
 ---
 id: PERF-005
 title: Remove the legacy TypeScript compiler — eliminate every avoidable use, then gate on upstream
-status: in-progress
+status: done
 priority: medium
 type: INFRA
+completed: 2026-07-27
 created: 2026-07-26
 depends_on: [PERF-004]
 ---
@@ -294,3 +295,7 @@ needed, so it is fixed rather than reported.
 Removing `typescript` from `package.json` remains gated on `@typescript-eslint` dropping its runtime
 import (peer `>=4.8.4 <6.1.0`). Re-check that range to know when it is possible. Phase 2 must also
 absorb the 96 baselined manifest declarations catalogued above.
+
+## Closed 2026-07-27
+
+Phase 1 complete — no first-party code imports the legacy compiler and a mechanical guard keeps it that way. Phase 2 is stated in the document as gated on upstream and explicitly not scheduled here, so it is not an open obligation of this item.


### PR DESCRIPTION
## Closed — the work landed and the status did not follow

| Item | Evidence |
| --- | --- |
| `HARNESS-051` | merged as #1492 |
| `HARNESS-053` | merged as #1491 |
| `INFRA-062` | all four acceptance criteria checked in the document |
| `PERF-005` | phase 1 done; phase 2 is stated there as upstream-gated and out of scope |
| `INFRA-060` | closed with a per-finding disposition table |

## Filed — three claims of "FILED" had no target

Reconciling `INFRA-060` surfaced the defect that audit was itself cataloguing: findings marked **FILED** where nothing had been filed. A claim that reads as closed and closes nothing.

| New | Was |
| --- | --- |
| `INFRA-064` | D2 — the Windows runner pays to re-run a pure function |
| `HARNESS-056` | D6 — a skipped scan renders as `✓`, so `all N scans passed` overstates what ran |
| `HARNESS-055` | the branch-head action references `scan-action-references` notes |

`HARNESS-055` is mine: I wrote "filed as HARNESS-055" into a scan's own output and a PR body before the file existed. D8 turned out already fixed — `check-patch-coverage --detect` carries `FAIL-CLOSED (HARNESS-052)` in code.

## Still open, deliberately

`HARNESS-052` gains one checked box (the advisory channel from #1491), with its unfinished half pointed at `HARNESS-056` rather than buried inside a checked item. 13 remain.

`INFRA-061` stays open because it **holds** six owner decisions — among them 35 open HIGH CodeQL alerts and an unchecksummed `osv-scanner` download executed twice in `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z