### PR TITLE
fix(dag-nodes): SEC-007 contain the tool node — the third Glob/Grep registration site

### DIFF
--- a/packages/dag-nodes/tool/docs/SPEC.md
+++ b/packages/dag-nodes/tool/docs/SPEC.md
@@ -16,7 +16,13 @@
 
 - `ToolNodeDefinition` — node with an optional `params` input port (JSON string) and `output` + `isError` output ports.
 - `config.toolName` selects the builtin. `config.params` supplies static tool arguments; the `params` input port (parsed as JSON) is merged over them (input wins).
-- File/shell builtins (`read`/`write`/`edit`/`shell`/`bash`) receive `config.cwd` as a path restriction (`ISandboxToolOptions.cwd`); pure builtins (`glob`/`grep`/`web-fetch`/`web-search`) ignore it.
+- **Containment (SEC-007).** Every builtin is constructed per invocation and bound to a containment root; none is taken from `agent-tools`' module-level singletons, which are documented as uncontained because a singleton is context-free by construction.
+  - The root is the directory the run was invoked from — the same anchor the `file-read`/`file-write` nodes use, since `INodeExecutionContext` carries no workspace root.
+  - `config.cwd` may only **narrow** that root. A `cwd` resolving outside the invocation directory — including via `..` or an escaping symlink — fails the node with `DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT`. It cannot widen the root, because it arrives in the same LLM-authorable `.dag.json` as the paths it would be containing.
+  - Containment is decided on **canonical** (symlink-resolved) paths through `@robota-sdk/agent-core`'s `isPathInside` SSOT.
+  - For `read`/`write`/`edit`/`glob`/`grep` the root is a **boundary**: an out-of-root path or search root is refused, and no entry whose canonical path escapes is enumerated or disclosed.
+  - For `shell`/`bash` the root is the **default working directory and deliberately not a boundary** — a cwd guard on arbitrary command execution is undone by the first `cd ..`, so it would constrain nothing while reading as a boundary in review. The boundary for command execution is the permission layer and the sandbox seam.
+  - `web-fetch`/`web-search` have no filesystem path and ignore the root.
 - Result mapping:
   - The builtin throws (`ValidationError` / `ToolExecutionError`) → node returns `ok: false` with `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
   - The builtin returns a JSON-encoded `IToolInvocationResult` with `success: false` (a soft, tool-reported failure — e.g. binary file) → node returns `ok: true` with `output` = the error text and `isError: true`.
@@ -25,11 +31,13 @@
 
 ## Type Ownership
 
-| Type                   | Location       | Purpose                         |
-| ---------------------- | -------------- | ------------------------------- |
-| `ToolNodeDefinition`   | `src/index.ts` | Node definition class           |
-| `ToolNodeConfigSchema` | `src/index.ts` | Zod config schema (exported)    |
-| `TToolNodeConfig`      | `src/index.ts` | Inferred config type (exported) |
+| Type                     | Location                | Purpose                                     |
+| ------------------------ | ----------------------- | ------------------------------------------- |
+| `ToolNodeDefinition`     | `src/index.ts`          | Node definition class                       |
+| `ToolNodeConfigSchema`   | `src/index.ts`          | Zod config schema (exported)                |
+| `TToolNodeConfig`        | `src/index.ts`          | Inferred config type (exported)             |
+| `TOOL_FACTORIES`         | `src/tool-factories.ts` | Builtin allowlist and per-tool construction |
+| `resolveContainmentRoot` | `src/containment.ts`    | Decides the security boundary for the node  |
 
 ## Public API Surface
 
@@ -43,7 +51,7 @@
 
 - Config `toolName`: one of `read`, `write`, `edit`, `shell`, `bash`, `glob`, `grep`, `web-fetch`, `web-search`.
 - Config `params`: static arguments merged under the `params` input.
-- Config `cwd`: path restriction forwarded to file/shell builtins.
+- Config `cwd`: **narrows** the containment root; must resolve inside the invocation directory (see Architecture Overview).
 - Config `baseCredits`: base cost per successful call.
-- Error codes: `DAG_VALIDATION_TOOL_UNKNOWN_TOOL`, `DAG_VALIDATION_TOOL_INVALID_PARAMS`, `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
-- Adding a builtin: extend `TOOL_NODE_ALLOWED_TOOLS` and the `TOOL_FACTORIES` map.
+- Error codes: `DAG_VALIDATION_TOOL_UNKNOWN_TOOL`, `DAG_VALIDATION_TOOL_INVALID_PARAMS`, `DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT`, `DAG_TASK_EXECUTION_TOOL_CALL_FAILED`.
+- Adding a builtin: extend the `TOOL_FACTORIES` map in `src/tool-factories.ts` (`TOOL_NODE_ALLOWED_TOOLS` derives from its keys). A new builtin that touches the filesystem must accept and honour the containment root.

--- a/packages/dag-nodes/tool/src/__tests__/path-containment.test.ts
+++ b/packages/dag-nodes/tool/src/__tests__/path-containment.test.ts
@@ -1,0 +1,221 @@
+/**
+ * SEC-007 part A, the registration site the assembly sweep did not reach.
+ *
+ * Part A contained `Glob`/`Grep` by making the two ASSEMBLIES build their own instances
+ * (`createDefaultTools`, `createCodingPack`) instead of importing the module-level singletons. This
+ * node is the THIRD registration site, and it kept handing back `globTool`/`grepTool` — the very
+ * objects whose doc comment says "UNCONTAINED, deliberately". It is registered in
+ * `dag-nodes-default`, so `{"nodeType":"tool","config":{"toolName":"grep"}}` in any `.dag.json`
+ * reached them.
+ *
+ * The threat model is the one part A already accepted for `file-read`/`file-write` in this same
+ * package family: a `.dag.json` is a shareable, LLM-authorable document. The `tool` node was strictly
+ * worse than the `file-*` nodes it sits beside — `toolName: "read"` with an absolute path bypassed
+ * `file-read`'s containment entirely, because `config.cwd` is optional and `checkPathWithinCwd` is a
+ * NO-OP when `cwd` is `undefined`. The guard was disarmed by omission, which is exactly what
+ * `pack-coding` makes `cwd` REQUIRED to prevent.
+ *
+ * And `config.cwd` could not have been the boundary even when set: it comes out of the same
+ * LLM-authorable document as the path it is supposed to contain, so `{"cwd":"/"}` disarms it. A root
+ * the attacker supplies is not a root. It may therefore only NARROW the invocation directory.
+ *
+ * Real filesystem, real symlinks — the pre-existing `tool-node.test.ts` reads out of `tmpdir()`,
+ * which only passed because nothing was contained.
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  symlinkSync,
+  rmSync,
+  realpathSync,
+  existsSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { globTool, grepTool } from '@robota-sdk/agent-tools';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+
+import { ToolNodeDefinition } from '../index.js';
+
+import type { INodeExecutionContext, TPortPayload } from '@robota-sdk/dag-core';
+
+let root: string;
+let workdir: string;
+let outside: string;
+let originalCwd: string;
+
+function makeContext(config: Record<string, unknown>): INodeExecutionContext {
+  return {
+    nodeDefinition: { nodeId: 'n1', nodeType: 'tool', config, inputs: [], outputs: [] },
+    dagRunId: 'run-1',
+    dagId: 'dag-1',
+  } as unknown as INodeExecutionContext; // allow-any: minimal test stub
+}
+
+beforeAll(() => {
+  originalCwd = process.cwd();
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'sec007-dag-tool-')));
+  workdir = join(root, 'workdir');
+  outside = join(root, 'outside');
+  mkdirSync(join(workdir, 'sub'), { recursive: true });
+  mkdirSync(outside, { recursive: true });
+  writeFileSync(join(outside, 'outside.txt'), 'SECRET-VALUE\n');
+  writeFileSync(join(workdir, 'inside.txt'), 'ordinary\n');
+  writeFileSync(join(workdir, 'sub', 'nested.txt'), 'nested-ordinary\n');
+  // The escape: an ordinary symlink, sitting inside the root, pointing out of it. `escape` is a
+  // perfectly plain path segment — no amount of segment validation would catch it.
+  symlinkSync(outside, join(workdir, 'escape'));
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  process.chdir(workdir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+});
+
+const node = new ToolNodeDefinition();
+
+async function run(
+  config: Record<string, unknown>,
+  input: TPortPayload = {},
+): Promise<{ ok: boolean; output: string; isError: boolean; code: string }> {
+  const result = await node.taskHandler.execute(input, makeContext(config));
+  if (!result.ok) return { ok: false, output: '', isError: true, code: result.error.code };
+  return {
+    ok: true,
+    output: String(result.value['output'] ?? ''),
+    isError: result.value['isError'] === true,
+    code: '',
+  };
+}
+
+describe('CONTROL — the singletons this node handed out really do escape', () => {
+  it('globTool enumerates out-of-root files through the escaping symlink', async () => {
+    const raw = await globTool.execute({ pattern: '**/*.txt' } as Parameters<
+      typeof globTool.execute
+    >[0]);
+    expect(JSON.stringify(raw.data)).toContain('escape/outside.txt');
+  });
+
+  it('grepTool returns the out-of-root file CONTENT through the escaping symlink', async () => {
+    const raw = await grepTool.execute({
+      pattern: 'SECRET-VALUE',
+      outputMode: 'content',
+    } as Parameters<typeof grepTool.execute>[0]);
+    expect(JSON.stringify(raw.data)).toContain('SECRET-VALUE');
+  });
+});
+
+describe('tool node — enumeration is confined to the invocation directory (SEC-007)', () => {
+  it('does not enumerate through a symlinked directory that escapes the root', async () => {
+    const result = await run({ toolName: 'glob', params: { pattern: '**/*.txt' } });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain('inside.txt');
+    expect(result.output).not.toContain('outside.txt');
+  });
+
+  it('refuses an explicit search root outside the invocation directory', async () => {
+    const result = await run({ toolName: 'glob', params: { pattern: '*.txt', path: outside } });
+    expect(result.output).not.toContain('outside.txt');
+  });
+
+  it('does not disclose out-of-root CONTENT via grep', async () => {
+    const result = await run({
+      toolName: 'grep',
+      params: { pattern: 'SECRET-VALUE', outputMode: 'content' },
+    });
+    expect(result.output).not.toContain('SECRET-VALUE');
+  });
+
+  it('still enumerates and searches normally inside the invocation directory', async () => {
+    const globbed = await run({ toolName: 'glob', params: { pattern: '**/*.txt' } });
+    expect(globbed.isError).toBe(false);
+    expect(globbed.output).toContain('inside.txt');
+    expect(globbed.output).toContain('nested.txt');
+
+    const grepped = await run({
+      toolName: 'grep',
+      params: { pattern: 'nested-ordinary', outputMode: 'content' },
+    });
+    expect(grepped.isError).toBe(false);
+    expect(grepped.output).toContain('nested-ordinary');
+  });
+});
+
+describe('tool node — the file builtins are contained too, not just the file-* nodes', () => {
+  it('refuses to READ an absolute path outside the invocation directory', async () => {
+    const result = await run({
+      toolName: 'read',
+      params: { filePath: join(outside, 'outside.txt') },
+    });
+    expect(result.output).not.toContain('SECRET-VALUE');
+    expect(result.isError).toBe(true);
+  });
+
+  it('refuses to READ through an escaping symlinked directory', async () => {
+    const result = await run({ toolName: 'read', params: { filePath: 'escape/outside.txt' } });
+    expect(result.output).not.toContain('SECRET-VALUE');
+    expect(result.isError).toBe(true);
+  });
+
+  it('refuses to WRITE outside the invocation directory, and plants nothing', async () => {
+    const target = join(outside, 'planted.sh');
+    const result = await run({ toolName: 'write', params: { filePath: target, content: 'x' } });
+    expect(result.isError).toBe(true);
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('still reads and writes ordinary files inside the invocation directory', async () => {
+    const written = await run({
+      toolName: 'write',
+      params: { filePath: join(workdir, 'out.txt'), content: 'fine' },
+    });
+    expect(written.isError).toBe(false);
+
+    const read = await run({ toolName: 'read', params: { filePath: join(workdir, 'out.txt') } });
+    expect(read.isError).toBe(false);
+    expect(read.output).toContain('fine');
+  });
+});
+
+describe('tool node — config.cwd may narrow the root, never widen it (SEC-007)', () => {
+  it('refuses a config.cwd that escapes the invocation directory', async () => {
+    const result = await run({
+      toolName: 'glob',
+      cwd: outside,
+      params: { pattern: '*.txt' },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT');
+    expect(result.output).not.toContain('outside.txt');
+  });
+
+  it('refuses a `..` config.cwd', async () => {
+    const result = await run({ toolName: 'glob', cwd: '../outside', params: { pattern: '*.txt' } });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT');
+  });
+
+  it('refuses a config.cwd reached through an escaping symlink', async () => {
+    const result = await run({ toolName: 'glob', cwd: 'escape', params: { pattern: '*.txt' } });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT');
+  });
+
+  it('honours a config.cwd that NARROWS to a subdirectory', async () => {
+    const result = await run({ toolName: 'glob', cwd: 'sub', params: { pattern: '**/*.txt' } });
+    expect(result.ok).toBe(true);
+    expect(result.isError).toBe(false);
+    expect(result.output).toContain('nested.txt');
+    expect(result.output).not.toContain('inside.txt');
+  });
+});

--- a/packages/dag-nodes/tool/src/__tests__/tool-node.test.ts
+++ b/packages/dag-nodes/tool/src/__tests__/tool-node.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -91,14 +91,22 @@ describe('ToolNodeDefinition execution', () => {
   const node = new ToolNodeDefinition();
   let dir: string;
   let file: string;
+  let originalCwd: string;
 
+  // SEC-007: the builtins this node runs are contained to the invocation directory, so these
+  // plumbing cases (params merging, result coercion) exercise a file INSIDE it. They previously read
+  // out of `tmpdir()` while the process ran elsewhere, which only passed because nothing was
+  // contained — the assertion was documenting the hole, not the contract.
   beforeAll(() => {
-    dir = mkdtempSync(join(tmpdir(), 'dag-tool-node-'));
+    originalCwd = process.cwd();
+    dir = realpathSync(mkdtempSync(join(tmpdir(), 'dag-tool-node-')));
     file = join(dir, 'hello.txt');
     writeFileSync(file, 'alpha\nbeta\ngamma\n', 'utf8');
+    process.chdir(dir);
   });
 
   afterAll(() => {
+    process.chdir(originalCwd);
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/dag-nodes/tool/src/containment.ts
+++ b/packages/dag-nodes/tool/src/containment.ts
@@ -1,0 +1,54 @@
+/**
+ * SEC-007 — the containment root every builtin the `tool` node runs is bound to.
+ *
+ * Split out of `index.ts` because deciding a security boundary is a different responsibility from
+ * running a node, and a boundary buried in an executor is a boundary nobody reviews.
+ */
+
+import { resolve } from 'node:path';
+
+import { isPathInside } from '@robota-sdk/agent-core';
+import { buildValidationError, type IDagError, type TResult } from '@robota-sdk/dag-core';
+
+/**
+ * Resolve the root, refusing a `config.cwd` that escapes the directory the run was invoked from.
+ *
+ * The boundary is the invocation directory. That is the same anchor the `file-read` and `file-write`
+ * nodes use, and for the same stated reason: `INodeExecutionContext` carries no workspace root, so
+ * this makes explicit the boundary the node was already implicitly claiming rather than inventing a
+ * new concept. Without it the `tool` node was the way AROUND those two — `toolName: "read"` with an
+ * absolute path did what `file-read` refuses.
+ *
+ * `config.cwd` may only NARROW that root. It comes out of the same LLM-authorable `.dag.json` as the
+ * paths it is nominally containing, so honouring it as the boundary would let `{"cwd":"/"}` disarm
+ * the guard in one line — a root the attacker supplies is not a root.
+ *
+ * Decided canonically through agent-core's shared `isPathInside` SSOT, so a `cwd` reached through an
+ * escaping symlink is refused too. A lexical check passes `escape/…` when `escape -> /`, because
+ * `resolve()` never consults the filesystem; segment validation would not catch it either, since
+ * `escape` is a perfectly plain segment.
+ */
+export function resolveContainmentRoot(
+  configCwd: string | undefined,
+  nodeId: string,
+): TResult<string, IDagError> {
+  const invocationRoot = process.cwd();
+  if (configCwd === undefined) return { ok: true, value: invocationRoot };
+
+  const requested = resolve(invocationRoot, configCwd);
+  if (!isPathInside(invocationRoot, requested)) {
+    return {
+      ok: false,
+      error: buildValidationError(
+        'DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT',
+        `cwd "${configCwd}" resolves outside the working directory`,
+        { nodeId },
+        {
+          action: 'set_config',
+          suggestion: 'Set cwd to a directory inside the directory the run was invoked from',
+        },
+      ),
+    };
+  }
+  return { ok: true, value: requested };
+}

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -1,8 +1,4 @@
 import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
-
-import { resolveContainmentRoot } from './containment.js';
-import { TOOL_FACTORIES, TOOL_NODE_ALLOWED_TOOLS, type FunctionTool } from './tool-factories.js';
-
 import {
   buildTaskExecutionError,
   buildValidationError,
@@ -15,6 +11,9 @@ import {
   type TResult,
 } from '@robota-sdk/dag-core';
 import { z } from 'zod';
+
+import { resolveContainmentRoot } from './containment.js';
+import { TOOL_FACTORIES, TOOL_NODE_ALLOWED_TOOLS, type FunctionTool } from './tool-factories.js';
 
 export { TOOL_NODE_ALLOWED_TOOLS } from './tool-factories.js';
 

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -1,16 +1,16 @@
 import {
   createBashTool,
   createEditTool,
+  createGlobTool,
+  createGrepTool,
   createReadTool,
   createShellTool,
   createWriteTool,
-  globTool,
-  grepTool,
   webFetchTool,
   webSearchTool,
-  type ISandboxToolOptions,
 } from '@robota-sdk/agent-tools';
-import { type ITool } from '@robota-sdk/agent-core';
+import { isPathInside, type ITool } from '@robota-sdk/agent-core';
+import { resolve } from 'node:path';
 import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
 
 /**
@@ -34,20 +34,31 @@ import {
 import { z } from 'zod';
 
 /**
- * A builtin factory receives sandbox/cwd options; pure builtins (glob/grep/web-*)
- * ignore them and return their shared singleton instance.
+ * A builtin factory, always given a containment root (SEC-007).
+ *
+ * `cwd` is REQUIRED here rather than optional, for the reason `pack-coding`'s `ICodingPackOptions`
+ * makes it required: `checkPathWithinCwd` is a NO-OP when `cwd` is `undefined`, so an optional root is
+ * a guard that disarms itself by omission. The two builtins that reach the network (`web-fetch`,
+ * `web-search`) have no filesystem path to contain and ignore it.
  */
-type ToolFactory = (options: ISandboxToolOptions) => FunctionTool;
+type ToolFactory = (options: { cwd: string }) => FunctionTool;
 
 /** Static allowlist mapping `toolName` → the agent-tools builtin factory. */
 const TOOL_FACTORIES: Readonly<Record<string, ToolFactory>> = {
   read: (o) => createReadTool(o),
   write: (o) => createWriteTool(o),
   edit: (o) => createEditTool(o),
+  // SEC-007: for these two the root is the DEFAULT WORKING DIRECTORY, not a boundary — deliberately,
+  // and not to be "fixed" by reflex. A cwd guard on arbitrary command execution is undone by the
+  // first `cd ..`, so it would constrain nothing while READING as a boundary in review. The real
+  // boundary for command execution is the permission layer and the sandbox seam.
   shell: (o) => createShellTool(o),
   bash: (o) => createBashTool(o),
-  glob: () => globTool,
-  grep: () => grepTool,
+  // SEC-007: built per invocation and bound to the root, not the module-level `globTool`/`grepTool`
+  // singletons this node used to hand back. Those are documented as UNCONTAINED precisely because a
+  // singleton is context-free by construction — there is nothing for a containment root to bind to.
+  glob: (o) => createGlobTool(o),
+  grep: (o) => createGrepTool(o),
   'web-fetch': () => webFetchTool,
   'web-search': () => webSearchTool,
 };
@@ -62,7 +73,11 @@ export const ToolNodeConfigSchema = z.object({
   toolName: z.string().min(1),
   /** Static tool arguments; the `params` input port is merged over these (input wins). */
   params: z.record(z.unknown()).default({}),
-  /** Path restriction forwarded to file/shell builtins (ISandboxToolOptions.cwd). */
+  /**
+   * NARROWS the containment root. Omitted, the root is the directory the run was invoked from; set,
+   * it must resolve INSIDE that directory or the node refuses to run (SEC-007). It cannot widen the
+   * root, because it arrives in the same `.dag.json` as the path it would be containing.
+   */
   cwd: z.string().optional(),
   /** Base credit cost per successful call (for cost estimation). */
   baseCredits: z.number().nonnegative().default(0),
@@ -107,6 +122,49 @@ function coerceToolResult(data: unknown): { output: string; isError: boolean } {
     // allow-fallback: non-JSON output is plain success text
   }
   return { output: text, isError: false };
+}
+
+/**
+ * SEC-007 — resolve the containment root every builtin this node runs is bound to.
+ *
+ * The boundary is the directory the run was invoked from. That is the same anchor the `file-read` and
+ * `file-write` nodes use, and for the same stated reason: `INodeExecutionContext` carries no workspace
+ * root, so this makes explicit the boundary the node was already implicitly claiming rather than
+ * inventing a new concept. Without it this node was the way AROUND those two — `toolName: "read"`
+ * with an absolute path did what `file-read` refuses.
+ *
+ * `config.cwd` may only NARROW that root. It comes out of the same LLM-authorable `.dag.json` as the
+ * paths it is nominally containing, so honouring it as the boundary would let `{"cwd":"/"}` disarm
+ * the guard by writing one line — a root the attacker supplies is not a root.
+ *
+ * Decided canonically through agent-core's shared `isPathInside` SSOT, so a `cwd` reached through a
+ * symlink that escapes is refused too. A lexical check passes `escape/…` when `escape -> /`, because
+ * `resolve()` never consults the filesystem; segment validation would not catch it either, since
+ * `escape` is a perfectly plain segment.
+ */
+function resolveContainmentRoot(
+  configCwd: string | undefined,
+  nodeId: string,
+): TResult<string, IDagError> {
+  const invocationRoot = process.cwd();
+  if (configCwd === undefined) return { ok: true, value: invocationRoot };
+
+  const requested = resolve(invocationRoot, configCwd);
+  if (!isPathInside(invocationRoot, requested)) {
+    return {
+      ok: false,
+      error: buildValidationError(
+        'DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT',
+        `cwd "${configCwd}" resolves outside the working directory`,
+        { nodeId },
+        {
+          action: 'set_config',
+          suggestion: 'Set cwd to a directory inside the directory the run was invoked from',
+        },
+      ),
+    };
+  }
+  return { ok: true, value: requested };
 }
 
 function invalidParamsError(toolName: string, message: string, suggestion: string): IDagError {
@@ -240,8 +298,11 @@ export class ToolNodeDefinition extends AbstractNodeDefinition<typeof ToolNodeCo
     const paramsResult = resolveInputParams(io.getInput('params'), config.toolName);
     if (!paramsResult.ok) return paramsResult;
 
+    const rootResult = resolveContainmentRoot(config.cwd, context.nodeDefinition.nodeId);
+    if (!rootResult.ok) return rootResult;
+
     const merged = { ...config.params, ...paramsResult.value };
-    const tool = factory(config.cwd !== undefined ? { cwd: config.cwd } : {});
+    const tool = factory({ cwd: rootResult.value });
     return runBuiltin(tool, merged, config.toolName, context.nodeDefinition.nodeId);
   }
 }

--- a/packages/dag-nodes/tool/src/index.ts
+++ b/packages/dag-nodes/tool/src/index.ts
@@ -1,25 +1,8 @@
-import {
-  createBashTool,
-  createEditTool,
-  createGlobTool,
-  createGrepTool,
-  createReadTool,
-  createShellTool,
-  createWriteTool,
-  webFetchTool,
-  webSearchTool,
-} from '@robota-sdk/agent-tools';
-import { isPathInside, type ITool } from '@robota-sdk/agent-core';
-import { resolve } from 'node:path';
 import { AbstractNodeDefinition, NodeIoAccessor } from '@robota-sdk/dag-node';
 
-/**
- * Structural tool contract these agent-tools builtins satisfy (`FunctionTool` is owned by
- * `@robota-sdk/agent-core`, DATA-005 SSOT). Typed by the `ITool` interface rather than the concrete
- * class so it unifies across agent-core's dual ESM/CJS `.d.ts` (the class's private `eventService`
- * would otherwise read as a distinct nominal type). Only `.execute()` is used here.
- */
-type FunctionTool = ITool;
+import { resolveContainmentRoot } from './containment.js';
+import { TOOL_FACTORIES, TOOL_NODE_ALLOWED_TOOLS, type FunctionTool } from './tool-factories.js';
+
 import {
   buildTaskExecutionError,
   buildValidationError,
@@ -33,40 +16,7 @@ import {
 } from '@robota-sdk/dag-core';
 import { z } from 'zod';
 
-/**
- * A builtin factory, always given a containment root (SEC-007).
- *
- * `cwd` is REQUIRED here rather than optional, for the reason `pack-coding`'s `ICodingPackOptions`
- * makes it required: `checkPathWithinCwd` is a NO-OP when `cwd` is `undefined`, so an optional root is
- * a guard that disarms itself by omission. The two builtins that reach the network (`web-fetch`,
- * `web-search`) have no filesystem path to contain and ignore it.
- */
-type ToolFactory = (options: { cwd: string }) => FunctionTool;
-
-/** Static allowlist mapping `toolName` → the agent-tools builtin factory. */
-const TOOL_FACTORIES: Readonly<Record<string, ToolFactory>> = {
-  read: (o) => createReadTool(o),
-  write: (o) => createWriteTool(o),
-  edit: (o) => createEditTool(o),
-  // SEC-007: for these two the root is the DEFAULT WORKING DIRECTORY, not a boundary — deliberately,
-  // and not to be "fixed" by reflex. A cwd guard on arbitrary command execution is undone by the
-  // first `cd ..`, so it would constrain nothing while READING as a boundary in review. The real
-  // boundary for command execution is the permission layer and the sandbox seam.
-  shell: (o) => createShellTool(o),
-  bash: (o) => createBashTool(o),
-  // SEC-007: built per invocation and bound to the root, not the module-level `globTool`/`grepTool`
-  // singletons this node used to hand back. Those are documented as UNCONTAINED precisely because a
-  // singleton is context-free by construction — there is nothing for a containment root to bind to.
-  glob: (o) => createGlobTool(o),
-  grep: (o) => createGrepTool(o),
-  'web-fetch': () => webFetchTool,
-  'web-search': () => webSearchTool,
-};
-
-/** The builtin tool names this node can run in-process. */
-export const TOOL_NODE_ALLOWED_TOOLS: readonly string[] = Object.freeze(
-  Object.keys(TOOL_FACTORIES),
-);
+export { TOOL_NODE_ALLOWED_TOOLS } from './tool-factories.js';
 
 export const ToolNodeConfigSchema = z.object({
   /** Which in-process agent-tools builtin to run (see TOOL_NODE_ALLOWED_TOOLS). */
@@ -122,49 +72,6 @@ function coerceToolResult(data: unknown): { output: string; isError: boolean } {
     // allow-fallback: non-JSON output is plain success text
   }
   return { output: text, isError: false };
-}
-
-/**
- * SEC-007 — resolve the containment root every builtin this node runs is bound to.
- *
- * The boundary is the directory the run was invoked from. That is the same anchor the `file-read` and
- * `file-write` nodes use, and for the same stated reason: `INodeExecutionContext` carries no workspace
- * root, so this makes explicit the boundary the node was already implicitly claiming rather than
- * inventing a new concept. Without it this node was the way AROUND those two — `toolName: "read"`
- * with an absolute path did what `file-read` refuses.
- *
- * `config.cwd` may only NARROW that root. It comes out of the same LLM-authorable `.dag.json` as the
- * paths it is nominally containing, so honouring it as the boundary would let `{"cwd":"/"}` disarm
- * the guard by writing one line — a root the attacker supplies is not a root.
- *
- * Decided canonically through agent-core's shared `isPathInside` SSOT, so a `cwd` reached through a
- * symlink that escapes is refused too. A lexical check passes `escape/…` when `escape -> /`, because
- * `resolve()` never consults the filesystem; segment validation would not catch it either, since
- * `escape` is a perfectly plain segment.
- */
-function resolveContainmentRoot(
-  configCwd: string | undefined,
-  nodeId: string,
-): TResult<string, IDagError> {
-  const invocationRoot = process.cwd();
-  if (configCwd === undefined) return { ok: true, value: invocationRoot };
-
-  const requested = resolve(invocationRoot, configCwd);
-  if (!isPathInside(invocationRoot, requested)) {
-    return {
-      ok: false,
-      error: buildValidationError(
-        'DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT',
-        `cwd "${configCwd}" resolves outside the working directory`,
-        { nodeId },
-        {
-          action: 'set_config',
-          suggestion: 'Set cwd to a directory inside the directory the run was invoked from',
-        },
-      ),
-    };
-  }
-  return { ok: true, value: requested };
 }
 
 function invalidParamsError(toolName: string, message: string, suggestion: string): IDagError {

--- a/packages/dag-nodes/tool/src/tool-factories.ts
+++ b/packages/dag-nodes/tool/src/tool-factories.ts
@@ -1,0 +1,63 @@
+/**
+ * The allowlist of agent-tools builtins this node can run in-process, and how each is constructed.
+ *
+ * Split out of `index.ts` because WHICH tools exist and HOW each is bound to a containment root is a
+ * registry concern, separate from executing a node.
+ */
+
+import {
+  createBashTool,
+  createEditTool,
+  createGlobTool,
+  createGrepTool,
+  createReadTool,
+  createShellTool,
+  createWriteTool,
+  webFetchTool,
+  webSearchTool,
+} from '@robota-sdk/agent-tools';
+
+import type { ITool } from '@robota-sdk/agent-core';
+
+/**
+ * Structural tool contract these agent-tools builtins satisfy (`FunctionTool` is owned by
+ * `@robota-sdk/agent-core`, DATA-005 SSOT). Typed by the `ITool` interface rather than the concrete
+ * class so it unifies across agent-core's dual ESM/CJS `.d.ts` (the class's private `eventService`
+ * would otherwise read as a distinct nominal type). Only `.execute()` is used here.
+ */
+export type FunctionTool = ITool;
+
+/**
+ * A builtin factory, always given a containment root (SEC-007).
+ *
+ * `cwd` is REQUIRED here rather than optional, for the reason `pack-coding`'s `ICodingPackOptions`
+ * makes it required: `checkPathWithinCwd` is a NO-OP when `cwd` is `undefined`, so an optional root is
+ * a guard that disarms itself by omission. The two builtins that reach the network (`web-fetch`,
+ * `web-search`) have no filesystem path to contain and ignore it.
+ */
+export type ToolFactory = (options: { cwd: string }) => FunctionTool;
+
+/** Static allowlist mapping `toolName` → the agent-tools builtin factory. */
+export const TOOL_FACTORIES: Readonly<Record<string, ToolFactory>> = {
+  read: (o) => createReadTool(o),
+  write: (o) => createWriteTool(o),
+  edit: (o) => createEditTool(o),
+  // SEC-007: for these two the root is the DEFAULT WORKING DIRECTORY, not a boundary — deliberately,
+  // and not to be "fixed" by reflex. A cwd guard on arbitrary command execution is undone by the
+  // first `cd ..`, so it would constrain nothing while READING as a boundary in review. The real
+  // boundary for command execution is the permission layer and the sandbox seam.
+  shell: (o) => createShellTool(o),
+  bash: (o) => createBashTool(o),
+  // SEC-007: built per invocation and bound to the root, not the module-level `globTool`/`grepTool`
+  // singletons this node used to hand back. Those are documented as UNCONTAINED precisely because a
+  // singleton is context-free by construction — there is nothing for a containment root to bind to.
+  glob: (o) => createGlobTool(o),
+  grep: (o) => createGrepTool(o),
+  'web-fetch': () => webFetchTool,
+  'web-search': () => webSearchTool,
+};
+
+/** The builtin tool names this node can run in-process. */
+export const TOOL_NODE_ALLOWED_TOOLS: readonly string[] = Object.freeze(
+  Object.keys(TOOL_FACTORIES),
+);


### PR DESCRIPTION
## What this is

SEC-007 parts **A and B are already landed** (PR #1452, on `develop`). I verified both rather than trusting the write-up, and this PR closes the one part-A gap that verification found.

### Verification of the landed work

**Part A is real, not accidental-green.** Reverse-applying the two containment hunks in `glob-tool.ts` / `path-guard.ts` turns 6 of the 13 `enumeration-containment` tests red, while the two CONTROL tests keep proving the escape is real on disk and the legitimate-in-sandbox cases stay green in both directions. Restored and re-confirmed at 13/13.

**Part B is real.** 21/21 harness tests, and the scan's red path is covered in both directions — it flags the reconstructed single-page query, passes it once paginated, flags the no-`per_page` and argv forms, and rejects a reason-less annotation; it does *not* flag prose, a non-collection endpoint, or an annotation carrying a reason.

**Part B's user-execution Scenario 3, recorded as "NOT YET RUN", is now run** — see below.

## The gap: a third `Glob`/`Grep` registration site

Part A contained `Glob`/`Grep` by making the two *assemblies* (`createDefaultTools`, `createCodingPack`) build their own instances instead of importing the module-level singletons. `packages/dag-nodes/tool` is a **third registration site**, and it kept handing back `globTool`/`grepTool` — the objects whose own doc comment reads *"UNCONTAINED, deliberately"*. It is registered in `dag-nodes-default`, so `{"nodeType":"tool","config":{"toolName":"grep"}}` in any `.dag.json` reached them.

The node was also the way **around** its own siblings. `toolName: "read"` with an absolute path did exactly what part A's `file-read` containment refuses, because `config.cwd` is optional and `checkPathWithinCwd` is a no-op when `cwd` is `undefined` — the guard disarmed by omission that `pack-coding` makes `cwd` required to prevent.

And `config.cwd` could not have been the boundary even when set: it arrives in the same LLM-authorable `.dag.json` as the path it is nominally containing, so `{"cwd":"/"}` disarmed it in one line. **A root the attacker supplies is not a root.**

## The fix

- Root = the directory the run was invoked from — the same anchor `file-read`/`file-write` use, and for the same stated reason (`INodeExecutionContext` carries no workspace root).
- `config.cwd` may only **narrow** it; escaping resolves to `DAG_VALIDATION_TOOL_CWD_OUTSIDE_ROOT`.
- Decided canonically through agent-core's `isPathInside` SSOT, so a `cwd` reached through an escaping symlink is refused too.
- `Shell`/`Bash` keep part A's deliberate non-containment — the root is their default working directory, not a boundary — documented at the spawn site and in the SPEC so it is not "fixed" by reflex.

## Red-first, on disk, through the node itself

Before the fix (real symlinks, real out-of-root files — **10 failed | 4 passed**):

```
× does not enumerate through a symlinked directory   → returned 'escape/outside.txt'
× does not disclose out-of-root CONTENT via grep     → returned 'SECRET-VALUE'
× refuses to READ an absolute path outside the root  → returned 'SECRET-VALUE'
× refuses to WRITE outside the root, plants nothing  → planted the file
× refuses a config.cwd that escapes / `..` / symlink → all honoured
```

Two CONTROL tests pin that the escape is genuine rather than hypothetical. Crucially, **the legitimate-use cases were green before AND after** — "still enumerates and searches normally inside the invocation directory" and "still reads and writes ordinary files inside" never failed, so the guard does not fire on correct use.

After: **26 passed**.

## Verification

| Check | Result |
| --- | --- |
| `pnpm harness:scan` | all 81 scans passed |
| `dag-node-tool` | 26 passed |
| `agent-tools` | 239 passed |
| `pack-coding` | 11 passed |
| `agent-framework` | 1302 passed |
| `dag-node-file-read` / `file-write` | 8 / 9 passed |
| `dag-nodes-default` | 13 passed |
| harness (`api-pagination`) | 21 passed |
| typecheck / lint | clean (0 errors) |

The `file-size` ceiling was resolved by splitting the two new responsibilities into `containment.ts` and `tool-factories.ts` rather than recording a new baseline.

## Scenario 3, now closed

```
gh api "…/code-scanning/alerts?state=open&per_page=100"   → exit 1
  [per-page-without-paginate] scripts/…:2
+ --paginate                                              → exit 0, "api-pagination scan passed."
```

**Note for the backlog:** the scenario's steps say "add a line to any file under `scripts/`", but that is only true for a **shell** file. The same line in a `.mjs` file is deliberately *not* flagged (the scan's own test asserts it does not flag prose in a Node script). As written, the steps would have produced a false "the scan is broken" conclusion. The probe file was removed; nothing under `scripts/` is modified by this PR.

## Behaviour change to be aware of

A `.dag.json` that previously set `config.cwd` to a directory *outside* the invocation directory now fails the node instead of running uncontained. That is the fix, not a regression, and the error carries a `set_config` remediation hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso
