### PR TITLE
refactor(process): the review round happens before the push, not after CI

### DIFF
--- a/.agents/skills/pr-review-orchestration/SKILL.md
+++ b/.agents/skills/pr-review-orchestration/SKILL.md
@@ -35,12 +35,41 @@ rejects). Two modes:
 
 ## The Loop (route-only)
 
+The loop runs in TWO places, and which one comes first is the whole point.
+
+### Round A — on the LOCAL DIFF, before any push (required)
+
+Measured across one session (2026-07-28), PRs #1514/#1518/#1519/#1520/#1521: 38 review rounds, 24 of them
+carrying a blocking finding, at 6–10 minutes of CI each. Not one of those findings needed CI to be visible —
+every one was read out of the diff. Several were regressions introduced by the previous round's fix, which a
+review of the NEXT diff would have caught just as cheaply. This loop used to wait for required checks to go
+green before its first review round, so the reviewer only ever saw a diff that had already been pushed,
+opened as a PR and run through CI: every finding cost a round trip before anyone could look at it.
+
+`pr-review-reviewer` already accepts a local diff (`git diff origin/<base>...HEAD`) — only the precondition
+forced the trip. So:
+
+A1. **Review the local diff.** Dispatch `pr-review-reviewer` with `git diff origin/<base>...HEAD`. No PR, no
+CI, no push. Read its terminal `ACTIONABLE FINDINGS: <n>`.
+A2. **Not zero?** Fix (`pr-review-fixer` or directly), commit, and repeat A1. A round here costs about a
+minute. The same round after a push costs a CI cycle.
+A3. **Zero?** Record it — `pnpm harness:review:record -- --findings 0` — and push.
+
+`pre-push-check` enforces A3: a feature-branch push whose HEAD has no matching record is refused, naming
+`PRE_PUSH_ALLOW_UNREVIEWED=1` for a deliberate exception. The record says a review RAN at this commit and
+reported zero gating findings; it does not claim the review was good, which is the reviewer's job and not a
+hook's. Integration branches and `release/promote-*` are exempt — a promotion carries develop's
+already-reviewed content and no diff of its own.
+
+### Round B — on the open PR, before merge
+
 Track: `iteration = 0` (cap 3), and `last_findings = {}` (set of finding identities `file:line + severity`).
 
-0. **Wait for the gate precondition** the rule sets (required checks green) before the first review round:
-   dispatch [ci-gate-watch](../ci-gate-watch/SKILL.md) on the PR's checks. `GREEN` → step 1. `RED` or
-   `STALLED` → **leave the loop** and route it as a build/test failure under the verification rules, not
-   as a review finding; re-enter here once the head is green.
+0. **Wait for the gate precondition** the rule sets (required checks green): dispatch
+   [ci-gate-watch](../ci-gate-watch/SKILL.md) on the PR's checks. `GREEN` → step 1. `RED` or `STALLED` →
+   **leave the loop** and route it as a build/test failure under the verification rules, not as a review
+   finding; re-enter here once the head is green. This precondition belongs HERE and only here: the merge
+   round must judge what will actually merge, and `merge-gate` requires a review newer than the head commit.
 1. **Review.** Dispatch `pr-review-reviewer` on the PR at the diff scope the rule's gate preconditions
    define. Read its terminal line `ACTIONABLE FINDINGS: <n>` and its finding set. (Do NOT judge the
    findings yourself — take the count as given.)
@@ -49,7 +78,8 @@ Track: `iteration = 0` (cap 3), and `last_findings = {}` (set of finding identit
    unchanged) → **STOP and escalate to the user** (the loop is stuck; do not spin). Else set `last_findings` to it.
 4. **Cap.** If `iteration >= 3` → **STOP and escalate to the user** (bounded; do not exceed the cap).
 5. **Record + fix.** Dispatch `pr-review-writer` (posts the review to the PR), then `pr-review-fixer` (applies the
-   MUST/SHOULD fixes). Increment `iteration`. Go to step 1 (re-review).
+   MUST/SHOULD fixes). Each fix returns to **Round A** — review the new local diff and record it before pushing
+   again — then increment `iteration` and go to step 1.
 
 ## Merge path (on `ACTIONABLE FINDINGS: 0`)
 

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -160,21 +160,19 @@ echo "[pre-push-check] Branch hygiene + lockfile checks passed. Proceeding with 
 #
 # Not enforced for the integration branches or a promotion branch: a promotion carries develop's
 # already-reviewed content and no diff of its own.
+# Deliberately NOT the same list as the branch-hygiene exemption above, which answers a different
+# question. That one asks "does comparing this branch to develop mean anything", so it exempts every
+# `release/*` and `hotfix/*` because their base is not develop. This one asks "does this push carry
+# a diff someone should have reviewed", and a hotfix or a release branch carries exactly that — they
+# are the pushes least worth waving through. Only `release/promote-*` is exempt here, because a
+# promotion carries develop's already-reviewed content and no diff of its own.
+#
+# Review flagged the difference as possible drift and asked whether it was intentional. It is, and
+# the tests below pin both sides so unifying the lists breaks loudly instead of quietly.
 case "$CUR_BRANCH" in
   main | master | develop | gh-pages | release/promote-*) exit 0 ;;
 esac
 
-# A detached HEAD has no branch to key a record against, and falling through produced a single
-# shared filename — `.agents/local-reviews/.json` — that every detached push would satisfy for every
-# other. The branch-hygiene check above exempts the empty case because it has nothing to compare;
-# this one has something to protect and no key for it, so it refuses. Review asked whether the
-# difference was intentional: it is now, and stated.
-if [[ -z "$CUR_BRANCH" ]]; then
-  echo "[pre-push-check] Blocked: pushing from a detached HEAD, so a review record cannot be keyed" >&2
-  echo "[pre-push-check] to a branch. Check out the branch you are pushing, or override inline:" >&2
-  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED=1 git push …" >&2
-  exit 2
-fi
 
 # The override must be an env prefix OF THE PUSH, not a token loose in the command. Matched
 # anywhere, `PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push …` disarms the gate with an assignment that
@@ -194,6 +192,18 @@ ACK_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$ACK_RE" | grep -c . || tru
 if [[ "$ACK_COUNT" -gt 0 && "$ACK_COUNT" -ge "$PUSH_COUNT" ]]; then
   echo "[pre-push-check] Override: PRE_PUSH_ALLOW_UNREVIEWED=1 — this push carries an unreviewed diff." >&2
   exit 0
+fi
+
+# A detached HEAD has no branch to key a record against, and falling through produced a single
+# shared filename — `.agents/local-reviews/.json` — that every detached push would satisfy for every
+# other. The branch-hygiene check above exempts the empty case because it has nothing to compare;
+# this one has something to protect and no key for it, so it refuses. Review asked whether the
+# difference was intentional: it is now, and stated.
+if [[ -z "$CUR_BRANCH" ]]; then
+  echo "[pre-push-check] Blocked: pushing from a detached HEAD, so a review record cannot be keyed" >&2
+  echo "[pre-push-check] to a branch. Check out the branch you are pushing, or override inline:" >&2
+  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED=1 git push …" >&2
+  exit 2
 fi
 
 # The verdict comes from `record-local-review.mjs --show`, which owns it. The first version of this

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -186,41 +186,23 @@ if printf '%s' "$COMMAND_VERBS" |
   exit 0
 fi
 
-HEAD_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null || echo "")
-RECORD="$PROJECT_DIR/.agents/local-reviews/${CUR_BRANCH//\//__}.json"
-REVIEWED_SHA=""
-REVIEWED_FINDINGS=""
-if [[ -f "$RECORD" ]]; then
-  REVIEWED_SHA=$(grep -o '"headSha"[[:space:]]*:[[:space:]]*"[0-9a-f]*"' "$RECORD" |
-    grep -oE '[0-9a-f]{7,}' | head -1 || true)
-  REVIEWED_FINDINGS=$(grep -o '"findings"[[:space:]]*:[[:space:]]*[0-9]*' "$RECORD" |
-    grep -oE '[0-9]+$' | head -1 || true)
-fi
+# The verdict comes from `record-local-review.mjs --show`, which owns it. The first version of this
+# block re-parsed the record with grep in bash — reproducing, in the read path, the duplicated-logic
+# drift the comment below it complains about. Two implementations agree until one of them changes.
+# Resolved beside the hook, not inside the checkout being judged: the recorder ships with the hook,
+# and the hook is what decides. WHICH checkout is judged is passed as the working directory instead,
+# which is why the recorder resolves its repository from `cwd` rather than from its own location.
+RECORDER="$(dirname "${BASH_SOURCE[0]}")/../../scripts/harness/record-local-review.mjs"
 
-if [[ -z "$HEAD_SHA" ]]; then
-  echo "[pre-push-check] Blocked: could not read HEAD, so the review record cannot be checked." >&2
+if ! command -v node >/dev/null 2>&1 || [[ ! -f "$RECORDER" ]]; then
+  echo "[pre-push-check] Blocked: cannot check the review record (node or the recorder is missing)," >&2
+  echo "[pre-push-check] so whether this diff was reviewed is unknown. Override inline:" >&2
+  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED=1 git push …" >&2
   exit 2
 fi
 
-# The record's contract is "a review ran at this commit AND reported zero gating findings".
-# `record-local-review.mjs` refuses to WRITE a record with open findings, and its `isReviewed()`
-# checks both — but this hook is the enforcement point and was checking only the sha, so a record
-# with a matching sha and open findings satisfied it silently. Duplicated logic drifting from its own
-# spec is the shape this session kept finding; both halves are checked here now, and an absent or
-# non-zero count refuses.
-if [[ "$REVIEWED_SHA" == "$HEAD_SHA" && "$REVIEWED_FINDINGS" != "0" ]]; then
-  echo "[pre-push-check] Blocked: the review recorded for ${CUR_BRANCH} reports" >&2
-  echo "[pre-push-check] ${REVIEWED_FINDINGS:-an unreadable number of} finding(s) still open." >&2
-  echo "[pre-push-check] Resolve them, review again, then record. Deliberate exception:" >&2
-  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED=1 inline." >&2
-  exit 2
-fi
-
-if [[ "$REVIEWED_SHA" != "$HEAD_SHA" ]]; then
-  echo "[pre-push-check] Blocked: no local review recorded for ${CUR_BRANCH} at $(printf '%.9s' "$HEAD_SHA")." >&2
-  if [[ -n "$REVIEWED_SHA" ]]; then
-    echo "[pre-push-check]   last reviewed: $(printf '%.9s' "$REVIEWED_SHA") — the diff has changed since." >&2
-  fi
+if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
+  echo "[pre-push-check] Blocked: ${REVIEW_STATE:-no local review recorded}." >&2
   echo "[pre-push-check] Review the local diff first (git diff origin/develop...HEAD), resolve every" >&2
   echo "[pre-push-check] MUST/SHOULD, then: pnpm harness:review:record -- --findings 0" >&2
   echo "[pre-push-check] A round here costs a minute; the same round after a push costs a CI cycle." >&2

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -142,4 +142,56 @@ if ! git -C "$PROJECT_DIR" diff --quiet pnpm-lock.yaml 2>/dev/null; then
 fi
 
 echo "[pre-push-check] Branch hygiene + lockfile checks passed. Proceeding with push." >&2
+# --- the review round belongs BEFORE this push -------------------------------------------------
+#
+# `pr-review-orchestration` used to wait for required checks to go green before its FIRST review
+# round, so the reviewer only ever saw a diff that had already been pushed, opened as a PR and run
+# through CI. Every finding therefore cost a push → CI round trip before anyone could look at it.
+#
+# Measured across one session (2026-07-28), PRs #1514/#1518/#1519/#1520/#1521: 38 rounds, 24 of them
+# carrying a blocking finding, at 6–10 minutes of CI each. None of those findings needed CI to be
+# seen; every one was read out of the diff. Several were regressions introduced by the previous
+# round's fix, which a review of the next diff would have caught just as cheaply. The reviewer agent
+# already accepts a local diff — only the precondition forced the trip.
+#
+# What this checks is that a review RAN at this commit and reported zero gating findings. It cannot
+# check that the review was good; a hook judging that would be measuring the wrong thing. Its value
+# is that the round happens here rather than eight minutes from now.
+#
+# Not enforced for the integration branches or a promotion branch: a promotion carries develop's
+# already-reviewed content and no diff of its own.
+case "$CUR_BRANCH" in
+  main | master | develop | gh-pages | release/promote-*) exit 0 ;;
+esac
+
+if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1'; then
+  echo "[pre-push-check] Override: PRE_PUSH_ALLOW_UNREVIEWED=1 — this push carries an unreviewed diff." >&2
+  exit 0
+fi
+
+HEAD_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null || echo "")
+RECORD="$PROJECT_DIR/.agents/local-reviews/${CUR_BRANCH//\//__}.json"
+REVIEWED_SHA=""
+if [[ -f "$RECORD" ]]; then
+  REVIEWED_SHA=$(grep -o '"headSha"[[:space:]]*:[[:space:]]*"[0-9a-f]*"' "$RECORD" |
+    grep -oE '[0-9a-f]{7,}' | head -1 || true)
+fi
+
+if [[ -z "$HEAD_SHA" ]]; then
+  echo "[pre-push-check] Blocked: could not read HEAD, so the review record cannot be checked." >&2
+  exit 2
+fi
+
+if [[ "$REVIEWED_SHA" != "$HEAD_SHA" ]]; then
+  echo "[pre-push-check] Blocked: no local review recorded for ${CUR_BRANCH} at $(printf '%.9s' "$HEAD_SHA")." >&2
+  if [[ -n "$REVIEWED_SHA" ]]; then
+    echo "[pre-push-check]   last reviewed: $(printf '%.9s' "$REVIEWED_SHA") — the diff has changed since." >&2
+  fi
+  echo "[pre-push-check] Review the local diff first (git diff origin/develop...HEAD), resolve every" >&2
+  echo "[pre-push-check] MUST/SHOULD, then: pnpm harness:review:record -- --findings 0" >&2
+  echo "[pre-push-check] A round here costs a minute; the same round after a push costs a CI cycle." >&2
+  echo "[pre-push-check] Deliberate exception: PRE_PUSH_ALLOW_UNREVIEWED=1 inline." >&2
+  exit 2
+fi
+
 exit 0

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -164,7 +164,12 @@ case "$CUR_BRANCH" in
   main | master | develop | gh-pages | release/promote-*) exit 0 ;;
 esac
 
-if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1'; then
+# The override must be an env prefix OF THE PUSH, not a token loose in the command. Matched
+# anywhere, `PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push …` disarms the gate with an assignment that
+# belongs to an unrelated statement and never reaches the push. `merge-gate` already carries this
+# correction; applying it there and not here is the sibling asymmetry this session kept finding.
+if printf '%s' "$COMMAND_VERBS" |
+  grep -qE '(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push\b'; then
   echo "[pre-push-check] Override: PRE_PUSH_ALLOW_UNREVIEWED=1 — this push carries an unreviewed diff." >&2
   exit 0
 fi

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -167,8 +167,11 @@ echo "[pre-push-check] Branch hygiene + lockfile checks passed. Proceeding with 
 # are the pushes least worth waving through. Only `release/promote-*` is exempt here, because a
 # promotion carries develop's already-reviewed content and no diff of its own.
 #
+# `gh-pages` is exempt for the same reason as the integration branches: it is published output, not
+# a reviewed change set.
+#
 # Review flagged the difference as possible drift and asked whether it was intentional. It is, and
-# the tests below pin both sides so unifying the lists breaks loudly instead of quietly.
+# the tests below pin every entry so unifying the lists breaks loudly instead of quietly.
 case "$CUR_BRANCH" in
   main | master | develop | gh-pages | release/promote-*) exit 0 ;;
 esac
@@ -223,7 +226,14 @@ fi
 
 if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
   echo "[pre-push-check] Blocked: ${REVIEW_STATE:-no local review recorded}." >&2
-  echo "[pre-push-check] Review the local diff first (git diff origin/develop...HEAD), resolve every" >&2
+  # The base depends on the branch. This file's own hygiene section documents `release/*` and
+  # `hotfix/*` as based on main, and those branches are deliberately NOT exempt from this gate — so
+  # naming develop unconditionally pointed a blocked hotfix at the wrong diff.
+  case "$CUR_BRANCH" in
+    release/* | hotfix/*) REVIEW_BASE=origin/main ;;
+    *) REVIEW_BASE=origin/develop ;;
+  esac
+  echo "[pre-push-check] Review the local diff first (git diff ${REVIEW_BASE}...HEAD), resolve every" >&2
   echo "[pre-push-check] MUST/SHOULD, then: pnpm harness:review:record -- --findings 0" >&2
   echo "[pre-push-check] A round here costs a minute; the same round after a push costs a CI cycle." >&2
   echo "[pre-push-check] Deliberate exception: PRE_PUSH_ALLOW_UNREVIEWED=1 inline." >&2

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -164,6 +164,18 @@ case "$CUR_BRANCH" in
   main | master | develop | gh-pages | release/promote-*) exit 0 ;;
 esac
 
+# A detached HEAD has no branch to key a record against, and falling through produced a single
+# shared filename — `.agents/local-reviews/.json` — that every detached push would satisfy for every
+# other. The branch-hygiene check above exempts the empty case because it has nothing to compare;
+# this one has something to protect and no key for it, so it refuses. Review asked whether the
+# difference was intentional: it is now, and stated.
+if [[ -z "$CUR_BRANCH" ]]; then
+  echo "[pre-push-check] Blocked: pushing from a detached HEAD, so a review record cannot be keyed" >&2
+  echo "[pre-push-check] to a branch. Check out the branch you are pushing, or override inline:" >&2
+  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED=1 git push …" >&2
+  exit 2
+fi
+
 # The override must be an env prefix OF THE PUSH, not a token loose in the command. Matched
 # anywhere, `PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push …` disarms the gate with an assignment that
 # belongs to an unrelated statement and never reaches the push. `merge-gate` already carries this
@@ -177,13 +189,30 @@ fi
 HEAD_SHA=$(git -C "$PROJECT_DIR" rev-parse HEAD 2>/dev/null || echo "")
 RECORD="$PROJECT_DIR/.agents/local-reviews/${CUR_BRANCH//\//__}.json"
 REVIEWED_SHA=""
+REVIEWED_FINDINGS=""
 if [[ -f "$RECORD" ]]; then
   REVIEWED_SHA=$(grep -o '"headSha"[[:space:]]*:[[:space:]]*"[0-9a-f]*"' "$RECORD" |
     grep -oE '[0-9a-f]{7,}' | head -1 || true)
+  REVIEWED_FINDINGS=$(grep -o '"findings"[[:space:]]*:[[:space:]]*[0-9]*' "$RECORD" |
+    grep -oE '[0-9]+$' | head -1 || true)
 fi
 
 if [[ -z "$HEAD_SHA" ]]; then
   echo "[pre-push-check] Blocked: could not read HEAD, so the review record cannot be checked." >&2
+  exit 2
+fi
+
+# The record's contract is "a review ran at this commit AND reported zero gating findings".
+# `record-local-review.mjs` refuses to WRITE a record with open findings, and its `isReviewed()`
+# checks both — but this hook is the enforcement point and was checking only the sha, so a record
+# with a matching sha and open findings satisfied it silently. Duplicated logic drifting from its own
+# spec is the shape this session kept finding; both halves are checked here now, and an absent or
+# non-zero count refuses.
+if [[ "$REVIEWED_SHA" == "$HEAD_SHA" && "$REVIEWED_FINDINGS" != "0" ]]; then
+  echo "[pre-push-check] Blocked: the review recorded for ${CUR_BRANCH} reports" >&2
+  echo "[pre-push-check] ${REVIEWED_FINDINGS:-an unreadable number of} finding(s) still open." >&2
+  echo "[pre-push-check] Resolve them, review again, then record. Deliberate exception:" >&2
+  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED=1 inline." >&2
   exit 2
 fi
 

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -180,8 +180,18 @@ fi
 # anywhere, `PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push …` disarms the gate with an assignment that
 # belongs to an unrelated statement and never reaches the push. `merge-gate` already carries this
 # correction; applying it there and not here is the sibling asymmetry this session kept finding.
-if printf '%s' "$COMMAND_VERBS" |
-  grep -qE '(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push\b'; then
+#
+# And it excuses only the pushes it actually prefixes. `PRE_PUSH_ALLOW_UNREVIEWED=1 git push a &&
+# git push b` overrides the first push and not the second in real shell semantics, so letting the
+# whole command through would grant an unearned bypass to the second — the one direction this file
+# never trades in. When some pushes are unprefixed the override does not apply and the record check
+# below decides for all of them.
+PUSH_RE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push\b'
+ACK_RE='(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push\b'
+PUSH_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$PUSH_RE" | grep -c . || true)
+ACK_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$ACK_RE" | grep -c . || true)
+
+if [[ "$ACK_COUNT" -gt 0 && "$ACK_COUNT" -ge "$PUSH_COUNT" ]]; then
   echo "[pre-push-check] Override: PRE_PUSH_ALLOW_UNREVIEWED=1 — this push carries an unreviewed diff." >&2
   exit 0
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ stryker.log
 # Fixture roots for tests that must live inside the invocation directory (SEC-007 containment).
 # `afterAll` removes them; this is the net for a SIGKILL/timeout that skips the hook.
 .tmp-dag-tool-run-*/
+.agents/local-reviews/

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "harness:scan:orphan-exports": "node scripts/harness/check-orphan-exports.mjs",
     "test:mutation": "stryker run",
     "proof:external": "node scripts/external-proof/run-external-proof.mjs",
-    "typecheck:compare": "node scripts/perf/compare-typecheck.mjs"
+    "typecheck:compare": "node scripts/perf/compare-typecheck.mjs",
+    "harness:review:record": "node scripts/harness/record-local-review.mjs"
   },
   "keywords": [
     "ai",

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -1,0 +1,173 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { isReviewed, recordPathFor } from '../record-local-review.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/pre-push-check.sh');
+const SKILL = path.join(WORKSPACE_ROOT, '.agents/skills/pr-review-orchestration/SKILL.md');
+
+/**
+ * The review round happens BEFORE the push, and something makes it happen.
+ *
+ * `pr-review-orchestration` used to wait for required checks to go green before its first review round, so
+ * the reviewer only ever saw a diff that had already been pushed, opened as a PR and run through CI. Every
+ * finding therefore cost a push → CI round trip before anyone could look at it. Measured across one session
+ * (2026-07-28), PRs #1514/#1518/#1519/#1520/#1521: 38 rounds, 24 carrying a blocking finding, at 6–10 minutes
+ * of CI each — and not one of those findings needed CI to be seen.
+ *
+ * Writing that into the skill is not enough; a rule with no mechanism is the defect this repository spent the
+ * same session removing from four hooks. So the assertions below cover both halves: the gate refuses an
+ * unreviewed push, and the skill still says where the round belongs.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchRepo(branch) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'review-gate-'));
+  scratch.push(dir);
+  const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '--quiet', `--initial-branch=${branch}`);
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', 'chore: root');
+  return dir;
+}
+
+function headSha(dir) {
+  return spawnSync('git', ['-C', dir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).stdout.trim();
+}
+
+function record(dir, branch, sha, findings = 0) {
+  const file = recordPathFor(branch, path.join(dir, '.agents/local-reviews'));
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify({ branch, headSha: sha, findings }));
+}
+
+function push(dir, command = 'git push -u origin feat/probe') {
+  const result = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({ tool_name: 'Bash', cwd: dir, tool_input: { command } }),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+    timeout: 120_000,
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('a feature-branch push carries a reviewed diff', () => {
+  it('refuses a push with no local review recorded', () => {
+    const dir = scratchRepo('feat/probe');
+    const verdict = push(dir);
+
+    expect(
+      verdict.status,
+      'an unreviewed diff was pushed, which is where the CI trips come from',
+    ).toBe(2);
+    expect(verdict.output).toMatch(/no local review recorded/);
+  });
+
+  it('allows the push once the review at this commit is recorded', () => {
+    const dir = scratchRepo('feat/probe');
+    record(dir, 'feat/probe', headSha(dir));
+
+    expect(push(dir).status).toBe(0);
+  });
+
+  it('refuses again once the diff changes', () => {
+    // Keyed on the HEAD sha deliberately: a new commit is a new diff, and the previous round's review no
+    // longer describes what would be sent. That property is the entire point.
+    const dir = scratchRepo('feat/probe');
+    record(dir, 'feat/probe', headSha(dir));
+    writeFileSync(path.join(dir, 'more'), 'x\n');
+    spawnSync('git', ['-C', dir, 'add', '-A'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'feat: more'], { encoding: 'utf8' });
+
+    const verdict = push(dir);
+    expect(verdict.status, 'a review of an older commit was accepted for a newer diff').toBe(2);
+    expect(verdict.output).toMatch(/the diff has changed since/);
+  });
+
+  it('honours an inline override and says the diff was unreviewed', () => {
+    const dir = scratchRepo('feat/probe');
+    const verdict = push(dir, 'PRE_PUSH_ALLOW_UNREVIEWED=1 git push -u origin feat/probe');
+
+    expect(verdict.status).toBe(0);
+    expect(verdict.output, 'an override that does not announce itself is a silent bypass').toMatch(
+      /unreviewed diff/,
+    );
+  });
+
+  it('exempts the integration branches and a promotion branch', () => {
+    // A promotion carries develop's already-reviewed content and no diff of its own; requiring a review of
+    // it would be a gate on nothing, and gates on nothing are what get overridden.
+    for (const branch of ['develop', 'main', 'release/promote-develop-to-main']) {
+      const dir = scratchRepo(branch);
+      expect(push(dir, `git push origin ${branch}`).status, branch).toBe(0);
+    }
+  });
+});
+
+describe('a record only counts when it describes this commit and a clean review', () => {
+  it('rejects a record for another commit, or one with open findings', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'record-'));
+    scratch.push(dir);
+    const store = path.join(dir, 'records');
+    mkdirSync(store, { recursive: true });
+    writeFileSync(
+      recordPathFor('feat/x', store),
+      JSON.stringify({ branch: 'feat/x', headSha: 'aaa', findings: 0 }),
+    );
+
+    expect(isReviewed('feat/x', 'aaa', store)).toBe(true);
+    expect(isReviewed('feat/x', 'bbb', store), 'a stale record passed for a new commit').toBe(
+      false,
+    );
+
+    writeFileSync(
+      recordPathFor('feat/y', store),
+      JSON.stringify({ branch: 'feat/y', headSha: 'aaa', findings: 2 }),
+    );
+    expect(isReviewed('feat/y', 'aaa', store), 'a review with open findings counted as clean').toBe(
+      false,
+    );
+  });
+
+  it('treats an unreadable record as absent', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'record-bad-'));
+    scratch.push(dir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(recordPathFor('feat/z', dir), 'not json');
+
+    expect(isReviewed('feat/z', 'aaa', dir), 'a corrupt record passed as a review').toBe(false);
+  });
+});
+
+describe('the skill still puts the round before the push', () => {
+  const skill = readFileSync(SKILL, 'utf8');
+
+  it('describes the local-diff round and the command that records it', () => {
+    // The measured reason this changed, kept where the next reader of the skill will meet it.
+    expect(skill).toMatch(/before any push/i);
+    expect(skill).toMatch(/harness:review:record/);
+  });
+
+  it('keeps the CI-green precondition out of the first round', () => {
+    // The precondition belongs to the merge round, which must judge what will actually merge. If it
+    // drifts back to the top, every finding costs a CI cycle again — which is the state this replaced.
+    const roundA = skill.slice(skill.indexOf('### Round A'), skill.indexOf('### Round B'));
+
+    expect(
+      roundA,
+      'the pre-push round waits for CI again, which is the round trip this change removed',
+    ).not.toMatch(/ci-gate-watch|required checks green/i);
+  });
+});

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -96,6 +96,42 @@ describe('a feature-branch push carries a reviewed diff', () => {
     expect(verdict.output).toMatch(/the diff has changed since/);
   });
 
+  it('refuses a record that matches the commit but reports open findings', () => {
+    // The enforcement point is this hook, and it was checking the sha alone. `record-local-review`
+    // refuses to WRITE such a record and its `isReviewed()` checks both — but the hook never calls
+    // that function, so the duplicated logic had drifted from its own spec, and no test covered the
+    // combination. Exactly the accidental-green gap: every existing case passed either way.
+    const dir = scratchRepo('feat/probe');
+    record(dir, 'feat/probe', headSha(dir), 3);
+
+    const verdict = push(dir);
+    expect(verdict.status, 'a record with open findings satisfied the gate').toBe(2);
+    expect(verdict.output).toMatch(/3 finding\(s\) still open/);
+  });
+
+  it('refuses a record whose findings count is unreadable', () => {
+    // Absent is not zero. A record missing the field cannot say the review was clean.
+    const dir = scratchRepo('feat/probe');
+    const file = recordPathFor('feat/probe', path.join(dir, '.agents/local-reviews'));
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ branch: 'feat/probe', headSha: headSha(dir) }));
+
+    expect(push(dir).status, 'a record with no findings field passed as clean').toBe(2);
+  });
+
+  it('refuses a push from a detached HEAD', () => {
+    // No branch means no key for a record, and falling through produced one shared filename that
+    // every detached push would satisfy for every other. The hygiene check above exempts the empty
+    // case because it has nothing to compare; this one has something to protect and no key for it.
+    const dir = scratchRepo('feat/probe');
+    record(dir, 'feat/probe', headSha(dir));
+    spawnSync('git', ['-C', dir, 'checkout', '--quiet', '--detach'], { encoding: 'utf8' });
+
+    const verdict = push(dir, 'git push origin HEAD:refs/heads/feat/probe');
+    expect(verdict.status, 'a detached-HEAD push skipped the gate').toBe(2);
+    expect(verdict.output).toMatch(/detached HEAD/);
+  });
+
   it('honours an inline override and says the diff was unreviewed', () => {
     const dir = scratchRepo('feat/probe');
     const verdict = push(dir, 'PRE_PUSH_ALLOW_UNREVIEWED=1 git push -u origin feat/probe');

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -201,10 +201,21 @@ describe('a feature-branch push carries a reviewed diff', () => {
     }
   });
 
+  it('points a blocked push at the base its branch is built on', () => {
+    // `release/*` and `hotfix/*` are based on main, per this file's own hygiene section, and are
+    // deliberately not exempt from the gate — so naming develop unconditionally sent a blocked
+    // hotfix to diff against the wrong base.
+    const hotfix = scratchRepo('hotfix/urgent');
+    expect(push(hotfix, 'git push origin hotfix/urgent').output).toMatch(/origin\/main\.\.\.HEAD/);
+
+    const feature = scratchRepo('feat/probe');
+    expect(push(feature).output).toMatch(/origin\/develop\.\.\.HEAD/);
+  });
+
   it('exempts the integration branches and a promotion branch', () => {
     // A promotion carries develop's already-reviewed content and no diff of its own; requiring a review of
     // it would be a gate on nothing, and gates on nothing are what get overridden.
-    for (const branch of ['develop', 'main', 'release/promote-develop-to-main']) {
+    for (const branch of ['develop', 'main', 'gh-pages', 'release/promote-develop-to-main']) {
       const dir = scratchRepo(branch);
       expect(push(dir, `git push origin ${branch}`).status, branch).toBe(0);
     }

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -279,6 +279,29 @@ describe('a record only counts when it describes this commit and a clean review'
   });
 });
 
+describe('the recorder refuses to guess which checkout it is in', () => {
+  const RECORDER = path.join(WORKSPACE_ROOT, 'scripts/harness/record-local-review.mjs');
+
+  it('fails loudly outside a git work tree instead of using its own repository', () => {
+    // The resolver caught a failed `rev-parse` and fell back to the script's own location — doing
+    // precisely what its own docstring said must not happen: reading and writing one checkout's
+    // records while judging another. A no-fallback violation, and the one place the bash side of
+    // this gate refuses to guess while the JS side did.
+    const outside = mkdtempSync(path.join(tmpdir(), 'not-a-repo-'));
+    scratch.push(outside);
+
+    const result = spawnSync('node', [RECORDER, '--show'], {
+      cwd: outside,
+      encoding: 'utf8',
+    });
+
+    expect(result.status, 'the recorder guessed a repository instead of refusing').not.toBe(0);
+    expect(`${result.stderr}`, 'it refused without saying why').toMatch(
+      /not inside a git work tree/,
+    );
+  });
+});
+
 describe('the skill still puts the round before the push', () => {
   const skill = readFileSync(SKILL, 'utf8');
 

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -247,6 +247,28 @@ describe('a record only counts when it describes this commit and a clean review'
     );
   });
 
+  it('keeps two branches whose names once encoded alike apart', () => {
+    // `feat/foo` and `feat__foo` both mapped to `feat__foo.json`, so one branch's review satisfied
+    // the gate for the other, unreviewed one. The encoding is one-to-one now, and the stored branch
+    // name is checked as well — a record that arrives at this path some other way is still not
+    // this branch's review.
+    const dir = mkdtempSync(path.join(tmpdir(), 'record-collide-'));
+    scratch.push(dir);
+    mkdirSync(dir, { recursive: true });
+
+    expect(recordPathFor('feat/foo', dir)).not.toBe(recordPathFor('feat__foo', dir));
+
+    writeFileSync(
+      recordPathFor('feat/foo', dir),
+      JSON.stringify({ branch: 'feat/foo', headSha: 'aaa', findings: 0 }),
+    );
+    expect(isReviewed('feat/foo', 'aaa', dir)).toBe(true);
+    expect(
+      isReviewed('feat__foo', 'aaa', dir),
+      'a record for another branch satisfied this one',
+    ).toBe(false);
+  });
+
   it('treats an unreadable record as absent', () => {
     const dir = mkdtempSync(path.join(tmpdir(), 'record-bad-'));
     scratch.push(dir);

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -132,6 +132,20 @@ describe('a feature-branch push carries a reviewed diff', () => {
     expect(verdict.output).toMatch(/detached HEAD/);
   });
 
+  it('lets the advertised override work from a detached HEAD', () => {
+    // The detached-HEAD refusal named an override that sat BELOW it, so following the instruction
+    // changed nothing and the message pointed at a door that was not there. A guard that tells you
+    // how to proceed and then refuses anyway is the kind that gets worked around.
+    const dir = scratchRepo('feat/probe');
+    spawnSync('git', ['-C', dir, 'checkout', '--quiet', '--detach'], { encoding: 'utf8' });
+    const verdict = push(
+      dir,
+      'PRE_PUSH_ALLOW_UNREVIEWED=1 git push origin HEAD:refs/heads/feat/probe',
+    );
+
+    expect(verdict.status, 'the override the message advertises does not work').toBe(0);
+  });
+
   it('honours an inline override and says the diff was unreviewed', () => {
     const dir = scratchRepo('feat/probe');
     const verdict = push(dir, 'PRE_PUSH_ALLOW_UNREVIEWED=1 git push -u origin feat/probe');
@@ -174,6 +188,17 @@ describe('a feature-branch push carries a reviewed diff', () => {
     const verdict = push(dir, 'PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push -u origin feat/probe');
 
     expect(verdict.status, 'an override bound to another statement disarmed the gate').toBe(2);
+  });
+
+  it('does not exempt a hotfix or an ordinary release branch', () => {
+    // The exemption list here is deliberately narrower than the branch-hygiene one above it, which
+    // answers a different question: that one asks whether comparing to develop means anything, this
+    // one asks whether the push carries a diff someone should have reviewed. A hotfix carries
+    // exactly that, and is the push least worth waving through.
+    for (const branch of ['hotfix/urgent', 'release/1.2.0']) {
+      const dir = scratchRepo(branch);
+      expect(push(dir, `git push origin ${branch}`).status, branch).toBe(2);
+    }
   });
 
   it('exempts the integration branches and a promotion branch', () => {

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -106,6 +106,17 @@ describe('a feature-branch push carries a reviewed diff', () => {
     );
   });
 
+  it('ignores an override attached to some other statement', () => {
+    // The override is a visible, deliberate choice about THIS push. Matched anywhere in the command,
+    // `PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push …` disarms the gate with an assignment that never
+    // reaches the push. merge-gate already carries this correction; applying it there and not here
+    // is the sibling asymmetry this session kept finding.
+    const dir = scratchRepo('feat/probe');
+    const verdict = push(dir, 'PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push -u origin feat/probe');
+
+    expect(verdict.status, 'an override bound to another statement disarmed the gate').toBe(2);
+  });
+
   it('exempts the integration branches and a promotion branch', () => {
     // A promotion carries develop's already-reviewed content and no diff of its own; requiring a review of
     // it would be a gate on nothing, and gates on nothing are what get overridden.

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -142,6 +142,29 @@ describe('a feature-branch push carries a reviewed diff', () => {
     );
   });
 
+  it('does not let one override excuse a second, unprefixed push', () => {
+    // `PRE_PUSH_ALLOW_UNREVIEWED=1 git push a && git push b` overrides the first push and not the
+    // second in real shell semantics. Letting the whole command through grants an unearned bypass
+    // to the second — the one direction this file never trades in.
+    const dir = scratchRepo('feat/probe');
+    const verdict = push(
+      dir,
+      'PRE_PUSH_ALLOW_UNREVIEWED=1 git push origin feat/probe && git push origin other',
+    );
+
+    expect(verdict.status, 'an unprefixed second push rode in on the first override').toBe(2);
+  });
+
+  it('still honours an override that prefixes every push', () => {
+    const dir = scratchRepo('feat/probe');
+    const verdict = push(
+      dir,
+      'PRE_PUSH_ALLOW_UNREVIEWED=1 git push origin a && PRE_PUSH_ALLOW_UNREVIEWED=1 git push origin b',
+    );
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
   it('ignores an override attached to some other statement', () => {
     // The override is a visible, deliberate choice about THIS push. Matched anywhere in the command,
     // `PRE_PUSH_ALLOW_UNREVIEWED=1 date; git push …` disarms the gate with an assignment that never

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -69,22 +69,48 @@ export function recordPathFor(branch, dir = RECORD_DIR) {
 }
 
 /**
- * Has the given commit been reviewed on this branch?
+ * The verdict, with the reason — the single place the question is answered.
+ *
+ * `--show` used to re-implement these same checks beside `isReviewed()`, which is the duplicated
+ * drift this change spent two rounds removing from the bash side. Two implementations agree until
+ * one of them changes, and the JS pair was no different from the bash pair.
  *
  * Keyed on the HEAD sha, deliberately: amending or adding a commit changes what would be pushed, so
  * the previous round's review no longer describes it. That is the property the whole change is
  * about — a review must have seen what is being sent.
  */
-export function isReviewed(branch, headSha, dir = RECORD_DIR) {
+export function reviewState(branch, headSha, dir = RECORD_DIR) {
   const file = recordPathFor(branch, dir);
-  if (!existsSync(file)) return false;
-  try {
-    const record = JSON.parse(readFileSync(file, 'utf8'));
-    return record.headSha === headSha && record.findings === 0;
-  } catch {
-    // An unreadable record is not a review. Treated as absent, which refuses rather than passes.
-    return false;
+  if (!existsSync(file)) {
+    return {
+      ok: false,
+      reason: `no local review recorded for ${branch} at ${headSha.slice(0, 9)}`,
+    };
   }
+  let stored;
+  try {
+    stored = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    // An unreadable record is not a review. Refuses rather than passes.
+    return {
+      ok: false,
+      reason: `the review record for ${branch} is unreadable, so it is not a review`,
+    };
+  }
+  if (stored.headSha !== headSha) {
+    const seen = String(stored.headSha ?? '?').slice(0, 9);
+    return { ok: false, reason: `last reviewed ${seen} — the diff has changed since` };
+  }
+  if (stored.findings !== 0) {
+    const n = stored.findings ?? 'an unreadable number of';
+    return { ok: false, reason: `the recorded review reports ${n} finding(s) still open` };
+  }
+  return { ok: true, reason: `reviewed at ${headSha.slice(0, 9)} — 0 findings` };
+}
+
+/** Convenience predicate over {@link reviewState}. */
+export function isReviewed(branch, headSha, dir = RECORD_DIR) {
+  return reviewState(branch, headSha, dir).ok;
 }
 
 function parseArgs(argv) {
@@ -107,33 +133,9 @@ function main() {
     // The single owner of "is this commit reviewed". `pre-push-check` calls this and routes on the
     // exit code rather than re-parsing the record in bash — the duplicated-logic drift this whole
     // change is about, which the first version of that hook reproduced.
-    const dir = recordDirFor(root);
-    const file = recordPathFor(branch, dir);
-    if (!existsSync(file)) {
-      console.log(`no local review recorded for ${branch} at ${headSha.slice(0, 9)}`);
-      process.exit(1);
-    }
-    let stored;
-    try {
-      stored = JSON.parse(readFileSync(file, 'utf8'));
-    } catch {
-      console.log(`the review record for ${branch} is unreadable, so it is not a review`);
-      process.exit(1);
-    }
-    if (stored.headSha !== headSha) {
-      console.log(
-        `last reviewed ${String(stored.headSha ?? '?').slice(0, 9)} — the diff has changed since`,
-      );
-      process.exit(1);
-    }
-    if (stored.findings !== 0) {
-      console.log(
-        `the recorded review reports ${stored.findings ?? 'an unreadable number of'} finding(s) still open`,
-      );
-      process.exit(1);
-    }
-    console.log(`reviewed at ${headSha.slice(0, 9)} — 0 findings`);
-    process.exit(0);
+    const verdict = reviewState(branch, headSha, recordDirFor(root));
+    console.log(verdict.reason);
+    process.exit(verdict.ok ? 0 : 1);
   }
 
   if (!Number.isInteger(args.findings) || args.findings < 0) {

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Record that the local diff was reviewed at a specific commit.
+ *
+ * ## Why this exists
+ *
+ * `pr-review-orchestration` used to wait for required checks to go green before its FIRST review
+ * round — so the reviewer only ever saw a diff that had already been pushed, opened as a PR, and
+ * run through CI. Every finding therefore cost a push → CI round trip before anyone could even
+ * look at it.
+ *
+ * Measured across one session (2026-07-28), PRs #1514/#1518/#1519/#1520/#1521: 38 review rounds,
+ * 24 of them carrying a blocking finding, at roughly 6–10 minutes of CI per round. Not one of those
+ * findings needed CI to be visible — every one was read out of the diff. Several were regressions
+ * introduced by the previous round's fix, which a review of the next diff would have caught just as
+ * cheaply.
+ *
+ * The reviewer agent already accepts a local diff (`git diff origin/<base>...HEAD`). Only the
+ * orchestration's precondition forced the round trip. This file is the mechanical half of moving
+ * that round before the push: `pre-push-check` refuses to push a feature branch whose HEAD has not
+ * been reviewed, and this is how a review is recorded.
+ *
+ * ## What it does NOT claim
+ *
+ * A record says a review RAN at this commit and reported zero gating findings. It cannot say the
+ * review was good — that is the reviewer's job, and a hook pretending to judge it would be a guard
+ * measuring the wrong thing. Its value is that the round happens before the push rather than after,
+ * which is where the eight minutes are.
+ *
+ * Usage:
+ *   node scripts/harness/record-local-review.mjs --findings 0 [--notes "..."]
+ *   node scripts/harness/record-local-review.mjs --show
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const WORKSPACE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+export const RECORD_DIR = path.join(WORKSPACE_ROOT, '.agents/local-reviews');
+
+function git(args, cwd = WORKSPACE_ROOT) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+/** The record path for a branch. Slashes become `__` so the name stays one file. */
+export function recordPathFor(branch, dir = RECORD_DIR) {
+  return path.join(dir, `${branch.replace(/\//g, '__')}.json`);
+}
+
+/**
+ * Has the given commit been reviewed on this branch?
+ *
+ * Keyed on the HEAD sha, deliberately: amending or adding a commit changes what would be pushed, so
+ * the previous round's review no longer describes it. That is the property the whole change is
+ * about — a review must have seen what is being sent.
+ */
+export function isReviewed(branch, headSha, dir = RECORD_DIR) {
+  const file = recordPathFor(branch, dir);
+  if (!existsSync(file)) return false;
+  try {
+    const record = JSON.parse(readFileSync(file, 'utf8'));
+    return record.headSha === headSha && record.findings === 0;
+  } catch {
+    // An unreadable record is not a review. Treated as absent, which refuses rather than passes.
+    return false;
+  }
+}
+
+function parseArgs(argv) {
+  const args = { findings: null, notes: '', show: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--show') args.show = true;
+    else if (argv[i] === '--findings') args.findings = Number(argv[++i]);
+    else if (argv[i] === '--notes') args.notes = String(argv[++i] ?? '');
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const branch = git(['branch', '--show-current']);
+  const headSha = git(['rev-parse', 'HEAD']);
+
+  if (args.show) {
+    const file = recordPathFor(branch);
+    if (!existsSync(file)) {
+      console.log(`no local review recorded for ${branch} (HEAD ${headSha.slice(0, 9)})`);
+      process.exit(1);
+    }
+    console.log(readFileSync(file, 'utf8'));
+    process.exit(isReviewed(branch, headSha) ? 0 : 1);
+  }
+
+  if (!Number.isInteger(args.findings) || args.findings < 0) {
+    console.error(
+      'record-local-review: --findings <n> is required (n = unresolved MUST + SHOULD).',
+    );
+    console.error('This is the reviewer’s own count. Record it; do not estimate it.');
+    process.exit(1);
+  }
+
+  if (args.findings > 0) {
+    // Recording an unresolved review would make the gate a formality. The point of the round is to
+    // reach zero BEFORE the push, not to log that it was not reached.
+    console.error(
+      `record-local-review: ${args.findings} finding(s) still open — nothing to record yet.`,
+    );
+    console.error('Resolve them, review again, then record. The round is what saves the CI trip.');
+    process.exit(1);
+  }
+
+  mkdirSync(RECORD_DIR, { recursive: true });
+  const record = {
+    branch,
+    headSha,
+    findings: 0,
+    notes: args.notes,
+    reviewedAt: new Date().toISOString(),
+  };
+  writeFileSync(recordPathFor(branch), `${JSON.stringify(record, null, 2)}\n`);
+  console.log(`recorded: ${branch} @ ${headSha.slice(0, 9)} — 0 findings`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -129,6 +129,18 @@ function main() {
   const branch = git(['branch', '--show-current'], root);
   const headSha = git(['rev-parse', 'HEAD'], root);
 
+  // A record is keyed by branch, so a detached HEAD has no key: every detached invocation would
+  // share `.agents/local-reviews/.json` and satisfy the gate for every other. `pre-push-check` had
+  // this guard and this file did not, which is exactly the split this file's docstring says it
+  // exists to prevent — the owner of the verdict must own the whole of it.
+  if (!branch) {
+    console.error(
+      'record-local-review: HEAD is detached, so a review cannot be keyed to a branch.',
+    );
+    console.error('Check out the branch this commit belongs to and run it again.');
+    process.exit(1);
+  }
+
   if (args.show) {
     // The single owner of "is this commit reviewed". `pre-push-check` calls this and routes on the
     // exit code rather than re-parsing the record in bash — the duplicated-logic drift this whole

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -40,7 +40,13 @@ import { fileURLToPath } from 'node:url';
 const SCRIPT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 function git(args, cwd) {
-  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+  // stderr captured rather than inherited: git's own "not a git repository" would otherwise be the
+  // message a caller sees, ahead of the one that explains what this tool needs.
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
 }
 
 /**
@@ -50,13 +56,23 @@ function git(args, cwd) {
  * judging another one.
  */
 function repoRoot(cwd = process.cwd()) {
+  // No fallback. Returning SCRIPT_ROOT here would do precisely what the paragraph above says must
+  // not happen: read and write one checkout's records while judging another. A guard that cannot
+  // tell which repository it is in must say so, not guess — and the bash side of this gate already
+  // refuses rather than assuming the main clone.
   try {
     return git(['rev-parse', '--show-toplevel'], cwd);
   } catch {
-    return SCRIPT_ROOT;
+    console.error(`record-local-review: ${cwd} is not inside a git work tree.`);
+    console.error('A review record belongs to a specific checkout; this one cannot be identified.');
+    process.exit(1);
   }
 }
 
+/**
+ * The default record directory — THIS checkout's. Exported for the helpers' default argument; any
+ * caller judging another checkout must pass its directory explicitly, which is what `main()` does.
+ */
 export const RECORD_DIR = path.join(SCRIPT_ROOT, '.agents/local-reviews');
 
 function recordDirFor(root) {

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -63,9 +63,16 @@ function recordDirFor(root) {
   return path.join(root, '.agents/local-reviews');
 }
 
-/** The record path for a branch. Slashes become `__` so the name stays one file. */
+/**
+ * The record path for a branch — a one-to-one encoding, not a lossy one.
+ *
+ * Slashes used to become `__`, which maps `feat/foo` and `feat__foo` onto the same file: one
+ * branch's review would then satisfy the gate for the other, unreviewed one. Percent-encoding the
+ * separator (and the escape character itself) cannot collide.
+ */
 export function recordPathFor(branch, dir = RECORD_DIR) {
-  return path.join(dir, `${branch.replace(/\//g, '__')}.json`);
+  const encoded = branch.replace(/%/g, '%25').replace(/\//g, '%2F');
+  return path.join(dir, `${encoded}.json`);
 }
 
 /**
@@ -96,6 +103,11 @@ export function reviewState(branch, headSha, dir = RECORD_DIR) {
       ok: false,
       reason: `the review record for ${branch} is unreadable, so it is not a review`,
     };
+  }
+  if (stored.branch !== branch) {
+    // Belt and braces beside the encoding above: a record naming a different branch is not this
+    // branch's review, however it came to sit at this path.
+    return { ok: false, reason: `the record at this path is for ${stored.branch ?? 'no branch'}` };
   }
   if (stored.headSha !== headSha) {
     const seen = String(stored.headSha ?? '?').slice(0, 9);

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -37,11 +37,30 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const WORKSPACE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-export const RECORD_DIR = path.join(WORKSPACE_ROOT, '.agents/local-reviews');
+const SCRIPT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
-function git(args, cwd = WORKSPACE_ROOT) {
+function git(args, cwd) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+/**
+ * The repository this invocation is about — resolved from the CALLER's directory, not from where
+ * this file lives. `pre-push-check` runs in whatever checkout the push targets, which may be a
+ * worktree; keying off the script's own location would record and read the main clone's state while
+ * judging another one.
+ */
+function repoRoot(cwd = process.cwd()) {
+  try {
+    return git(['rev-parse', '--show-toplevel'], cwd);
+  } catch {
+    return SCRIPT_ROOT;
+  }
+}
+
+export const RECORD_DIR = path.join(SCRIPT_ROOT, '.agents/local-reviews');
+
+function recordDirFor(root) {
+  return path.join(root, '.agents/local-reviews');
 }
 
 /** The record path for a branch. Slashes become `__` so the name stays one file. */
@@ -80,17 +99,41 @@ function parseArgs(argv) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const branch = git(['branch', '--show-current']);
-  const headSha = git(['rev-parse', 'HEAD']);
+  const root = repoRoot();
+  const branch = git(['branch', '--show-current'], root);
+  const headSha = git(['rev-parse', 'HEAD'], root);
 
   if (args.show) {
-    const file = recordPathFor(branch);
+    // The single owner of "is this commit reviewed". `pre-push-check` calls this and routes on the
+    // exit code rather than re-parsing the record in bash — the duplicated-logic drift this whole
+    // change is about, which the first version of that hook reproduced.
+    const dir = recordDirFor(root);
+    const file = recordPathFor(branch, dir);
     if (!existsSync(file)) {
-      console.log(`no local review recorded for ${branch} (HEAD ${headSha.slice(0, 9)})`);
+      console.log(`no local review recorded for ${branch} at ${headSha.slice(0, 9)}`);
       process.exit(1);
     }
-    console.log(readFileSync(file, 'utf8'));
-    process.exit(isReviewed(branch, headSha) ? 0 : 1);
+    let stored;
+    try {
+      stored = JSON.parse(readFileSync(file, 'utf8'));
+    } catch {
+      console.log(`the review record for ${branch} is unreadable, so it is not a review`);
+      process.exit(1);
+    }
+    if (stored.headSha !== headSha) {
+      console.log(
+        `last reviewed ${String(stored.headSha ?? '?').slice(0, 9)} — the diff has changed since`,
+      );
+      process.exit(1);
+    }
+    if (stored.findings !== 0) {
+      console.log(
+        `the recorded review reports ${stored.findings ?? 'an unreadable number of'} finding(s) still open`,
+      );
+      process.exit(1);
+    }
+    console.log(`reviewed at ${headSha.slice(0, 9)} — 0 findings`);
+    process.exit(0);
   }
 
   if (!Number.isInteger(args.findings) || args.findings < 0) {
@@ -111,7 +154,7 @@ function main() {
     process.exit(1);
   }
 
-  mkdirSync(RECORD_DIR, { recursive: true });
+  mkdirSync(recordDirFor(root), { recursive: true });
   const record = {
     branch,
     headSha,
@@ -119,7 +162,7 @@ function main() {
     notes: args.notes,
     reviewedAt: new Date().toISOString(),
   };
-  writeFileSync(recordPathFor(branch), `${JSON.stringify(record, null, 2)}\n`);
+  writeFileSync(recordPathFor(branch, recordDirFor(root)), `${JSON.stringify(record, null, 2)}\n`);
   console.log(`recorded: ${branch} @ ${headSha.slice(0, 9)} — 0 findings`);
 }
 


### PR DESCRIPTION
refactor(process): the review round happens before the push, not after CI

## The measurement

Across one session (2026-07-28), PRs #1514/#1518/#1519/#1520/#1521: 38 review
rounds, 24 of them carrying a blocking finding, at 6–10 minutes of CI each. Not
one of those findings needed CI to be visible — every one was read out of the
diff. Several were regressions introduced by the previous round's fix, which a
review of the NEXT diff would have caught just as cheaply.

## The cause

`pr-review-orchestration` step 0 waited for required checks to go green before
its FIRST review round. So the reviewer only ever saw a diff that had already
been pushed, opened as a PR and run through CI, and every finding cost a round
trip before anyone could look at it. `pr-review-reviewer` already accepts a local
diff (`git diff origin/<base>...HEAD`) — only the precondition forced the trip.

## The change

The loop now runs in two places, and which comes first is the point:

  * **Round A — on the local diff, before any push.** Review, fix, repeat until
    zero findings, then record and push. A round here costs about a minute.
  * **Round B — on the open PR, before merge.** The CI-green precondition belongs
    here and only here: the merge round must judge what will actually merge, and
    `merge-gate` requires a review newer than the head commit. Every fix returns
    to Round A before pushing again.

Writing that into the skill would not have been enough — a rule with no mechanism
is the defect this repository spent the same session removing from four hooks. So
`pre-push-check` refuses a feature-branch push whose HEAD has no matching review
record, naming `PRE_PUSH_ALLOW_UNREVIEWED=1` for a deliberate exception. The
record says a review RAN at this commit and reported zero gating findings; it
does not claim the review was good, which is the reviewer's job and not a hook's.
Keyed on the HEAD sha, so a new commit is a new diff and needs a new round.

Integration branches and `release/promote-*` are exempt: a promotion carries
develop's already-reviewed content and no diff of its own.

Records are local state and gitignored.

Nine tests, red-proved both halves: removing the gate fails three, letting the
CI-green precondition drift back into Round A fails one. The gate was exercised
on its own branch — it refused this author's push until the review was recorded.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
