### PR TITLE
test(agent-core): widen the idle-timeout refresh test's real-timer margin

### DIFF
--- a/packages/agent-core/src/services/execution-service.test.ts
+++ b/packages/agent-core/src/services/execution-service.test.ts
@@ -933,13 +933,20 @@ describe('ExecutionService', () => {
       expect(result.response).toContain('Request failed: Provider call idle timeout after 10ms');
     });
 
+    // Timings are in milliseconds and are raced against REAL timers, so the margin between a delta
+    // and the deadline it refreshes is the whole test. The original spacing — deltas at 10ms and
+    // 25ms against a 30ms idle timeout, resolving at 40ms — left 15ms of slack, and a loaded CI
+    // runner ate it: this failed in `release-grade verification` with `expected false to be true`
+    // while passing locally every time. The ratios below are identical and every interval is 10x
+    // longer, so the same behaviour is exercised with 150ms of slack instead of 15ms. The test
+    // still finishes in well under a second.
     it('should refresh provider idle timeout when streaming deltas arrive', async () => {
       const streamed = 'still working';
       mockProvider.chat = vi.fn(
         (_messages: TUniversalMessage[], options?: IChatOptions) =>
           new Promise<TUniversalMessage>((resolve) => {
-            setTimeout(() => options?.onTextDelta?.('still '), 10);
-            setTimeout(() => options?.onTextDelta?.('working'), 25);
+            setTimeout(() => options?.onTextDelta?.('still '), 100);
+            setTimeout(() => options?.onTextDelta?.('working'), 250);
             setTimeout(() => {
               resolve({
                 id: 'msg-streaming',
@@ -948,7 +955,7 @@ describe('ExecutionService', () => {
                 state: 'complete' as const,
                 timestamp: new Date(),
               });
-            }, 40);
+            }, 400);
           }),
       );
 
@@ -963,7 +970,7 @@ describe('ExecutionService', () => {
             model: 'gpt-4',
           },
           systemMessage: 'You are a helpful assistant.',
-          timeout: 30,
+          timeout: 300,
         },
         {
           conversationId: 'provider-timeout-refresh-test',


### PR DESCRIPTION
`release-grade verification` failed on the promotion PR (#1500) with `expected false to be true` at `execution-service.test.ts:973` — `result.success`.

## The margin

The test races **real** timers: deltas at 10ms and 25ms refresh a 30ms idle timeout so a resolve at 40ms succeeds. The gap between the last delta and the deadline it has to beat is **15ms**.

Every interval is now 10x longer with identical ratios — 100ms / 250ms / 400ms against a 300ms timeout — so the same behaviour is exercised with 150ms of margin. The test still finishes in well under a second.

## Not reproduced locally, and not claimed as such

The original timings passed **4/4 here with 14 cores held busy**. This is a 20-core workstation; the runner is not. So the evidence is:

- the CI failure at that exact assertion,
- a green local run every time, including under load,
- a 15ms real-time margin.

Strong, but circumstantial. If it recurs after this, timer drift was not the cause — and this change will have ruled that out rather than hidden it.

## The better fix, and why not now

Fake timers. That is a larger change to how this suite drives the provider promise, and widening the margin does not stand in its way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z