### PR TITLE
docs(rules): the folder/status floor IS registered — say so

### DIFF
--- a/.agents/rules/spec-workflow.md
+++ b/.agents/rules/spec-workflow.md
@@ -169,9 +169,11 @@ A gate PASS that changes the status and the folder does both or neither: a docum
 folder for its status is treated as NON-COMPLIANCE **on its next gate run**. A document that has
 already reached `done/` has no next gate run, which is why that force alone was never enough;
 `scripts/harness/scan-doc-folder-status-agreement.mjs` checks the agreement over the whole tree
-instead, deriving this table as its criteria rather than copying it. **It is not yet wired into
-`pnpm harness:scan`**, and documents that predate the rule still violate it, so run it directly until
-both are closed. Each status transition is a gate, and every gate must leave an
+instead, deriving this table as its criteria rather than copying it, and it runs in
+`pnpm harness:scan`. The tree agrees today: five documents that predated the rule were corrected
+from their own recorded `[GATE-COMPLETE] — ✅ PASS`, and `DATA-002` — shipped in all three phases
+with no GATE-COMPLETE entry at all — is a recorded exception in the scan under anti-rot, because
+neither available correction is derivable without running that gate. Each status transition is a gate, and every gate must leave an
 Evidence Log entry (PASS / FAIL / NON-COMPLIANCE) in the format the
 [gate catalogue](../specs/gate-catalogue.md) defines.
 


### PR DESCRIPTION
Review's MUST on #1503, which I merged before reading it.

`.agents/rules/spec-workflow.md` still said the scan was **"not yet wired into `pnpm harness:scan`"** in the same change that wired it, and told the reader to run it directly until documents predating the rule were fixed — which that change also did.

It now states what is true: the scan runs in the suite, the tree agrees, five documents were corrected from their own recorded `[GATE-COMPLETE] — ✅ PASS`, and `DATA-002` is a recorded exception under anti-rot because neither available correction is derivable without running that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z