### PR TITLE
fix(hooks): every guard was reachable from at most one way of writing a command

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -37,6 +37,9 @@ fi
 # The executable part, computed BEFORE the overrides are read: an override named inside a heredoc
 # body is text, and text must not be able to switch this guard off.
 COMMAND_EXEC=$(hook_executable_part "$COMMAND")
+# Verb detection reads the same command with quoted ARGUMENTS blanked; extraction below keeps them,
+# because branch names and `-C` paths are routinely quoted.
+COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 
 if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_DELETE=1
@@ -58,7 +61,7 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # `|| true` is load-bearing: grep exits 1 when the command has no `-C`, which is the common case, and
 # under `set -euo pipefail` a failed command substitution ABORTS the hook — silently, exit 1, before
 # a single check runs. That is a total bypass wearing the costume of a passing guard.
-GIT_C_PATH=$(printf '%s' "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
+GIT_C_PATH=$(printf '%s' "$COMMAND_EXEC" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
 EFFECTIVE_DIR="${CLAUDE_PROJECT_DIR:-.}"
 if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   EFFECTIVE_DIR="$HOOK_CWD"
@@ -97,20 +100,25 @@ IS_GH_DELETE_BRANCH=false
 # inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
 # quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
 
-GITPFX='(^|[;&|({]|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
+# A quote is a boundary too. `bash -c "git push origin main"` really runs a push, and
+# hook_blank_quoted_args deliberately leaves that string intact — but the character before the
+# verb is then `"`, so without this the preserved string matched nothing and the exception was
+# decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
+# false positive it sits next to.
+GITPFX='(^|[;&|({"'"'"']|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
 # Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
 # read as a merge and `git commit-tree` as a commit — false positives that, now that the leading
 # match is loose, would block ordinary read-only work on a protected branch. It also covers the verb
 # ending a line (`git commit\ngit push`), which a bare `(\s|$)` misses.
 GITEND='([^-[:alnum:]_]|$)'
-echo "$COMMAND_EXEC" | grep -qE "${GITPFX}commit${GITEND}" && IS_COMMIT=true
-echo "$COMMAND_EXEC" | grep -qE "${GITPFX}push${GITEND}" && IS_PUSH=true
-echo "$COMMAND_EXEC" | grep -qE "${GITPFX}merge${GITEND}" && IS_MERGE=true
+echo "$COMMAND_VERBS" | grep -qE "${GITPFX}commit${GITEND}" && IS_COMMIT=true
+echo "$COMMAND_VERBS" | grep -qE "${GITPFX}push${GITEND}" && IS_PUSH=true
+echo "$COMMAND_VERBS" | grep -qE "${GITPFX}merge${GITEND}" && IS_MERGE=true
 # Tolerate flags between the subcommand and the create flag (e.g. `git checkout -q -b x`, which
 # previously slipped past the create-guard entirely). `-B`/`-C` are the force-create spellings and
 # create a branch just as much as `-b`/`-c` do.
-echo "$COMMAND_EXEC" | grep -qE "${GITPFX}checkout\s+(-\S+\s+)*-[bB]${GITEND}" && IS_BRANCH_CREATE=true
-echo "$COMMAND_EXEC" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-[cC]${GITEND}" && IS_BRANCH_CREATE=true
+echo "$COMMAND_VERBS" | grep -qE "${GITPFX}checkout\s+(-\S+\s+)*-[bB]${GITEND}" && IS_BRANCH_CREATE=true
+echo "$COMMAND_VERBS" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-[cC]${GITEND}" && IS_BRANCH_CREATE=true
 # `gh pr merge --delete-branch` is banned (git-branch.md): it once deleted the
 # develop integration branch. Match ONLY when --delete-branch is an actual argument
 # of a `gh pr merge` invocation — strip shell comments first, then require the flag

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -17,7 +17,7 @@ INPUT=$(cat)
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
-TOOL_NAME=$(hook_json_string "$INPUT" 'tool_name' || true)
+TOOL_NAME=$(hook_tool_name_of "$INPUT")
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -255,7 +255,15 @@ fi
 # Enforce feature branch naming convention <type>/<desc> (git-branch.md).
 # Long-lived branches are exempt; override with BRANCH_GUARD_ALLOW_BADNAME=1.
 if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1" ]]; then
-  NEW_BRANCH=$(printf '%s' "$COMMAND_EXEC" | sed -E 's/.*[[:space:]]-[bBcC][[:space:]]+([^[:space:]]+).*/\1/')
+  # Read the branch name out of the checkout/switch invocation itself. The previous expression
+  # ran a greedy `.*` over the WHOLE command and captured whatever followed the LAST
+  # -b/-B/-c/-C, so `git checkout -b feat/x && git -C /other status` yielded /other and
+  # refused a correctly named branch. Adding -C to that alternation made a long-standing
+  # weakness reachable.
+  GIT_PREFIX_RE='((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+|-[^[:space:]]+[[:space:]]+)*'
+  NEW_BRANCH=$(printf '%s' "$COMMAND_VERBS" |
+    grep -oE "git[[:space:]]+${GIT_PREFIX_RE}(checkout|switch)[[:space:]]+${GIT_PREFIX_RE}-[bBcC][[:space:]]+[^[:space:]]+" |
+    head -1 | grep -oE '[^[:space:]]+$' || true)
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
   if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -117,7 +117,7 @@ IS_GH_DELETE_BRANCH=false
 # verb is then `"`, so without this the preserved string matched nothing and the exception was
 # decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
 # false positive it sits next to.
-GITPFX='(^|[;&|({"'"'"']|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
+GITPFX='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
 # Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
 # read as a merge and `git commit-tree` as a commit — false positives that, now that the leading
 # match is loose, would block ordinary read-only work on a protected branch. It also covers the verb
@@ -271,7 +271,7 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1"
   # `-C` target and the delete name follow. Pulling it straight out of the masked string returned
   # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
   NEW_BRANCH=$(hook_match_extract "$COMMAND_EXEC" \
-    '(^|[ \t;&|({\n"\047])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+' || true)
+    '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+' || true)
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
   if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -99,8 +99,9 @@ IS_GH_DELETE_BRANCH=false
 # from pre-push-check; it lived here in a variable and was reused for every action. A guard no real
 # invocation reaches is indistinguishable from no guard.
 #
-# Boundaries are line start, `;`, `&&`, `||`, `|`, `(`, whitespace, and the literal `\n` that
-# survives JSON extraction (the command is read with grep, not a JSON parser, so a multi-line block
+# Boundaries are line start, `;`, `&&`, `||`, `|`, `(`, whitespace and a quote. A newline is one too:
+# the command is decoded as JSON now and carries REAL newlines, so grep's `^` is a line start (a
+# multi-line block
 # keeps its escapes — and that is the shape that slipped through).
 # A heredoc BODY is data, not commands. `git commit -F - <<'EOF' … EOF` carries prose that may
 # quote a git invocation — this hook blocked a commit whose MESSAGE contained
@@ -266,10 +267,11 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1"
   # -b/-B/-c/-C, so `git checkout -b feat/x && git -C /other status` yielded /other and
   # refused a correctly named branch. Adding -C to that alternation made a long-standing
   # weakness reachable.
-  GIT_PREFIX_RE='((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+|-[^[:space:]]+[[:space:]]+)*'
-  NEW_BRANCH=$(printf '%s' "$COMMAND_VERBS" |
-    grep -oE "git[[:space:]]+${GIT_PREFIX_RE}(checkout|switch)[[:space:]]+${GIT_PREFIX_RE}-[bBcC][[:space:]]+[^[:space:]]+" |
-    head -1 | grep -oE '[^[:space:]]+$' || true)
+  # Read the name from the ORIGINAL, positioned by a match in the masked text — the same rule the
+  # `-C` target and the delete name follow. Pulling it straight out of the masked string returned
+  # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
+  NEW_BRANCH=$(hook_match_extract "$COMMAND_EXEC" \
+    '(^|[ \t;&|({\n"\047])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+' || true)
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
   if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -40,20 +40,23 @@ fi
 # The `VAR=1` prefix runs in the TOOL's shell, not this hook's process, so a plain env check never sees it —
 # the documented overrides were unusable inline until this. Worktree-parallel subagents rely on
 # BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1 to each carry their own concurrent branch (git-branch.md § Git Worktree).
-# The executable part, computed BEFORE the overrides are read: an override named inside a heredoc
-# body is text, and text must not be able to switch this guard off.
+# Computed BEFORE the overrides are read, and the overrides read the MASKED form. An override
+# named inside a heredoc body or a quoted argument is text, and text must not be able to switch this
+# guard off — `git commit -m "note: BRANCH_GUARD_ALLOW_DELETE=1 was tried" && git push origin
+# --delete develop` did exactly that, disarming the check that exists because develop was once
+# deleted by accident.
 COMMAND_EXEC=$(hook_executable_part "$COMMAND")
 # Verb detection reads the same command with quoted ARGUMENTS blanked; extraction below keeps them,
 # because branch names and `-C` paths are routinely quoted.
 COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 
-if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'; then
+if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_DELETE=1
 fi
-if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1([[:space:]]|$)'; then
+if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
 fi
-if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAME=1([[:space:]]|$)'; then
+if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAME=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_BADNAME=1
 fi
 

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -10,34 +10,48 @@ set -euo pipefail
 
 INPUT=$(cat)
 
+# One parser, not four. `command-scan.sh` explains what each hand-rolled copy got wrong; the short
+# version is that the old `grep -o '"command"…"[^"]*"' ` stopped at the first quote inside the
+# command, so everything after `-m "…"` — including the verb being guarded — was never examined.
+# shellcheck source=lib/command-scan.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+
 # Extract tool_name without jq — match "tool_name":"Bash"
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+TOOL_NAME=$(hook_json_string "$INPUT" 'tool_name' || true)
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0
 fi
 
 # Extract command from tool_input.command
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+if ! COMMAND=$(hook_command_of "$INPUT"); then
+  echo "[branch-guard] Blocked: the tool command could not be decoded, so it cannot be judged." >&2
+  echo "[branch-guard] Install jq or python3 so this guard can read what it is judging." >&2
+  exit 2
+fi
 
 # Honor inline override tokens written IN the command string (e.g. `BRANCH_GUARD_ALLOW_DELETE=1 git push …`).
 # The `VAR=1` prefix runs in the TOOL's shell, not this hook's process, so a plain env check never sees it —
 # the documented overrides were unusable inline until this. Worktree-parallel subagents rely on
 # BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1 to each carry their own concurrent branch (git-branch.md § Git Worktree).
-if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'; then
+# The executable part, computed BEFORE the overrides are read: an override named inside a heredoc
+# body is text, and text must not be able to switch this guard off.
+COMMAND_EXEC=$(hook_executable_part "$COMMAND")
+
+if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_DELETE=1
 fi
-if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1([[:space:]]|$)'; then
+if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
 fi
-if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAME=1([[:space:]]|$)'; then
+if printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAME=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_BADNAME=1
 fi
 
 # Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
 # a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),
 # producing false blocks. Precedence: `git -C <path>` in the command > hook-input `cwd` > project dir.
-HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
+HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # Unanchored: `git -C <path>` is almost never the first thing on the line (`cd /elsewhere && git -C
 # <repo> commit`). The `^`-anchored version simply never found it, so the hook fired and then judged
 # whichever checkout it happened to sit in — passing a commit it should have refused.
@@ -82,24 +96,8 @@ IS_GH_DELETE_BRANCH=false
 # Deliberately narrow: it strips only `<<MARKER … MARKER`, whose boundaries are unambiguous. A verb
 # inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
 # quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
-strip_heredocs() {
-  printf '%s' "$1" | sed 's/\\n/\n/g' | awk '
-    /<<-?'"'"'?[A-Za-z_][A-Za-z0-9_]*'"'"'?/ && !inbody {
-      marker = $0
-      sub(/.*<<-?'"'"'?/, "", marker)
-      sub(/'"'"'?[[:space:]].*$/, "", marker)
-      sub(/'"'"'.*$/, "", marker)
-      inbody = 1
-      print
-      next
-    }
-    inbody { if ($0 == marker) { inbody = 0 }; next }
-    { print }
-  '
-}
-COMMAND_EXEC=$(strip_heredocs "$COMMAND")
 
-GITPFX='(^|[;&|(]|[[:space:]]|\\n)[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
+GITPFX='(^|[;&|({]|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
 # Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
 # read as a merge and `git commit-tree` as a commit — false positives that, now that the leading
 # match is loose, would block ordinary read-only work on a protected branch. It also covers the verb
@@ -118,7 +116,7 @@ echo "$COMMAND_EXEC" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-[cC]${GITEND}" && 
 # of a `gh pr merge` invocation — strip shell comments first, then require the flag
 # to sit in the same command segment as `gh pr merge` (no intervening ; | &). This
 # avoids false positives from the flag mentioned in a comment or a separate echo.
-COMMAND_NO_COMMENTS=$(printf '%s' "$COMMAND" | sed 's/[[:space:]]#[^"]*$//')
+COMMAND_NO_COMMENTS="$COMMAND_EXEC"
 if printf '%s' "$COMMAND_NO_COMMENTS" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge\b[^|;&]*--delete-branch'; then
   IS_GH_DELETE_BRANCH=true
 fi
@@ -140,7 +138,7 @@ DELETE_BRANCH_NAME=""
 # Scan only the command up to the first heredoc opener (`<<`): everything after it is DATA
 # (e.g. a `git commit -F - <<'EOF' …` message that may legitimately mention `git push --delete`
 # or `refs/heads/`), not an executed command. This prevents a commit message from tripping the guard.
-DELETE_SCAN="${COMMAND_NO_COMMENTS%%<<*}"
+DELETE_SCAN="$COMMAND_NO_COMMENTS"
 if printf '%s' "$DELETE_SCAN" | grep -qE 'gh[[:space:]]+api[^|;&]*-X[[:space:]]+DELETE[^|;&]*/git/refs/heads/'; then
   DELETE_BRANCH_NAME=$(printf '%s' "$DELETE_SCAN" | sed -E 's#.*/git/refs/heads/([A-Za-z0-9._/-]+).*#\1#')
 elif printf '%s' "$DELETE_SCAN" | grep -qE 'git[[:space:]]+push[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+(--delete[[:space:]]|:)'; then
@@ -247,7 +245,7 @@ fi
 # Enforce feature branch naming convention <type>/<desc> (git-branch.md).
 # Long-lived branches are exempt; override with BRANCH_GUARD_ALLOW_BADNAME=1.
 if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1" ]]; then
-  NEW_BRANCH=$(printf '%s' "$COMMAND" | sed -E 's/.*[[:space:]]-[bBcC][[:space:]]+([^[:space:]]+).*/\1/')
+  NEW_BRANCH=$(printf '%s' "$COMMAND_EXEC" | sed -E 's/.*[[:space:]]-[bBcC][[:space:]]+([^[:space:]]+).*/\1/')
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
   if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -112,11 +112,10 @@ IS_GH_DELETE_BRANCH=false
 # inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
 # quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
 
-# A quote is a boundary too. `bash -c "git push origin main"` really runs a push, and
-# hook_blank_quoted_args deliberately leaves that string intact — but the character before the
-# verb is then `"`, so without this the preserved string matched nothing and the exception was
-# decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
-# false positive it sits next to.
+# A quote and a backtick are boundaries too: a KEPT region — `bash -c "git push"`, or a backtick
+# subshell — puts one immediately before the verb, and without them the region survived masking and
+# still matched nothing. Quoted payloads are masked before this runs, so this cannot resurrect the
+# false positive it sits beside.
 GITPFX='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
 # Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
 # read as a merge and `git commit-tree` as a commit — false positives that, now that the leading

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -38,7 +38,13 @@ fi
 # a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),
 # producing false blocks. Precedence: `git -C <path>` in the command > hook-input `cwd` > project dir.
 HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
-GIT_C_PATH=$(printf '%s' "$COMMAND" | sed -nE 's/^[[:space:]]*git[[:space:]]+-C[[:space:]]+"?([^"[:space:]]+)"?.*/\1/p')
+# Unanchored: `git -C <path>` is almost never the first thing on the line (`cd /elsewhere && git -C
+# <repo> commit`). The `^`-anchored version simply never found it, so the hook fired and then judged
+# whichever checkout it happened to sit in — passing a commit it should have refused.
+# `|| true` is load-bearing: grep exits 1 when the command has no `-C`, which is the common case, and
+# under `set -euo pipefail` a failed command substitution ABORTS the hook — silently, exit 1, before
+# a single check runs. That is a total bypass wearing the costume of a passing guard.
+GIT_C_PATH=$(printf '%s' "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
 EFFECTIVE_DIR="${CLAUDE_PROJECT_DIR:-.}"
 if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   EFFECTIVE_DIR="$HOOK_CWD"
@@ -55,14 +61,58 @@ IS_BRANCH_CREATE=false
 IS_GH_DELETE_BRANCH=false
 # GITPFX tolerates global git flags before the subcommand — `git -C <path> commit`, `git -c k=v push` —
 # which previously slipped past every action regex (worktree-blindness, parallel-wave lesson).
-GITPFX='^\s*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
-echo "$COMMAND" | grep -qE "${GITPFX}commit\b" && IS_COMMIT=true
-echo "$COMMAND" | grep -qE "${GITPFX}push(\s|$)" && IS_PUSH=true
-echo "$COMMAND" | grep -qE "${GITPFX}merge\b" && IS_MERGE=true
-# Tolerate flags between the subcommand and -b/-c (e.g. `git checkout -q -b x`, which
-# previously slipped past the create-guard entirely).
-echo "$COMMAND" | grep -qE "${GITPFX}checkout\s+(-\S+\s+)*-b\b" && IS_BRANCH_CREATE=true
-echo "$COMMAND" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-c\b" && IS_BRANCH_CREATE=true
+#
+# It matches at any STATEMENT boundary, not only at the start of the command. The `^`-anchored
+# version fired only when the WHOLE command began with the verb — and a branch is created as
+# `cd <repo> && git checkout -b …`, a commit made after a `cd`, a merge on a later line of a block.
+# Measured 2026-07-28 against a scratch repository on `main`: commit, push, merge, `checkout -b` and
+# `switch -c` were ALL bypassed in 4 of the 5 shapes commands are actually written in here. The
+# branch-create guard had therefore never fired on a real branch creation. Same defect #1510 removed
+# from pre-push-check; it lived here in a variable and was reused for every action. A guard no real
+# invocation reaches is indistinguishable from no guard.
+#
+# Boundaries are line start, `;`, `&&`, `||`, `|`, `(`, whitespace, and the literal `\n` that
+# survives JSON extraction (the command is read with grep, not a JSON parser, so a multi-line block
+# keeps its escapes — and that is the shape that slipped through).
+# A heredoc BODY is data, not commands. `git commit -F - <<'EOF' … EOF` carries prose that may
+# quote a git invocation — this hook blocked a commit whose MESSAGE contained
+# "branches are made as `cd <repo> && git checkout -b …`", reading the sentence as the act it
+# describes. Verb detection therefore runs over the command with heredoc bodies removed.
+#
+# Deliberately narrow: it strips only `<<MARKER … MARKER`, whose boundaries are unambiguous. A verb
+# inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
+# quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
+strip_heredocs() {
+  printf '%s' "$1" | sed 's/\\n/\n/g' | awk '
+    /<<-?'"'"'?[A-Za-z_][A-Za-z0-9_]*'"'"'?/ && !inbody {
+      marker = $0
+      sub(/.*<<-?'"'"'?/, "", marker)
+      sub(/'"'"'?[[:space:]].*$/, "", marker)
+      sub(/'"'"'.*$/, "", marker)
+      inbody = 1
+      print
+      next
+    }
+    inbody { if ($0 == marker) { inbody = 0 }; next }
+    { print }
+  '
+}
+COMMAND_EXEC=$(strip_heredocs "$COMMAND")
+
+GITPFX='(^|[;&|(]|[[:space:]]|\\n)[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
+# Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
+# read as a merge and `git commit-tree` as a commit — false positives that, now that the leading
+# match is loose, would block ordinary read-only work on a protected branch. It also covers the verb
+# ending a line (`git commit\ngit push`), which a bare `(\s|$)` misses.
+GITEND='([^-[:alnum:]_]|$)'
+echo "$COMMAND_EXEC" | grep -qE "${GITPFX}commit${GITEND}" && IS_COMMIT=true
+echo "$COMMAND_EXEC" | grep -qE "${GITPFX}push${GITEND}" && IS_PUSH=true
+echo "$COMMAND_EXEC" | grep -qE "${GITPFX}merge${GITEND}" && IS_MERGE=true
+# Tolerate flags between the subcommand and the create flag (e.g. `git checkout -q -b x`, which
+# previously slipped past the create-guard entirely). `-B`/`-C` are the force-create spellings and
+# create a branch just as much as `-b`/`-c` do.
+echo "$COMMAND_EXEC" | grep -qE "${GITPFX}checkout\s+(-\S+\s+)*-[bB]${GITEND}" && IS_BRANCH_CREATE=true
+echo "$COMMAND_EXEC" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-[cC]${GITEND}" && IS_BRANCH_CREATE=true
 # `gh pr merge --delete-branch` is banned (git-branch.md): it once deleted the
 # develop integration branch. Match ONLY when --delete-branch is an actual argument
 # of a `gh pr merge` invocation — strip shell comments first, then require the flag
@@ -158,11 +208,17 @@ if [[ -z "$CURRENT_BRANCH" ]]; then
   exit 0
 fi
 
-# Block new branch creation when local branches have commits not yet in main.
-# Uses git rev-list --count main..<branch>: non-zero means unmerged commits exist.
+# Block new branch creation when local branches have commits not yet in the INTEGRATION branch.
+# `git-branch.md` § One-Branch-At-A-Time names the comparison itself — `git branch --no-merged
+# develop` — and this compared against `main`. `main` trails `develop` between promotions, so 53 of
+# 140 local branches here were counted unmerged while already being in `develop`. Measured, and a
+# straight contradiction of the rule this check enforces.
 # This correctly handles squash-merged branches (their commits appear reachable
 # from main after squash) as long as the local branch pointer is deleted post-merge.
 if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" != "1" ]]; then
+  # Prefer the remote-tracking integration head; fall back to local `develop` when offline.
+  INTEGRATION_REF=origin/develop
+  git -C "$PROJECT_DIR" rev-parse --verify --quiet "$INTEGRATION_REF" >/dev/null 2>&1 || INTEGRATION_REF=develop
   UNMERGED_BRANCHES=()
   SKIP_PATTERNS="^(main|master|develop|gh-pages)$"
   while IFS= read -r candidate; do
@@ -170,9 +226,9 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
     candidate="${candidate#\* }"  # strip current-branch marker
     [[ "$candidate" =~ $SKIP_PATTERNS ]] && continue
     [[ -z "$candidate" ]] && continue
-    ahead=$(git -C "$PROJECT_DIR" rev-list --count "main..$candidate" 2>/dev/null || echo 0)
+    ahead=$(git -C "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
     if [[ "$ahead" -gt 0 ]]; then
-      UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of main)")
+      UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
     fi
   done < <(git -C "$PROJECT_DIR" branch 2>/dev/null)
 
@@ -191,7 +247,7 @@ fi
 # Enforce feature branch naming convention <type>/<desc> (git-branch.md).
 # Long-lived branches are exempt; override with BRANCH_GUARD_ALLOW_BADNAME=1.
 if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1" ]]; then
-  NEW_BRANCH=$(printf '%s' "$COMMAND" | sed -E 's/.*[[:space:]](-b|-c)[[:space:]]+([^[:space:]]+).*/\2/')
+  NEW_BRANCH=$(printf '%s' "$COMMAND" | sed -E 's/.*[[:space:]]-[bBcC][[:space:]]+([^[:space:]]+).*/\1/')
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
   if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -126,7 +126,9 @@ echo "$COMMAND_VERBS" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-[cC]${GITEND}" &&
 # of a `gh pr merge` invocation — strip shell comments first, then require the flag
 # to sit in the same command segment as `gh pr merge` (no intervening ; | &). This
 # avoids false positives from the flag mentioned in a comment or a separate echo.
-COMMAND_NO_COMMENTS="$COMMAND_EXEC"
+# Delete detection reads the MASKED command, like every other verb check. It was the last pair
+# still scanning quoted text, so a commit message naming `--delete-branch` refused the commit.
+COMMAND_NO_COMMENTS="$COMMAND_VERBS"
 if printf '%s' "$COMMAND_NO_COMMENTS" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge\b[^|;&]*--delete-branch'; then
   IS_GH_DELETE_BRANCH=true
 fi
@@ -148,12 +150,7 @@ DELETE_BRANCH_NAME=""
 # Scan only the command up to the first heredoc opener (`<<`): everything after it is DATA
 # (e.g. a `git commit -F - <<'EOF' …` message that may legitimately mention `git push --delete`
 # or `refs/heads/`), not an executed command. This prevents a commit message from tripping the guard.
-DELETE_SCAN="$COMMAND_NO_COMMENTS"
-if printf '%s' "$DELETE_SCAN" | grep -qE 'gh[[:space:]]+api[^|;&]*-X[[:space:]]+DELETE[^|;&]*/git/refs/heads/'; then
-  DELETE_BRANCH_NAME=$(printf '%s' "$DELETE_SCAN" | sed -E 's#.*/git/refs/heads/([A-Za-z0-9._/-]+).*#\1#')
-elif printf '%s' "$DELETE_SCAN" | grep -qE 'git[[:space:]]+push[[:space:]]+[^[:space:]-][^[:space:]]*[[:space:]]+(--delete[[:space:]]|:)'; then
-  DELETE_BRANCH_NAME=$(printf '%s' "$DELETE_SCAN" | sed -E 's#.*git[[:space:]]+push[[:space:]]+[^[:space:]]+[[:space:]]+(--delete[[:space:]]+|:)([A-Za-z0-9._/-]+).*#\2#')
-fi
+DELETE_BRANCH_NAME=$(hook_deleted_branch "$COMMAND_EXEC" || true)
 
 if [[ -n "$DELETE_BRANCH_NAME" && "${BRANCH_GUARD_ALLOW_DELETE:-0}" != "1" ]]; then
   if printf '%s' "$DELETE_BRANCH_NAME" | grep -qE '^(main|master|develop|gh-pages)$'; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -17,7 +17,13 @@ INPUT=$(cat)
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
-TOOL_NAME=$(hook_tool_name_of "$INPUT")
+# Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
+# under `set -e` and the hook exits 1 with nothing said — which the hook protocol treats as
+# non-blocking. Silent exit and "it is fine" are the two states this file refuses to conflate.
+if ! TOOL_NAME=$(hook_tool_name_of "$INPUT"); then
+  echo "[branch-guard] Blocked: the hook payload names no tool, so nothing can be judged." >&2
+  exit 2
+fi
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -61,7 +61,9 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # `|| true` is load-bearing: grep exits 1 when the command has no `-C`, which is the common case, and
 # under `set -euo pipefail` a failed command substitution ABORTS the hook — silently, exit 1, before
 # a single check runs. That is a total bypass wearing the costume of a passing guard.
-GIT_C_PATH=$(printf '%s' "$COMMAND_EXEC" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
+# One extractor, matched against a masked command so a quoted mention of `git -C` cannot
+# redirect this guard at another repository. See lib/command-scan.sh.
+GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
 EFFECTIVE_DIR="${CLAUDE_PROJECT_DIR:-.}"
 if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   EFFECTIVE_DIR="$HOOK_CWD"

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -79,6 +79,16 @@ fi
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 RELATIVE_PATH="${FILE_PATH#$PROJECT_DIR/}"
+# The scope filter above was widened to accept any prefix so worktree paths would be checked; this
+# strip was not, so a path under `.claude/worktrees/<agent>/` does not begin with $PROJECT_DIR and
+# survived whole — the log and the refusal then printed an absolute path, in exactly the scenario
+# the widening was for. Fall back to cutting at the workspace segment the filter matched on.
+if [[ "$RELATIVE_PATH" == /* ]]; then
+  case "$FILE_PATH" in
+    */packages/*) RELATIVE_PATH="packages/${FILE_PATH#*/packages/}" ;;
+    */apps/*) RELATIVE_PATH="apps/${FILE_PATH#*/apps/}" ;;
+  esac
+fi
 SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || true)
 BLOCKED=false
 BLOCK_MESSAGES=""

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -18,11 +18,21 @@
 set -uo pipefail
 
 INPUT=$(cat)
+
+# shellcheck source=lib/command-scan.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 LOG_FILE="$PROJECT_DIR/.agents/evals/local-metrics/blocks.jsonl"
 
 # ── scope filter ──────────────────────────────────────────────────────────────
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+# The first field read is the first place a missing decoder could pass silently — and it did:
+# without jq this came back empty and the hook exited 0 before reaching any check. An absent path
+# is normal (many tools carry none) and still exits 0; only an UNREADABLE payload refuses.
+if ! FILE_PATH=$(hook_json_string "$INPUT" 'tool_input.file_path'); then
+  echo "[check-forbidden-patterns] Blocked: the hook payload could not be decoded, so the edit" >&2
+  echo "[check-forbidden-patterns] cannot be checked. Install jq or python3." >&2
+  exit 2
+fi
 
 if [ -z "$FILE_PATH" ]; then
   exit 0
@@ -57,11 +67,11 @@ esac
 #
 # NotebookEdit is deliberately NOT handled: it carries `notebook_path`/`new_source` and never a
 # TypeScript `file_path`, so the packages/*/src scope filter above can never match it.
-CONTENT=$(echo "$INPUT" | jq -r '
-  .tool_input.content
-  // .tool_input.new_string
-  // ([.tool_input.edits[]?.new_string] | join("\n"))
-  // ""')
+if ! CONTENT=$(hook_edit_content_of "$INPUT"); then
+  echo "[check-forbidden-patterns] Blocked: the edit content could not be decoded, so it cannot be" >&2
+  echo "[check-forbidden-patterns] checked. Install jq or python3." >&2
+  exit 2
+fi
 
 if [ -z "$CONTENT" ]; then
   exit 0
@@ -69,7 +79,7 @@ fi
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 RELATIVE_PATH="${FILE_PATH#$PROJECT_DIR/}"
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || true)
 BLOCKED=false
 BLOCK_MESSAGES=""
 

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -28,12 +28,17 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Only check production TypeScript under packages/*/src
+# Only check production TypeScript under packages/*/src.
+#
+# Matched on the path's SHAPE, not on a `"$CLAUDE_PROJECT_DIR"` prefix. A worktree lives at
+# `<project>/.claude/worktrees/<agent>/packages/…`, which never carries the `<project>/packages/…`
+# prefix the old patterns required — so for a worktree-parallel agent, which is how work is normally
+# done here, this guard was off for every write it exists to check. Measured 2026-07-28: identical
+# offending content blocked in the main checkout, waved through in a worktree. A relative
+# `file_path`, and an unset CLAUDE_PROJECT_DIR (making the prefix a bare `.`), were blind the same way.
 case "$FILE_PATH" in
-  "$PROJECT_DIR"/packages/*/src/*.ts|\
-  "$PROJECT_DIR"/packages/*/src/**/*.ts|\
-  "$PROJECT_DIR"/packages/*/src/*.tsx|\
-  "$PROJECT_DIR"/packages/*/src/**/*.tsx) ;;
+  */packages/*/src/*.ts|packages/*/src/*.ts|\
+  */packages/*/src/*.tsx|packages/*/src/*.tsx) ;;
   *) exit 0 ;;
 esac
 
@@ -43,8 +48,20 @@ case "$FILE_PATH" in
 esac
 
 # ── extract NEW content from stdin (not disk) ─────────────────────────────────
-# Write tool → tool_input.content  |  Edit tool → tool_input.new_string
-CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // .tool_input.new_string // ""')
+# Write → tool_input.content | Edit → tool_input.new_string | MultiEdit → tool_input.edits[].new_string
+#
+# MultiEdit was measured bypassing this guard entirely on 2026-07-28: it carries its replacements in
+# an `edits` array, so neither field above existed, CONTENT came back empty and the hook exited 0 on
+# content it would have refused from Edit. It was also absent from the hook's matcher in
+# settings.json, so the same content was unguarded twice over — once by registration, once by shape.
+#
+# NotebookEdit is deliberately NOT handled: it carries `notebook_path`/`new_source` and never a
+# TypeScript `file_path`, so the packages/*/src scope filter above can never match it.
+CONTENT=$(echo "$INPUT" | jq -r '
+  .tool_input.content
+  // .tool_input.new_string
+  // ([.tool_input.edits[]?.new_string] | join("\n"))
+  // ""')
 
 if [ -z "$CONTENT" ]; then
   exit 0

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -134,108 +134,76 @@ hook_executable_part() {
   printf '%s\n' "$1" | hook_strip_heredocs | hook_strip_comments
 }
 
-# Mask the CONTENTS of quoted strings, one character for one, so offsets are preserved.
+# Quoted contents are masked one character for one — EXCEPT the string an interpreter is told to
+# run, which is a command and is left intact.
 #
-# Whole-input, not per line. The `sed 's/"[^"]*"/""/g'` this replaces worked a line at a time, so a
-# quoted argument spanning a newline had its opening and closing quotes on different lines and was
-# never masked — a second line reading `git push` inside a message would then be read as a push.
-hook_mask_quoted() {
-  awk '
-    { lines[NR] = $0 }
-    END {
-      q = ""
-      for (n = 1; n <= NR; n++) {
-        s = lines[n]
-        out = ""
-        for (i = 1; i <= length(s); i++) {
-          c = substr(s, i, 1)
-          if (q == "") {
-            out = out c
-            if (c == "\"" || c == "\047") { q = c }
-          } else if (c == q) {
-            out = out c
-            q = ""
-          } else {
-            out = out "\001"
-          }
+# The exception is per-string, not per-command. Applying it to the whole command the moment any
+# interpreter appeared produced both errors at once, and review found both: a `-C` inside
+# `bash -c "..."` was masked away so the branch check judged the wrong repository, and an unrelated
+# commit message on the same line stayed unmasked so an ordinary commit was read as a push. Deciding
+# at the opening quote — by what immediately precedes it — is what makes each string answer for
+# itself.
+#
+# One program serves both readers so they can never disagree about what the command says. MODE=mask
+# returns the masked command for verb matching; MODE=gitc locates `git -C` in the mask, where a
+# mention cannot match, and reads its value from the ORIGINAL at the same offset, because a path is
+# routinely quoted and masking it would leave the guard with no path at all.
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])((ba|z|da|k|c)?sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|xargs|env)[ \t]+-[[:alnum:]]*[ceE][ \t]*$'
+
+HOOK_SCAN_AWK='
+  { lines[NR] = $0 }
+  END {
+    # One string, so a quote opened on one line still masks the next. The sed this replaces worked a
+    # line at a time and left multi-line arguments unmasked entirely.
+    s = ""
+    for (n = 1; n <= NR; n++) { s = s (n > 1 ? "\n" : "") lines[n] }
+
+    mask = ""
+    q = ""
+    keep = 0
+    for (i = 1; i <= length(s); i++) {
+      c = substr(s, i, 1)
+      if (q == "") {
+        mask = mask c
+        if (c == "\"" || c == "\047") {
+          q = c
+          keep = (substr(s, 1, i - 1) ~ IRE)
         }
-        print out
+      } else if (c == q) {
+        mask = mask c
+        q = ""
+        keep = 0
+      } else {
+        mask = mask (keep ? c : "\001")
       }
     }
-  '
-}
 
-# Commands that RUN a string argument. When one is present nothing is masked, because the quoted
-# text is a command and must be read as one.
-#
-# `bash -c` was the whole list; `python3 -c`, `node -e`, `perl -e` run their strings just as truly,
-# and masking theirs turned a false positive into a bypass. The list errs toward preserving: a
-# command wrongly left unmasked is examined too closely, which is the only direction a guard may be
-# wrong in.
-HOOK_INTERPRETER_RE='(^|[[:space:];&|(])((ba|z|da|k|c)?sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|xargs|env)[[:space:]]+(-[[:alnum:]]*[ceE])([[:space:]]|$)|(^|[[:space:];&|(])eval([[:space:]]|$)'
+    if (MODE == "mask") { print mask; exit }
 
-# What a verb-detection matcher should read: the executable part, with quoted contents masked.
-#
-# Deliberately NOT the string used to extract names and paths. A branch name, a `git -C` target and
-# a `refs/heads/<name>` URL are routinely quoted; `hook_git_c_path` masks to LOCATE and reads the
-# ORIGINAL to extract, which is how both properties hold at once.
+    # A quote is a boundary. Inside a preserved interpreter string the character before the
+    # verb is `"`, and without it here the exception that keeps that string readable found
+    # nothing in it — the finding review raised.
+    if (!match(mask, /(^|[ \t;&|({\n"\047])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+/)) { exit }
+    p = RSTART + RLENGTH
+    c = substr(s, p, 1)
+    if (c == "\"" || c == "\047") {
+      p++
+      end = index(substr(s, p), c)
+      print (end > 0 ? substr(s, p, end - 1) : substr(s, p))
+    } else {
+      v = substr(s, p)
+      sub(/[ \t\n].*$/, "", v)
+      print v
+    }
+  }
+'
+
+# What a verb-detection matcher should read.
 hook_verb_scan() {
-  local exec_part
-  exec_part=$(hook_executable_part "$1")
-  if printf '%s' "$exec_part" | grep -qE "$HOOK_INTERPRETER_RE"; then
-    printf '%s\n' "$exec_part"
-    return 0
-  fi
-  printf '%s\n' "$exec_part" | hook_mask_quoted
+  hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" "$HOOK_SCAN_AWK"
 }
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
-#
-# This is the asymmetry review caught: verb detection blanked quoted contents, while the extraction
-# that decides WHICH REPOSITORY gets judged still read them. `git commit -m "... git -C /other ..."
-# && git push origin main` then pointed the branch check at /other and let a push to a protected
-# branch through — worse than the false positive the blanking removed, because it is silent.
-#
-# Blanking cannot simply be applied here: a path is often quoted (`git -C "/a b"`), and blanking it
-# would leave the guard with no path at all. So the command is MASKED — every character inside
-# quotes replaced one-for-one, preserving offsets — the flag is located in the mask, where a
-# mention cannot match, and the value is then read from the ORIGINAL at the same offset.
 hook_git_c_path() {
-  printf '%s\n' "$1" | awk '
-    { lines[NR] = $0 }
-    END {
-      # One string, so a quote opened on one line still masks the next — the same whole-input rule
-      # hook_mask_quoted follows, and the reason this is not two passes over separate strings.
-      s = ""
-      for (n = 1; n <= NR; n++) { s = s (n > 1 ? "\n" : "") lines[n] }
-
-      mask = ""
-      q = ""
-      for (i = 1; i <= length(s); i++) {
-        c = substr(s, i, 1)
-        if (q == "") {
-          mask = mask c
-          if (c == "\"" || c == "\047") { q = c }
-        } else if (c == q) {
-          mask = mask c
-          q = ""
-        } else {
-          mask = mask "\001"
-        }
-      }
-
-      if (!match(mask, /(^|[ \t;&|({\n])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+/)) { exit }
-      p = RSTART + RLENGTH                # first character of the value, in both strings
-      c = substr(s, p, 1)
-      if (c == "\"" || c == "\047") {
-        p++
-        end = index(substr(s, p), c)
-        print (end > 0 ? substr(s, p, end - 1) : substr(s, p))
-      } else {
-        v = substr(s, p)
-        sub(/[ \t\n].*$/, "", v)
-        print v
-      }
-    }
-  '
+  printf '%s\n' "$1" | awk -v MODE=gitc -v IRE="$HOOK_INTERPRETER_RE" "$HOOK_SCAN_AWK"
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -264,5 +264,11 @@ hook_deleted_branch() {
     [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
   fi
 
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)'
+  # `git push <remote> --delete <branch>` and `git push <remote> :<branch>`.
+  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)')
+  [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
+
+  # `git push --delete <remote> <branch>` — git accepts the flag before the remote, and the guard
+  # never did. Pre-existing rather than new, but a delete this misses is a delete it permits.
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+push[ \t]+--delete[ \t]+[^ \t]+[ \t]+'
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -251,10 +251,19 @@ HOOK_SCAN_AWK='
           # A double-quoted string still expands `$(...)` and backticks, so its contents are run no
           # matter what surrounds them. Look ahead to the closing quote and keep such a region.
           if (!keep && c == "\"") {
-            rest = substr(s, i + 1)
-            endq = index(rest, "\"")
-            inner = (endq > 0 ? substr(rest, 1, endq - 1) : rest)
-            if (index(inner, "$(") > 0 || index(inner, "`") > 0) { keep = 1 }
+            # Walk to the TRUE closing quote, stepping over backslash escapes. `index(rest, "\"")`
+            # stopped at the first `\\"` inside the string, so a `$(...)` written after one was not
+            # seen, the region was masked, and the command bash actually runs disappeared from the
+            # scan. Escapes and substitution had a test each; both in one string had none.
+            j = i + 1
+            while (j <= length(s)) {
+              ch = substr(s, j, 1)
+              if (ch == "\\") { j += 2; continue }
+              if (ch == "\"") { break }
+              if (ch == "`") { keep = 1 }
+              if (ch == "$" && substr(s, j + 1, 1) == "(") { keep = 1 }
+              j++
+            }
           }
         }
       } else if (c == q) {

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -203,8 +203,12 @@ hook_executable_part() {
 # `[^ \t;&|(\n/]*sh` matches any shell-named binary and an optional path prefix allows
 # `/bin/bash`, so a wrapper this list never heard of is still covered. Any number of arguments
 # may sit between the interpreter and its string — allowing exactly one meant `bash -x -c "…"`,
-# `ssh -o Opt host "…"` and `python3 -u -c "…"` all fell out of the exception and were masked; `ssh`, `expect`, `tclsh`, `timeout`, `nohup`, `sudo` and `env` were added after review
-# observed that a closed list is a list of the ways past the guard.
+# `ssh -o Opt host "…"` and `python3 -u -c "…"` all fell out of the exception and were masked.
+#
+# `ssh`, `expect` and `tclsh` are on the list because a closed list is a list of the ways past the
+# guard. `env`, `timeout`, `nohup`, `nice`, `flock`, `sudo`, `su` and `xargs` are deliberately NOT:
+# they exec an argument vector rather than evaluating a string, so listing them would widen
+# over-blocking for nothing. `timeout 5 bash -c "…"` stays covered — by the `bash -c` inside it.
 #
 # The boundary is real, and stated rather than implied: this is still an allowlist, so a quoted
 # string run by something outside it is masked and its verbs go unseen. Inverting the default —
@@ -222,68 +226,86 @@ HOOK_SCAN_AWK='
     # line at a time and left multi-line arguments unmasked entirely.
     s = ""
     for (n = 1; n <= NR; n++) { s = s (n > 1 ? "\n" : "") lines[n] }
+    len = length(s)
 
-    mask = ""
     q = ""
     keep = 0
     esc = 0
-    for (i = 1; i <= length(s); i++) {
+    for (i = 1; i <= len; i++) {
       c = substr(s, i, 1)
 
       # A backslash-escaped quote neither opens nor closes a string. Without this the tracker went
-      # out of phase at the first `\\"` and every offset after it was wrong — and this parser is now
-      # the only thing three guards believe. Single quotes are the exception: inside them a
-      # backslash is an ordinary character, which is why `q` is checked here.
-      if (esc) {
-        esc = 0
-        mask = mask (q == "" ? c : (keep ? c : "\001"))
-        continue
-      }
-      if (c == "\\" && q != "\047") {
-        esc = 1
-        mask = mask (q == "" ? c : (keep ? c : "\001"))
-        continue
-      }
+      # out of phase at the first escaped quote and every offset after it was wrong. Inside single
+      # quotes a backslash is an ordinary character, which is why q is checked.
+      if (esc) { esc = 0; m[i] = (q == "" || keep) ? c : "\001"; continue }
+      if (c == "\\" && q != "\047") { esc = 1; m[i] = (q == "" || keep) ? c : "\001"; continue }
 
       if (q == "") {
-        mask = mask c
+        m[i] = c
         if (c == "\"" || c == "\047") {
           q = c
+          openq = i
           keep = (substr(s, 1, i - 1) ~ IRE)
-          # A double-quoted string still expands `$(...)` and backticks, so its contents are run no
-          # matter what surrounds them. Look ahead to the closing quote and keep such a region.
-          if (!keep && c == "\"") {
-            # Walk to the TRUE closing quote, stepping over backslash escapes. `index(rest, "\"")`
-            # stopped at the first `\\"` inside the string, so a `$(...)` written after one was not
-            # seen, the region was masked, and the command bash actually runs disappeared from the
-            # scan. Escapes and substitution had a test each; both in one string had none.
+
+          # A quoted SINGLE WORD is a token of the command line, not a data payload. Quoting one
+          # changes nothing about what runs, so `git "push" origin main`, `git reset "--hard"` and
+          # `gh pr merge 1 --merge "--delete-branch"` must read exactly as their bare forms — and
+          # quoting every token is ordinary defensive shell style, not an exotic evasion. Only a
+          # quoted string containing whitespace is treated as a payload.
+          if (!keep) {
             j = i + 1
-            while (j <= length(s)) {
+            spaced = 0
+            while (j <= len) {
               ch = substr(s, j, 1)
-              if (ch == "\\") { j += 2; continue }
-              if (ch == "\"") { break }
-              if (ch == "`") { keep = 1 }
-              if (ch == "$" && substr(s, j + 1, 1) == "(") { keep = 1 }
+              if (ch == "\\" && q != "\047") { j += 2; continue }
+              if (ch == q) { break }
+              if (ch == " " || ch == "\t" || ch == "\n") { spaced = 1; break }
               j++
             }
+            if (!spaced) { keep = 1 }
           }
+
+          # The quote characters themselves become spaces around a KEPT region, so a matcher reads
+          # `git "push"` exactly as `git  push `. Without this the region survived masking and still
+          # matched nothing, because every verb pattern expects whitespace before the verb. Length is
+          # preserved one for one, so the offsets the extractors depend on stay valid.
+          if (keep) { m[openq] = " " }
         }
       } else if (c == q) {
-        mask = mask c
+        m[i] = keep ? " " : c
         q = ""
         keep = 0
       } else {
-        mask = mask (keep ? c : "\001")
+        m[i] = keep ? c : "\001"
       }
     }
 
+    # Command substitution runs whatever the quoting around it, so its span is restored from the
+    # original — the SPAN, not the whole enclosing string. Keeping the entire string meant a message
+    # holding both a substitution and an unrelated mention of a guarded verb was read as that verb.
+    for (i = 1; i <= len; i++) {
+      if (substr(s, i, 2) == "$(") {
+        depth = 0
+        for (j = i + 1; j <= len; j++) {
+          cj = substr(s, j, 1)
+          if (cj == "(") { depth++ } else if (cj == ")") { depth--; if (depth == 0) { break } }
+        }
+        stop = (j <= len) ? j : len
+        for (k = i; k <= stop; k++) { m[k] = substr(s, k, 1) }
+        i = stop
+      } else if (substr(s, i, 1) == "`") {
+        for (j = i + 1; j <= len; j++) { if (substr(s, j, 1) == "`") { break } }
+        stop = (j <= len) ? j : len
+        for (k = i; k <= stop; k++) { m[k] = substr(s, k, 1) }
+        i = stop
+      }
+    }
+
+    mask = ""
+    for (i = 1; i <= len; i++) { mask = mask m[i] }
+
     if (MODE == "mask") { print mask; exit }
 
-    # Locate in the MASK, where a quoted mention cannot match; read the value from the ORIGINAL at
-    # the same offset, because the value itself is routinely quoted and masking it would leave the
-    # guard with nothing. Every extraction that decides WHAT a guard acts on goes through here — the
-    # `git -C` target, and the branch name a delete would remove. Writing each by hand is how the
-    # delete checks kept reading quoted text as commands after every other check had stopped.
     # Anchor in the mask, then search the ORIGINAL from that offset. Needed when the value sits
     # INSIDE a quoted argument — a `gh api` refs/heads URL nearly always does — where the mask
     # hides it. Reading the original from position zero instead is what let a decoy in a commit
@@ -298,6 +320,9 @@ HOOK_SCAN_AWK='
       exit
     }
 
+    # Locate in the MASK, where a quoted mention cannot match; read the value from the ORIGINAL at
+    # the same offset, because the value itself is routinely quoted and masking it would leave the
+    # guard with nothing.
     if (!match(mask, ERE)) { exit }
     p = RSTART + RLENGTH
     c = substr(s, p, 1)
@@ -307,7 +332,7 @@ HOOK_SCAN_AWK='
       print (endq > 0 ? substr(s, p, endq - 1) : substr(s, p))
     } else {
       v = substr(s, p)
-      sub(/[ \t\n"\047].*$/, "", v)   # a value inside a quoted argument ends at the closing quote
+      sub(/[ \t\n"\047].*$/, "", v)
       print v
     }
   }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -58,7 +58,13 @@ sys.stdout.write(node if isinstance(node, str) else "")
 
 # The Bash tool's command. Non-zero return means "could not decode" — refuse, do not proceed.
 hook_command_of() {
-  hook_json_string "$1" 'tool_input.command'
+  local cmd
+  cmd=$(hook_json_string "$1" 'tool_input.command') || return 1
+  # jq's `// ""` turns an absent or null field into a successful empty string, so a payload with no
+  # command decoded "fine" and then matched nothing — a silent pass wearing the costume of a clean
+  # scan. A Bash call without a command is not something this guard can judge.
+  [[ -n "$cmd" ]] || return 1
+  printf '%s' "$cmd"
 }
 
 # The tool being invoked.
@@ -154,7 +160,21 @@ hook_executable_part() {
 # returns the masked command for verb matching; MODE=gitc locates `git -C` in the mask, where a
 # mention cannot match, and reads its value from the ORIGINAL at the same offset, because a path is
 # routinely quoted and masking it would leave the guard with no path at all.
-HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])(((ba|z|da|k|c)?sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|xargs|env)[ \t]+-[[:alnum:]]*[ceE]|eval)[ \t]+$'
+# Commands that RUN a string argument. When one precedes a quoted string, nothing inside it is
+# masked, because that text is a command and must be read as one.
+#
+# `[^ \t;&|(\n/]*sh` matches any shell-named binary, so a wrapper this list never heard of is still
+# covered; `ssh`, `expect`, `tclsh`, `timeout`, `nohup`, `sudo` and `env` were added after review
+# observed that a closed list is a list of the ways past the guard.
+#
+# The boundary is real, and stated rather than implied: this is still an allowlist, so a quoted
+# string run by something outside it is masked and its verbs go unseen. Inverting the default —
+# examine every quoted string unless a known message flag precedes it — was considered and
+# rejected: in this repository `rg "git push" docs/` and `grep -E "git push"` are ordinary
+# commands, and reading their arguments as commands would refuse routine work many times a day.
+# That is the self-blocking these hooks have already inflicted once. The trade runs this way
+# because of the threat model: the commands guarded here are the agent's own, written plainly.
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])((([^ \t;&|(\n/]*sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh|xargs|env|timeout|nohup|nice|flock|sudo|su)[ \t]+(-[[:alnum:]]*[ceE][ \t]+|[^ \t;&|(-][^ \t;&|(]*[ \t]+))|eval[ \t]+)$'
 
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -200,8 +200,10 @@ hook_executable_part() {
 # Commands that RUN a string argument. When one precedes a quoted string, nothing inside it is
 # masked, because that text is a command and must be read as one.
 #
-# `[^ \t;&|(\n/]*sh` matches any shell-named binary, so a wrapper this list never heard of is still
-# covered; `ssh`, `expect`, `tclsh`, `timeout`, `nohup`, `sudo` and `env` were added after review
+# `[^ \t;&|(\n/]*sh` matches any shell-named binary and an optional path prefix allows
+# `/bin/bash`, so a wrapper this list never heard of is still covered. Any number of arguments
+# may sit between the interpreter and its string — allowing exactly one meant `bash -x -c "…"`,
+# `ssh -o Opt host "…"` and `python3 -u -c "…"` all fell out of the exception and were masked; `ssh`, `expect`, `tclsh`, `timeout`, `nohup`, `sudo` and `env` were added after review
 # observed that a closed list is a list of the ways past the guard.
 #
 # The boundary is real, and stated rather than implied: this is still an allowlist, so a quoted
@@ -211,7 +213,7 @@ hook_executable_part() {
 # commands, and reading their arguments as commands would refuse routine work many times a day.
 # That is the self-blocking these hooks have already inflicted once. The trade runs this way
 # because of the threat model: the commands guarded here are the agent's own, written plainly.
-HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])((([^ \t;&|(\n/]*sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh)[ \t]+(-[[:alnum:]]*[ceE][ \t]+|[^ \t;&|(-][^ \t;&|(]*[ \t]+))|ssh[ \t]+[^ \t;&|(-][^ \t;&|(]*[ \t]+|eval[ \t]+)$'
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])(([^ \t;&|(\n]*/)?([^ \t;&|(\n/]*sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh)[ \t]+([^ \t;&|(\n]+[ \t]+)*|eval[ \t]+)$'
 
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -1,0 +1,110 @@
+# shellcheck shell=bash
+#
+# One parser for the PreToolUse Bash hooks, because four of them had four.
+#
+# Every hook here re-implemented the same two jobs by hand: pull the command out of the hook JSON,
+# and decide which part of it is a command rather than text. Both were wrong, in different ways, in
+# different files:
+#
+#   * `grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"'` stops at the FIRST double quote inside
+#     the command. `git commit -m "x" && git push origin main` was read as `git commit -m ` — the
+#     push, the thing the guard exists to see, was not in the string it examined. Copied verbatim
+#     into four hooks. Filed as HARNESS-061 and raised twice on review before this.
+#   * `SCAN="${COMMAND%%<<*}"` throws away everything from the first heredoc opener onward, so a
+#     `git reset --hard` written after a CLOSED heredoc is invisible.
+#   * Keeping the heredoc body does the opposite damage: prose in a commit message that describes
+#     `git checkout -b` was read as the act of running it, which self-blocked an entire session.
+#
+# A guard that examines a truncated command is not a weaker guard, it is a guard checking something
+# other than what will run — the failure mode `enforcement-architecture.md` names, and the one
+# PROC-003 was opened for. So the parse gets a single owner and a test, and hooks ask it for what
+# they need.
+#
+# Contract for callers:
+#   - Source this file, then use the functions. All are safe under `set -euo pipefail`.
+#   - `hook_command_of` returns non-zero when it cannot decode. Callers MUST treat that as a refusal
+#     for the commands they govern, never as an empty command that matches nothing.
+#   - Decoded output carries REAL newlines. Match with grep's own line semantics (`^` is a line
+#     start); do not match the two-character `\n` sequence, which no longer appears.
+
+# Decode a string field from the hook JSON.
+#
+# jq first, python3 second, refuse third. Both parse JSON properly, which is the entire point: the
+# payload is JSON and every hand-rolled decoder in this directory has been wrong about it.
+# `\uXXXX`, `\"`, `\\` and `\n` all come back as the characters they denote.
+hook_json_string() {
+  local json="$1" path="$2"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$json" | jq -r ".${path} // \"\"" 2>/dev/null && return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    doc = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+node = doc
+for key in sys.argv[1].split("."):
+    if not isinstance(node, dict):
+        node = None
+        break
+    node = node.get(key)
+sys.stdout.write(node if isinstance(node, str) else "")
+' "$path" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+# The Bash tool's command. Non-zero return means "could not decode" — refuse, do not proceed.
+hook_command_of() {
+  hook_json_string "$1" 'tool_input.command'
+}
+
+# The directory the tool reports it will run in. Absence is normal, so callers use `|| true`.
+hook_cwd_of() {
+  hook_json_string "$1" 'cwd'
+}
+
+# Remove heredoc BODIES from a command, keeping everything else — including whatever follows the
+# terminator, which is the part `%%<<*` discarded.
+#
+# The body is data the shell feeds to a program; it is never executed, so a guard reading it is
+# reading text and calling it a command. Everything outside the body IS a command, including the
+# commands after the heredoc closes, so a guard not reading those is blind to them. Both halves
+# matter and each was gotten wrong separately.
+#
+# Known limit, stated rather than hidden: only the first opener on a line is tracked, so
+# `cmd <<A <<B` strips A's body and treats B's opener as ordinary text. Multiple heredocs on one
+# line do not occur in commands this guards, and a wrong guess here would drop real commands.
+hook_strip_heredocs() {
+  awk '
+    BEGIN { inbody = 0 }
+    inbody {
+      line = $0
+      sub(/^[ \t]+/, "", line)     # <<- allows a tab-indented terminator
+      if (line == term) { inbody = 0 }
+      next
+    }
+    {
+      if (match($0, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/)) {
+        term = substr($0, RSTART, RLENGTH)
+        sub(/^<<-?[ \t]*/, "", term)
+        gsub(/[\047"]/, "", term)
+        inbody = 1
+        $0 = substr($0, 1, RSTART - 1)   # keep the command, drop the opener and its tail
+      }
+      print
+    }
+  '
+}
+
+# Strip trailing shell comments so a `#` remark naming a verb cannot trip a matcher.
+hook_strip_comments() {
+  sed 's/[[:space:]]#[^"]*$//'
+}
+
+# What a guard should actually examine: the command with heredoc bodies and comments removed.
+hook_executable_part() {
+  printf '%s\n' "$1" | hook_strip_heredocs | hook_strip_comments
+}

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -61,6 +61,27 @@ hook_command_of() {
   hook_json_string "$1" 'tool_input.command'
 }
 
+# The tool being invoked.
+#
+# Kept separate from `hook_command_of` on purpose. `tool_name` is a bare identifier — `Bash`,
+# `Edit` — and can never contain a quote, so the grep read that is wrong for a command is exactly
+# right for this field. That matters: routing `TOOL_NAME` through the JSON decoders would make a
+# machine without jq AND without python3 produce an empty tool name, and every hook would then take
+# its "not a Bash call" branch and exit 0 in silence. Three guards disabled, nothing said — the
+# fail-open this file exists to eliminate, reintroduced by the fix for it. Review caught it.
+hook_tool_name_of() {
+  local name rest
+  name=$(hook_json_string "$1" 'tool_name') && [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
+
+  # Pure parameter expansion — no grep, no sed, no subprocess. The point of this fallback is a
+  # machine missing jq AND python3, and a fallback that needs its own tools would fail there too,
+  # which is how the first attempt turned a silent bypass into exit 127.
+  rest="${1#*\"tool_name\"}"
+  [[ "$rest" == "$1" ]] && return 1
+  rest="${rest#*\"}"
+  printf '%s' "${rest%%\"*}"
+}
+
 # The directory the tool reports it will run in. Absence is normal, so callers use `|| true`.
 hook_cwd_of() {
   hook_json_string "$1" 'cwd'
@@ -113,38 +134,60 @@ hook_executable_part() {
   printf '%s\n' "$1" | hook_strip_heredocs | hook_strip_comments
 }
 
-# Blank the CONTENTS of quoted strings, so a verb written inside an argument is not read as a verb.
+# Mask the CONTENTS of quoted strings, one character for one, so offsets are preserved.
 #
-# Same principle as the heredoc body: `gh pr create --body "notes; git push later"` contains the
-# characters of a push and performs none. Until the decode was fixed, the truncated command hid this
-# by accident — `pre-push-check`'s own comment said so, and said the trap would come alive the day
-# the decode was corrected. This is that day, and that hook BLOCKS, so the false positive would be
-# one more self-inflicted stop of exactly the kind these guards exist to avoid.
+# Whole-input, not per line. The `sed 's/"[^"]*"/""/g'` this replaces worked a line at a time, so a
+# quoted argument spanning a newline had its opening and closing quotes on different lines and was
+# never masked — a second line reading `git push` inside a message would then be read as a push.
+hook_mask_quoted() {
+  awk '
+    { lines[NR] = $0 }
+    END {
+      q = ""
+      for (n = 1; n <= NR; n++) {
+        s = lines[n]
+        out = ""
+        for (i = 1; i <= length(s); i++) {
+          c = substr(s, i, 1)
+          if (q == "") {
+            out = out c
+            if (c == "\"" || c == "\047") { q = c }
+          } else if (c == q) {
+            out = out c
+            q = ""
+          } else {
+            out = out "\001"
+          }
+        }
+        print out
+      }
+    }
+  '
+}
+
+# Commands that RUN a string argument. When one is present nothing is masked, because the quoted
+# text is a command and must be read as one.
 #
-# The quotes and the shape of the command are kept — `git push origin "main"` becomes
-# `git push origin ""`, still a push, still matched. Only what is INSIDE them goes.
+# `bash -c` was the whole list; `python3 -c`, `node -e`, `perl -e` run their strings just as truly,
+# and masking theirs turned a false positive into a bypass. The list errs toward preserving: a
+# command wrongly left unmasked is examined too closely, which is the only direction a guard may be
+# wrong in.
+HOOK_INTERPRETER_RE='(^|[[:space:];&|(])((ba|z|da|k|c)?sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|xargs|env)[[:space:]]+(-[[:alnum:]]*[ceE])([[:space:]]|$)|(^|[[:space:];&|(])eval([[:space:]]|$)'
+
+# What a verb-detection matcher should read: the executable part, with quoted contents masked.
 #
-# Exception, and it is the important one: `bash -c "git push"` really does run a push, so when the
-# command invokes a shell on a string, nothing is stripped and the string is examined in full.
-# Erring toward examining more is the only direction a guard may err in.
-hook_blank_quoted_args() {
-  local text="$1"
-  if printf '%s' "$text" | grep -qE '(^|[[:space:];&|(])(ba|z|da)?sh[[:space:]]+-[[:alnum:]]*c([[:space:]]|$)|(^|[[:space:];&|(])eval([[:space:]]|$)'; then
-    printf '%s\n' "$text"
+# Deliberately NOT the string used to extract names and paths. A branch name, a `git -C` target and
+# a `refs/heads/<name>` URL are routinely quoted; `hook_git_c_path` masks to LOCATE and reads the
+# ORIGINAL to extract, which is how both properties hold at once.
+hook_verb_scan() {
+  local exec_part
+  exec_part=$(hook_executable_part "$1")
+  if printf '%s' "$exec_part" | grep -qE "$HOOK_INTERPRETER_RE"; then
+    printf '%s\n' "$exec_part"
     return 0
   fi
-  printf '%s\n' "$text" | sed 's/"[^"]*"/""/g; s/\x27[^\x27]*\x27/\x27\x27/g'
+  printf '%s\n' "$exec_part" | hook_mask_quoted
 }
-
-# What a verb-detection matcher should read: the executable part, with quoted arguments blanked.
-#
-# Deliberately NOT the same string used to extract names and paths. A branch name, a `git -C`
-# target and a `refs/heads/<name>` URL are routinely quoted, and blanking them there would make the
-# extraction find nothing — a guard that stops seeing what it is protecting.
-hook_verb_scan() {
-  hook_blank_quoted_args "$(hook_executable_part "$1")"
-}
-
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 #
@@ -158,9 +201,14 @@ hook_verb_scan() {
 # quotes replaced one-for-one, preserving offsets — the flag is located in the mask, where a
 # mention cannot match, and the value is then read from the ORIGINAL at the same offset.
 hook_git_c_path() {
-  printf '%s' "$1" | awk '
-    {
-      s = $0
+  printf '%s\n' "$1" | awk '
+    { lines[NR] = $0 }
+    END {
+      # One string, so a quote opened on one line still masks the next — the same whole-input rule
+      # hook_mask_quoted follows, and the reason this is not two passes over separate strings.
+      s = ""
+      for (n = 1; n <= NR; n++) { s = s (n > 1 ? "\n" : "") lines[n] }
+
       mask = ""
       q = ""
       for (i = 1; i <= length(s); i++) {
@@ -172,11 +220,11 @@ hook_git_c_path() {
           mask = mask c
           q = ""
         } else {
-          mask = mask "\001"      # same length, so offsets in the mask are offsets in s
+          mask = mask "\001"
         }
       }
 
-      if (!match(mask, /(^|[ \t;&|({])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+/)) { next }
+      if (!match(mask, /(^|[ \t;&|({\n])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+/)) { exit }
       p = RSTART + RLENGTH                # first character of the value, in both strings
       c = substr(s, p, 1)
       if (c == "\"" || c == "\047") {
@@ -185,9 +233,9 @@ hook_git_c_path() {
         print (end > 0 ? substr(s, p, end - 1) : substr(s, p))
       } else {
         v = substr(s, p)
-        sub(/[ \t].*$/, "", v)
+        sub(/[ \t\n].*$/, "", v)
         print v
       }
     }
-  ' | head -1
+  '
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -111,8 +111,14 @@ hook_strip_heredocs() {
       next
     }
     {
-      if (match($0, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/)) {
-        term = substr($0, RSTART, RLENGTH)
+      # A herestring is not a heredoc. `<<< "x"` has no body and no terminator, but the pattern
+      # below matches from the SECOND `<`, so everything after it was swallowed as body and never
+      # came back — every later command in that call went unexamined. Neutralising `<<<` first is
+      # length-preserving, so offsets into $0 stay valid.
+      probe = $0
+      gsub(/<<</, "\002\002\002", probe)
+      if (match(probe, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/)) {
+        term = substr(probe, RSTART, RLENGTH)
         dashed = (substr(term, 3, 1) == "-")
         sub(/^<<-?[ \t]*/, "", term)
         gsub(/[\047"]/, "", term)

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -88,6 +88,43 @@ hook_tool_name_of() {
   printf '%s' "${rest%%\"*}"
 }
 
+# The NEW content an edit would write: Write's `content`, Edit's `new_string`, MultiEdit's
+# `edits[].new_string` joined.
+#
+# Same ladder as every other field here — jq, then python3, then refuse. It was jq alone, so a
+# machine without jq produced empty content and the forbidden-pattern check exited 0 on content it
+# would otherwise have refused: the silent bypass this file exists to remove, surviving in the one
+# hook that guards a different tool. Review caught it.
+hook_edit_content_of() {
+  local content
+  if command -v jq >/dev/null 2>&1; then
+    content=$(printf '%s' "$1" | jq -r '
+      .tool_input.content
+      // .tool_input.new_string
+      // ([.tool_input.edits[]?.new_string] | join("\n"))
+      // ""' 2>/dev/null) && { printf '%s' "$content"; return 0; }
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$1" | python3 -c '
+import json, sys
+try:
+    doc = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+ti = doc.get("tool_input") or {}
+for key in ("content", "new_string"):
+    if isinstance(ti.get(key), str):
+        sys.stdout.write(ti[key])
+        break
+else:
+    edits = ti.get("edits") or []
+    parts = [e.get("new_string", "") for e in edits if isinstance(e, dict)]
+    sys.stdout.write("\n".join(parts))
+' 2>/dev/null && return 0
+  fi
+  return 1
+}
+
 # The directory the tool reports it will run in. Absence is normal, so callers use `|| true`.
 hook_cwd_of() {
   hook_json_string "$1" 'cwd'
@@ -174,7 +211,7 @@ hook_executable_part() {
 # commands, and reading their arguments as commands would refuse routine work many times a day.
 # That is the self-blocking these hooks have already inflicted once. The trade runs this way
 # because of the threat model: the commands guarded here are the agent's own, written plainly.
-HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])((([^ \t;&|(\n/]*sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh|xargs|env|timeout|nohup|nice|flock|sudo|su)[ \t]+(-[[:alnum:]]*[ceE][ \t]+|[^ \t;&|(-][^ \t;&|(]*[ \t]+))|eval[ \t]+)$'
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])((([^ \t;&|(\n/]*sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh)[ \t]+(-[[:alnum:]]*[ceE][ \t]+|[^ \t;&|(-][^ \t;&|(]*[ \t]+))|ssh[ \t]+[^ \t;&|(-][^ \t;&|(]*[ \t]+|eval[ \t]+)$'
 
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -200,8 +200,9 @@ hook_executable_part() {
 # Commands that RUN a string argument. When one precedes a quoted string, nothing inside it is
 # masked, because that text is a command and must be read as one.
 #
-# `[^ \t;&|(\n/]*sh` matches any shell-named binary and an optional path prefix allows
-# `/bin/bash`, so a wrapper this list never heard of is still covered. Any number of arguments
+# The shells are NAMED. `[^ \t;&|(\n/]*sh` matched any token ending in those two letters —
+# `git stash push -m "…"` read `stash` as an interpreter and opened the message to verb
+# scanning, refusing an ordinary command. An optional path prefix still allows `/bin/bash`. Any number of arguments
 # may sit between the interpreter and its string — allowing exactly one meant `bash -x -c "…"`,
 # `ssh -o Opt host "…"` and `python3 -u -c "…"` all fell out of the exception and were masked.
 #
@@ -217,7 +218,7 @@ hook_executable_part() {
 # commands, and reading their arguments as commands would refuse routine work many times a day.
 # That is the self-blocking these hooks have already inflicted once. The trade runs this way
 # because of the threat model: the commands guarded here are the agent's own, written plainly.
-HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])(([^ \t;&|(\n]*/)?([^ \t;&|(\n/]*sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh)[ \t]+([^ \t;&|(\n]+[ \t]+)*|eval[ \t]+)$'
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n`])(([^ \t;&|(\n]*/)?(sh|bash|zsh|dash|ksh|tcsh|csh|ash|fish|mksh|busybox|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh)[ \t]+([^ \t;&|(\n]+[ \t]+)*|eval[ \t]+)$'
 
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }
@@ -357,7 +358,7 @@ hook_verb_scan() {
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 hook_git_c_path() {
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+'
 }
 
 # The branch a remote-delete would remove, in either spelling the guard recognises.
@@ -376,15 +377,15 @@ hook_deleted_branch() {
     # match anywhere meant `git commit -m "note /git/refs/heads/scratch" && gh api -X DELETE
     # .../heads/develop` reported scratch, so the protected-branch and merged-PR checks never saw
     # the branch actually being deleted.
-    name=$(hook_match_extract_after "$1" '(^|[ \t;&|({\n"\047])gh[ \t]+api([ \t]|$)' '/git/refs/heads/')
+    name=$(hook_match_extract_after "$1" '(^|[ \t;&|({\n"\047`])gh[ \t]+api([ \t]|$)' '/git/refs/heads/')
     [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
   fi
 
   # `git push <remote> --delete <branch>` and `git push <remote> :<branch>`.
-  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)')
+  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)')
   [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
 
   # `git push --delete <remote> <branch>` — git accepts the flag before the remote, and the guard
   # never did. Pre-existing rather than new, but a delete this misses is a delete it permits.
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+push[ \t]+--delete[ \t]+[^ \t]+[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t]+[ \t]+'
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -108,3 +108,35 @@ hook_strip_comments() {
 hook_executable_part() {
   printf '%s\n' "$1" | hook_strip_heredocs | hook_strip_comments
 }
+
+# Blank the CONTENTS of quoted strings, so a verb written inside an argument is not read as a verb.
+#
+# Same principle as the heredoc body: `gh pr create --body "notes; git push later"` contains the
+# characters of a push and performs none. Until the decode was fixed, the truncated command hid this
+# by accident — `pre-push-check`'s own comment said so, and said the trap would come alive the day
+# the decode was corrected. This is that day, and that hook BLOCKS, so the false positive would be
+# one more self-inflicted stop of exactly the kind these guards exist to avoid.
+#
+# The quotes and the shape of the command are kept — `git push origin "main"` becomes
+# `git push origin ""`, still a push, still matched. Only what is INSIDE them goes.
+#
+# Exception, and it is the important one: `bash -c "git push"` really does run a push, so when the
+# command invokes a shell on a string, nothing is stripped and the string is examined in full.
+# Erring toward examining more is the only direction a guard may err in.
+hook_blank_quoted_args() {
+  local text="$1"
+  if printf '%s' "$text" | grep -qE '(^|[[:space:];&|(])(ba|z|da)?sh[[:space:]]+-[[:alnum:]]*c([[:space:]]|$)|(^|[[:space:];&|(])eval([[:space:]]|$)'; then
+    printf '%s\n' "$text"
+    return 0
+  fi
+  printf '%s\n' "$text" | sed 's/"[^"]*"/""/g; s/\x27[^\x27]*\x27/\x27\x27/g'
+}
+
+# What a verb-detection matcher should read: the executable part, with quoted arguments blanked.
+#
+# Deliberately NOT the same string used to extract names and paths. A branch name, a `git -C`
+# target and a `refs/heads/<name>` URL are routinely quoted, and blanking them there would make the
+# extraction find nothing — a guard that stops seeing what it is protecting.
+hook_verb_scan() {
+  hook_blank_quoted_args "$(hook_executable_part "$1")"
+}

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -150,7 +150,36 @@ hook_strip_heredocs() {
       # indented body line that happens to equal the terminator ends the body early, and the rest of
       # the body is then scanned as if it were commands.
       if (dashed) { sub(/^[ \t]+/, "", line) }
-      if (line == term) { inbody = 0 }
+      if (line == term) { inbody = 0; next }
+
+      # `<<EOF` — an UNQUOTED delimiter — is expanded by the shell, so `$(…)` and backticks in the
+      # body genuinely run. `<<\047EOF\047` and `<<"EOF"` are literal and stay data. Treating every
+      # body as data meant `git commit -F- <<EOF` with `$(git push --force …)` inside executed the
+      # push while no guard saw it — the same principle applied elsewhere in this file to quoted
+      # strings, and not here. Only the substitution spans are emitted; the prose around them is
+      # still data.
+      if (!quoted) {
+        out = ""
+        n = length($0)
+        for (i = 1; i <= n; i++) {
+          if (substr($0, i, 2) == "$(") {
+            depth = 0
+            for (j = i + 1; j <= n; j++) {
+              cj = substr($0, j, 1)
+              if (cj == "(") { depth++ } else if (cj == ")") { depth--; if (depth == 0) { break } }
+            }
+            stop = (j <= n) ? j : n
+            out = out substr($0, i, stop - i + 1) " "
+            i = stop
+          } else if (substr($0, i, 1) == "`") {
+            for (j = i + 1; j <= n; j++) { if (substr($0, j, 1) == "`") { break } }
+            stop = (j <= n) ? j : n
+            out = out substr($0, i, stop - i + 1) " "
+            i = stop
+          }
+        }
+        if (out != "") { print out }
+      }
       next
     }
     {
@@ -163,6 +192,7 @@ hook_strip_heredocs() {
       if (match(probe, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/)) {
         term = substr(probe, RSTART, RLENGTH)
         dashed = (substr(term, 3, 1) == "-")
+        quoted = (term ~ /[\047"]/)
         sub(/^<<-?[ \t]*/, "", term)
         gsub(/[\047"]/, "", term)
         inbody = 1
@@ -203,7 +233,10 @@ hook_executable_part() {
 # The shells are NAMED. `[^ \t;&|(\n/]*sh` matched any token ending in those two letters —
 # `git stash push -m "…"` read `stash` as an interpreter and opened the message to verb
 # scanning, refusing an ordinary command. An optional path prefix still allows `/bin/bash`. Any number of arguments
-# may sit between the interpreter and its string — allowing exactly one meant `bash -x -c "…"`,
+# may sit between the interpreter and its string, but none of them may itself be quoted: after
+# `python3 -c "x=1"` the NEXT quoted argument is a positional one the interpreter does not run,
+# and treating it as code refused ordinary commands. Allowing exactly one argument meant
+# `bash -x -c "…"`,
 # `ssh -o Opt host "…"` and `python3 -u -c "…"` all fell out of the exception and were masked.
 #
 # `ssh`, `expect` and `tclsh` are on the list because a closed list is a list of the ways past the
@@ -218,7 +251,7 @@ hook_executable_part() {
 # commands, and reading their arguments as commands would refuse routine work many times a day.
 # That is the self-blocking these hooks have already inflicted once. The trade runs this way
 # because of the threat model: the commands guarded here are the agent's own, written plainly.
-HOOK_INTERPRETER_RE='(^|[ \t;&|(\n`])(([^ \t;&|(\n]*/)?(sh|bash|zsh|dash|ksh|tcsh|csh|ash|fish|mksh|busybox|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh)[ \t]+([^ \t;&|(\n]+[ \t]+)*|eval[ \t]+)$'
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n`])(([^ \t;&|(\n]*/)?(sh|bash|zsh|dash|ksh|tcsh|csh|ash|fish|mksh|busybox|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh)[ \t]+([^ \t;&|(\n"\047]+[ \t]+)*|eval[ \t]+)$'
 
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -167,8 +167,25 @@ HOOK_SCAN_AWK='
     mask = ""
     q = ""
     keep = 0
+    esc = 0
     for (i = 1; i <= length(s); i++) {
       c = substr(s, i, 1)
+
+      # A backslash-escaped quote neither opens nor closes a string. Without this the tracker went
+      # out of phase at the first `\\"` and every offset after it was wrong — and this parser is now
+      # the only thing three guards believe. Single quotes are the exception: inside them a
+      # backslash is an ordinary character, which is why `q` is checked here.
+      if (esc) {
+        esc = 0
+        mask = mask (q == "" ? c : (keep ? c : "\001"))
+        continue
+      }
+      if (c == "\\" && q != "\047") {
+        esc = 1
+        mask = mask (q == "" ? c : (keep ? c : "\001"))
+        continue
+      }
+
       if (q == "") {
         mask = mask c
         if (c == "\"" || c == "\047") {
@@ -194,30 +211,58 @@ HOOK_SCAN_AWK='
 
     if (MODE == "mask") { print mask; exit }
 
-    # A quote is a boundary. Inside a preserved interpreter string the character before the
-    # verb is `"`, and without it here the exception that keeps that string readable found
-    # nothing in it — the finding review raised.
-    if (!match(mask, /(^|[ \t;&|({\n"\047])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+/)) { exit }
+    # Locate in the MASK, where a quoted mention cannot match; read the value from the ORIGINAL at
+    # the same offset, because the value itself is routinely quoted and masking it would leave the
+    # guard with nothing. Every extraction that decides WHAT a guard acts on goes through here — the
+    # `git -C` target, and the branch name a delete would remove. Writing each by hand is how the
+    # delete checks kept reading quoted text as commands after every other check had stopped.
+    if (!match(mask, ERE)) { exit }
     p = RSTART + RLENGTH
     c = substr(s, p, 1)
     if (c == "\"" || c == "\047") {
       p++
-      end = index(substr(s, p), c)
-      print (end > 0 ? substr(s, p, end - 1) : substr(s, p))
+      endq = index(substr(s, p), c)
+      print (endq > 0 ? substr(s, p, endq - 1) : substr(s, p))
     } else {
       v = substr(s, p)
-      sub(/[ \t\n].*$/, "", v)
+      sub(/[ \t\n"\047].*$/, "", v)   # a value inside a quoted argument ends at the closing quote
       print v
     }
   }
 '
 
+# Print the token that follows a match, located where quotes cannot lie. $2 is an ERE ending where
+# the value begins.
+hook_match_extract() {
+  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v ERE="$2" "$HOOK_SCAN_AWK"
+}
+
 # What a verb-detection matcher should read.
 hook_verb_scan() {
-  hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" "$HOOK_SCAN_AWK"
+  hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v ERE="" "$HOOK_SCAN_AWK"
 }
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 hook_git_c_path() {
-  printf '%s\n' "$1" | awk -v MODE=gitc -v IRE="$HOOK_INTERPRETER_RE" "$HOOK_SCAN_AWK"
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+'
+}
+
+# The branch a remote-delete would remove, in either spelling the guard recognises.
+#
+# The VERB is judged in the mask, so a delete named inside a commit message is not a delete. The
+# VALUE is then read from the original, because an argument is legitimately quoted — a `gh api`
+# URL almost always is — and masking it would leave the guard unable to name what it is protecting.
+# That split is the whole rule; writing it out by hand at each site is how these two checks stayed
+# on unmasked text after every other check had moved off it.
+hook_deleted_branch() {
+  local verbs name
+  verbs=$(hook_verb_scan "$1")
+
+  if printf '%s' "$verbs" | grep -qE 'gh[[:space:]]+api[^|;&]*-X[[:space:]]+DELETE[^|;&]*'; then
+    name=$(printf '%s' "$1" | grep -oE '/git/refs/heads/[A-Za-z0-9._/-]+' | head -1 |
+      sed 's#.*/git/refs/heads/##')
+    [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
+  fi
+
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)'
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -216,6 +216,20 @@ HOOK_SCAN_AWK='
     # guard with nothing. Every extraction that decides WHAT a guard acts on goes through here — the
     # `git -C` target, and the branch name a delete would remove. Writing each by hand is how the
     # delete checks kept reading quoted text as commands after every other check had stopped.
+    # Anchor in the mask, then search the ORIGINAL from that offset. Needed when the value sits
+    # INSIDE a quoted argument — a `gh api` refs/heads URL nearly always does — where the mask
+    # hides it. Reading the original from position zero instead is what let a decoy in a commit
+    # message stand in for the real branch being deleted.
+    if (MODE == "after") {
+      if (!match(mask, ERE)) { exit }
+      rest = substr(s, RSTART)
+      if (!match(rest, VRE)) { exit }
+      v = substr(rest, RSTART + RLENGTH)
+      sub(/[ \t\n"\047].*$/, "", v)
+      print v
+      exit
+    }
+
     if (!match(mask, ERE)) { exit }
     p = RSTART + RLENGTH
     c = substr(s, p, 1)
@@ -234,12 +248,18 @@ HOOK_SCAN_AWK='
 # Print the token that follows a match, located where quotes cannot lie. $2 is an ERE ending where
 # the value begins.
 hook_match_extract() {
-  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v ERE="$2" "$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v ERE="$2" -v VRE="" "$HOOK_SCAN_AWK"
+}
+
+# Like hook_match_extract, but the value is found by $3 searched in the ORIGINAL starting at the
+# anchor $2's position in the mask. For values that legitimately live inside a quoted argument.
+hook_match_extract_after() {
+  printf '%s\n' "$1" | awk -v MODE=after -v IRE="$HOOK_INTERPRETER_RE" -v ERE="$2" -v VRE="$3" "$HOOK_SCAN_AWK"
 }
 
 # What a verb-detection matcher should read.
 hook_verb_scan() {
-  hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v ERE="" "$HOOK_SCAN_AWK"
+  hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v ERE="" -v VRE="" "$HOOK_SCAN_AWK"
 }
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
@@ -259,8 +279,11 @@ hook_deleted_branch() {
   verbs=$(hook_verb_scan "$1")
 
   if printf '%s' "$verbs" | grep -qE 'gh[[:space:]]+api[^|;&]*-X[[:space:]]+DELETE[^|;&]*'; then
-    name=$(printf '%s' "$1" | grep -oE '/git/refs/heads/[A-Za-z0-9._/-]+' | head -1 |
-      sed 's#.*/git/refs/heads/##')
+    # From the `gh api` call's own position, not from the start of the string. Taking the first
+    # match anywhere meant `git commit -m "note /git/refs/heads/scratch" && gh api -X DELETE
+    # .../heads/develop` reported scratch, so the protected-branch and merged-PR checks never saw
+    # the branch actually being deleted.
+    name=$(hook_match_extract_after "$1" '(^|[ \t;&|({\n"\047])gh[ \t]+api([ \t]|$)' '/git/refs/heads/')
     [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
   fi
 

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -82,13 +82,17 @@ hook_strip_heredocs() {
     BEGIN { inbody = 0 }
     inbody {
       line = $0
-      sub(/^[ \t]+/, "", line)     # <<- allows a tab-indented terminator
+      # Only `<<-` lets the terminator be indented. Stripping indentation unconditionally means an
+      # indented body line that happens to equal the terminator ends the body early, and the rest of
+      # the body is then scanned as if it were commands.
+      if (dashed) { sub(/^[ \t]+/, "", line) }
       if (line == term) { inbody = 0 }
       next
     }
     {
       if (match($0, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/)) {
         term = substr($0, RSTART, RLENGTH)
+        dashed = (substr(term, 3, 1) == "-")
         sub(/^<<-?[ \t]*/, "", term)
         gsub(/[\047"]/, "", term)
         inbody = 1
@@ -139,4 +143,51 @@ hook_blank_quoted_args() {
 # extraction find nothing — a guard that stops seeing what it is protecting.
 hook_verb_scan() {
   hook_blank_quoted_args "$(hook_executable_part "$1")"
+}
+
+
+# The directory a command will act on, read from a real `git -C` and not from a quoted mention.
+#
+# This is the asymmetry review caught: verb detection blanked quoted contents, while the extraction
+# that decides WHICH REPOSITORY gets judged still read them. `git commit -m "... git -C /other ..."
+# && git push origin main` then pointed the branch check at /other and let a push to a protected
+# branch through — worse than the false positive the blanking removed, because it is silent.
+#
+# Blanking cannot simply be applied here: a path is often quoted (`git -C "/a b"`), and blanking it
+# would leave the guard with no path at all. So the command is MASKED — every character inside
+# quotes replaced one-for-one, preserving offsets — the flag is located in the mask, where a
+# mention cannot match, and the value is then read from the ORIGINAL at the same offset.
+hook_git_c_path() {
+  printf '%s' "$1" | awk '
+    {
+      s = $0
+      mask = ""
+      q = ""
+      for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+        if (q == "") {
+          mask = mask c
+          if (c == "\"" || c == "\047") { q = c }
+        } else if (c == q) {
+          mask = mask c
+          q = ""
+        } else {
+          mask = mask "\001"      # same length, so offsets in the mask are offsets in s
+        }
+      }
+
+      if (!match(mask, /(^|[ \t;&|({])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+/)) { next }
+      p = RSTART + RLENGTH                # first character of the value, in both strings
+      c = substr(s, p, 1)
+      if (c == "\"" || c == "\047") {
+        p++
+        end = index(substr(s, p), c)
+        print (end > 0 ? substr(s, p, end - 1) : substr(s, p))
+      } else {
+        v = substr(s, p)
+        sub(/[ \t].*$/, "", v)
+        print v
+      }
+    }
+  ' | head -1
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -154,7 +154,7 @@ hook_executable_part() {
 # returns the masked command for verb matching; MODE=gitc locates `git -C` in the mask, where a
 # mention cannot match, and reads its value from the ORIGINAL at the same offset, because a path is
 # routinely quoted and masking it would leave the guard with no path at all.
-HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])((ba|z|da|k|c)?sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|xargs|env)[ \t]+-[[:alnum:]]*[ceE][ \t]*$'
+HOOK_INTERPRETER_RE='(^|[ \t;&|(\n])(((ba|z|da|k|c)?sh|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|xargs|env)[ \t]+-[[:alnum:]]*[ceE]|eval)[ \t]+$'
 
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }
@@ -174,6 +174,14 @@ HOOK_SCAN_AWK='
         if (c == "\"" || c == "\047") {
           q = c
           keep = (substr(s, 1, i - 1) ~ IRE)
+          # A double-quoted string still expands `$(...)` and backticks, so its contents are run no
+          # matter what surrounds them. Look ahead to the closing quote and keep such a region.
+          if (!keep && c == "\"") {
+            rest = substr(s, i + 1)
+            endq = index(rest, "\"")
+            inner = (endq > 0 ? substr(rest, 1, endq - 1) : rest)
+            if (index(inner, "$(") > 0 || index(inner, "`") > 0) { keep = 1 }
+          }
         }
       } else if (c == q) {
         mask = mask c

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -74,7 +74,7 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # verb is then `"`, so without this the preserved string matched nothing and the exception was
 # decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
 # false positive it sits next to.
-printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -51,7 +51,8 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # real invocation can reach is indistinguishable from no enforcement.
 #
 # Boundaries are STATEMENT separators only — line start, `;`, `&&`, `||`, `|`, `(`, and the literal
-# a real newline, matched by grep's own `^`. Bare whitespace is NOT a boundary, deliberately: with it,
+# a real newline, matched by grep's own `^`. Whitespace IS a boundary — `time git push`, `command git push`, `nice git push` reach the
+# guard only through it. It was excluded while the false positive below was live:
 # `gh pr create --body "… git push …"` and `git commit -m "fix: git push guard"` both match, and a
 # guard that blocks ordinary work is one that gets switched off.
 #
@@ -66,15 +67,14 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # at the first escaped quote, so the text after `--body \"` is never seen (HARNESS-061). It would
 # come alive the moment that extraction is repaired — so it is excluded here rather than left as a
 # trap for whoever fixes it.
-# `\n` appears as the two literal characters backslash-n: the command arrives as JSON and is read
-# with grep, not a JSON parser, so a multi-line block keeps its escapes. That form — `cd <repo>` on
-# one line, `git push` on the next — is exactly the one that slipped through, so it is a boundary too.
-# A quote is a boundary too. `bash -c "git push origin main"` really runs a push, and
-# hook_blank_quoted_args deliberately leaves that string intact — but the character before the
-# verb is then `"`, so without this the preserved string matched nothing and the exception was
-# decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
-# false positive it sits next to.
-printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+# Boundaries: line start, `;`, `&&`, `||`, `|`, `(`, `{`, a quote, a backtick, a newline — and
+# whitespace. `time git push`, `command git push` and `nice git push` reach this guard only through
+# the last one, and it was excluded while the false positive it guarded against was live: back then
+# the whole command was scanned raw, so `gh pr create --body "… git push …"` matched. Quoted
+# payloads are masked before this runs now, so the exclusion protected nothing and cost the forms
+# above. A quote and a backtick are boundaries because a kept region — `bash -c "git push"`,
+# `` `git push` `` — puts one immediately before the verb.
+printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -51,7 +51,7 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # real invocation can reach is indistinguishable from no enforcement.
 #
 # Boundaries are STATEMENT separators only — line start, `;`, `&&`, `||`, `|`, `(`, and the literal
-# `\n` that survives JSON extraction. Bare whitespace is NOT a boundary, deliberately: with it,
+# a real newline, matched by grep's own `^`. Bare whitespace is NOT a boundary, deliberately: with it,
 # `gh pr create --body "… git push …"` and `git commit -m "fix: git push guard"` both match, and a
 # guard that blocks ordinary work is one that gets switched off.
 #

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -32,6 +32,7 @@ fi
 # Heredoc bodies and comments are text; only the rest is a command. Shared with the other Bash
 # hooks so all three answer "what will run" the same way.
 COMMAND_EXEC=$(hook_executable_part "$COMMAND")
+COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 
 # Only intercept git push commands (tolerating env prefixes + global git flags like `git -C <path>`).
 #
@@ -62,7 +63,12 @@ COMMAND_EXEC=$(hook_executable_part "$COMMAND")
 # `\n` appears as the two literal characters backslash-n: the command arrives as JSON and is read
 # with grep, not a JSON parser, so a multi-line block keeps its escapes. That form — `cd <repo>` on
 # one line, `git push` on the next — is exactly the one that slipped through, so it is a boundary too.
-printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[;&|({])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+# A quote is a boundary too. `bash -c "git push origin main"` really runs a push, and
+# hook_blank_quoted_args deliberately leaves that string intact — but the character before the
+# verb is then `"`, so without this the preserved string matched nothing and the exception was
+# decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
+# false positive it sits next to.
+printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -17,7 +17,7 @@ INPUT=$(cat)
 # shellcheck source=lib/command-scan.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 
-TOOL_NAME=$(hook_json_string "$INPUT" 'tool_name' || true)
+TOOL_NAME=$(hook_tool_name_of "$INPUT")
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -17,7 +17,13 @@ INPUT=$(cat)
 # shellcheck source=lib/command-scan.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 
-TOOL_NAME=$(hook_tool_name_of "$INPUT")
+# Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
+# under `set -e` and the hook exits 1 with nothing said — which the hook protocol treats as
+# non-blocking. Silent exit and "it is fine" are the two states this file refuses to conflate.
+if ! TOOL_NAME=$(hook_tool_name_of "$INPUT"); then
+  echo "[pre-push-check] Blocked: the hook payload names no tool, so nothing can be judged." >&2
+  exit 2
+fi
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -73,7 +73,9 @@ printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'])[[:space:]]*(\S+=\S+[[
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.
 HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
-GIT_C_PATH=$(printf '%s' "$COMMAND_EXEC" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
+# One extractor, matched against a masked command so a quoted mention of `git -C` cannot
+# redirect this guard at another repository. See lib/command-scan.sh.
+GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   PROJECT_DIR="$HOOK_CWD"

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -11,13 +11,27 @@ set -euo pipefail
 
 INPUT=$(cat)
 
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+# One parser, not four. `command-scan.sh` explains what each hand-rolled copy got wrong; the short
+# version is that the old `grep -o '"command"…"[^"]*"' ` stopped at the first quote inside the
+# command, so everything after `-m "…"` — including the verb being guarded — was never examined.
+# shellcheck source=lib/command-scan.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+
+TOOL_NAME=$(hook_json_string "$INPUT" 'tool_name' || true)
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0
 fi
 
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+if ! COMMAND=$(hook_command_of "$INPUT"); then
+  echo "[pre-push-check] Blocked: the tool command could not be decoded, so the push cannot be judged." >&2
+  echo "[pre-push-check] Install jq or python3 so this guard can read what it is judging." >&2
+  exit 2
+fi
+
+# Heredoc bodies and comments are text; only the rest is a command. Shared with the other Bash
+# hooks so all three answer "what will run" the same way.
+COMMAND_EXEC=$(hook_executable_part "$COMMAND")
 
 # Only intercept git push commands (tolerating env prefixes + global git flags like `git -C <path>`).
 #
@@ -48,12 +62,12 @@ COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | 
 # `\n` appears as the two literal characters backslash-n: the command arrives as JSON and is read
 # with grep, not a JSON parser, so a multi-line block keeps its escapes. That form — `cd <repo>` on
 # one line, `git push` on the next — is exactly the one that slipped through, so it is a boundary too.
-echo "$COMMAND" | grep -qE '(^|[;&|({]|\\n)[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+printf '%s' "$COMMAND_EXEC" | grep -qE '(^|[;&|({])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.
-HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
-GIT_C_PATH=$(printf '%s' "$COMMAND" | sed -nE 's/^[[:space:]]*git[[:space:]]+-C[[:space:]]+"?([^"[:space:]]+)"?.*/\1/p')
+HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
+GIT_C_PATH=$(printf '%s' "$COMMAND_EXEC" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   PROJECT_DIR="$HOOK_CWD"

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -66,6 +66,7 @@ fi
 # Scan only up to the first heredoc opener (`<<`) and strip trailing comments, so a commit message
 # or echoed text mentioning these commands cannot trip the guard (same defense as branch-guard).
 SCAN=$(hook_executable_part "$COMMAND")
+VERBS=$(hook_verb_scan "$COMMAND")
 
 # GITPFX tolerates env prefixes and global git flags before the subcommand (`git -C <path> reset`,
 # `git -c k=v push`) — the same pattern branch-guard uses.
@@ -76,17 +77,22 @@ SCAN=$(hook_executable_part "$COMMAND")
 # Measured 2026-07-28: this guard was reachable from `;`, `&&` and env prefixes but silently bypassed
 # by exactly that shape — and a destructive command on a later line of a block is the shape of the
 # incident it exists to prevent.
-GITPFX='(^|[[:space:];&|({])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
+# A quote is a boundary too. `bash -c "git push origin main"` really runs a push, and
+# hook_blank_quoted_args deliberately leaves that string intact — but the character before the
+# verb is then `"`, so without this the preserved string matched nothing and the exception was
+# decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
+# false positive it sits next to.
+GITPFX='(^|[[:space:];&|({"'"'"'])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
 
 IS_DESTRUCTIVE=false
 # git reset --hard
-printf '%s' "$SCAN" | grep -qE "${GITPFX}reset\b[^|;&]*--hard\b" && IS_DESTRUCTIVE=true
+printf '%s' "$VERBS" | grep -qE "${GITPFX}reset\b[^|;&]*--hard\b" && IS_DESTRUCTIVE=true
 # git clean with a force flag (-f, -fd, -fdx, -xf, --force)
-printf '%s' "$SCAN" | grep -qE "${GITPFX}clean\b[^|;&]*(-[[:alnum:]]*f|--force)" && IS_DESTRUCTIVE=true
+printf '%s' "$VERBS" | grep -qE "${GITPFX}clean\b[^|;&]*(-[[:alnum:]]*f|--force)" && IS_DESTRUCTIVE=true
 # git checkout -- <path> (discards working-tree changes, e.g. `git checkout -- .`)
-printf '%s' "$SCAN" | grep -qE "${GITPFX}checkout\b[^|;&]*[[:space:]]--([[:space:]]|$)" && IS_DESTRUCTIVE=true
+printf '%s' "$VERBS" | grep -qE "${GITPFX}checkout\b[^|;&]*[[:space:]]--([[:space:]]|$)" && IS_DESTRUCTIVE=true
 # git push --force / --force-with-lease
-printf '%s' "$SCAN" | grep -qE "${GITPFX}push\b[^|;&]*--force" && IS_DESTRUCTIVE=true
+printf '%s' "$VERBS" | grep -qE "${GITPFX}push\b[^|;&]*--force" && IS_DESTRUCTIVE=true
 
 if [[ "$IS_DESTRUCTIVE" != "true" ]]; then
   exit 0

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -35,7 +35,13 @@ INPUT=$(cat)
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
-TOOL_NAME=$(hook_tool_name_of "$INPUT")
+# Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
+# under `set -e` and the hook exits 1 with nothing said — which the hook protocol treats as
+# non-blocking. Silent exit and "it is fine" are the two states this file refuses to conflate.
+if ! TOOL_NAME=$(hook_tool_name_of "$INPUT"); then
+  echo "[worktree-cwd-guard] Blocked: the hook payload names no tool, so nothing can be judged." >&2
+  exit 2
+fi
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -77,17 +77,16 @@ VERBS=$(hook_verb_scan "$COMMAND")
 # GITPFX tolerates env prefixes and global git flags before the subcommand (`git -C <path> reset`,
 # `git -c k=v push`) — the same pattern branch-guard uses.
 #
-# `\n` — the two literal characters backslash-n — is a boundary too. The command arrives as JSON and
+# A newline is a boundary too. The command arrives decoded as JSON with real newlines, and
 # is decoded as JSON now and carries real newlines, so grep's `^` is a line start and the second line
 # of `cd <repo>` + newline + `git reset --hard` begins with no whitespace, no `;` and no `&`.
 # Measured 2026-07-28: this guard was reachable from `;`, `&&` and env prefixes but silently bypassed
 # by exactly that shape — and a destructive command on a later line of a block is the shape of the
 # incident it exists to prevent.
-# A quote is a boundary too. `bash -c "git push origin main"` really runs a push, and
-# hook_blank_quoted_args deliberately leaves that string intact — but the character before the
-# verb is then `"`, so without this the preserved string matched nothing and the exception was
-# decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
-# false positive it sits next to.
+# A quote and a backtick are boundaries too: a KEPT region — `bash -c "git push"`, or a backtick
+# subshell — puts one immediately before the verb, and without them the region survived masking and
+# still matched nothing. Quoted payloads are masked before this runs, so this cannot resurrect the
+# false positive it sits beside.
 GITPFX='(^|[[:space:];&|({"'"'"'`])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
 
 IS_DESTRUCTIVE=false

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -111,7 +111,9 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # --hard` — the exact cross-checkout shape this guard exists for — resolved to the worktree and passed.
 # `|| true` is load-bearing: grep exits 1 when there is no `-C`, and under `set -euo pipefail` a
 # failed command substitution aborts the hook silently before any check runs.
-GIT_C_PATH=$(printf '%s' "$SCAN" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
+# One extractor, matched against a masked command so a quoted mention of `git -C` cannot
+# redirect this guard at another repository. See lib/command-scan.sh.
+GIT_C_PATH=$(hook_git_c_path "$SCAN" || true)
 EFFECTIVE_DIR=""
 if [[ -n "$GIT_C_PATH" ]]; then
   EFFECTIVE_DIR="$GIT_C_PATH"

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -78,7 +78,7 @@ VERBS=$(hook_verb_scan "$COMMAND")
 # `git -c k=v push`) — the same pattern branch-guard uses.
 #
 # `\n` — the two literal characters backslash-n — is a boundary too. The command arrives as JSON and
-# is read with grep, not a JSON parser, so a multi-line block keeps its escapes and the second line
+# is decoded as JSON now and carries real newlines, so grep's `^` is a line start and the second line
 # of `cd <repo>` + newline + `git reset --hard` begins with no whitespace, no `;` and no `&`.
 # Measured 2026-07-28: this guard was reachable from `;`, `&&` and env prefixes but silently bypassed
 # by exactly that shape — and a destructive command on a later line of a block is the shape of the

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -35,7 +35,7 @@ INPUT=$(cat)
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
-TOOL_NAME=$(hook_json_string "$INPUT" 'tool_name' || true)
+TOOL_NAME=$(hook_tool_name_of "$INPUT")
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -28,15 +28,25 @@ set -euo pipefail
 
 INPUT=$(cat)
 
+# One parser, not four. `command-scan.sh` explains what each hand-rolled copy got wrong; the short
+# version is that the old `grep -o '"command"…"[^"]*"' ` stopped at the first quote inside the
+# command, so everything after `-m "…"` — including the verb being guarded — was never examined.
+# shellcheck source=lib/command-scan.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+
 # Extract tool_name without jq — match "tool_name":"Bash"
-TOOL_NAME=$(echo "$INPUT" | grep -o '"tool_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tool_name"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+TOOL_NAME=$(hook_json_string "$INPUT" 'tool_name' || true)
 
 if [[ "$TOOL_NAME" != "Bash" ]]; then
   exit 0
 fi
 
 # Extract command from tool_input.command
-COMMAND=$(echo "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"command"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+if ! COMMAND=$(hook_command_of "$INPUT"); then
+  echo "[worktree-cwd-guard] Blocked: the tool command could not be decoded, so the command cannot be judged." >&2
+  echo "[worktree-cwd-guard] Install jq or python3 so this guard can read what it is judging." >&2
+  exit 2
+fi
 
 # Honor the inline override token written IN the command string. The `VAR=1` prefix runs in the
 # TOOL's shell, not this hook's process, so a plain env check never sees it (same reasoning as
@@ -55,8 +65,7 @@ fi
 # --- Detect destructive git commands ------------------------------------------------------------
 # Scan only up to the first heredoc opener (`<<`) and strip trailing comments, so a commit message
 # or echoed text mentioning these commands cannot trip the guard (same defense as branch-guard).
-COMMAND_NO_COMMENTS=$(printf '%s' "$COMMAND" | sed 's/[[:space:]]#[^"]*$//')
-SCAN="${COMMAND_NO_COMMENTS%%<<*}"
+SCAN=$(hook_executable_part "$COMMAND")
 
 # GITPFX tolerates env prefixes and global git flags before the subcommand (`git -C <path> reset`,
 # `git -c k=v push`) — the same pattern branch-guard uses.
@@ -67,7 +76,7 @@ SCAN="${COMMAND_NO_COMMENTS%%<<*}"
 # Measured 2026-07-28: this guard was reachable from `;`, `&&` and env prefixes but silently bypassed
 # by exactly that shape — and a destructive command on a later line of a block is the shape of the
 # incident it exists to prevent.
-GITPFX='(^|[[:space:];&|(]|\\n)([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
+GITPFX='(^|[[:space:];&|({])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
 
 IS_DESTRUCTIVE=false
 # git reset --hard
@@ -90,13 +99,13 @@ fi
 # — resolving its toplevel would judge an unrelated checkout (this caused a fail-safe bug: a non-git
 # cwd fell back to `.`, which resolved to the hook's own checkout and blocked). If no concrete dir can
 # be named, we cannot positively confirm anything → FAIL-SAFE, do not block.
-HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
+HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # Unanchored: `git -C <path>` is almost never the first thing on the line. Anchored, the highest-
 # precedence input to this resolution was never available, so a `cd <worktree> && git -C <main> reset
 # --hard` — the exact cross-checkout shape this guard exists for — resolved to the worktree and passed.
 # `|| true` is load-bearing: grep exits 1 when there is no `-C`, and under `set -euo pipefail` a
 # failed command substitution aborts the hook silently before any check runs.
-GIT_C_PATH=$(printf '%s' "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
+GIT_C_PATH=$(printf '%s' "$SCAN" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
 EFFECTIVE_DIR=""
 if [[ -n "$GIT_C_PATH" ]]; then
   EFFECTIVE_DIR="$GIT_C_PATH"

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -88,7 +88,7 @@ VERBS=$(hook_verb_scan "$COMMAND")
 # verb is then `"`, so without this the preserved string matched nothing and the exception was
 # decorative. Elsewhere quoted content is already blanked, so this cannot resurrect the
 # false positive it sits next to.
-GITPFX='(^|[[:space:];&|({"'"'"'])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
+GITPFX='(^|[[:space:];&|({"'"'"'`])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
 
 IS_DESTRUCTIVE=false
 # git reset --hard

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -60,7 +60,14 @@ SCAN="${COMMAND_NO_COMMENTS%%<<*}"
 
 # GITPFX tolerates env prefixes and global git flags before the subcommand (`git -C <path> reset`,
 # `git -c k=v push`) — the same pattern branch-guard uses.
-GITPFX='(^|[[:space:];&|(])([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
+#
+# `\n` — the two literal characters backslash-n — is a boundary too. The command arrives as JSON and
+# is read with grep, not a JSON parser, so a multi-line block keeps its escapes and the second line
+# of `cd <repo>` + newline + `git reset --hard` begins with no whitespace, no `;` and no `&`.
+# Measured 2026-07-28: this guard was reachable from `;`, `&&` and env prefixes but silently bypassed
+# by exactly that shape — and a destructive command on a later line of a block is the shape of the
+# incident it exists to prevent.
+GITPFX='(^|[[:space:];&|(]|\\n)([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*'
 
 IS_DESTRUCTIVE=false
 # git reset --hard
@@ -84,7 +91,12 @@ fi
 # cwd fell back to `.`, which resolved to the hook's own checkout and blocked). If no concrete dir can
 # be named, we cannot positively confirm anything → FAIL-SAFE, do not block.
 HOOK_CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"cwd"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//' || true)
-GIT_C_PATH=$(printf '%s' "$COMMAND" | sed -nE 's/^[[:space:]]*git[[:space:]]+-C[[:space:]]+"?([^"[:space:]]+)"?.*/\1/p')
+# Unanchored: `git -C <path>` is almost never the first thing on the line. Anchored, the highest-
+# precedence input to this resolution was never available, so a `cd <worktree> && git -C <main> reset
+# --hard` — the exact cross-checkout shape this guard exists for — resolved to the worktree and passed.
+# `|| true` is load-bearing: grep exits 1 when there is no `-C`, and under `set -euo pipefail` a
+# failed command substitution aborts the hook silently before any check runs.
+GIT_C_PATH=$(printf '%s' "$COMMAND" | grep -oE 'git[[:space:]]+-C[[:space:]]+"?[^"[:space:]]+' | head -1 | sed -E 's/.*-C[[:space:]]+"?//' || true)
 EFFECTIVE_DIR=""
 if [[ -n "$GIT_C_PATH" ]]; then
   EFFECTIVE_DIR="$GIT_C_PATH"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -56,7 +56,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -1,5 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -193,6 +200,63 @@ describe('a hook examines the command that will run', () => {
         cwd,
       });
       expect(result.status, `branch-guard judged the wrong repository for -C ${target}`).toBe(0);
+    }
+  });
+
+  it('reads a command an interpreter is told to run', () => {
+    // `bash -c` was the entire exception list, and `python3 -c` / `node -e` run their strings just
+    // as truly. Masking theirs converted the false positive that masking removed into a bypass,
+    // which is the trade a guard may never make.
+    const cwd = scratchRepo('main');
+    const cases = [
+      `python3 -c "import os; os.system('git push origin main')"`,
+      `node -e "sh('git push origin main')"`,
+    ];
+
+    for (const command of cases) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard missed a push inside: ${command}`).toBe(2);
+    }
+  });
+
+  it('masks a quoted argument that spans lines', () => {
+    // The masking was `sed`, which works a line at a time, so an argument opened on one line and
+    // closed on the next was never masked — and a second line reading `git push` blocked an
+    // ordinary commit. Multi-line messages are exactly where that text appears.
+    const cwd = scratchRepo('feat/probe');
+    const result = runHook(
+      'branch-guard.sh',
+      'git commit -m "line one\nthen git push origin main"',
+      {
+        cwd,
+      },
+    );
+
+    expect(result.status, 'a push named on the second line of a message was read as a push').toBe(
+      0,
+    );
+  });
+
+  it('refuses rather than falls silent when it cannot decode', () => {
+    // The regression review caught: routing tool_name through the JSON decoders meant a machine
+    // with neither jq nor python3 produced an empty tool name, every hook took its "not a Bash
+    // call" branch, and three guards switched off without a word. Measured before the fix: exit 0.
+    const cwd = scratchRepo('main');
+    const bin = mkdtempSync(path.join(tmpdir(), 'hook-nojson-'));
+    scratchRoots.push(bin);
+    for (const tool of ['bash', 'dirname', 'grep', 'sed', 'awk', 'head', 'tr', 'cat', 'git']) {
+      const found = spawnSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf8' });
+      const target = (found.stdout ?? '').trim();
+      if (target) symlinkSync(target, path.join(bin, tool));
+    }
+
+    for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh']) {
+      const result = runHook(hook, 'git push origin main', {
+        cwd,
+        env: { PATH: bin, ROBOTA_AGENT_WORKTREE: '1' },
+      });
+      expect(result.status, `${hook} passed silently with no JSON decoder available`).not.toBe(0);
+      expect(result.output, `${hook} refused without saying why`).toMatch(/could not be decoded/);
     }
   });
 

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -135,9 +135,35 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('reads a quoted argument as text, not as a command', { timeout: 120_000 }, () => {
+    // The mirror image, and the one that BLOCKS. `pre-push-check`'s own comment recorded this trap
+    // as latent — unreachable only because the decoder truncated at the first quote — and predicted
+    // it would come alive the day the decode was fixed. It was fixed here, so it is live here.
+    // `gh pr create --body "...; git push later"` performs no push, and a guard that stops it is a
+    // guard stopping its own author, which is the failure this whole PR exists to end.
+    const cwd = scratchRepo('main');
+    const mention = 'gh pr create --body "notes; git push later"';
+
+    for (const hook of ['branch-guard.sh', 'pre-push-check.sh']) {
+      const result = runHook(hook, mention, { cwd });
+      expect(result.status, `${hook} treated a quoted mention of a push as a push`).toBe(0);
+    }
+  });
+
+  it('still reads a command a shell is told to run', { timeout: 120_000 }, () => {
+    // The limit of the rule above, and why it cannot be "ignore anything in quotes": `bash -c` runs
+    // its string. Blanking that content would convert a false positive into a bypass, which is the
+    // one direction a guard must never trade in.
+    const cwd = scratchRepo('main');
+    const result = runHook('branch-guard.sh', 'bash -c "git push origin main"', { cwd });
+
+    expect(result.status, 'branch-guard missed a push inside `bash -c`').toBe(2);
+    expect(result.output).toMatch(/protected branch/);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
-    for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh']) {
+    for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {
       const result = runHook(hook, `cd ${cwd} && git status`, {
         cwd,
         env: { ROBOTA_AGENT_WORKTREE: '1' },

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -582,6 +582,38 @@ describe('a hook examines the command that will run', () => {
     expect(result.output).toMatch(/protected branch/);
   });
 
+  it('sees a substitution written after an escaped quote', () => {
+    // Escapes had a test and substitution had a test; both in one string had none, and that is
+    // exactly where the lookahead broke. It stopped at the first `\\"` inside the argument, so a
+    // real `$(...)` after one was never seen, the region was masked, and the command bash actually
+    // runs vanished from the scan.
+    const cwd = scratchRepo('main');
+    const result = runHook(
+      'branch-guard.sh',
+      'git commit -m "note \\"x\\" $(git push --force origin main)"',
+      { cwd },
+    );
+
+    expect(result.status, 'a push inside a substitution went unseen after an escaped quote').toBe(
+      2,
+    );
+  });
+
+  it('accepts a quoted branch name', () => {
+    // The new-branch name was pulled straight out of the MASKED text, so a quoted name came back as
+    // the \\001 fill and a correctly named branch was refused. Position in the mask, value from the
+    // original — the rule the other two extractions already follow.
+    const cwd = scratchRepo('develop');
+
+    for (const command of ['git checkout -b "feat/my-branch"', 'git checkout -b feat/my-branch']) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard refused a well-named branch: ${command}`).toBe(0);
+    }
+
+    const bad = runHook('branch-guard.sh', 'git checkout -b BAD_NAME', { cwd });
+    expect(bad.status, 'branch-guard stopped checking names altogether').toBe(2);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -161,6 +161,41 @@ describe('a hook examines the command that will run', () => {
     expect(result.output).toMatch(/protected branch/);
   });
 
+  it('does not let a quoted mention choose which repository is judged', () => {
+    // The asymmetry review caught after the first pass: verb detection ignored quoted contents while
+    // the `git -C` extraction — which decides WHICH repository the branch check runs against — still
+    // read them. A commit message naming another checkout redirected the guard there, and a push to
+    // a protected branch went through silently. Worse than the false positive it sat beside.
+    const protectedRepo = scratchRepo('main');
+    const elsewhere = scratchRepo('feat/elsewhere');
+    const result = runHook(
+      'branch-guard.sh',
+      `git commit -m "note git -C ${elsewhere} here" && git push origin main`,
+      { cwd: protectedRepo },
+    );
+
+    expect(
+      result.status,
+      'a `git -C` written inside a quoted argument redirected the branch check at another ' +
+        'repository. Locate the flag in a masked command; read its value from the original.',
+    ).toBe(2);
+  });
+
+  it('still reads a real -C target, quoted or not', () => {
+    // The other half, and why the mention case cannot be fixed by blanking quotes here: a path is
+    // routinely quoted, and a guard that loses it judges the wrong repository in the other
+    // direction. Both spellings must resolve to the same checkout.
+    const cwd = scratchRepo('main');
+    const elsewhere = scratchRepo('feat/elsewhere');
+
+    for (const target of [elsewhere, `"${elsewhere}"`]) {
+      const result = runHook('branch-guard.sh', `git -C ${target} push origin feat/elsewhere`, {
+        cwd,
+      });
+      expect(result.status, `branch-guard judged the wrong repository for -C ${target}`).toBe(0);
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -342,6 +342,37 @@ describe('a hook examines the command that will run', () => {
     expect(result.status, 'a `-C` path was read as the new branch name').toBe(0);
   });
 
+  it('does not read a delete named in a message as a delete', () => {
+    // The last pair still scanning unmasked text after every other check had moved off it. A commit
+    // message quoting `--delete-branch` refused the commit — the same class this change closes
+    // everywhere else, left in the two places that reach out to `gh` before refusing.
+    const cwd = scratchRepo('feat/probe');
+    const cases = [
+      'git commit -m "example: gh pr merge --delete-branch"',
+      'git commit -m "e.g. git push origin --delete old-branch"',
+      'git commit -m "she said \\"hi\\"" && git commit -m x',
+    ];
+
+    for (const command of cases) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard read a quoted mention as a delete: ${command}`).toBe(0);
+    }
+  });
+
+  it('still refuses a real delete', () => {
+    // The other half. `--delete-branch` once removed the develop integration branch, and a remote
+    // delete is refused until a merged PR is confirmed — neither may be lost to the masking above.
+    const cwd = scratchRepo('feat/probe');
+
+    for (const command of [
+      'gh pr merge 1 --merge --delete-branch',
+      'git push origin --delete some-branch',
+    ]) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard let a real delete through: ${command}`).toBe(2);
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -311,6 +311,37 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('reads what eval and command substitution will run', () => {
+    // `eval \"...\"` is the plainest way a shell runs a string, and it fell out of the interpreter
+    // list when that expression was rewritten — a regression introduced by a fix. `$(...)` and
+    // backticks run whatever the surrounding quotes are, so a masked region containing them hides a
+    // real command.
+    const cwd = scratchRepo('main');
+    const cases = ['eval "git push --force origin main"', 'echo "$(git push origin main)"'];
+
+    for (const command of cases) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard missed a push in: ${command}`).toBe(2);
+    }
+  });
+
+  it('reads a new branch name from the checkout that creates it', () => {
+    // The extraction ran a greedy `.*` over the whole command and took whatever followed the LAST
+    // -b/-B/-c/-C, so a later `git -C /other` supplied the \"branch name\" and a correctly named
+    // branch was refused. Worktree-parallel work puts those two in one command routinely.
+    const cwd = scratchRepo('develop');
+    const elsewhere = scratchRepo('main');
+    const result = runHook(
+      'branch-guard.sh',
+      `git checkout -b feat/x && git -C ${elsewhere} status`,
+      {
+        cwd,
+      },
+    );
+
+    expect(result.status, 'a `-C` path was read as the new branch name').toBe(0);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -419,6 +419,50 @@ describe('a hook examines the command that will run', () => {
     );
   });
 
+  it('reads strings run by wrappers, not only by bash', () => {
+    // A closed interpreter list is a list of the ways past the guard. `ssh`, `expect`, `timeout`
+    // and any shell-named wrapper run their strings; masking them made a precise guard a blind one.
+    const cwd = scratchRepo('main');
+    const cases = [
+      'ssh host "git push --force origin main"',
+      'timeout 5 bash -c "git push origin main"',
+      'myfish -c "git push origin main"',
+    ];
+
+    for (const command of cases) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard missed a push in: ${command}`).toBe(2);
+    }
+  });
+
+  it('still says nothing about a search for those words', () => {
+    // The boundary the widened list must not cross. `rg "git push" docs/` is ordinary work here,
+    // and reading its argument as a command would refuse routine commands many times a day — the
+    // self-blocking these hooks have already inflicted once.
+    const cwd = scratchRepo('main');
+
+    for (const command of ['rg "git push" docs/', 'grep -rn "git push --force" .']) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard blocked a search: ${command}`).toBe(0);
+    }
+  });
+
+  it('refuses a payload carrying no command', () => {
+    // jq's `// ""` made an absent field decode "successfully" as empty, which then matched nothing
+    // — a silent pass wearing the costume of a clean scan.
+    const cwd = scratchRepo('main');
+    const payload = JSON.stringify({ tool_name: 'Bash', tool_input: {} });
+
+    for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh']) {
+      const result = spawnSync('bash', [path.join(HOOKS_DIR, hook)], {
+        input: payload,
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, ROBOTA_AGENT_WORKTREE: '1' },
+      });
+      expect(result.status, `${hook} passed a payload with no command`).toBe(2);
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -714,6 +714,36 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('reports a repo-relative path for a file outside the project dir', () => {
+    // The scope filter was widened to accept any prefix so worktree paths would be checked, but the
+    // strip that makes a path repo-relative still assumed the file sat under CLAUDE_PROJECT_DIR. A
+    // path that does not survived whole, so the refusal and blocks.jsonl printed an absolute path —
+    // in exactly the scenario the widening was for.
+    const projectDir = scratchRepo('main');
+    const elsewhere = mkdtempSync(path.join(tmpdir(), 'hook-elsewhere-'));
+    scratchRoots.push(elsewhere);
+    const file = path.join(elsewhere, 'packages/p/src/a.ts');
+    mkdirSync(path.dirname(file), { recursive: true });
+
+    const result = spawnSync('bash', [path.join(HOOKS_DIR, 'check-forbidden-patterns.sh')], {
+      input: JSON.stringify({
+        tool_name: 'Edit',
+        tool_input: {
+          file_path: file,
+          new_string: 'try {\n  go();\n} catch (e) {\n  return 0;\n}\n',
+        },
+      }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+    });
+
+    expect(result.status, 'the forbidden pattern was not caught at all').toBe(2);
+    expect(`${result.stderr}`, 'an absolute path leaked into the refusal').toContain(
+      'packages/p/src/a.ts',
+    );
+    expect(`${result.stderr}`, 'an absolute path leaked into the refusal').not.toContain(elsewhere);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -621,6 +621,44 @@ describe('a hook examines the command that will run', () => {
     expect(bad.status, 'branch-guard stopped checking names altogether').toBe(2);
   });
 
+  it('reads a quoted verb as the verb it is', () => {
+    // Quoting a bare word changes nothing about what the shell runs, so `git \"push\"` must read
+    // exactly as `git push`. Masking every quoted region by default made all of these invisible —
+    // and quoting each token is ordinary defensive shell style, so this was reachable by habit,
+    // not only by someone routing around the guard.
+    const cwd = scratchRepo('main');
+    const cases = [
+      { hook: 'branch-guard.sh', env: {}, command: 'git \"push\" origin main' },
+      { hook: 'branch-guard.sh', env: {}, command: "git 'push' origin main" },
+      { hook: 'branch-guard.sh', env: {}, command: 'git \"commit\" -m x' },
+      { hook: 'branch-guard.sh', env: {}, command: 'gh pr merge 1 --merge \"--delete-branch\"' },
+      {
+        hook: 'worktree-cwd-guard.sh',
+        env: { ROBOTA_AGENT_WORKTREE: '1' },
+        command: 'git reset \"--hard\" origin/main',
+      },
+    ];
+
+    for (const { hook, command, env } of cases) {
+      const result = runHook(hook, command, { cwd, env });
+      expect(result.status, `${hook} did not see a quoted verb: ${command}`).toBe(2);
+    }
+  });
+
+  it('restores only the substitution, not the message around it', () => {
+    // Keeping the WHOLE quoted string once it contained a substitution meant an ordinary message
+    // holding both `$(...)` and an unrelated mention of a guarded verb was read as that verb. Only
+    // the substitution's own span runs, so only that span is restored.
+    const cwd = scratchRepo('feat/probe');
+    const result = runHook(
+      'branch-guard.sh',
+      'git commit -m \"Bumps $(cat VERSION); prose about git push\"',
+      { cwd },
+    );
+
+    expect(result.status, 'prose beside a substitution was read as a command').toBe(0);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -428,6 +428,13 @@ describe('a hook examines the command that will run', () => {
       'ssh host "git push --force origin main"',
       'timeout 5 bash -c "git push origin main"',
       'myfish -c "git push origin main"',
+      // More than one argument between the interpreter and its string. Allowing exactly one meant
+      // every one of these fell out of the exception and was masked — the bypass class this
+      // exception exists to close, reopened by the shape of the expression rather than the list.
+      'bash -x -c "git push origin main"',
+      'ssh -o StrictHostKeyChecking=no host "git push origin main"',
+      'python3 -u -c "os.system(1); git push origin main"',
+      '/bin/bash -c "git push origin main"',
     ];
 
     for (const command of cases) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -695,6 +695,25 @@ describe('a hook examines the command that will run', () => {
     expect(result.status, 'branch-guard read a stash message as a push').toBe(0);
   });
 
+  it('reaches a push introduced by a plain word', () => {
+    // pre-push-check alone kept whitespace out of its boundary set, so `time git push`,
+    // `command git push` and `nice git push` never reached it and skipped branch-hygiene and
+    // lockfile checks entirely. The exclusion existed for a false positive that masking has since
+    // removed — the same reachability gap this PR fixes twice over, left in the third hook.
+    const cwd = scratchRepo('feat/probe');
+
+    for (const command of [
+      'time git push origin feat/probe',
+      'command git push origin feat/probe',
+      'nice git push origin feat/probe',
+    ]) {
+      const result = runHook('pre-push-check.sh', command, { cwd });
+      expect(result.output.trim().length, `pre-push-check never saw: ${command}`).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -260,6 +260,40 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('reads a -C target inside a string an interpreter runs', () => {
+    // The interpreter exception kept `bash -c \"git push\"` visible to verb detection but not to the
+    // `-C` extraction, so the branch check judged some other directory while the real target went
+    // unexamined. Verb and target must be read out of the same string.
+    const protectedRepo = scratchRepo('main');
+    const cwd = scratchRepo('feat/elsewhere');
+    const result = runHook(
+      'branch-guard.sh',
+      `bash -c "git -C ${protectedRepo} push origin main"`,
+      {
+        cwd,
+      },
+    );
+
+    expect(
+      result.status,
+      'the `-C` target inside an interpreter string was masked away, so the guard judged the ' +
+        'wrong repository and let a push to a protected branch through.',
+    ).toBe(2);
+  });
+
+  it('exempts only the string the interpreter runs', () => {
+    // Applying the exception to the whole command meant one `bash -c` anywhere unmasked every other
+    // quoted argument on the line, and an ordinary commit whose message mentioned a push was read
+    // as a push. Each quoted string answers for itself.
+    const cwd = scratchRepo('feat/probe');
+    const command = 'bash -c "echo hi" && git commit -m "dont run git push in CI"';
+
+    for (const hook of ['branch-guard.sh', 'pre-push-check.sh']) {
+      const result = runHook(hook, command, { cwd });
+      expect(result.status, `${hook} read an unrelated message as a command`).toBe(0);
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -402,6 +402,23 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('names the branch the delete actually targets', () => {
+    // The `gh api` path read the first `/git/refs/heads/…` anywhere in the raw command, so a decoy
+    // in a quoted commit message stood in for the real target and the protected-branch and
+    // merged-PR checks were run against a branch nobody was deleting. The verb was judged in the
+    // mask; only the value was not position-mapped to it.
+    const cwd = scratchRepo('feat/probe');
+    const command =
+      'git commit -m "note /git/refs/heads/scratch" && ' +
+      'gh api -X DELETE repos/o/r/git/refs/heads/develop';
+    const result = runHook('branch-guard.sh', command, { cwd });
+
+    expect(result.status, 'a decoy branch name displaced the real delete target').toBe(2);
+    expect(result.output, 'the refusal named the decoy, not the branch being deleted').toMatch(
+      /develop/,
+    );
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -744,6 +744,56 @@ describe('a hook examines the command that will run', () => {
     expect(`${result.stderr}`, 'an absolute path leaked into the refusal').not.toContain(elsewhere);
   });
 
+  it('expands an unquoted heredoc body the way the shell does', () => {
+    // `<<EOF` is expanded: `$(…)` and backticks in the body genuinely run. `<<\'EOF\'` and `<<"EOF"`
+    // are literal. Treating every body as data meant `git commit -F- <<EOF` with a push inside a
+    // substitution executed it while no guard saw it — the principle this file applies to quoted
+    // strings, not applied to the one place the shell applies it too.
+    const live = scratchRepo('main');
+    const inert = scratchRepo('feat/probe');
+
+    const expanded = runHook(
+      'branch-guard.sh',
+      ['git commit -F- <<EOF', '$(git push --force origin main)', 'EOF'].join('\n'),
+      { cwd: live },
+    );
+    expect(expanded.status, 'a substitution in an expanded heredoc body went unseen').toBe(2);
+
+    const literal = runHook(
+      'branch-guard.sh',
+      ["git commit -F- <<'EOF'", '$(git push --force origin main)', 'EOF'].join('\n'),
+      { cwd: inert },
+    );
+    expect(literal.status, 'a quoted delimiter makes the body data; it was read as a command').toBe(
+      0,
+    );
+
+    const prose = runHook(
+      'branch-guard.sh',
+      ['git commit -F- <<EOF', 'prose about git push here', 'EOF'].join('\n'),
+      { cwd: inert },
+    );
+    expect(prose.status, 'prose in an expanded body is still prose').toBe(0);
+  });
+
+  it("runs only the interpreter's own argument", () => {
+    // The exception ran to every quoted string later in the statement, so the positional argument in
+    // `python3 -c "x=1" "…"` was scanned as code and an ordinary command was refused. A quoted
+    // argument ends the run; the first string still counts.
+    const cwd = scratchRepo('feat/probe');
+    const positional = runHook(
+      'branch-guard.sh',
+      'python3 -c "x=1" "just text mentioning git push"',
+      { cwd },
+    );
+    expect(positional.status, 'a positional argument was read as code').toBe(0);
+
+    const real = runHook('branch-guard.sh', 'bash -x -c "git push origin main"', {
+      cwd: scratchRepo('main'),
+    });
+    expect(real.status, "the interpreter's own string stopped being read").toBe(2);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -427,7 +427,12 @@ describe('a hook examines the command that will run', () => {
     const cases = [
       'ssh host "git push --force origin main"',
       'timeout 5 bash -c "git push origin main"',
-      'myfish -c "git push origin main"',
+      // A NAMED shell, not an arbitrary token ending in `sh`. Matching `[^/]*sh` covered unknown
+      // wrappers but also read `git stash push -m "…"` as an interpreter and refused it. The
+      // boundary is stated in command-scan.sh: a string run by something outside the list is
+      // masked, and that is the price of not refusing ordinary commands.
+      'fish -c "git push origin main"',
+      'ksh -c "git push origin main"',
       // More than one argument between the interpreter and its string. Allowing exactly one meant
       // every one of these fell out of the exception and was masked — the bypass class this
       // exception exists to close, reopened by the shape of the expression rather than the list.

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -294,6 +294,23 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('does not mistake a herestring for a heredoc', () => {
+    // `<<< \"x\"` has no body and no terminator, but the opener pattern matched from the second `<`,
+    // so every line after it was swallowed as body and never came back — one Bash call, and the
+    // command that mattered was the one nobody looked at. A new instance of the exact class this
+    // whole change exists to close, and green until this case existed.
+    const cwd = scratchRepo('main');
+    const command = 'cat <<< \"x\"\ngit push --force origin main';
+
+    for (const [hook, env] of [
+      ['branch-guard.sh', {}],
+      ['worktree-cwd-guard.sh', { ROBOTA_AGENT_WORKTREE: '1' }],
+    ]) {
+      const result = runHook(hook, command, { cwd, env });
+      expect(result.status, `${hook} lost every command after a herestring`).toBe(2);
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -464,6 +464,63 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('scans a MultiEdit the same as an Edit', () => {
+    // The bug this hook's own comment records — MultiEdit carries its replacements in an `edits`
+    // array, so neither field the extraction read existed, content came back empty and the hook
+    // passed content it refuses from Edit. The fix went in without a case that sends an actual
+    // MultiEdit payload, so it could regress to silently unscanned and stay green: the
+    // accidental-green shape this repo has a rule against.
+    const cwd = scratchRepo('main');
+    const src = path.join(cwd, 'packages/p/src');
+    mkdirSync(src, { recursive: true });
+    const forbidden = 'try {\n  go();\n} catch (e) {\n  return 0;\n}\n';
+
+    const payloads = [
+      {
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(src, 'a.ts'), new_string: forbidden },
+      },
+      {
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: path.join(src, 'a.ts'),
+          edits: [{ old_string: 'x', new_string: forbidden }],
+        },
+      },
+    ];
+
+    for (const payload of payloads) {
+      const result = spawnSync('bash', [path.join(HOOKS_DIR, 'check-forbidden-patterns.sh')], {
+        input: JSON.stringify(payload),
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: cwd },
+      });
+      expect(result.status, `${payload.tool_name} content went unscanned`).toBe(2);
+    }
+  });
+
+  it('is registered for every tool whose content it scans', () => {
+    // Reading the content was only half the bypass: MultiEdit was also absent from the hook's
+    // matcher, so the handling could not run at all. Unguarded twice over — once by shape, once by
+    // registration — and the second half is invisible to any test that invokes the hook directly.
+    const settings = JSON.parse(
+      readFileSync(path.join(WORKSPACE_ROOT, '.claude/settings.json'), 'utf8'),
+    );
+    const matchers = (settings.hooks?.PreToolUse ?? [])
+      .filter((entry) =>
+        (entry.hooks ?? []).some((h) => `${h.command}`.includes('check-forbidden-patterns')),
+      )
+      .map((entry) => entry.matcher ?? '');
+
+    expect(matchers.length, 'check-forbidden-patterns is not registered at all').toBeGreaterThan(0);
+    for (const tool of ['Write', 'Edit', 'MultiEdit']) {
+      expect(
+        matchers.some((m) => m.split('|').includes(tool)),
+        `check-forbidden-patterns never runs for ${tool}, so its handling of it cannot fire`,
+      ).toBe(true);
+    }
+  });
+
   it('refuses an edit it cannot read', () => {
     // check-forbidden-patterns guards a different tool and was left out of this PR's fail-closed
     // pass. Its FIRST field came from bare jq, so a machine without jq read an empty file path and
@@ -507,6 +564,22 @@ describe('a hook examines the command that will run', () => {
     });
 
     expect(result.status, 'check-forbidden-patterns passed an edit it could not read').toBe(2);
+  });
+
+  it('does not let a quoted mention disarm an override', () => {
+    // Overrides were the last check reading unmasked text. `git commit -m \"note:
+    // BRANCH_GUARD_ALLOW_DELETE=1 was tried\" && git push origin --delete develop` set the override
+    // from inside the message and skipped the protected-branch refusal — the guard that exists
+    // because develop was once deleted by accident, switched off by prose.
+    const cwd = scratchRepo('feat/probe');
+    const result = runHook(
+      'branch-guard.sh',
+      'git commit -m "note: BRANCH_GUARD_ALLOW_DELETE=1 was tried" && git push origin --delete develop',
+      { cwd },
+    );
+
+    expect(result.status, 'a quoted mention switched the delete guard off').toBe(2);
+    expect(result.output).toMatch(/protected branch/);
   });
 
   it('leaves ordinary work alone', () => {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -1,0 +1,194 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * What a guard EXAMINES must be what will RUN.
+ *
+ * Reachability — does the hook fire at all — is the sibling question, pinned next door. This file
+ * asks the one after it: once fired, is the hook looking at the command? Three ways it was not,
+ * each measured on 2026-07-28 against the hooks as they then stood:
+ *
+ *   1. Every hook decoded the payload with `grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"'`,
+ *      which stops at the first double quote INSIDE the command. `echo "go" && git push origin
+ *      main` was read as `echo `, so branch-guard let a push to a protected branch through. Four
+ *      hooks carried the same copy.
+ *   2. `worktree-cwd-guard` scanned `${COMMAND%%<<*}` — everything from the first heredoc opener
+ *      onward discarded — so `git reset --hard` written after a CLOSED heredoc was invisible.
+ *   3. The opposite error is equally real: reading a heredoc BODY treats prose as a command, and a
+ *      commit message describing `git checkout -b` self-blocked a whole session.
+ *
+ * A guard reading a truncated command is not a weaker guard; it is a guard judging something other
+ * than what will run, which `enforcement-architecture.md` names as the defect to prevent. The
+ * shapes below are the contract for `lib/command-scan.sh` and for every hook that uses it.
+ */
+
+/** Scratch repos created during the run, removed in `afterAll` so probes leave no litter. */
+const scratchRoots = [];
+
+afterAll(() => {
+  for (const dir of scratchRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * A throwaway repository for the hook to judge, on a named branch.
+ *
+ * Never the real working tree: these probes make guards run their real work against whatever
+ * `CLAUDE_PROJECT_DIR` points at, and the verdict would then depend on a developer's local state.
+ */
+function scratchRepo(branch) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'hook-parse-'));
+  scratchRoots.push(dir);
+  const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '--quiet', `--initial-branch=${branch}`);
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', 'chore: root');
+  return dir;
+}
+
+/**
+ * `spawnSync`, not `execFileSync`: hooks speak on stderr, and `execFileSync`'s success path returns
+ * stdout only — a hook that spoke and exited 0 would read as silence, which once produced a
+ * reported bypass that was not there.
+ */
+function runHook(hookFile, command, { cwd, env = {} } = {}) {
+  const payload = JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } });
+  const result = spawnSync('bash', [path.join(HOOKS_DIR, hookFile)], {
+    input: payload,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, ...env },
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
+
+describe('a hook examines the command that will run', () => {
+  it('sees a guarded verb that follows a quoted argument', () => {
+    // The HARNESS-061 shape. Measured against the pre-fix hook: exit 0, silent — a push to a
+    // protected branch waved through because the decoder stopped at `echo "`.
+    const cwd = scratchRepo('main');
+    const result = runHook('branch-guard.sh', 'echo "starting release" && git push origin main', {
+      cwd,
+    });
+
+    expect(
+      result.status,
+      'branch-guard let a push to `main` through because the command was truncated at the first ' +
+        'quote. Decode the payload as JSON; do not read it with grep.',
+    ).toBe(2);
+    expect(result.output).toMatch(/protected branch/);
+  });
+
+  it('sees a destructive command written after a closed heredoc', () => {
+    // The `%%<<*` shape: truncating at the first opener threw away the rest of the command.
+    const cwd = scratchRepo('main');
+    const command = [
+      'git commit -F- <<EOF',
+      'a message',
+      'EOF',
+      'git reset --hard origin/main',
+    ].join('\n');
+    const result = runHook('worktree-cwd-guard.sh', command, {
+      cwd,
+      env: { ROBOTA_AGENT_WORKTREE: '1' },
+    });
+
+    expect(
+      result.status,
+      'worktree-cwd-guard did not see a `git reset --hard` that follows a closed heredoc. ' +
+        'Strip heredoc BODIES; keep what comes after the terminator.',
+    ).toBe(2);
+  });
+
+  it('does not read a heredoc body as a command', () => {
+    // The opposite error, and the one that cost a session: prose describing a command is not the
+    // command. A guard that cannot tell them apart blocks its own author.
+    const cwd = scratchRepo('main');
+    const cases = [
+      {
+        hook: 'branch-guard.sh',
+        env: {},
+        command: ['git log --oneline <<EOF', 'then run git push origin main', 'EOF'].join('\n'),
+      },
+      {
+        hook: 'worktree-cwd-guard.sh',
+        env: { ROBOTA_AGENT_WORKTREE: '1' },
+        command: ['git commit -F- <<EOF', 'we ran git reset --hard once', 'EOF'].join('\n'),
+      },
+    ];
+
+    for (const { hook, command, env } of cases) {
+      const result = runHook(hook, command, { cwd, env });
+      expect(result.status, `${hook} read a heredoc body as a command`).toBe(0);
+      expect(result.output.trim(), `${hook} spoke about text inside a heredoc`).toBe('');
+    }
+  });
+
+  it('leaves ordinary work alone', () => {
+    const cwd = scratchRepo('feat/probe');
+    for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh']) {
+      const result = runHook(hook, `cd ${cwd} && git status`, {
+        cwd,
+        env: { ROBOTA_AGENT_WORKTREE: '1' },
+      });
+      expect(result.status, `${hook} blocked an ordinary command`).toBe(0);
+    }
+  });
+});
+
+describe('the command parse has one owner', () => {
+  /**
+   * The defects above were one defect copied four times. Sharing the parser is what makes fixing it
+   * once enough — so a hook growing its own decoder again is the regression to catch, not the
+   * individual mis-parse it would reintroduce.
+   */
+  const bashHooks = readdirSync(HOOKS_DIR).filter((name) => name.endsWith('.sh'));
+
+  it('finds hooks to check', () => {
+    // Fail closed: a moved directory would make the assertions below pass over nothing.
+    expect(bashHooks.length).toBeGreaterThan(0);
+  });
+
+  for (const hook of bashHooks) {
+    it(`${hook} does not re-implement the command decode`, () => {
+      const source = readFileSync(path.join(HOOKS_DIR, hook), 'utf8');
+      const handRolled = source
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .some((line) => /grep\s+-o\s+'"(command|cwd|tool_name)"/.test(line));
+
+      expect(
+        handRolled,
+        `${hook} decodes the hook payload with grep. That expression stops at the first quote ` +
+          'inside the value. Source lib/command-scan.sh and use hook_command_of / hook_cwd_of.',
+      ).toBe(false);
+    });
+  }
+
+  it('truncates no command at the first heredoc opener', () => {
+    for (const hook of bashHooks) {
+      const source = readFileSync(path.join(HOOKS_DIR, hook), 'utf8');
+      const truncatesAtHeredoc = source
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .some((line) => /%%<<\*/.test(line));
+
+      expect(
+        truncatesAtHeredoc,
+        `${hook} discards everything from the first heredoc opener onward, so a command written ` +
+          'after the terminator is never examined. Use hook_strip_heredocs.',
+      ).toBe(false);
+    }
+  });
+});

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -373,6 +373,35 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('refuses a payload that names no tool', () => {
+    // The fail-open moved to the call site: left bare, a non-zero return aborts the assignment under
+    // `set -e` and the hook exits 1 saying nothing — which the hook protocol treats as non-blocking.
+    // The same conflation the decode path already refuses, one line further out.
+    const cwd = scratchRepo('main');
+    const payload = JSON.stringify({ tool_input: { command: 'git push origin main' } });
+
+    for (const hook of ['branch-guard.sh', 'pre-push-check.sh', 'worktree-cwd-guard.sh']) {
+      const result = spawnSync('bash', [path.join(HOOKS_DIR, hook)], {
+        input: payload,
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, ROBOTA_AGENT_WORKTREE: '1' },
+      });
+      expect(result.status, `${hook} exited non-blocking on a payload with no tool_name`).toBe(2);
+      expect(`${result.stderr}`, `${hook} refused without saying why`).toMatch(/names no tool/);
+    }
+  });
+
+  it('sees a delete however the flag is ordered', () => {
+    // `git push --delete <remote> <branch>` is accepted by git and was never matched — pre-existing,
+    // and a delete the guard misses is a delete it permits.
+    const cwd = scratchRepo('feat/probe');
+
+    for (const command of ['git push origin --delete gone', 'git push --delete origin gone']) {
+      const result = runHook('branch-guard.sh', command, { cwd });
+      expect(result.status, `branch-guard let a delete through: ${command}`).toBe(2);
+    }
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -659,6 +659,37 @@ describe('a hook examines the command that will run', () => {
     expect(result.status, 'prose beside a substitution was read as a command').toBe(0);
   });
 
+  it('sees a backtick subshell', () => {
+    // `$(...)` was covered because `(` sits in every boundary set; the backtick spelling of the same
+    // substitution had no boundary character at all, so the verb right after it matched nothing.
+    // Closing one spelling of a construct and leaving the other is the asymmetry, not the depth.
+    const cwd = scratchRepo('main');
+    const cases = [
+      { hook: 'branch-guard.sh', env: {}, command: 'echo `git push origin main`' },
+      {
+        hook: 'worktree-cwd-guard.sh',
+        env: { ROBOTA_AGENT_WORKTREE: '1' },
+        command: 'echo `git reset --hard origin/main`',
+      },
+    ];
+
+    for (const { hook, command, env } of cases) {
+      const result = runHook(hook, command, { cwd, env });
+      expect(result.status, `${hook} missed a backtick subshell: ${command}`).toBe(2);
+    }
+  });
+
+  it('does not mistake a token ending in sh for a shell', () => {
+    // `[^ /]*sh` matched `stash`, `squash`, `wash`. `git stash push -m \"…\"` therefore read `stash`
+    // as an interpreter, opened its message to verb scanning, and refused an ordinary command.
+    const cwd = scratchRepo('feat/probe');
+    const result = runHook('branch-guard.sh', 'git stash push -m "wip before git push to main"', {
+      cwd,
+    });
+
+    expect(result.status, 'branch-guard read a stash message as a push').toBe(0);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import {
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -461,6 +462,51 @@ describe('a hook examines the command that will run', () => {
       });
       expect(result.status, `${hook} passed a payload with no command`).toBe(2);
     }
+  });
+
+  it('refuses an edit it cannot read', () => {
+    // check-forbidden-patterns guards a different tool and was left out of this PR's fail-closed
+    // pass. Its FIRST field came from bare jq, so a machine without jq read an empty file path and
+    // exited 0 before any check ran — the same silent bypass, in the one hook nobody was looking at.
+    const cwd = scratchRepo('main');
+    const src = path.join(cwd, 'packages/p/src');
+    mkdirSync(src, { recursive: true });
+    const payload = JSON.stringify({
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: path.join(src, 'a.ts'),
+        new_string: 'try {\n  go();\n} catch (e) {\n  return 0;\n}\n',
+      },
+    });
+
+    // A PATH with neither jq nor python3 on it — the condition the ladder exists for.
+    const bin = mkdtempSync(path.join(tmpdir(), 'hook-nojson-edit-'));
+    scratchRoots.push(bin);
+    for (const tool of [
+      'bash',
+      'dirname',
+      'grep',
+      'sed',
+      'awk',
+      'head',
+      'tr',
+      'cat',
+      'date',
+      'mkdir',
+      'cut',
+    ]) {
+      const found = spawnSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf8' });
+      const target = (found.stdout ?? '').trim();
+      if (target) symlinkSync(target, path.join(bin, tool));
+    }
+
+    const result = spawnSync('bash', [path.join(HOOKS_DIR, 'check-forbidden-patterns.sh')], {
+      input: payload,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: bin, CLAUDE_PROJECT_DIR: cwd },
+    });
+
+    expect(result.status, 'check-forbidden-patterns passed an edit it could not read').toBe(2);
   });
 
   it('leaves ordinary work alone', () => {


### PR DESCRIPTION
Stacks on #1510 — it carries that commit until #1510 lands, then collapses to four commits.

## What was measured

An audit of all 11 hooks in `.claude/hooks/`, against the question: can this hook be reached by the command forms this project actually uses, and does it then do what its name promises? Every claim below was measured against scratch repositories, not read off the source.

| Hook | Verdict |
|---|---|
| `branch-guard.sh` | **Bypassed in 4 of 5 command shapes, for all 5 verbs it guards.** Fixed |
| `worktree-cwd-guard.sh` | **Bypassed by the multi-line shape** (`\n` was not a boundary). Fixed |
| `pre-push-check.sh` | Trigger fixed by #1510; its **`git -C` target extraction was still anchored**. Fixed |
| `check-forbidden-patterns.sh` | **Off entirely for worktree paths**, relative paths, and unset `CLAUDE_PROJECT_DIR`; **MultiEdit bypassed it twice over**. Fixed |
| `post-tool-format.sh` | Reachable. Registered for MultiEdit now |
| `memory-mirror-reminder.sh` | Reachable, path-based, advisory. No change |
| `spec-first-gate.sh` | Reachable; always exits 0 by design. Reported, not changed |
| `correction-detect.sh` | Reachable; skips `agent*` session ids by design (LESSON-010). Reported, not changed |
| `task-tracking.sh` | Reachable, registered for both `start` and `stop`. No change |
| `eval-log-stop.sh` | Reachable. No change |
| `revert-detect.sh` | Not in settings.json — chained from `eval-log-stop.sh`. Chain now verified by test |

## The defect, and why it kept recurring

`branch-guard` held the same `^`-anchor #1510 removed from `pre-push-check`, but in a variable, `GITPFX`, reused for `commit`, `push`, `merge`, `checkout -b` and `switch -c`. All five fired only on a bare verb. A branch is created as `cd <repo> && git checkout -b …`, so **the branch-create guard had never once fired on a real branch creation** — which is how a branch was cut from a promotion branch and broke the promotion-ancestry gate.

Three further gaps closed while loosening the leading match:

- The trailing boundary `\b` read `git merge-base` as a merge and `git commit-tree` as a commit — harmless while the guard was unreachable, a false positive on ordinary read-only work now that it isn't. It is `[^-[:alnum:]_]` instead, which also catches a verb ending a line.
- `-B`/`-C` force-create a branch and were not matched.
- All three command hooks extracted `git -C <path>` with an anchored sed, so `cd /elsewhere && git -C <repo> commit` fired the guard **against the wrong repository**.

One finding is worth singling out: adding `|| true` to those extractions is load-bearing. `grep` exits 1 when a command has no `-C`, and under `set -euo pipefail` a failed command substitution aborts the hook — exit 1, no output, before a single check runs. A total bypass wearing the costume of a working guard. It was caught only because the test measures the hook's real exit status; my own shell probe read `PIPESTATUS[0]`, which is `printf`'s, and reported green.

## The test was green over the bypass

`hook-command-reachability` checked one verb per hook, and the verb chosen for `branch-guard` was `git push --delete`, whose matcher is separately un-anchored. Four of that hook's five verbs went unmeasured while the file read green.

So the hand-written list is no longer trusted. Every command hook spells its matchers `${GITPFX}<verb>${GITEND}`, and the test **derives** each hook's verbs from its own source, failing on any verb with no case. That derivation immediately found two verbs of `worktree-cwd-guard` nothing was measuring.

## Proof

Every fix is proven both ways, and every assertion was proven sensitive by mutation:

- Restoring `branch-guard`'s anchor turns 5 cases red; reverting `worktree-cwd-guard`'s `\n` boundary turns 4 red; injecting a `${GITPFX}stash` matcher turns the derivation red; reverting the MultiEdit extraction turns 2 red.
- Each blocked case has a legitimate counterpart — same verb, same five shapes, ordinary branch — that must pass **silently**, because a guard that blocks ordinary work is the first thing an agent disables.
- `git status`, `git log`, `git merge-base`, `gh pr view`, `git diff`, `pnpm test` are asserted silent on every command hook.

39 cases in `hook-command-reachability`; 1519/1520 across `scripts/harness/__tests__`. The one failure (`verify-like-ci` asserting `packages/*/node_modules` exists) is the unbuilt-worktree condition and is unrelated.

## Follow-ups — reported, not filed, and no IDs created

1. `spec-first-gate.sh` always exits 0. Its own header points at `scan-spec-research.mjs` + GATE-WRITE as the mechanical floor, so this reads as an advisory nudge by design — but `enforcement-architecture.md` claims every guardian has a floor, and that document is owned by another agent right now.
2. `correction-detect.sh` skips session ids starting with `agent`. This is LESSON-010 and deliberate; reverting it re-inflates the metric it fixed. Worth noting the filter matches the *eval harness* naming — real subagent sessions carry UUIDs, so the concern that it never fires for subagents appears unfounded. Worth confirming against a real transcript.
3. `revert-detect.sh` is invoked as `… >/dev/null 2>&1 || true`, so a crash in it is unobservable. The chain is now test-verified, but the swallowing is not addressed.
4. `check-forbidden-patterns.sh` and `spec-first-gate.sh` depend on `jq` and exit 0 silently if it is absent — a fail-open on a missing dependency.
5. The `COMMAND` extraction every command hook shares is `grep -o '"command"…"[^"]*"'`, which truncates at the first escaped quote inside the command. A command containing a quoted string is only partially seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso