### PR TITLE
fix(agent-framework): the checkpoint recorder read files the sandbox refused

### DIFF
--- a/packages/agent-framework/src/checkpoints/__tests__/capture-containment.test.ts
+++ b/packages/agent-framework/src/checkpoints/__tests__/capture-containment.test.ts
@@ -1,0 +1,93 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { EditCheckpointStore } from '../edit-checkpoint-store';
+
+const MARKER = 'TOP-SECRET-CONTENTS-abc123';
+
+/** Every file under `dir` whose bytes contain the marker — i.e. what leaked into the sandbox. */
+function leakedInto(dir: string): string[] {
+  const found: string[] = [];
+  const walk = (d: string) => {
+    if (!existsSync(d)) return;
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else {
+        try {
+          if (readFileSync(p, 'utf8').includes(MARKER)) found.push(p);
+        } catch {
+          /* unreadable entries cannot carry the marker onward */
+        }
+      }
+    }
+  };
+  walk(dir);
+  return found;
+}
+
+function scratch() {
+  const base = mkdtempSync(join(tmpdir(), 'checkpoint-containment-'));
+  const sandbox = join(base, 'sandbox');
+  const outside = join(base, 'outside');
+  mkdirSync(sandbox, { recursive: true });
+  mkdirSync(outside, { recursive: true });
+  writeFileSync(join(outside, 'secret.txt'), MARKER);
+  return { base, sandbox, outside };
+}
+
+describe('EditCheckpointStore.captureFile containment', () => {
+  // captureFile runs BEFORE the contained tool refuses, so without containment the snapshot IS the
+  // read the sandbox denied: the bytes land inside the working directory and stay there for a later
+  // in-sandbox Read. Proven end-to-end before the fix.
+  it('does not pull a file outside the working directory into the sandbox', async () => {
+    const { sandbox, outside } = scratch();
+    const store = new EditCheckpointStore({ cwd: sandbox });
+    await store.beginTurn({ sessionId: 's1', prompt: 'p' });
+    await store.captureFile(join(outside, 'secret.txt'));
+    await store.finalizeTurn();
+
+    expect(leakedInto(join(sandbox, '.robota'))).toEqual([]);
+  });
+
+  // Containment is decided on the canonical path, so a symlink planted inside the tree cannot be
+  // used to walk out of it.
+  it('does not follow a symlink out of the working directory', async () => {
+    const { sandbox, outside } = scratch();
+    const link = join(sandbox, 'link-to-secret.txt');
+    symlinkSync(join(outside, 'secret.txt'), link);
+
+    const store = new EditCheckpointStore({ cwd: sandbox });
+    await store.beginTurn({ sessionId: 's2', prompt: 'p' });
+    await store.captureFile(link);
+    await store.finalizeTurn();
+
+    expect(leakedInto(join(sandbox, '.robota'))).toEqual([]);
+  });
+
+  // The guard must not break what checkpoints are for: an in-sandbox file still gets its snapshot,
+  // otherwise a restore point silently stops existing and the fix costs more than the hole.
+  it('still snapshots a file inside the working directory', async () => {
+    const { sandbox } = scratch();
+    const target = join(sandbox, 'tracked.txt');
+    writeFileSync(target, MARKER);
+
+    const store = new EditCheckpointStore({ cwd: sandbox });
+    await store.beginTurn({ sessionId: 's3', prompt: 'p' });
+    await store.captureFile(target);
+    await store.finalizeTurn();
+
+    expect(leakedInto(join(sandbox, '.robota')).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agent-framework/src/checkpoints/edit-checkpoint-store-helpers.ts
+++ b/packages/agent-framework/src/checkpoints/edit-checkpoint-store-helpers.ts
@@ -1,0 +1,73 @@
+import { dirname, join, relative, resolve } from 'node:path';
+
+import type { IEditCheckpointManifest } from './edit-checkpoint-types.js';
+import type { IFileSystem, IFileSystemAsync } from '@robota-sdk/agent-core';
+
+/** The branch a checkpoint belongs to when a session has not switched away from the default. */
+export const DEFAULT_BRANCH_ID = 'main';
+
+/**
+ * SELFHOST-007 migration: reconstruct the branch tree for legacy (v1) manifests. A v1 manifest has no
+ * `parentId`/`branchId`, so — sorted by sequence — it is treated as a LINEAR chain: each node's parent
+ * is the previous node, all on the `'main'` branch. v2 manifests keep their stored branch fields. Pure;
+ * does not mutate the inputs.
+ */
+export function migrateManifestsToTree(
+  manifests: IEditCheckpointManifest[],
+): IEditCheckpointManifest[] {
+  return manifests.map((manifest, index) => {
+    if (manifest.version === 2 && manifest.branchId !== undefined) return manifest;
+    const previous = index > 0 ? manifests[index - 1] : undefined;
+    return {
+      ...manifest,
+      version: 2,
+      branchId: DEFAULT_BRANCH_ID,
+      ...(previous ? { parentId: previous.id } : {}),
+    };
+  });
+}
+
+export function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+export function isInside(parent: string, child: string): boolean {
+  const rel = relative(parent, child);
+  return rel.length === 0 || (!rel.startsWith('..') && !rel.startsWith('/'));
+}
+
+export async function pathExists(
+  fsAsync: IFileSystemAsync,
+  fs: IFileSystem,
+  path: string,
+): Promise<boolean> {
+  try {
+    await fsAsync.access(path, fs.constants.F_OK);
+    return true;
+  } catch {
+    // allow-fallback: access failure means file absent, false is the correct result
+    return false;
+  }
+}
+
+export function readDirSyncSafe(fs: IFileSystem, dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch {
+    // allow-fallback: missing directory returns empty list, not an error
+    return [];
+  }
+}
+
+export function readJsonManifest(
+  fs: IFileSystem,
+  path: string,
+): IEditCheckpointManifest | undefined {
+  try {
+    const raw = fs.readFileSync(path, 'utf8');
+    return JSON.parse(raw) as IEditCheckpointManifest;
+  } catch {
+    // allow-fallback: corrupted/missing manifest is filtered out by caller
+    return undefined;
+  }
+}

--- a/packages/agent-framework/src/checkpoints/edit-checkpoint-store-helpers.ts
+++ b/packages/agent-framework/src/checkpoints/edit-checkpoint-store-helpers.ts
@@ -1,4 +1,4 @@
-import { dirname, join, relative, resolve } from 'node:path';
+import { relative } from 'node:path';
 
 import type { IEditCheckpointManifest } from './edit-checkpoint-types.js';
 import type { IFileSystem, IFileSystemAsync } from '@robota-sdk/agent-core';

--- a/packages/agent-framework/src/checkpoints/edit-checkpoint-store.ts
+++ b/packages/agent-framework/src/checkpoints/edit-checkpoint-store.ts
@@ -1,4 +1,4 @@
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import { canonicalizePath, isPathInside } from '@robota-sdk/agent-core';
 import { CheckpointTree } from '@robota-sdk/agent-session';

--- a/packages/agent-framework/src/checkpoints/edit-checkpoint-store.ts
+++ b/packages/agent-framework/src/checkpoints/edit-checkpoint-store.ts
@@ -1,10 +1,20 @@
 import { dirname, join, relative, resolve } from 'node:path';
 
+import { canonicalizePath, isPathInside } from '@robota-sdk/agent-core';
 import { CheckpointTree } from '@robota-sdk/agent-session';
 
 import { NodeFileSystem, NodeFileSystemAsync } from '../adapters/node-file-system.js';
 import { projectPaths } from '../paths.js';
 import { buildEditCheckpointInspection } from './edit-checkpoint-inspection.js';
+import {
+  DEFAULT_BRANCH_ID,
+  isInside,
+  migrateManifestsToTree,
+  pathExists,
+  readDirSyncSafe,
+  readJsonManifest,
+  safePathSegment,
+} from './edit-checkpoint-store-helpers.js';
 
 import type {
   IEditCheckpointFileRecord,
@@ -22,7 +32,6 @@ const SNAPSHOT_DIR = 'files';
 const ID_PAD = 4;
 const SNAPSHOT_PAD = 6;
 /** SELFHOST-007: the default branch a session's checkpoints belong to. */
-const DEFAULT_BRANCH_ID = 'main';
 interface IActiveEditCheckpointTurn {
   manifest: IEditCheckpointManifest;
   dir: string;
@@ -101,6 +110,13 @@ export class EditCheckpointStore {
     const originalPath = resolve(this.cwd, filePath);
     if (this.activeTurn.capturedPaths.has(originalPath)) return;
     if (isInside(this.rootDir, originalPath)) return;
+
+    // Runs BEFORE the contained tool refuses, so without this the snapshot IS the read the sandbox
+    // denied: `Write { filePath: '/etc/shadow' }` copied it into `<cwd>/.robota/checkpoints/…` and
+    // then returned "Access denied", leaving the bytes for a later in-sandbox `Read`. Canonical
+    // path, so a symlink cannot walk out (SEC-006's rule, its helper). Nothing is lost — a file the
+    // tools refuse to edit never needs a restore point.
+    if (!isPathInside(canonicalizePath(this.cwd), canonicalizePath(originalPath))) return;
 
     const record = await this.createFileRecord(originalPath, this.activeTurn);
     this.activeTurn.manifest.files.push(record);
@@ -376,65 +392,4 @@ function toSummary(manifest: IEditCheckpointManifest): IEditCheckpointSummary {
     createdAt: manifest.createdAt,
     fileCount: manifest.fileCount,
   };
-}
-
-/**
- * SELFHOST-007 migration: reconstruct the branch tree for legacy (v1) manifests. A v1 manifest has no
- * `parentId`/`branchId`, so — sorted by sequence — it is treated as a LINEAR chain: each node's parent
- * is the previous node, all on the `'main'` branch. v2 manifests keep their stored branch fields. Pure;
- * does not mutate the inputs.
- */
-function migrateManifestsToTree(manifests: IEditCheckpointManifest[]): IEditCheckpointManifest[] {
-  return manifests.map((manifest, index) => {
-    if (manifest.version === 2 && manifest.branchId !== undefined) return manifest;
-    const previous = index > 0 ? manifests[index - 1] : undefined;
-    return {
-      ...manifest,
-      version: 2,
-      branchId: DEFAULT_BRANCH_ID,
-      ...(previous ? { parentId: previous.id } : {}),
-    };
-  });
-}
-
-function safePathSegment(value: string): string {
-  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
-}
-
-function isInside(parent: string, child: string): boolean {
-  const rel = relative(parent, child);
-  return rel.length === 0 || (!rel.startsWith('..') && !rel.startsWith('/'));
-}
-
-async function pathExists(
-  fsAsync: IFileSystemAsync,
-  fs: IFileSystem,
-  path: string,
-): Promise<boolean> {
-  try {
-    await fsAsync.access(path, fs.constants.F_OK);
-    return true;
-  } catch {
-    // allow-fallback: access failure means file absent, false is the correct result
-    return false;
-  }
-}
-
-function readDirSyncSafe(fs: IFileSystem, dir: string): string[] {
-  try {
-    return fs.readdirSync(dir);
-  } catch {
-    // allow-fallback: missing directory returns empty list, not an error
-    return [];
-  }
-}
-
-function readJsonManifest(fs: IFileSystem, path: string): IEditCheckpointManifest | undefined {
-  try {
-    const raw = fs.readFileSync(path, 'utf8');
-    return JSON.parse(raw) as IEditCheckpointManifest;
-  } catch {
-    // allow-fallback: corrupted/missing manifest is filtered out by caller
-    return undefined;
-  }
 }


### PR DESCRIPTION
Found while verifying SEC-007. **A tool refusal that leaves the bytes inside the sandbox is not a refusal.**

## The escape

`EditCheckpointToolWrapper.execute` calls `recorder.captureFile(filePath)` on the **raw tool argument**, then delegates to the contained tool. `EditCheckpointStore.captureFile` resolved that path with no containment — its one `isInside` call excludes the checkpoint directory from itself, which is not a boundary check.

So:

1. `Write { filePath: "/etc/shadow" }`
2. `captureFile` copies it to `<cwd>/.robota/checkpoints/<id>/turn-0001/files/000001.content`
3. the delegate returns **"Access denied"**
4. `Read { filePath: ".robota/checkpoints/…/000001.content" }` — inside the sandbox, allowed

Arbitrary read of anything the process can read, **through the tool that refused it**. On by default in interactive sessions; under `acceptEdits` it runs with no human in the loop.

## Proven, not argued

Before the fix, an outside file's contents were found at that exact path. The two new tests fail without the guard — direct path **and** symlink — and a third pins that an in-sandbox file still gets its snapshot and passes in **both** directions, so containment was not bought by breaking what checkpoints are for.

```
without the guard:  2 failed | 1 passed
with the guard:     3 passed
```

## The fix

Containment on the **canonical** path via agent-core's `isPathInside`/`canonicalizePath` — the rule SEC-006 established for the file tools, reusing their helper rather than a second implementation that can drift. Nothing legitimate is lost: a file the tools refuse to edit never needs a restore point.

## A ratchet did its job

`file-size` then refused the growth — this file was already baselined over the limit and the rule has no bump path, by design. Six module-level helpers and a constant moved to a sibling, taking it **441 → 398** instead.

## Related, not fixed here

Restore at `edit-checkpoint-store.ts` takes write and delete paths from a manifest the model can write. Same file, different trust question; worth its own item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z