### PR TITLE
fix(hooks): the push guard was unreachable from how commands are written

### DIFF
--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -29,14 +29,19 @@ COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | 
 # registered, and was unreachable from the way commands are actually issued — enforcement that no
 # real invocation can reach is indistinguishable from no enforcement.
 #
-# Boundaries are line start, `;`, `&&`, `||`, `|`, and `(`. A `git push` mentioned inside a quoted
-# string on its own line can false-positive; that is the deliberate trade. A false positive costs one
-# blocked command whose branch is already unclean, and it passes on a clean branch. A false negative
-# cost this repository a promotion-ancestry break.
+# Boundaries are STATEMENT separators only — line start, `;`, `&&`, `||`, `|`, `(`, and the literal
+# `\n` that survives JSON extraction. Bare whitespace is NOT a boundary, deliberately: with it,
+# `gh pr create --body "… git push …"` and `git commit -m "fix: git push guard"` both match, and a
+# guard that blocks ordinary work is one that gets switched off.
+#
+# That false positive does not reproduce today only because the shared COMMAND extraction truncates
+# at the first escaped quote, so the text after `--body \"` is never seen (HARNESS-061). It would
+# come alive the moment that extraction is repaired — so it is excluded here rather than left as a
+# trap for whoever fixes it.
 # `\n` appears as the two literal characters backslash-n: the command arrives as JSON and is read
 # with grep, not a JSON parser, so a multi-line block keeps its escapes. That form — `cd <repo>` on
 # one line, `git push` on the next — is exactly the one that slipped through, so it is a boundary too.
-echo "$COMMAND" | grep -qE '(^|[;&|(]|[[:space:]]|\\n)[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+echo "$COMMAND" | grep -qE '(^|[;&|(]|\\n)[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -34,6 +34,13 @@ COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | 
 # `gh pr create --body "… git push …"` and `git commit -m "fix: git push guard"` both match, and a
 # guard that blocks ordinary work is one that gets switched off.
 #
+# THE CEILING, stated rather than discovered later. This is `grep` over a command string; it does not
+# understand shell quoting, so a separator INSIDE a quoted argument —
+# `git commit -m 'note: cd x; git push'` — reads as a real one and the hook runs. That is a genuine
+# false positive and the trade is deliberate: a missed push cost a promotion-ancestry break, while a
+# spurious run costs one lockfile check and passes silently on a clean branch. Understanding quoting
+# needs the shell-aware extraction filed as HARNESS-061, not a longer regex.
+#
 # That false positive does not reproduce today only because the shared COMMAND extraction truncates
 # at the first escaped quote, so the text after `--body \"` is never seen (HARNESS-061). It would
 # come alive the moment that extraction is repaired — so it is excluded here rather than left as a
@@ -41,7 +48,7 @@ COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | 
 # `\n` appears as the two literal characters backslash-n: the command arrives as JSON and is read
 # with grep, not a JSON parser, so a multi-line block keeps its escapes. That form — `cd <repo>` on
 # one line, `git push` on the next — is exactly the one that slipped through, so it is a boundary too.
-echo "$COMMAND" | grep -qE '(^|[;&|(]|\\n)[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+echo "$COMMAND" | grep -qE '(^|[;&|({]|\\n)[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -19,8 +19,24 @@ fi
 
 COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
 
-# Only intercept git push commands (tolerating env prefixes + global git flags like `git -C <path>`)
-echo "$COMMAND" | grep -qE '^\s*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*push(\s|$)' || exit 0
+# Only intercept git push commands (tolerating env prefixes + global git flags like `git -C <path>`).
+#
+# Matched at any STATEMENT boundary, not only at the start of the command. The `^`-anchored version
+# fired only when the whole command began with `git push`, so every compound form slipped past it
+# silently — and `cd <repo> && git push`, or a multi-line block whose push is on a later line, is how
+# a push is normally written here. Measured 2026-07-27: EVERY push in a long session bypassed this
+# guard, which is why the branch-hygiene rule it enforces kept being violated. The guard existed, was
+# registered, and was unreachable from the way commands are actually issued — enforcement that no
+# real invocation can reach is indistinguishable from no enforcement.
+#
+# Boundaries are line start, `;`, `&&`, `||`, `|`, and `(`. A `git push` mentioned inside a quoted
+# string on its own line can false-positive; that is the deliberate trade. A false positive costs one
+# blocked command whose branch is already unclean, and it passes on a clean branch. A false negative
+# cost this repository a promotion-ancestry break.
+# `\n` appears as the two literal characters backslash-n: the command arrives as JSON and is read
+# with grep, not a JSON parser, so a multi-line block keeps its escapes. That form — `cd <repo>` on
+# one line, `git push` on the next — is exactly the one that slipped through, so it is a boundary too.
+echo "$COMMAND" | grep -qE '(^|[;&|(]|[[:space:]]|\\n)[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/scripts/harness/__tests__/hook-command-reachability.test.mjs
+++ b/scripts/harness/__tests__/hook-command-reachability.test.mjs
@@ -1,0 +1,106 @@
+import { spawnSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * The command forms a hook must recognise.
+ *
+ * A PreToolUse hook decides whether to act by matching the Bash command it is handed. Matching with
+ * a `^`-anchor recognises only a command that BEGINS with the interesting verb — and essentially
+ * every command issued here begins with `cd <repo>`, or puts the verb on a later line of a
+ * multi-line block. Measured 2026-07-27: `pre-push-check` was anchored that way, so every push in a
+ * long session bypassed it silently. The branch-hygiene rule it enforces was violated repeatedly and
+ * the guard never spoke, which ended in a promotion-ancestry break.
+ *
+ * A hook that no realistic invocation reaches is indistinguishable from no hook. So the shapes below
+ * are the contract: whatever a hook intercepts, it must intercept in all of them.
+ */
+const COMPOUND_FORMS = [
+  (verb) => verb,
+  (verb) => `cd ${WORKSPACE_ROOT}\n${verb}`,
+  (verb) => `cd ${WORKSPACE_ROOT} && ${verb}`,
+  (verb) => `git status; ${verb}`,
+];
+
+/** Hooks that intercept a specific command verb, and a command they MUST recognise. */
+const INTERCEPTORS = [
+  { hook: 'pre-push-check.sh', verb: 'git push -u origin feat/probe' },
+  { hook: 'branch-guard.sh', verb: 'git push origin --delete feat/probe' },
+];
+
+/**
+ * `spawnSync`, not `execFileSync`: hooks write their notices to stderr, and `execFileSync`'s SUCCESS
+ * path returns stdout only — so a hook that spoke and exited 0 would read as silence and this test
+ * would report a bypass that is not there. It did, on the first run.
+ */
+function runHook(hookFile, command) {
+  const payload = JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+  const result = spawnSync('bash', [path.join(HOOKS_DIR, hookFile)], {
+    input: payload,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: WORKSPACE_ROOT },
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
+
+describe('hooks are reachable from the command forms actually used', () => {
+  it('finds the hooks it claims to check', () => {
+    // Fail closed: a renamed hook would make every case below pass over nothing.
+    const present = readdirSync(HOOKS_DIR);
+    for (const { hook } of INTERCEPTORS) expect(present).toContain(hook);
+  });
+
+  for (const { hook, verb } of INTERCEPTORS) {
+    // Generous timeout: reachability is measured by EXECUTING each hook, and a hook may legitimately
+    // do real work once it has decided to act — `pre-push-check` runs `pnpm install` to check
+    // lockfile sync. Eight executions against the default 10s limit passed locally at 9.97s and
+    // timed out on the CI runner. The fix is the budget, not a lighter probe: replacing execution
+    // with source inspection would test the matcher's TEXT rather than whether the hook is reached,
+    // which is the whole question.
+    it(`${hook} recognises its verb in every compound form`, { timeout: 120_000 }, () => {
+      const reactions = COMPOUND_FORMS.map((shape) => {
+        const result = runHook(hook, shape(verb));
+        // "Reacted" = said something or refused. Silence with status 0 is the bypass being measured.
+        return result.output.trim().length > 0 || result.status !== 0;
+      });
+
+      expect(
+        reactions.every(Boolean),
+        `${hook} stayed silent on ${reactions.filter((r) => !r).length} of ${reactions.length} ` +
+          'command forms. A hook that only matches a command it also STARTS is unreachable from ' +
+          '`cd <repo> && …` and from multi-line blocks, which is how commands are normally written.',
+      ).toBe(true);
+    });
+  }
+
+  it('does not react to an unrelated command', { timeout: 60_000 }, () => {
+    // The other half: a matcher loose enough to fire on anything would pass the test above while
+    // blocking ordinary work, which is how a guard gets disabled.
+    for (const { hook } of INTERCEPTORS) {
+      const result = runHook(hook, `cd ${WORKSPACE_ROOT}\necho hello`);
+      expect(result.status, `${hook} blocked an unrelated command`).toBe(0);
+      expect(result.output.trim(), `${hook} spoke on an unrelated command`).toBe('');
+    }
+  });
+
+  it('anchors no interceptor pattern at the start of the command', () => {
+    // The specific mistake, pinned by source: `grep -qE '^...git...'` over the extracted command.
+    for (const { hook } of INTERCEPTORS) {
+      const source = readFileSync(path.join(HOOKS_DIR, hook), 'utf8');
+      const anchoredVerbMatch = /grep\s+-[a-zA-Z]*E?\s*'\^[^']*\\?s\*\(?[^']*git[^']*'/.test(
+        source,
+      );
+      expect(anchoredVerbMatch, `${hook} matches its verb with a start-anchored pattern`).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/scripts/harness/__tests__/hook-command-reachability.test.mjs
+++ b/scripts/harness/__tests__/hook-command-reachability.test.mjs
@@ -27,11 +27,20 @@ const COMPOUND_FORMS = [
   (verb) => `git status; ${verb}`,
 ];
 
-/** Hooks that intercept a specific command verb, and a command they MUST recognise. */
-const INTERCEPTORS = [
-  { hook: 'pre-push-check.sh', verb: 'git push -u origin feat/probe' },
-  { hook: 'branch-guard.sh', verb: 'git push origin --delete feat/probe' },
-];
+/**
+ * Hooks that intercept command verbs, and commands they MUST recognise — **every** verb, not one.
+ *
+ * Listing one verb per hook is how this test was green while four of `branch-guard`'s five verbs
+ * were unreachable: the one I happened to pick, `--delete`, has a separately un-anchored matcher.
+ * A hand-listed set standing in for an enumerated one is a recurring defect in this repository, and
+ * it recurred here inside the test written to catch a sibling of it.
+ *
+ * `branch-guard.sh` is deliberately absent below: repairing all five of its verbs is a larger change
+ * to a hook another branch is rewriting, and pinning it here with one verb would restore exactly the
+ * false assurance this comment records. It is covered by that branch's own suite, which derives each
+ * hook's verbs from the hook's source rather than from a list.
+ */
+const INTERCEPTORS = [{ hook: 'pre-push-check.sh', verb: 'git push -u origin feat/probe' }];
 
 /**
  * `spawnSync`, not `execFileSync`: hooks write their notices to stderr, and `execFileSync`'s SUCCESS


### PR DESCRIPTION
The branch-hygiene rule kept being violated and the guard never spoke. It was not missing and not wrong — **it was unreachable**.

`pre-push-check.sh` matched `git push` with a `^`-anchored pattern, so it fired only when the whole command *began* with it. Nearly every command here begins with `cd <repo>`, or puts the push on a later line of a multi-line block.

**Measured:** every push in a long session bypassed it silently — ending in a branch cut from a promotion branch whose merge commit entered `develop` and broke the promotion-ancestry gate.

## Proven end-to-end

On a scratch repository reproducing the incident shape (a branch based on `main`, carrying a merge commit over `origin/develop`), pushed as `cd <repo>` + newline + `git push`:

```
[pre-push-check] Blocked: branch 'feat/wrong-base' carries merge commits in its range over origin/develop:
[pre-push-check]   8811f92 Merge branch develop into main-based branch
exit=2
```

A correctly-based branch still passes (exit 0), and unrelated commands still go unremarked.

## The class, pinned

`hook-command-reachability` requires every intercepting hook to recognise its verb in all four command shapes, to stay silent on an unrelated command, and to **not** match with a start-anchor. Restoring the anchor turns it red.

## Related finding, not fixed here

`branch-guard.sh` has the same defect: `GITPFX='^\s*…'` start-anchors **every** action it detects — commit, push, merge, and branch-create. That is why its create-guard never fired. Being audited under a wider sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z