### PR TITLE
fix(harness): make three scans' pass-run findings readable (scan reachability audit)

### DIFF
--- a/scripts/harness/__tests__/check-build-output-contracts.test.mjs
+++ b/scripts/harness/__tests__/check-build-output-contracts.test.mjs
@@ -5,14 +5,47 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { ADVISORY_MARKER, extractAdvisories } from '../run-all-scans.mjs';
 import {
   findDtsExtensionFindings,
   findDistFileFindings,
   findBinPathFindings,
   findExportPathFindings,
+  renderDistCoverage,
 } from '../check-build-output-contracts.mjs';
 
 const PKG = '@test/pkg';
+
+// ── dist COVERAGE reporting ─────────────────────────────────────────────────
+
+/**
+ * HARNESS-052, reachability axis. `findDistFileFindings` returns `[]` the moment a package has no
+ * `dist/` (measured: the same package with an EMPTY `dist/` yields two findings), and ci.yml's
+ * `quality` job restores `dist` only `if: needs.build.outputs.package_dist_required == 'true'` —
+ * false for every docs-only, `.agents/**` or `scripts/harness/**` PR (measured through
+ * `createVerificationPlan`). On those PRs the job's `pnpm harness:scan:build-contracts` step ran the
+ * dist-file rule against nothing and printed `Build output contract check passed for N package(s)`.
+ * The count in the pass line is now the count whose `dist/` was actually READ, and the shortfall is
+ * an advisory rather than silence.
+ */
+describe('renderDistCoverage', () => {
+  it('states the resolved count and says nothing extra when every dist/ was read', () => {
+    const lines = renderDistCoverage({ checked: 31, distPresent: 31 });
+    expect(lines).toEqual([
+      'Build output contract check passed for 31 package(s), dist/ read on 31.',
+    ]);
+    expect(extractAdvisories(lines.join('\n'))).toEqual([]);
+  });
+
+  it('advertises the shortfall when dist/ was absent, so the no-op is not read as coverage', () => {
+    const lines = renderDistCoverage({ checked: 31, distPresent: 0 });
+    expect(lines[0]).toContain('dist/ read on 0');
+    const advisories = extractAdvisories(lines.join('\n'));
+    expect(advisories).toHaveLength(1);
+    expect(advisories[0]).toContain('31');
+    expect(lines.some((line) => line.includes(ADVISORY_MARKER))).toBe(true);
+  });
+});
 
 // ── findDtsExtensionFindings ────────────────────────────────────────────────
 

--- a/scripts/harness/__tests__/scan-action-references.test.mjs
+++ b/scripts/harness/__tests__/scan-action-references.test.mjs
@@ -20,6 +20,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { ADVISORY_MARKER, extractAdvisories } from '../run-all-scans.mjs';
 import {
   classifyResolution,
   expandFindings,
@@ -29,6 +30,7 @@ import {
   parseReferences,
   readWorkflowSources,
   resolveAll,
+  unverifiedResolvabilityLine,
 } from '../scan-action-references.mjs';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
@@ -461,5 +463,29 @@ describe('the real repository', () => {
         classifyResolution({ raw: 'x', ref: SHA, claimedTag: 'v9.9.9' }, resolved(undefined)),
       ).not.toBeNull();
     });
+  });
+});
+
+// ── the OFF-run notice, and whether anyone can read it ──────────────────────
+
+/**
+ * HARNESS-052, reachability axis. The live half is off locally AND off when `GITHUB_BASE_REF` is
+ * `main` — and `harness:scan` is the only path that runs this scan in either place. `run-all-scans`
+ * discards a passing scan's stdout, so the line saying "an action that does not exist passes this
+ * run" was itself unreadable on every run that printed it. It now carries `ADVISORY_MARKER`
+ * (HARNESS-053), which survives the 0 exit without changing the verdict.
+ */
+describe('unverifiedResolvabilityLine', () => {
+  it('is absent on a live run — there is nothing unverified to declare', () => {
+    expect(unverifiedResolvabilityLine({ live: true, why: 'CI' }, 12)).toBeNull();
+  });
+
+  it('reaches a reader of a PASSING run, naming the mode and the unchecked count', () => {
+    const line = unverifiedResolvabilityLine({ live: false, why: '--offline' }, 12);
+    expect(line).toContain(ADVISORY_MARKER);
+    const [advisory] = extractAdvisories(line);
+    expect(advisory).toContain('--offline');
+    expect(advisory).toContain('12 reference(s)');
+    expect(advisory).toContain('does not exist passes this run');
   });
 });

--- a/scripts/harness/__tests__/scan-legacy-typescript.test.mjs
+++ b/scripts/harness/__tests__/scan-legacy-typescript.test.mjs
@@ -4,12 +4,14 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { ADVISORY_MARKER, extractAdvisories } from '../run-all-scans.mjs';
 import {
   collectInstalledCopies,
   findBelowMinimumDeclarations,
   findBelowMinimumInstalled,
   findLegacyDependencies,
   findLegacyImportsInSource,
+  formatNotices,
   installedMajor,
   lowestMajorAdmitted,
 } from '../scan-legacy-typescript.mjs';
@@ -422,5 +424,30 @@ describe('scan-legacy-typescript — store edge (collectInstalledCopies)', () =>
   it('ignores a directory with no manifest at all', () => {
     mkdirSync(path.join(root, 'node_modules', 'typescript'), { recursive: true });
     expect(collectInstalledCopies(root)).toEqual([]);
+  });
+});
+
+// ── notice VISIBILITY ────────────────────────────────────────────────────────
+
+/**
+ * HARNESS-052, reachability axis. This scan's own comment calls its uninstalled-tree notice "Loud
+ * rather than silent", and it was MEASURED silent on the only path anyone runs it on: `run-all-scans`
+ * discards a passing scan's stdout, so `pnpm harness:scan` printed `✓ legacy-typescript` and nothing
+ * else — byte-identical to a run where the installed-copy edge DID execute. Notices now carry
+ * `ADVISORY_MARKER`, the one channel that survives a 0 exit (HARNESS-053).
+ */
+describe('formatNotices', () => {
+  it('emits nothing when there is nothing to say', () => {
+    expect(formatNotices([])).toEqual([]);
+  });
+
+  it('marks every notice so a PASSING run still surfaces it', () => {
+    const lines = formatNotices(['no node_modules at /x', 'y/package.json no longer declares it']);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) expect(line).toContain(ADVISORY_MARKER);
+    expect(extractAdvisories(lines.join('\n'))).toEqual([
+      'no node_modules at /x',
+      'y/package.json no longer declares it',
+    ]);
   });
 });

--- a/scripts/harness/check-build-output-contracts.mjs
+++ b/scripts/harness/check-build-output-contracts.mjs
@@ -11,6 +11,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 import { listWorkspaceScopes, readJson, WORKSPACE_ROOT } from './shared.mjs';
 
 const DIST_PATH_PATTERN = /(?:^|\/)dist\//u;
@@ -207,9 +208,40 @@ export async function findBuildOutputContractFindings(root = WORKSPACE_ROOT) {
   return findings;
 }
 
+/**
+ * The pass-line plus, when the dist-file rule could not run everywhere, ONE advisory line.
+ *
+ * HARNESS-052, reachability axis. `findDistFileFindings` returns `[]` the moment a package has no
+ * `dist/` — measured: the same manifest with an EMPTY `dist/` yields two findings — and ci.yml's
+ * `quality` job restores `dist` only `if: needs.build.outputs.package_dist_required == 'true'`.
+ * Measured through `createVerificationPlan`, that is FALSE for every docs-only, `.agents/**` and
+ * `scripts/harness/**` PR, so on those the job's `pnpm harness:scan:build-contracts` step ran the
+ * dist-file rule against nothing while printing `Build output contract check passed for N
+ * package(s)` — a count of manifests inspected, read as a count of contracts resolved.
+ *
+ * The pass line now states the count whose `dist/` was actually READ, and the shortfall goes out on
+ * `ADVISORY_MARKER` (HARNESS-053), which reaches `pnpm harness:scan`'s summary without touching the
+ * verdict. Turning the shortfall into a FAILURE would redden `quality` on every docs-only PR; that
+ * is a workflow change (this file cannot restore an artifact) and is recorded, not made here.
+ */
+export function renderDistCoverage({ checked, distPresent }) {
+  const lines = [
+    `Build output contract check passed for ${checked} package(s), dist/ read on ${distPresent}.`,
+  ];
+  if (distPresent < checked) {
+    lines.push(
+      `${ADVISORY_MARKER} the dist-file rule resolved NOTHING for ${checked - distPresent} of ` +
+        `${checked} package(s) with a dist contract — no dist/ on this tree. Declared ` +
+        `main/types/exports paths went unverified for them; run \`pnpm build\` first to check them.`,
+    );
+  }
+  return lines;
+}
+
 async function main() {
   const scopes = await listWorkspaceScopes();
   let checkedPackages = 0;
+  let distPresentPackages = 0;
   const findings = [];
 
   for (const scope of scopes.filter((item) => item.kind === 'package')) {
@@ -218,6 +250,7 @@ async function main() {
     if (!hasDistContract(packageJson)) continue;
 
     checkedPackages += 1;
+    if (fs.existsSync(path.join(pkgDir, 'dist'))) distPresentPackages += 1;
     const name = scope.workspaceName;
     findings.push(...findScriptPairFindings(name, packageJson));
     findings.push(...findPackageFieldFindings(name, packageJson));
@@ -235,7 +268,12 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`Build output contract check passed for ${checkedPackages} package(s).`);
+  for (const line of renderDistCoverage({
+    checked: checkedPackages,
+    distPresent: distPresentPackages,
+  })) {
+    console.log(line);
+  }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/harness/scan-action-references.mjs
+++ b/scripts/harness/scan-action-references.mjs
@@ -65,6 +65,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 import { envWithoutGitVars } from './shared.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -419,6 +420,28 @@ function referenceKey(reference) {
   return `${reference.raw} ${reference.claimedTag ?? ''}`;
 }
 
+/**
+ * The line an OFF run owes its reader, or `null` when the live half ran.
+ *
+ * Never a silent skip: the one thing this scan exists to check did not happen on this run, and the
+ * line says so in the words of the defect rather than in the words of a flag.
+ *
+ * HARNESS-052, reachability axis: saying it was not enough. The live half is off locally AND off
+ * when `GITHUB_BASE_REF` is `main`, and `harness:scan` is the only path that runs this scan in
+ * either place — where `run-all-scans` discards a passing scan's stdout. So the sentence "an action
+ * that does not exist passes this run" was itself unreadable on every run that printed it, which is
+ * the same shape as the reference it warns about. `ADVISORY_MARKER` (HARNESS-053) survives the 0
+ * exit and reaches the summary; it cannot change the verdict, which is what keeps a github.com
+ * outage from blocking a promotion.
+ */
+export function unverifiedResolvabilityLine(mode, unique) {
+  if (mode.live) return null;
+  return (
+    `  ${ADVISORY_MARKER} RESOLVABILITY NOT VERIFIED on this run (${mode.why}): ${unique} ` +
+    `reference(s) were parsed but none was resolved. An action that does not exist passes this run.`
+  );
+}
+
 export async function main(argv = process.argv.slice(2)) {
   const write = (line) => process.stdout.write(`${line}\n`);
   const sources = readWorkflowSources();
@@ -464,13 +487,8 @@ export async function main(argv = process.argv.slice(2)) {
       `  note: ${branchPinned.length} reference(s) resolve through a branch head, not a tag — a moving pointer that still resolves (HARNESS-055).`,
     );
   }
-  if (!mode.live) {
-    // Never a silent skip: the one thing this scan exists to check did not happen on this run, and
-    // the line says so in the words of the defect rather than in the words of a flag.
-    write(
-      `  RESOLVABILITY NOT VERIFIED on this run (${mode.why}): ${unique} reference(s) were parsed but none was resolved. An action that does not exist passes this run.`,
-    );
-  }
+  const unverified = unverifiedResolvabilityLine(mode, unique);
+  if (unverified !== null) write(unverified);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/harness/scan-legacy-typescript.mjs
+++ b/scripts/harness/scan-legacy-typescript.mjs
@@ -98,6 +98,7 @@ import { existsSync, readFileSync, readdirSync, realpathSync, writeFileSync } fr
 import path from 'node:path';
 
 import * as ts from './lib/ts-ast.mjs';
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const BASELINE_PATH = path.join(WORKSPACE_ROOT, 'scripts/harness/legacy-typescript-baseline.json');
@@ -575,6 +576,22 @@ export function findLegacyTypeScriptFindings(root = WORKSPACE_ROOT, options = {}
   return findings;
 }
 
+/**
+ * Render each notice as ONE advisory line.
+ *
+ * HARNESS-052, reachability axis. The uninstalled-tree notice above calls itself "Loud rather than
+ * silent", and it was MEASURED silent: `run-all-scans` discards a passing scan's stdout, so
+ * `pnpm harness:scan` — the only path anyone runs this on — printed `✓ legacy-typescript` and
+ * nothing else, byte-identical to a run where the installed-copy edge DID execute. `ADVISORY_MARKER`
+ * (HARNESS-053) is the one channel that survives a 0 exit, and it cannot change the verdict.
+ *
+ * Both notice kinds route through here deliberately: the ratchet-tighten notice has exactly the same
+ * problem — it asks for work in the same PR and nobody could see it being asked.
+ */
+export function formatNotices(notices) {
+  return notices.map((notice) => `${ADVISORY_MARKER} ${notice}`);
+}
+
 /** Freeze the manifests that currently declare the dependency (excluding the reasoned exemption). */
 function writeBaseline() {
   const manifests = [];
@@ -604,7 +621,7 @@ function main() {
   }
   const notices = [];
   const findings = findLegacyTypeScriptFindings(WORKSPACE_ROOT, { notices });
-  for (const notice of notices) console.log(`note: ${notice}`);
+  for (const line of formatNotices(notices)) console.log(line);
   if (findings.length === 0) {
     console.log('legacy-typescript scan passed.');
     process.exit(0);


### PR DESCRIPTION
## What this is

The reachability half of HARNESS-052. That item asked "does a check report success over work it
did not do". This one asks the prior question: **is the check reached at all, and on the path that
matters?** Every claim below was executed; anything reasoned-but-not-run is labelled `hypothesis`.

Three fixes here, each proven RED then GREEN. Everything else is reported for filing.

## Measured inventory

- **85** `scan-*` / `check-*` / `audit-*` files under `scripts/harness/`; **81** registered in
  `run-all-scans.mjs` (82 entries — `docs-structure` runs `pnpm docs:validate-structure`).
- **0 orphans.** The 4 unregistered files are all reached elsewhere and by design:
  `check-patch-coverage` and `check-regression-red-proof` from `ci.yml` (both advisory, both
  declared non-required), `check-review-gate` from `review-gate.yml` + `pnpm harness:review-gate`,
  `check-plan` as a library (imported by `verify-change`, `plan-change`, `verify-like-ci`,
  `scan-build-tooling-scope`). **Nothing needed registering.**
- **0 phantom registrations** — every registered path exists.

## Where the suite is reached

| Path | Runs | Evidence |
| --- | --- | --- |
| PR → `develop`, `scans` job | 79 of 81 (`--skip dist --skip build-contracts`) | ci.yml:407, `if: github.base_ref != 'main'` |
| PR → `develop`, `quality` job | `build-contracts` | ci.yml:353 |
| PR → `main` | all 81 via `release-grade-verify` → `harness:verify:release` | ci.yml:477/511; `scans`/`quality` carry `if: base_ref != 'main'` |
| `pnpm harness:scan` (manual) | all 82 | measured: `all 82 scans passed` on a built tree |
| **`.husky/pre-push`** | **0–2 of 81** | measured below |

`dist` runs in **no CI job on a develop PR** — `--skip`ped in `scans`, and never in `quality`.
It is reached on a `main` PR (`build:deps` = full `pnpm build`, then an unskipped `harness:scan`).

## The pre-push gap (highest consequence, measured)

`scans` is a REQUIRED context on `protect-develop`, declared mirrored by `pnpm harness:verify-like-ci`.
Nothing runs either automatically. `.husky/pre-push` → `harness:pre-push` runs `harness:plan`,
`harness:verify` and a CLI smoke — never `run-all-scans`, never `verify-like-ci`.
`.claude/hooks/pre-push-check.sh:7` states "harness:pre-push and CI already own those gates".

`verify-change.mjs` can reach exactly 3 of the 81 (`test-plans`, `consistency`, `publish`), and only
when the plan asks for them. Measured through `createVerificationPlan`:

| Change set | repositoryChecks | scans reached at pre-push |
| --- | --- | --- |
| `packages/agent-core/src/index.ts` | `[]` | **0 of 81** |
| `packages/agent-core/package.json` | `[]` | **0 of 81** |
| `README.md` | `repository-review` (no executable check) | **0 of 81** |
| `scripts/harness/*.mjs` | `harness-tests`, `harness-consistency` | 1 of 81 |
| `.agents/rules/*.md` | `harness-consistency`, `task-plan-scan` | 2 of 81 |

The 81-scan suite is reached locally only by an agent reading a rule and typing the command.
`harness:scan` is named in 11 rule files and many skills; `verify-like-ci` appears in **one** rule
(`git-branch.md`) and **zero** skills.

## Fixed here — output visibility (axis 4)

`run-all-scans` discards a passing scan's stdout; `ADVISORY_MARKER` (HARNESS-053) is the only channel
that survives a 0 exit, and **2 of 81 scans used it**. Three scans that print a sentence about their
own coverage on a passing run now route it there.

| Scan | Falsified | After |
| --- | --- | --- |
| `scan-legacy-typescript` | node_modules parked → `runScans` rendered `✓ legacy-typescript` and dropped `note: no node_modules at …`, byte-identical to a run where the installed-copy edge executed | the same run prints `⚑ legacy-typescript: no node_modules at …` |
| `check-build-output-contracts` | `findDistFileFindings` returns `[]` with no `dist/`; the SAME manifest with an EMPTY `dist/` yields 2 findings. Pass line said "passed for 75 package(s)" | pass line states `dist/ read on N`; shortfall is an advisory |
| `scan-action-references` | live half off locally and off when `GITHUB_BASE_REF=main`; its "an action that does not exist passes this run" line was itself unreadable | reaches the summary as `⚑ action-references: RESOLVABILITY NOT VERIFIED …` |

`build-contracts` matters because ci.yml's `quality` restores dist only
`if: needs.build.outputs.package_dist_required == 'true'`, which `createVerificationPlan` resolves
FALSE for every docs-only, `.agents/**` and `scripts/harness/**` PR — including this one. On those
PRs the REQUIRED job's build-contracts step ran the dist-file rule against nothing. Making that a
FAILURE needs the workflow to restore the artifact (outside this change's ownership); the shortfall
is advertised instead.

Verification: `pnpm harness:scan` surfaced **1** advisory before, **3** after (2 under CI's
`--skip dist --skip build-contracts`, 2 on a fully built tree where build-contracts has nothing to
advertise). `pnpm harness:test` 102 files / **1487** tests green (1481 before, +6). `pnpm harness:scan`
on a built tree: `all 82 scans passed`.

## Reported, not fixed

- **Pre-push runs 0 of 81 scans for a package source change.** Needs a decision about what the local
  gate costs, not a one-line patch.
- **`build-contracts` should FAIL, not advise, when dist is absent** — needs `ci.yml` to restore the
  artifact unconditionally in `quality` (or to move the scan). Outside ownership.
- **`check-architecture-map-completeness` prints 10 `[warn]` lines and exits 0**;
  `check-spec-doc-frontmatter` prints 4 (`duplicate spec-doc ID`: CMD-004, HARNESS-011, SELFHOST-008
  ×6, SELFHOST-011). All discarded on a pass. Routing 14 lines into every summary is a noise
  judgement, not a mechanical repair.
- **`scan-guard-scope-fail-closed` leaks `fatal: not a git repository: .git`** into its own output
  (a classified finder shells out to `git ls-files` against the bare probe root). Cosmetic, but it
  is noise in a guard whose subject is honest output.
- **`check-build-output-contracts` crashes under `node --input-type=module -e`** —
  `pathToFileURL(process.argv[1])` with `argv[1]` undefined. Only affects ad-hoc importers.
- `hypothesis`: `verify-change.mjs`'s repository-check gating means a `packages/**`-only PR runs no
  repository check at all locally — the second half of HARNESS-052's `check-plan.mjs:97,100` finding.

Do not merge — this is for review alongside the audit report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso
