### PR TITLE
fix(hooks): a squash-merged branch is merged, whatever the ancestry says

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -251,14 +251,39 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
   #
   # Bounded, because this runs on every branch creation. Before this check the path was entirely
   # local; it now makes a network call, and a SLOW response is not a failed one — without a limit a
-  # stalled connection would hang the hook indefinitely instead of taking the fallback below. The
-  # fallback exists for exactly this: over-report, and say why.
+  # stalled connection would hang the hook indefinitely instead of taking the fallback below.
+  #
+  # The bound is hand-rolled rather than delegated to `timeout`, which is absent on a stock macOS.
+  # Branching on whether it exists would leave the promise above true on one platform and silently
+  # false on another, with the untested path being the one nobody runs — the shape of defect this
+  # directory has spent the week removing. One path, everywhere.
   GH_TIMEOUT=10
-  GH_RUNNER=()
-  command -v timeout >/dev/null 2>&1 && GH_RUNNER=(timeout "$GH_TIMEOUT")
+  bounded_merged_refs() {
+    local out pid waited=0
+    out=$(mktemp) || return 1
+    (gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
+      --jq '.[] | "\(.headRefName) \(.headRefOid)"' >"$out" 2>/dev/null) &
+    pid=$!
+    while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt "$GH_TIMEOUT" ]]; do
+      sleep 1
+      waited=$((waited + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null || true
+      rm -f "$out"
+      return 1
+    fi
+    if wait "$pid"; then
+      cat "$out"
+      rm -f "$out"
+      return 0
+    fi
+    rm -f "$out"
+    return 1
+  }
+
   if command -v gh >/dev/null 2>&1; then
-    if MERGED_REFS=$("${GH_RUNNER[@]}" gh pr list --state merged --limit "$MERGED_LIMIT" \
-      --json headRefName,headRefOid --jq '.[] | "\(.headRefName) \(.headRefOid)"' 2>/dev/null); then
+    if MERGED_REFS=$(bounded_merged_refs); then
       MERGED_REFS_READ=true
     fi
   fi

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -259,21 +259,34 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
   # directory has spent the week removing. One path, everywhere.
   GH_TIMEOUT=10
   bounded_merged_refs() {
-    local out pid waited=0
+    local out pid watcher rc
     out=$(mktemp) || return 1
     (gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
       --jq '.[] | "\(.headRefName) \(.headRefOid)"' >"$out" 2>/dev/null) &
     pid=$!
-    while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt "$GH_TIMEOUT" ]]; do
-      sleep 1
-      waited=$((waited + 1))
-    done
-    if kill -0 "$pid" 2>/dev/null; then
+
+    # A watchdog rather than a `kill -0` polling loop. Polling asks "is the child still alive", and a
+    # child that has exited but not yet been reaped can still answer yes — on a shell where it does,
+    # every successful query would burn the whole deadline and then be thrown away as a timeout, so
+    # the feature would always fall back and every branch creation would cost ten seconds. Measured
+    # here at 1.2s with the polling version, so it did not reproduce on this bash; `wait` removes the
+    # question rather than leaving it to the platform, and returns the instant the query finishes.
+    # stdout detached deliberately. This function runs inside a command substitution, and a command
+    # substitution does not return until EVERY process holding the write end of its pipe is gone —
+    # so a watchdog inheriting that pipe kept it open for the full deadline even after the query had
+    # answered and the watchdog itself was killed, because the `sleep` it spawned still held the fd.
+    # Measured: the success path took 10.2s that way, worse than the polling it replaced.
+    (
+      sleep "$GH_TIMEOUT"
       kill -TERM "$pid" 2>/dev/null || true
-      rm -f "$out"
-      return 1
-    fi
-    if wait "$pid"; then
+    ) >/dev/null 2>&1 &
+    watcher=$!
+
+    if wait "$pid"; then rc=0; else rc=1; fi
+    kill -TERM "$watcher" 2>/dev/null || true
+    wait "$watcher" 2>/dev/null || true
+
+    if [[ "$rc" -eq 0 ]]; then
       cat "$out"
       rm -f "$out"
       return 0

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -248,9 +248,17 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
   MERGED_REFS=""
   MERGED_REFS_READ=false
   MERGED_LIMIT=500
+  #
+  # Bounded, because this runs on every branch creation. Before this check the path was entirely
+  # local; it now makes a network call, and a SLOW response is not a failed one — without a limit a
+  # stalled connection would hang the hook indefinitely instead of taking the fallback below. The
+  # fallback exists for exactly this: over-report, and say why.
+  GH_TIMEOUT=10
+  GH_RUNNER=()
+  command -v timeout >/dev/null 2>&1 && GH_RUNNER=(timeout "$GH_TIMEOUT")
   if command -v gh >/dev/null 2>&1; then
-    if MERGED_REFS=$(gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
-      --jq '.[] | "\(.headRefName) \(.headRefOid)"' 2>/dev/null); then
+    if MERGED_REFS=$("${GH_RUNNER[@]}" gh pr list --state merged --limit "$MERGED_LIMIT" \
+      --json headRefName,headRefOid --jq '.[] | "\(.headRefName) \(.headRefOid)"' 2>/dev/null); then
       MERGED_REFS_READ=true
     fi
   fi

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -239,13 +239,29 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
   # that gets overridden as a reflex, and it was: twice in one session, by me. The message under
   # this loop already told people to delete squash-merged branches; the check never used what the
   # message knew.
-  MERGED_HEADS=""
-  MERGED_HEADS_READ=false
+  #
+  # Matched on NAME AND COMMIT, never name alone. A branch name gets reused: merge `feat/x`, leave the
+  # local branch, and stack new work on it, and a name-only match would wave those new commits through
+  # — silently disabling the very rule this check enforces. The delete-guard below already carries that
+  # lesson ("a merged PR earlier in this branch's history does not make deletion safe"); this path was
+  # written without it.
+  MERGED_REFS=""
+  MERGED_REFS_READ=false
+  MERGED_LIMIT=500
   if command -v gh >/dev/null 2>&1; then
-    if MERGED_HEADS=$(gh pr list --state merged --limit 500 --json headRefName \
-      --jq '.[].headRefName' 2>/dev/null); then
-      MERGED_HEADS_READ=true
+    if MERGED_REFS=$(gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
+      --jq '.[] | "\(.headRefName) \(.headRefOid)"' 2>/dev/null); then
+      MERGED_REFS_READ=true
     fi
+  fi
+
+  # A full page may mean the list was truncated, so older merged branches would be missing and the
+  # check would over-report again — without the notice that explains why. Say it rather than let the
+  # list quietly grow back.
+  MERGED_TRUNCATED=false
+  if [[ "$MERGED_REFS_READ" == "true" ]] &&
+    [[ "$(printf '%s\n' "$MERGED_REFS" | grep -c .)" -ge "$MERGED_LIMIT" ]]; then
+    MERGED_TRUNCATED=true
   fi
 
   UNMERGED_BRANCHES=()
@@ -258,10 +274,13 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
     [[ -z "$candidate" ]] && continue
     ahead=$(git -C "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
     [[ "$ahead" -gt 0 ]] || continue
-    # A merged PR settles it, whatever the ancestry says.
-    if [[ "$MERGED_HEADS_READ" == "true" ]] &&
-      printf '%s\n' "$MERGED_HEADS" | grep -Fxq -- "$candidate"; then
-      continue
+    # A merged PR settles it — for the COMMIT that was merged, not for the name.
+    if [[ "$MERGED_REFS_READ" == "true" ]]; then
+      candidate_sha=$(git -C "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
+      if [[ -n "$candidate_sha" ]] &&
+        printf '%s\n' "$MERGED_REFS" | grep -Fxq -- "$candidate $candidate_sha"; then
+        continue
+      fi
     fi
     UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
   done < <(git -C "$PROJECT_DIR" branch 2>/dev/null)
@@ -273,9 +292,12 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
       echo "  - $b" >&2
     done
     echo "[branch-guard] After squash-merge via PR, delete the local branch: git branch -D <name>" >&2
-    if [[ "$MERGED_HEADS_READ" != "true" ]]; then
+    if [[ "$MERGED_REFS_READ" != "true" ]]; then
       echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
       echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2
+    elif [[ "$MERGED_TRUNCATED" == "true" ]]; then
+      echo "[branch-guard] NOTE: the merged-PR list came back full ($MERGED_LIMIT), so older merged" >&2
+      echo "[branch-guard] branches may be missing from it and listed here as unmerged." >&2
     fi
     echo "[branch-guard] To override: set BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1" >&2
     exit 2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -233,17 +233,37 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
   # Prefer the remote-tracking integration head; fall back to local `develop` when offline.
   INTEGRATION_REF=origin/develop
   git -C "$PROJECT_DIR" rev-parse --verify --quiet "$INTEGRATION_REF" >/dev/null 2>&1 || INTEGRATION_REF=develop
+  # A branch whose PR was SQUASH-merged keeps commits git cannot find in the integration branch, so
+  # ancestry alone calls it unmerged forever. Measured 2026-07-28: 83 branches reported, 73 of them
+  # with a MERGED PR — an 88% false-positive rate. A guard wrong seven times out of eight is one
+  # that gets overridden as a reflex, and it was: twice in one session, by me. The message under
+  # this loop already told people to delete squash-merged branches; the check never used what the
+  # message knew.
+  MERGED_HEADS=""
+  MERGED_HEADS_READ=false
+  if command -v gh >/dev/null 2>&1; then
+    if MERGED_HEADS=$(gh pr list --state merged --limit 500 --json headRefName \
+      --jq '.[].headRefName' 2>/dev/null); then
+      MERGED_HEADS_READ=true
+    fi
+  fi
+
   UNMERGED_BRANCHES=()
   SKIP_PATTERNS="^(main|master|develop|gh-pages)$"
   while IFS= read -r candidate; do
     candidate="${candidate#  }"   # strip leading spaces
     candidate="${candidate#\* }"  # strip current-branch marker
+    candidate="${candidate#+ }"   # strip the worktree marker, which otherwise yielded a bogus name
     [[ "$candidate" =~ $SKIP_PATTERNS ]] && continue
     [[ -z "$candidate" ]] && continue
     ahead=$(git -C "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
-    if [[ "$ahead" -gt 0 ]]; then
-      UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
+    [[ "$ahead" -gt 0 ]] || continue
+    # A merged PR settles it, whatever the ancestry says.
+    if [[ "$MERGED_HEADS_READ" == "true" ]] &&
+      printf '%s\n' "$MERGED_HEADS" | grep -Fxq -- "$candidate"; then
+      continue
     fi
+    UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
   done < <(git -C "$PROJECT_DIR" branch 2>/dev/null)
 
   if [[ "${#UNMERGED_BRANCHES[@]}" -gt 0 ]]; then
@@ -253,6 +273,10 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
       echo "  - $b" >&2
     done
     echo "[branch-guard] After squash-merge via PR, delete the local branch: git branch -D <name>" >&2
+    if [[ "$MERGED_HEADS_READ" != "true" ]]; then
+      echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
+      echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2
+    fi
     echo "[branch-guard] To override: set BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1" >&2
     exit 2
   fi

--- a/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
@@ -54,7 +54,7 @@ function scratchRepo(branches) {
  * `--state merged` is the only query the hook makes here; anything else exits non-zero so a change
  * in what the hook asks for shows up as an unread answer rather than a silently different verdict.
  */
-function stubbedPath(mergedHeads, { broken = false } = {}) {
+function stubbedPath(mergedRefs, { broken = false } = {}) {
   const dir = mkdtempSync(path.join(tmpdir(), 'gh-stub-'));
   scratch.push(dir);
   const gh = path.join(dir, 'gh');
@@ -65,7 +65,7 @@ function stubbedPath(mergedHeads, { broken = false } = {}) {
       broken ? 'exit 1' : '',
       'case "$*" in',
       '  *"--state merged"*)',
-      mergedHeads.map((h) => `    echo ${JSON.stringify(h)}`).join('\n'),
+      mergedRefs.map((r) => `    echo ${JSON.stringify(r)}`).join('\n'),
       '    exit 0 ;;',
       'esac',
       'exit 1',
@@ -77,7 +77,15 @@ function stubbedPath(mergedHeads, { broken = false } = {}) {
   return `${dir}:${process.env.PATH}`;
 }
 
-function judge(cwd, mergedHeads, options) {
+/** The line gh returns for a merged PR: the branch name and the commit that was merged. */
+function mergedRef(dir, branch) {
+  const oid = spawnSync('git', ['-C', dir, 'rev-parse', branch], {
+    encoding: 'utf8',
+  }).stdout.trim();
+  return `${branch} ${oid}`;
+}
+
+function judge(cwd, mergedRefs, options) {
   const result = spawnSync('bash', [HOOK], {
     input: JSON.stringify({
       tool_name: 'Bash',
@@ -87,7 +95,7 @@ function judge(cwd, mergedHeads, options) {
     encoding: 'utf8',
     env: {
       ...process.env,
-      PATH: stubbedPath(mergedHeads, options),
+      PATH: stubbedPath(mergedRefs, options),
       CLAUDE_PROJECT_DIR: cwd,
     },
   });
@@ -97,7 +105,7 @@ function judge(cwd, mergedHeads, options) {
 describe('branch-guard counts only branches that are really still open', () => {
   it('allows a new branch when every open-looking branch has a merged PR', () => {
     const cwd = scratchRepo(['feat/a', 'feat/b']);
-    const verdict = judge(cwd, ['feat/a', 'feat/b']);
+    const verdict = judge(cwd, [mergedRef(cwd, 'feat/a'), mergedRef(cwd, 'feat/b')]);
 
     expect(
       verdict.status,
@@ -109,11 +117,31 @@ describe('branch-guard counts only branches that are really still open', () => {
   it('still refuses while a branch has no merged PR', () => {
     // The rule itself is unchanged: real unmerged work still blocks a new branch.
     const cwd = scratchRepo(['feat/a', 'feat/open']);
-    const verdict = judge(cwd, ['feat/a']);
+    const verdict = judge(cwd, [mergedRef(cwd, 'feat/a')]);
 
     expect(verdict.status, 'genuinely unmerged work stopped blocking').toBe(2);
     expect(verdict.output).toMatch(/feat\/open/);
     expect(verdict.output, 'a merged branch was named as unmerged').not.toMatch(/- feat\/a /);
+  });
+
+  it('does not accept a merged name carrying new commits', () => {
+    // A branch name gets reused: merge `feat/a`, leave the local branch, stack new work on it. Matching
+    // the NAME alone waves those commits through and disables the rule this check enforces. The
+    // delete-guard in the same file already carries that lesson; this path was written without it.
+    const cwd = scratchRepo(['feat/a']);
+    const mergedAt = mergedRef(cwd, 'feat/a');
+
+    const git = (...args) => spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+    git('checkout', '--quiet', 'feat/a');
+    writeFileSync(path.join(cwd, 'after-merge'), 'z\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'feat: work stacked after the merge');
+    git('checkout', '--quiet', 'develop');
+
+    const verdict = judge(cwd, [mergedAt]);
+
+    expect(verdict.status, 'new commits on a merged branch name were counted as merged').toBe(2);
+    expect(verdict.output).toMatch(/feat\/a/);
   });
 
   it('says so when merged PRs could not be read', () => {

--- a/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
@@ -1,0 +1,131 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/branch-guard.sh');
+
+/**
+ * The one-branch-at-a-time rule, judged by whether a branch is ACTUALLY still open.
+ *
+ * A squash-merged PR leaves commits that git cannot find in the integration branch, so ancestry
+ * alone calls such a branch unmerged forever. Measured on 2026-07-28 in this repository: 83 local
+ * branches reported as unmerged, 73 of them with a MERGED PR — an 88% false-positive rate. A guard
+ * that is wrong seven times out of eight is overridden as a reflex, and it was, twice in one
+ * session. The check's own failure message already told people to delete squash-merged branches;
+ * it simply never used what the message knew.
+ *
+ * So the assertions below are about the DECISION, and `gh` is stubbed to state the world.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchRepo(branches) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'branch-guard-'));
+  scratch.push(dir);
+  const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '--quiet', '--initial-branch=develop');
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  writeFileSync(path.join(dir, 'root'), 'x\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', 'chore: root');
+
+  // Each extra branch carries a commit develop does not have — the shape a squash merge leaves.
+  for (const name of branches) {
+    git('checkout', '--quiet', '-b', name);
+    writeFileSync(path.join(dir, name.replace(/\//g, '-')), 'y\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', `feat: ${name}`);
+    git('checkout', '--quiet', 'develop');
+  }
+  return dir;
+}
+
+/**
+ * A PATH whose `gh` reports exactly the merged head refs given.
+ *
+ * `--state merged` is the only query the hook makes here; anything else exits non-zero so a change
+ * in what the hook asks for shows up as an unread answer rather than a silently different verdict.
+ */
+function stubbedPath(mergedHeads, { broken = false } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'gh-stub-'));
+  scratch.push(dir);
+  const gh = path.join(dir, 'gh');
+  writeFileSync(
+    gh,
+    [
+      '#!/bin/sh',
+      broken ? 'exit 1' : '',
+      'case "$*" in',
+      '  *"--state merged"*)',
+      mergedHeads.map((h) => `    echo ${JSON.stringify(h)}`).join('\n'),
+      '    exit 0 ;;',
+      'esac',
+      'exit 1',
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  );
+  chmodSync(gh, 0o755);
+  return `${dir}:${process.env.PATH}`;
+}
+
+function judge(cwd, mergedHeads, options) {
+  const result = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      cwd,
+      tool_input: { command: 'git checkout -b feat/next' },
+    }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: stubbedPath(mergedHeads, options),
+      CLAUDE_PROJECT_DIR: cwd,
+    },
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('branch-guard counts only branches that are really still open', () => {
+  it('allows a new branch when every open-looking branch has a merged PR', () => {
+    const cwd = scratchRepo(['feat/a', 'feat/b']);
+    const verdict = judge(cwd, ['feat/a', 'feat/b']);
+
+    expect(
+      verdict.status,
+      'squash-merged branches were counted as unmerged, which is the 88%-false-positive shape that ' +
+        'made this check something to override rather than something to obey.',
+    ).toBe(0);
+  });
+
+  it('still refuses while a branch has no merged PR', () => {
+    // The rule itself is unchanged: real unmerged work still blocks a new branch.
+    const cwd = scratchRepo(['feat/a', 'feat/open']);
+    const verdict = judge(cwd, ['feat/a']);
+
+    expect(verdict.status, 'genuinely unmerged work stopped blocking').toBe(2);
+    expect(verdict.output).toMatch(/feat\/open/);
+    expect(verdict.output, 'a merged branch was named as unmerged').not.toMatch(/- feat\/a /);
+  });
+
+  it('says so when merged PRs could not be read', () => {
+    // Without gh the check falls back to ancestry, which over-reports. That is the safe direction,
+    // but a list that is longer than the real backlog must say why — an unexplained wall of names
+    // is what gets overridden.
+    const cwd = scratchRepo(['feat/a']);
+    const verdict = judge(cwd, [], { broken: true });
+
+    expect(verdict.status).toBe(2);
+    expect(verdict.output, 'the fallback did not explain that the list is inflated').toMatch(
+      /merged PRs could not be read/,
+    );
+  });
+});

--- a/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
@@ -54,7 +54,7 @@ function scratchRepo(branches) {
  * `--state merged` is the only query the hook makes here; anything else exits non-zero so a change
  * in what the hook asks for shows up as an unread answer rather than a silently different verdict.
  */
-function stubbedPath(mergedRefs, { broken = false } = {}) {
+function stubbedPath(mergedRefs, { broken = false, hangs = false } = {}) {
   const dir = mkdtempSync(path.join(tmpdir(), 'gh-stub-'));
   scratch.push(dir);
   const gh = path.join(dir, 'gh');
@@ -63,6 +63,7 @@ function stubbedPath(mergedRefs, { broken = false } = {}) {
     [
       '#!/bin/sh',
       broken ? 'exit 1' : '',
+      hangs ? 'sleep 120' : '',
       'case "$*" in',
       '  *"--state merged"*)',
       mergedRefs.map((r) => `    echo ${JSON.stringify(r)}`).join('\n'),
@@ -142,6 +143,24 @@ describe('branch-guard counts only branches that are really still open', () => {
 
     expect(verdict.status, 'new commits on a merged branch name were counted as merged').toBe(2);
     expect(verdict.output).toMatch(/feat\/a/);
+  });
+
+  it('does not hang when the merged-PR query stalls', { timeout: 60_000 }, () => {
+    // This path was entirely local before the check made a network call, and it runs on every branch
+    // creation. A SLOW response is not a failed one: without a bound, a stalled connection hangs the
+    // hook indefinitely rather than taking the fallback written for exactly this case.
+    const cwd = scratchRepo(['feat/a']);
+    const started = Date.now();
+    const verdict = judge(cwd, [], { hangs: true });
+    const elapsed = Date.now() - started;
+
+    expect(elapsed, 'the hook waited on a stalled query instead of falling back').toBeLessThan(
+      40_000,
+    );
+    expect(verdict.status).toBe(2);
+    expect(verdict.output, 'the fallback did not explain why the list is inflated').toMatch(
+      /merged PRs could not be read/,
+    );
   });
 
   it('says so when merged PRs could not be read', () => {

--- a/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
@@ -145,6 +145,24 @@ describe('branch-guard counts only branches that are really still open', () => {
     expect(verdict.output).toMatch(/feat\/a/);
   });
 
+  it('returns as soon as the query answers', () => {
+    // The deadline must bound the SLOW case without taxing the fast one. Two ways that was got
+    // wrong here, both found by measuring rather than reading: a `kill -0` polling loop paid a
+    // second of granularity on every success, and the watchdog that replaced it inherited the
+    // command substitution's pipe — which does not close until every process holding it is gone —
+    // so a successful query still waited the full ten seconds, worse than what it replaced.
+    const cwd = scratchRepo(['feat/a']);
+    const started = Date.now();
+    const verdict = judge(cwd, [mergedRef(cwd, 'feat/a')]);
+    const elapsed = Date.now() - started;
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(
+      elapsed,
+      'a successful query paid the deadline anyway, so every branch creation costs it',
+    ).toBeLessThan(5_000);
+  });
+
   it('does not hang when the merged-PR query stalls', { timeout: 60_000 }, () => {
     // This path was entirely local before the check made a network call, and it runs on every branch
     // creation. A SLOW response is not a failed one: without a bound, a stalled connection hangs the


### PR DESCRIPTION
fix(hooks): a squash-merged branch is merged, whatever the ancestry says

The one-branch-at-a-time check counted any local branch with commits the
integration branch lacks. A squash merge leaves exactly that, so every
squash-merged branch was reported as unmerged forever.

Measured in this repository on 2026-07-28: 83 branches reported, 73 of them with
a MERGED PR — an 88% false-positive rate. A guard wrong seven times out of eight
is overridden as a reflex, and it was: twice in one session, by me. The failure
message under the check already told people to delete squash-merged branches; the
check simply never used what the message knew. After the fix the same repository
reports 10, and those 10 have no merged PR.

A merged PR settles it. One `gh pr list --state merged` call, not one per branch.
When gh cannot answer, the check falls back to ancestry and SAYS the list is
inflated — over-reporting is the safe direction, but an unexplained wall of names
is what gets overridden.

Also strips the `+ ` worktree marker from the branch listing, which otherwise
produced a bogus name whose ancestry query failed and silently counted zero.

Three decision tests, red-proved: removing the merged-PR recognition fails two.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
