### PR TITLE
fix(harness): a quoted or transitional ratio is not a progress report

### DIFF
--- a/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
+++ b/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
@@ -65,6 +65,26 @@ describe('findBareRatioProgressStatements — the rule', () => {
 });
 
 describe('findBareRatioProgressStatements — measured false-positive classes stay silent', () => {
+  it('stays silent on a ratio that is being QUOTED rather than asserted', () => {
+    // Measured 2026-07-26 and again 2026-07-28: a message about this scan's own false positive —
+    // `제 문장의 "6/7"(버전 번호)을 진행률 비율로 오인해` — was itself reported. Writing about the
+    // defect reproduced it, and the scan blocked the release gate both times. A guard that cannot
+    // be discussed without tripping is a guard nobody can fix.
+    expect(
+      findBareRatioProgressStatements(
+        '스캔이 제 문장의 "6/7"(버전 번호)을 진행률 비율로 오인해 막고 있습니다',
+        POLICY,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('stays silent on a version transition written with an arrow', () => {
+    // `5 → 6/7` is a transition between tool versions, not six sevenths of a task finished.
+    expect(
+      findBareRatioProgressStatements('**5 → 6/7 병행 전환 완료.** 타입체크·빌드는 통과', POLICY),
+    ).toHaveLength(0);
+  });
+
   it.each([
     ['completed result, not mid-work progress', '45/45 scans pass — all green, work complete.'],
     ['identifier list', 'ARL-04/05/06/07 resolved and moved to done.'],

--- a/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
+++ b/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
@@ -78,6 +78,21 @@ describe('findBareRatioProgressStatements — measured false-positive classes st
     ).toHaveLength(0);
   });
 
+  it('still catches a real progress report that happens to use an arrow', () => {
+    // The suppression is for a version transition, `5 → 6/7`, where a NUMBER sits before the arrow.
+    // An arrow used as ordinary punctuation must not become a way to write a bare ratio — and a
+    // test covering only the suppressed shape would pass whether or not that held.
+    expect(
+      findBareRatioProgressStatements('마이그레이션 작업 → 6/7 완료. 계속합니다.', POLICY),
+    ).toHaveLength(1);
+  });
+
+  it('still catches a real progress report quoted for emphasis', () => {
+    // The quote suppression is for a ratio the sentence talks ABOUT. Quotes used for emphasis
+    // around an asserted ratio — `'6/7' 완료` — are still an assertion, and still a violation.
+    expect(findBareRatioProgressStatements("'6/7' 완료. 계속 진행합니다.", POLICY)).toHaveLength(1);
+  });
+
   it('stays silent on a version transition written with an arrow', () => {
     // `5 → 6/7` is a transition between tool versions, not six sevenths of a task finished.
     expect(

--- a/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
+++ b/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
@@ -87,6 +87,19 @@ describe('findBareRatioProgressStatements — measured false-positive classes st
     ).toHaveLength(1);
   });
 
+  it('still catches a quoted report whose keyword is a long word', () => {
+    // The suppression tested the 10-character `after` slice, which a closing quote and a space cut
+    // to seven or eight — so `remaining`, `completing`, `converted` and `processed` were truncated
+    // before the word boundary could match and the violation was dropped. Only `완료` (two
+    // characters) was covered, which is why the shipped tests did not see it.
+    for (const keyword of ['remaining', 'completing', 'converted', 'processed']) {
+      expect(
+        findBareRatioProgressStatements(`'6/7' ${keyword}, continuing later`, POLICY),
+        keyword,
+      ).toHaveLength(1);
+    }
+  });
+
   it('still catches a real progress report quoted for emphasis', () => {
     // The quote suppression is for a ratio the sentence talks ABOUT. Quotes used for emphasis
     // around an asserted ratio — `'6/7' 완료` — are still an assertion, and still a violation.

--- a/scripts/harness/scan-progress-report-quantification.mjs
+++ b/scripts/harness/scan-progress-report-quantification.mjs
@@ -104,14 +104,19 @@ export function findBareRatioProgressStatements(messageText, policy) {
       // 2026-07-26 and again on 2026-07-28, a message reading `제 문장의 "6/7"(버전 번호)을 …
       // 오인해` was itself reported, so writing about the false positive reproduced it. A guard
       // that cannot be discussed without tripping is a guard nobody can fix.
-      if (/["'“‘「『]\s*$/.test(before) && /^\s*["'”’」』]/.test(after)) {
-        continue;
-      }
+      // Narrow deliberately: a quoted ratio FOLLOWED BY a completion word is asserting completion
+      // with the quotes used for emphasis (`'6/7' 완료`), and must still be caught. Only a quoted
+      // ratio the sentence then talks ABOUT is a citation.
+      const quoted = /["'“‘「『]\s*$/.test(before) && /^\s*["'”’」』]/.test(after);
+      const assertedAfterQuote = completionPattern.test(after.replace(/^\s*["'”’」』]\s*/, ''));
+      if (quoted && !assertedAfterQuote) continue;
 
       // Preceded by a transition arrow — `5 → 6/7` is a version or state transition, not a count
       // of finished work out of a total. Measured on the same transcript: a line about migrating
       // between tool versions was read as six sevenths of a task being done.
-      if (/(?:->|=>|~>|→|⇒)\s*$/.test(before)) continue;
+      // A NUMBER must sit before the arrow: `5 → 6/7` is one version to another. `작업 → 6/7 완료`
+      // is a progress statement that happens to use an arrow, and stays a violation.
+      if (/(?:^|[^\w.])\d[\d.]*\s*(?:->|=>|~>|→|⇒)\s*$/.test(before)) continue;
 
       findings.push({
         line: i + 1,

--- a/scripts/harness/scan-progress-report-quantification.mjs
+++ b/scripts/harness/scan-progress-report-quantification.mjs
@@ -99,6 +99,20 @@ export function findBareRatioProgressStatements(messageText, policy) {
       if (identifierNounPattern.test(before)) continue;
       if (identifierNounSuffixPattern.test(after)) continue;
 
+      // QUOTED — the ratio is being cited, not asserted. Without this the scan fires on any
+      // sentence that discusses a ratio, including a sentence about this scan: measured on
+      // 2026-07-26 and again on 2026-07-28, a message reading `제 문장의 "6/7"(버전 번호)을 …
+      // 오인해` was itself reported, so writing about the false positive reproduced it. A guard
+      // that cannot be discussed without tripping is a guard nobody can fix.
+      if (/["'“‘「『]\s*$/.test(before) && /^\s*["'”’」』]/.test(after)) {
+        continue;
+      }
+
+      // Preceded by a transition arrow — `5 → 6/7` is a version or state transition, not a count
+      // of finished work out of a total. Measured on the same transcript: a line about migrating
+      // between tool versions was read as six sevenths of a task being done.
+      if (/(?:->|=>|~>|→|⇒)\s*$/.test(before)) continue;
+
       findings.push({
         line: i + 1,
         excerpt: line.trim().slice(0, 200),

--- a/scripts/harness/scan-progress-report-quantification.mjs
+++ b/scripts/harness/scan-progress-report-quantification.mjs
@@ -108,7 +108,20 @@ export function findBareRatioProgressStatements(messageText, policy) {
       // with the quotes used for emphasis (`'6/7' 완료`), and must still be caught. Only a quoted
       // ratio the sentence then talks ABOUT is a citation.
       const quoted = /["'“‘「『]\s*$/.test(before) && /^\s*["'”’」』]/.test(after);
-      const assertedAfterQuote = completionPattern.test(after.replace(/^\s*["'”’」』]\s*/, ''));
+      // The FIRST TOKEN after the closing quote, not a window of characters.
+      //
+      // The 10-character `after` slice is sized for short suffix words like `단계`, and a closing
+      // quote plus a space eats two of the ten — so `remaining`, `completing`, `converted` and
+      // `processed` were truncated before the word boundary could match, the sentence read as a
+      // citation, and the violation was dropped. Widening the window instead reached a completion
+      // word further along the sentence — `"6/7"(버전 번호)을 진행률 비율로 오인해` contains
+      // `진행` — and broke the suppression it was written for. Adjacency is what actually
+      // distinguishes the two: `'6/7' 완료` asserts, `"6/7"(...)` is talked about.
+      const afterQuote = line
+        .slice(match.index + matched.length, match.index + matched.length + 64)
+        .replace(/^\s*["'”’」』]\s*/, '');
+      const nextToken = /^[^\s.,;:!?()[\]{}]+/.exec(afterQuote)?.[0] ?? '';
+      const assertedAfterQuote = completionPattern.test(nextToken);
       if (quoted && !assertedAfterQuote) continue;
 
       // Preceded by a transition arrow — `5 → 6/7` is a version or state transition, not a count


### PR DESCRIPTION
fix(harness): a quoted or transitional ratio is not a progress report

The progress-report scan reads session transcripts, and it fired on two shapes
that are not progress reports. Both blocked the release gate — the second time
while promoting develop to main, which is how this surfaced.

  * A ratio inside quotes is being CITED, not asserted. A message about this
    scan's own false positive was itself reported, on 2026-07-26 and again on
    2026-07-28. Writing about the defect reproduced it, and a guard that cannot
    be discussed without tripping is a guard nobody can fix.
  * A ratio after a transition arrow is a version or state transition. Two tool
    versions written with an arrow are not a fraction of a task finished.

Both suppressions are structural, like the slash-chain and glued-identifier
checks beside them, so they stay in the engine while vocabulary stays in policy.
The rule itself is unchanged: a bare ratio in a completion sentence still fails
in English and in Korean, and adding the percentage still passes. 30 tests green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
