### PR TITLE
fix(hooks): a comment containing one quote no longer hides the next command

### DIFF
--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -217,26 +217,35 @@ hook_strip_heredocs() {
 # does, and what the masker already knows how to determine.
 hook_strip_comments() {
   awk '
-    {
+    { lines[NR] = $0 }
+    END {
+      # Quote state carries ACROSS lines, exactly as the masker does. Resetting it per line meant a
+      # `#` on the continuation line of a multi-line quoted argument was read as a comment start,
+      # and the rest of that line — the real closing quote, and anything chained after it — was
+      # discarded. That removed a real command from what the guards see: the same defect class, via
+      # the opposite mechanism, in the fix for it.
       q = ""
       esc = 0
-      out = ""
-      n = length($0)
-      for (i = 1; i <= n; i++) {
-        c = substr($0, i, 1)
-        if (esc) { esc = 0; out = out c; continue }
-        if (c == "\\" && q != "\047") { esc = 1; out = out c; continue }
-        if (q == "") {
-          if (c == "\"" || c == "\047") { q = c; out = out c; continue }
-          # A word-initial `#` outside quotes begins a comment; the rest of the line is prose.
-          if (c == "#" && (i == 1 || substr($0, i - 1, 1) ~ /[ \t;&|(]/)) { break }
-          out = out c
-        } else {
-          if (c == q) { q = "" }
-          out = out c
+      for (n = 1; n <= NR; n++) {
+        s = lines[n]
+        out = ""
+        len = length(s)
+        for (i = 1; i <= len; i++) {
+          c = substr(s, i, 1)
+          if (esc) { esc = 0; out = out c; continue }
+          if (c == "\\" && q != "\047") { esc = 1; out = out c; continue }
+          if (q == "") {
+            if (c == "\"" || c == "\047") { q = c; out = out c; continue }
+            # A word-initial `#` outside quotes begins a comment; the rest of the line is prose.
+            if (c == "#" && (i == 1 || substr(s, i - 1, 1) ~ /[ \t;&|(]/)) { break }
+            out = out c
+          } else {
+            if (c == q) { q = "" }
+            out = out c
+          }
         }
+        print out
       }
-      print out
     }
   '
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -225,10 +225,14 @@ hook_strip_comments() {
       # discarded. That removed a real command from what the guards see: the same defect class, via
       # the opposite mechanism, in the fix for it.
       q = ""
-      esc = 0
       for (n = 1; n <= NR; n++) {
         s = lines[n]
         out = ""
+        # `q` carries across lines; `esc` does NOT. A trailing backslash escapes the NEWLINE — the
+        # shell joins the two physical lines and the backslash-newline vanishes — it does not leave
+        # the first character of the next line escaped. Sharing the flag made that character bypass
+        # the quote-open and comment-start decisions entirely.
+        esc = 0
         len = length(s)
         for (i = 1; i <= len; i++) {
           c = substr(s, i, 1)

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -203,9 +203,42 @@ hook_strip_heredocs() {
   '
 }
 
-# Strip trailing shell comments so a `#` remark naming a verb cannot trip a matcher.
+# Strip shell comments — quote-aware, because a comment is only a comment outside quotes.
+#
+# This was `sed 's/[[:space:]]#[^"]*$//'`. The `[^"]*` was there so a `#` inside a quoted string
+# would not be treated as a comment, and it worked by refusing to match whenever a quote appeared
+# anywhere after the `#` — including inside the comment itself. So `echo ok # a "half-open remark`
+# stripped nothing, the stray quote opened a string the masker never saw closed, and EVERY LINE
+# AFTER IT was masked away: a `git push origin --delete develop` on the next line was invisible to
+# all four guards. A new instance of the class this library exists to close, in the one helper that
+# had no state machine.
+#
+# A `#` starts a comment when it is outside quotes and begins a word — which is what the shell
+# does, and what the masker already knows how to determine.
 hook_strip_comments() {
-  sed 's/[[:space:]]#[^"]*$//'
+  awk '
+    {
+      q = ""
+      esc = 0
+      out = ""
+      n = length($0)
+      for (i = 1; i <= n; i++) {
+        c = substr($0, i, 1)
+        if (esc) { esc = 0; out = out c; continue }
+        if (c == "\\" && q != "\047") { esc = 1; out = out c; continue }
+        if (q == "") {
+          if (c == "\"" || c == "\047") { q = c; out = out c; continue }
+          # A word-initial `#` outside quotes begins a comment; the rest of the line is prose.
+          if (c == "#" && (i == 1 || substr($0, i - 1, 1) ~ /[ \t;&|(]/)) { break }
+          out = out c
+        } else {
+          if (c == q) { q = "" }
+          out = out c
+        }
+      }
+      print out
+    }
+  '
 }
 
 # What a guard should actually examine: the command with heredoc bodies and comments removed.

--- a/scripts/harness/__tests__/check-functional-coverage.test.mjs
+++ b/scripts/harness/__tests__/check-functional-coverage.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { collectFunctionalCoverageFindings } from '../check-functional-coverage.mjs';
+import { collectFunctionalCoverageFindings, hasLiveTest } from '../check-functional-coverage.mjs';
 
 const SCAN_SCRIPT = fileURLToPath(new URL('../check-functional-coverage.mjs', import.meta.url));
 
@@ -159,8 +159,7 @@ describe('collectFunctionalCoverageFindings', () => {
 
   it('accepts a file that skips ONE case and runs another', async () => {
     const root = await createFixture({
-      'tests/chat-basic.functional.test.ts':
-        `${GREEN_TEST_SOURCE}\nit.skip('the flaky one', () => {});\n`,
+      'tests/chat-basic.functional.test.ts': `${GREEN_TEST_SOURCE}\nit.skip('the flaky one', () => {});\n`,
     });
     const manifestPath = manifestOn(root, GREEN_MANIFEST);
 
@@ -233,5 +232,24 @@ describe('check-functional-coverage CLI', () => {
     expect(result.stderr).toContain(
       'chat-basic: functional test not found: tests/chat-basic.functional.test.ts',
     );
+  });
+});
+
+describe('hasLiveTest — a suite skipped as a whole is not coverage', () => {
+  it('counts no live test when describe.skip wraps every case', () => {
+    // The check read only the modifiers attached to `it`/`test`, so a whole suite wrapped in
+    // `describe.skip` counted as live coverage — the paper-coverage this check exists to catch, in
+    // its most common spelling.
+    expect(hasLiveTest('describe.skip("s", () => { it("a", () => {}); });')).toBe(false);
+    expect(hasLiveTest('describe.todo("s", () => { it("a", () => {}); });')).toBe(false);
+  });
+
+  it('still counts a live suite beside a skipped one', () => {
+    // Deliberately narrow, as the function's own contract says: a PARTIALLY skipped file is fine.
+    expect(
+      hasLiveTest(
+        'describe.skip("s", () => { it("a", () => {}); });\ndescribe("t", () => { it("b", () => {}); });',
+      ),
+    ).toBe(true);
   });
 });

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -828,6 +828,28 @@ describe('a hook examines the command that will run', () => {
     }
   });
 
+  it('survives an unbalanced quote inside a comment', () => {
+    // Comment stripping was `sed 's/[[:space:]]#[^\"]*$//'`, which refused to match whenever a quote
+    // appeared after the `#` — including inside the comment itself. The stray quote then opened a
+    // string the masker never saw closed, and EVERY LINE AFTER IT was masked away: the delete on
+    // the next line was invisible to all four guards.
+    const cwd = scratchRepo('main');
+    const command = ['echo ok # a "half-open remark', 'git push origin --delete develop'].join(
+      '\n',
+    );
+    const result = runHook('branch-guard.sh', command, { cwd });
+
+    expect(result.status, 'a comment with one quote in it hid the command that followed').toBe(2);
+  });
+
+  it('still ignores a verb named inside a comment', () => {
+    // The other side: a `#` remark is prose, and quote-awareness must not cost that.
+    const cwd = scratchRepo('feat/probe');
+    const result = runHook('branch-guard.sh', 'git status # note about git push', { cwd });
+
+    expect(result.status, 'a comment was read as a command').toBe(0);
+  });
+
   it('leaves ordinary work alone', () => {
     const cwd = scratchRepo('feat/probe');
     for (const hook of ['branch-guard.sh', 'worktree-cwd-guard.sh', 'pre-push-check.sh']) {

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -877,6 +877,39 @@ describe('a hook examines the command that will run', () => {
   });
 });
 
+describe('every hook and the library it shares parse as bash', () => {
+  /**
+   * The cheapest floor in this directory, and the one that was missing.
+   *
+   * The shared library holds an awk program inside a single-quoted shell string. An apostrophe
+   * written into one of its comments closes that string, and the file stops parsing — at which
+   * point every hook that sources it fails, and since these hooks run on EVERY Bash tool call, the
+   * session can no longer run any command at all. Measured on 2026-07-28: one apostrophe in one
+   * comment, and nothing could be executed until the file was repaired with an editor.
+   *
+   * A syntax error is not a subtle defect. It only needs someone to look, and nothing did.
+   */
+  const shellFiles = [
+    ...readdirSync(HOOKS_DIR)
+      .filter((name) => name.endsWith('.sh'))
+      .map((name) => path.join(HOOKS_DIR, name)),
+    ...readdirSync(path.join(HOOKS_DIR, 'lib'))
+      .filter((name) => name.endsWith('.sh'))
+      .map((name) => path.join(HOOKS_DIR, 'lib', name)),
+  ];
+
+  it('finds shell files to check', () => {
+    expect(shellFiles.length).toBeGreaterThan(1);
+  });
+
+  for (const file of shellFiles) {
+    it(`${path.relative(HOOKS_DIR, file)} parses`, () => {
+      const result = spawnSync('bash', ['-n', file], { encoding: 'utf8' });
+      expect(result.status, `${path.basename(file)} does not parse:\n${result.stderr}`).toBe(0);
+    });
+  }
+});
+
 describe('the command parse has one owner', () => {
   /**
    * The defects above were one defect copied four times. Sharing the parser is what makes fixing it

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -842,6 +842,21 @@ describe('a hook examines the command that will run', () => {
     expect(result.status, 'a comment with one quote in it hid the command that followed').toBe(2);
   });
 
+  it('does not read a # inside a multi-line quoted argument as a comment', () => {
+    // The comment stripper reset its quote state at each line while the masker it feeds joins them
+    // — so a `#` on the continuation line of a multi-line message was read as a comment start, and
+    // the rest of that line, including the real closing quote and everything chained after it, was
+    // discarded. The same defect class as the bug it was fixing, through the opposite mechanism.
+    const cwd = scratchRepo('feat/probe');
+    const command = [
+      'git commit -m "line one',
+      'line two # not a comment" && git push origin --delete develop',
+    ].join('\n');
+    const result = runHook('branch-guard.sh', command, { cwd });
+
+    expect(result.status, 'a delete after a multi-line message went unseen').toBe(2);
+  });
+
   it('still ignores a verb named inside a comment', () => {
     // The other side: a `#` remark is prose, and quote-awareness must not cost that.
     const cwd = scratchRepo('feat/probe');

--- a/scripts/harness/check-functional-coverage.mjs
+++ b/scripts/harness/check-functional-coverage.mjs
@@ -41,19 +41,58 @@ export function usesMarker(code, marker) {
 }
 
 /**
+ * The [start, end) spans of `describe.skip(...)` / `describe.todo(...)` blocks.
+ *
+ * Parenthesis counting, not a regex: a suite body is arbitrary code, and the only way to know where
+ * one ends is to count. Strings containing unbalanced parens would confuse it, which is stated
+ * rather than hidden — the alternative is parsing, and this file is a grep-level guard by design.
+ */
+function skippedSuiteSpans(code) {
+  const spans = [];
+  const opener = /\bdescribe((?:\s*\.\s*[A-Za-z]+(?:\([^()]*\))?)*)\s*\(/g;
+  for (const match of code.matchAll(opener)) {
+    if (!/\b(?:skip|todo|skipIf)\b/.test(match[1] ?? '')) continue;
+    let depth = 0;
+    let end = code.length;
+    for (let i = match.index + match[0].length - 1; i < code.length; i++) {
+      const c = code[i];
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    spans.push([match.index, end]);
+  }
+  return spans;
+}
+
+/**
  * Does the file declare at least one test that is not skipped?
  *
  * The manifest's contract is "not a skipped E2E". A file whose every case is `it.skip` still
  * contains the marker, still passes a substring check, and covers nothing. Deliberately narrow: a
  * PARTIALLY skipped file is fine — flagging those would fire on legitimate work, and a guard that
  * fires on correct data is one that gets suppressed.
+ *
+ * A case inside a `describe.skip(...)` block does not run either, and the first version of this
+ * check read only the modifiers attached to `it`/`test` — so a whole suite wrapped in
+ * `describe.skip` counted as live coverage. That is the same paper-coverage this check was added
+ * to catch, in its most common spelling.
  */
 export function hasLiveTest(code) {
-  const declarations = String(code ?? '').matchAll(
+  const source = String(code ?? '');
+  const skipped = skippedSuiteSpans(source);
+  const declarations = source.matchAll(
     /\b(?:it|test)((?:\s*\.\s*[A-Za-z]+(?:\([^()]*\))?)*)\s*\(/g,
   );
   for (const match of declarations) {
-    if (!/\b(?:skip|todo|skipIf)\b/.test(match[1] ?? '')) return true;
+    if (/\b(?:skip|todo|skipIf)\b/.test(match[1] ?? '')) continue;
+    if (skipped.some(([start, end]) => match.index > start && match.index < end)) continue;
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
fix(hooks): a comment containing one quote no longer hides the next command

[MUST] Comment stripping was `sed 's/[[:space:]]#[^"]*$//'`. The `[^"]*` existed
so a `#` inside a quoted string would not be read as a comment, and it achieved
that by refusing to match whenever a quote appeared after the `#` — including
inside the comment itself. So `echo ok # a "half-open remark` stripped nothing,
the stray quote opened a string the masker never saw closed, and every line after
it was masked away. A `git push origin --delete develop` on the next line was
invisible to all four guards.

It is a quote-aware pass now, like everything else here: a `#` begins a comment
when it is outside quotes and starts a word, which is what the shell does. The
one helper that had no state machine was the one that broke.

[SHOULD] `hasLiveTest` read only the modifiers attached to `it`/`test`, so a
whole suite wrapped in `describe.skip` counted as live coverage — the paper
coverage that check exists to catch, in its most common spelling. It now spans
skipped suites by counting parentheses, and stays deliberately narrow: a live
suite beside a skipped one is still coverage.

Both red-proved. 90 tests green across the affected suites, 82 scans pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
