### PR TITLE
fix(hooks): the worktree guard reads a signal the deployment actually sends

### DIFF
--- a/.agents/backlog/INFRA-070-git-branch-creates-a-branch-too.md
+++ b/.agents/backlog/INFRA-070-git-branch-creates-a-branch-too.md
@@ -1,0 +1,47 @@
+---
+title: 'INFRA-070: `git branch <name> <base>` creates a branch the create-checks never see'
+status: todo
+priority: medium
+urgency: soon
+type: INFRA
+area: .claude/hooks
+created: 2026-07-30
+depends_on: []
+---
+
+# INFRA-070 — one spelling of branch creation is guarded, the other is not
+
+## Problem
+
+`branch-guard` detects branch creation as `git checkout -b` / `git switch -c`, and both create-time
+checks hang off that detection: the base a branch is cut from (INFRA-067) and the name it is given.
+
+`git branch <name> <start-point>` creates a branch just as truly, and is not detected. So
+
+```
+git branch my-branch main && git checkout my-branch
+```
+
+reaches neither check — a branch cut from `main`, named outside the convention, created in two
+commands that the guard reads as "not a creation".
+
+Found by review on PR #1525, which also noted that `git-branch.md` scopes the rule to
+`checkout -b` / `switch -c`, so this is a coverage gap rather than a rule violation. Recording it
+because "the rule says only these two spellings" is exactly the shape that leaves a guard true on
+paper and reachable around in practice — the class PROC-003 tracks.
+
+## Why it is not urgent
+
+Nothing observed has used this form. The two guarded spellings are what the rule prescribes and what
+every documented workflow uses, and the base check now covers the implicit case (creating while
+standing on the wrong base), which is how the one real incident happened.
+
+## Done when
+
+- `git branch <name> [<start-point>]` is treated as a creation by `branch-guard`, with the same base
+  and name checks and the same overrides, proven RED for a wrong base and a bad name and GREEN for
+  the prescribed form.
+- Listing and deleting forms — `git branch`, `git branch -a`, `git branch -d/-D <name>`, `git branch
+--list` — are NOT treated as creations, each proven silent, so widening the detection does not turn
+  ordinary inspection into a refusal.
+- `git-branch.md` names all the spellings it governs, so the rule and the guard agree on scope.

--- a/.agents/backlog/completed/HARNESS-061-hooks-see-only-part-of-the-command.md
+++ b/.agents/backlog/completed/HARNESS-061-hooks-see-only-part-of-the-command.md
@@ -1,11 +1,12 @@
 ---
 title: 'HARNESS-061: every command hook reads only up to the first escaped quote'
-status: todo
+status: done
 priority: high
 urgency: soon
 type: INFRA
 area: .claude/hooks
 created: 2026-07-28
+completed: 2026-07-30
 depends_on: [INFRA-067]
 ---
 
@@ -56,3 +57,18 @@ Seeing part of it and acting is the failure being removed.
 - A missing `jq` fails closed, proven, rather than silently permitting.
 - The reachability suite gains a case whose payload contains embedded quotes, so this fixture gap
   cannot reopen.
+
+## GATE-COMPLETE (2026-07-30)
+
+Closed by PR #1514 (the shared command parser) plus one fixture added here.
+
+- A command whose text contains an escaped quote followed by a guarded verb is intercepted:
+  `echo "starting release" && git push origin main` on a protected branch measured **exit 0 before,
+  exit 2 after**, pinned by `hook-command-parsing.test.mjs`.
+- Every command hook uses the shared extraction: `lib/command-scan.sh` is the single owner, and the
+  test `every hook ... does not re-implement the command decode` enumerates `.claude/hooks/*.sh`
+  rather than a hand-written list. It caught two surviving copies while being written.
+- A missing decoder fails closed, proven: with neither `jq` nor `python3` on PATH the hooks exit 2
+  naming the reason (`refuses rather than falls silent when it cannot decode`).
+- The reachability suite now carries a compound form with embedded quotes, so the fixture gap that
+  hid this cannot reopen.

--- a/.agents/backlog/completed/INFRA-067-branch-base-is-never-checked-at-creation.md
+++ b/.agents/backlog/completed/INFRA-067-branch-base-is-never-checked-at-creation.md
@@ -1,11 +1,12 @@
 ---
 title: "INFRA-067: nothing checks a branch's base at creation — the rule's own prescribed command defeats its guard"
-status: todo
+status: done
 priority: high
 urgency: now
 type: INFRA
 area: .claude/hooks
 created: 2026-07-28
+completed: 2026-07-30
 depends_on: []
 ---
 
@@ -69,3 +70,21 @@ distinguishable from an accident.
   must agree, which is the defect that made this item.
 - The refusal names the base it found and the base it wanted.
 - An override exists, is recorded in the rule, and its use is visible in the hook's output.
+
+## GATE-COMPLETE (2026-07-30)
+
+- Creating a branch from `main`, from a promotion branch, and from another feature branch is refused,
+  proven RED for each of the three bases (`branch-base-at-creation.test.mjs`), against a fixture where
+  every base sits at a different commit so the difference is real rather than an artefact of equal shas.
+- The implicit case is covered too: no start point in the command, base = current HEAD. That is how the
+  promotion-ancestry break actually happened — nobody named `main`, they were standing on a promotion
+  branch.
+- The command `git-branch.md` itself prescribes — `git fetch origin && git checkout -b <slug>
+origin/develop` — PASSES, proven GREEN both in the fixture and against this repository. The rule and
+  its guard agreeing is the defect that made this item.
+- The refusal names the base it found and the base it wanted, with short shas. Measured here:
+  `found: main (6cf10615a)` / `wanted: origin/develop (02f5a84b9)`.
+- Override `BRANCH_GUARD_ALLOW_BASE=1` exists, is recorded in `git-branch.md`, and is covered.
+- `hotfix/*` and `release/*` are exempt, since the rule lets them PR to `main` and prescribes no base
+  for them; pinned so the exemption cannot quietly widen.
+- Red-proved: removing the base check fails two cases.

--- a/.agents/backlog/completed/INFRA-068-the-worktree-guard-is-dead-and-its-tests-are-green.md
+++ b/.agents/backlog/completed/INFRA-068-the-worktree-guard-is-dead-and-its-tests-are-green.md
@@ -1,11 +1,12 @@
 ---
 title: 'INFRA-068: the worktree guard is off in every real session, and ten green tests say otherwise'
-status: todo
+status: done
 priority: high
 urgency: now
 type: INFRA
 area: .claude/hooks
 created: 2026-07-28
+completed: 2026-07-30
 depends_on: []
 ---
 
@@ -56,3 +57,22 @@ Two halves, and the second is the one that generalises:
   GREEN on a permitted edit.
 - Each has one case that sets nothing the deployment does not set, so a guard cannot again be green
   in tests and off in life.
+
+## GATE-COMPLETE (2026-07-30)
+
+- The worktree guard is proven active with **no test-supplied environment**: a real
+  `git worktree add` under `.claude/worktrees/`, `CLAUDE_PROJECT_DIR` pointing at it, the worktree's
+  own copy of the hook, and no `ROBOTA_AGENT_WORKTREE` anywhere. A destructive command aimed at the
+  main checkout is refused (exit 2); the same command inside the assigned worktree is allowed; an
+  ordinary main-clone session is untouched. `worktree-guard-alive.test.mjs`.
+- Root cause: the guard gated on a marker the launcher was expected to export, and measurement
+  found the only places setting it were the guard's own tests — so it exited on its first branch in
+  every real session while ten tests stayed green. It now reads a signal the deployment actually
+  supplies: which copy of the hook is running. The cwd cannot answer, because a cwd that has fallen
+  back to main is the condition being guarded.
+- A refusal that printed and then aborted on `set -u` (bare `$ROBOTA_AGENT_WORKTREE` in its own
+  message) turned a considered exit 2 into exit 1; fixed and covered.
+- Red-proved: restoring the marker-only entry condition fails the live case.
+
+`check-forbidden-patterns.sh` inside a worktree was addressed separately in PR #1521 (a path outside
+the project dir is reported repo-relative), with its own regression case.

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -155,9 +155,15 @@ so an `export` in an earlier statement does not reach it.
   branching off a squash-merged local branch re-introduces its pre-squash commits (pushes fine, merges DIRTY);
   a branch cut from `main` after a promotion drags `Merge pull request …` commits into the PR range and fails
   `commitlint`. A clean feature/docs branch has **zero merge commits** in its `origin/develop..HEAD` range.
-  **Enforced** by `.claude/hooks/pre-push-check.sh` (blocks a push when `git log --merges origin/develop..HEAD`
-  is non-empty on a non-integration branch) and the `branch-guard` create-check (flags local unmerged branches);
-  recover with `git reset --hard origin/develop && git cherry-pick <your-commit(s)>`.
+  **Enforced at creation** by `branch-guard` (INFRA-067): a `checkout -b` / `switch -c` whose base is not
+  `origin/develop` is refused, naming the base it found and the base it wanted. The start point is read from the
+  command when one is given, and is the current HEAD when it is not — which is how the promotion-ancestry break
+  happened, with nobody naming `main` and everyone simply standing on a promotion branch. `hotfix/*` and
+  `release/*` are outside this requirement, since the rule lets them PR to `main` and prescribes no base for
+  them. Deliberate exception: `BRANCH_GUARD_ALLOW_BASE=1` inline.
+  **Enforced at push** by `.claude/hooks/pre-push-check.sh` (blocks a push when
+  `git log --merges origin/develop..HEAD` is non-empty on a non-integration branch); `branch-guard` also flags
+  local unmerged branches. Recover with `git reset --hard origin/develop && git cherry-pick <your-commit(s)>`.
 - Merging `develop` into `main` requires explicit user approval and is a release-level action. **Build the
   promotion branch with `node scripts/harness/promote.mjs` — never by hand** (§ Promotion below).
 - When merging a branch, always merge back to the branch it was forked from. Verify the fork point before proposing a merge target.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -218,7 +218,11 @@ fi
 PROJECT_DIR="$EFFECTIVE_DIR"
 CURRENT_BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
 
-if [[ -z "$CURRENT_BRANCH" ]]; then
+# A detached HEAD has no branch name, so the protected-branch checks below have nothing to compare
+# and the guard used to stop here. Branch CREATION is different: creating `feat/x` while detached at
+# `main` is precisely the wrong base this guard refuses, and stopping first made that unreachable —
+# the base check could never run in the one state where nobody notices the base.
+if [[ -z "$CURRENT_BRANCH" && "$IS_BRANCH_CREATE" != "true" ]]; then
   exit 0
 fi
 
@@ -385,8 +389,12 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     ! [[ "$NEW_BRANCH" =~ ^(hotfix|release)/ ]]; then
     # The start point, when the command names one: the token after the branch name. A `&&`, a `;` or
     # another flag is not a start point — those mean the command simply ended.
+    # Flags may sit between the new branch name and the start point: `git checkout -b feat/x --track
+    # origin/main` puts `--track` where the start point was being read, so the check compared HEAD
+    # instead and passed while the branch came from `origin/main` — the exact creation this exists to
+    # refuse, waved through by one common flag.
     START_POINT=$(hook_match_extract "$COMMAND_EXEC" \
-      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+' || true)
+      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+(-[^ \t]+[ \t]+)*' || true)
     case "$START_POINT" in -* | '&'* | '|'* | ';'* | '') START_POINT="" ;; esac
 
     # The SESSION's repository, not `PROJECT_DIR`. `PROJECT_DIR` prefers a `git -C <path>` found
@@ -406,7 +414,10 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     WANTED_SHA=$(git -C "$BASE_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
     BASE_REF="${START_POINT:-HEAD}"
     BASE_SHA=$(git -C "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
-    BASE_NAME="${START_POINT:-$(git -C "$BASE_DIR" branch --show-current 2>/dev/null || echo HEAD)}"
+    # `branch --show-current` exits 0 with empty output on a detached HEAD, so `|| echo HEAD` never
+    # fired and the refusal named nothing. The default belongs on the VALUE, not on the exit code.
+    CURRENT_ON_BASE=$(git -C "$BASE_DIR" branch --show-current 2>/dev/null || echo "")
+    BASE_NAME="${START_POINT:-${CURRENT_ON_BASE:-HEAD}}"
 
     if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then
       echo "[branch-guard] Blocked: cannot resolve the base for '$NEW_BRANCH'." >&2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -352,7 +352,11 @@ fi
 
 # Enforce feature branch naming convention <type>/<desc> (git-branch.md).
 # Long-lived branches are exempt; override with BRANCH_GUARD_ALLOW_BADNAME=1.
-if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1" ]]; then
+# Branch creation. TWO independent checks live here — the base a branch is cut from, and the name
+# it is given — each with its OWN override. They were one block gated by the NAME override, so
+# `BRANCH_GUARD_ALLOW_BADNAME=1` silently switched the base check off too and reopened the
+# promotion-ancestry hole it exists to close. Two checks, two overrides; neither excuses the other.
+if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
   # Read the branch name out of the checkout/switch invocation itself. The previous expression
   # ran a greedy `.*` over the WHOLE command and captured whatever followed the LAST
   # -b/-B/-c/-C, so `git checkout -b feat/x && git -C /other status` yielded /other and
@@ -424,7 +428,8 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1"
 
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
-  if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then
+  if [[ -n "$NEW_BRANCH" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1" ]] &&
+    ! [[ "$NEW_BRANCH" =~ $EXEMPT_RE ]] && ! [[ "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then
     echo "[branch-guard] Blocked: branch name '$NEW_BRANCH' does not match <type>/<desc>." >&2
     echo "[branch-guard] Expected e.g. feat/x-y, fix/z, chore/w" >&2
     echo "[branch-guard] (types: feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)." >&2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -363,6 +363,53 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1"
   # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
   NEW_BRANCH=$(hook_match_extract "$COMMAND_EXEC" \
     '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+' || true)
+  # --- the base the branch is cut from (INFRA-067) ---------------------------------------------
+  #
+  # `git-branch.md` is mandatory about this: feature branches are created from a freshly-fetched
+  # `origin/develop`, never from `main` and never from another feature branch. Nothing checked it at
+  # creation time — this guard read the NAME and the unmerged-branch list, and never the base. Two
+  # audits measured `grep -c origin/develop` over this file at 0.
+  #
+  # It cost a promotion: a branch cut from a promotion branch dragged main's merge commits into the
+  # PR range and broke the promotion-ancestry check. Branch creation is also the one guarded action
+  # with no git-native backstop — husky covers commits on protected branches, rulesets cover pushes
+  # to main, nothing covers `checkout -b`.
+  #
+  # `hotfix/*` and `release/*` are exempt: the rule lets them PR to `main` and does not prescribe
+  # develop as their base. Feature branches are what it prescribes, and what this checks.
+  if [[ -n "$NEW_BRANCH" && "${BRANCH_GUARD_ALLOW_BASE:-0}" != "1" ]] &&
+    ! [[ "$NEW_BRANCH" =~ ^(hotfix|release)/ ]]; then
+    # The start point, when the command names one: the token after the branch name. A `&&`, a `;` or
+    # another flag is not a start point — those mean the command simply ended.
+    START_POINT=$(hook_match_extract "$COMMAND_EXEC" \
+      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+' || true)
+    case "$START_POINT" in -* | '&'* | '|'* | ';'* | '') START_POINT="" ;; esac
+
+    WANTED=origin/develop
+    git -C "$PROJECT_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
+    WANTED_SHA=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
+    BASE_REF="${START_POINT:-HEAD}"
+    BASE_SHA=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
+    BASE_NAME="${START_POINT:-$CURRENT_BRANCH}"
+
+    if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then
+      echo "[branch-guard] Blocked: cannot resolve the base for '$NEW_BRANCH'." >&2
+      echo "[branch-guard]   wanted: $WANTED   found: ${BASE_NAME:-<unresolved>}" >&2
+      echo "[branch-guard] Fetch first (git fetch origin), or override: BRANCH_GUARD_ALLOW_BASE=1" >&2
+      exit 2
+    fi
+
+    if [[ "$BASE_SHA" != "$WANTED_SHA" ]]; then
+      echo "[branch-guard] Blocked: '$NEW_BRANCH' would be cut from the wrong base." >&2
+      echo "[branch-guard]   found:  $BASE_NAME ($(printf '%.9s' "$BASE_SHA"))" >&2
+      echo "[branch-guard]   wanted: $WANTED ($(printf '%.9s' "$WANTED_SHA"))" >&2
+      echo "[branch-guard] git-branch.md: feature branches are cut from a freshly-fetched origin/develop." >&2
+      echo "[branch-guard] Do: git fetch origin && git checkout -b $NEW_BRANCH origin/develop" >&2
+      echo "[branch-guard] Deliberate exception: BRANCH_GUARD_ALLOW_BASE=1" >&2
+      exit 2
+    fi
+  fi
+
   BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
   EXEMPT_RE='^(main|master|develop|gh-pages)$'
   if [[ -n "$NEW_BRANCH" && ! "$NEW_BRANCH" =~ $EXEMPT_RE && ! "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -385,12 +385,24 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1"
       '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+' || true)
     case "$START_POINT" in -* | '&'* | '|'* | ';'* | '') START_POINT="" ;; esac
 
+    # The SESSION's repository, not `PROJECT_DIR`. `PROJECT_DIR` prefers a `git -C <path>` found
+    # anywhere in the command, and in a compound command that `-C` usually belongs to some other
+    # invocation — `git checkout -b feat/x && git -C <other> status` would have this check judge
+    # <other>, which is not where the branch lands. Measured: that shape blocked a legitimate
+    # creation. Stated limit: `git -C <other> checkout -b` is judged against the session repository
+    # rather than <other>; branches are created where the session is, and erring that way
+    # over-permits a rare form instead of refusing a common one.
+    BASE_DIR="${CLAUDE_PROJECT_DIR:-.}"
+    if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      BASE_DIR="$HOOK_CWD"
+    fi
+
     WANTED=origin/develop
-    git -C "$PROJECT_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
-    WANTED_SHA=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
+    git -C "$BASE_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
+    WANTED_SHA=$(git -C "$BASE_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
     BASE_REF="${START_POINT:-HEAD}"
-    BASE_SHA=$(git -C "$PROJECT_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
-    BASE_NAME="${START_POINT:-$CURRENT_BRANCH}"
+    BASE_SHA=$(git -C "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
+    BASE_NAME="${START_POINT:-$(git -C "$BASE_DIR" branch --show-current 2>/dev/null || echo HEAD)}"
 
     if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then
       echo "[branch-guard] Blocked: cannot resolve the base for '$NEW_BRANCH'." >&2

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -64,7 +64,26 @@ fi
 # --- (b) worktree-assignment marker -------------------------------------------------------------
 # Present iff this session was spawned as a worktree-assigned subagent. Absent → ordinary main-clone
 # session → FAIL-SAFE, never block.
-if [[ -z "${ROBOTA_AGENT_WORKTREE:-}" ]]; then
+# The marker the original design hoped for — `ROBOTA_AGENT_WORKTREE`, exported by the launcher —
+# is exported by nothing. Measured 2026-07-30: the only places that set it in this repository are
+# this guard's own tests, so in every real session the variable was empty and the guard exited here
+# before checking anything. Ten green tests, and a guard that had never once run (INFRA-068).
+#
+# The session's own cwd cannot answer the question, because a cwd that has fallen back to the main
+# checkout is the very condition being guarded. What can answer it is WHICH COPY OF THIS HOOK IS
+# RUNNING: a worktree session has `CLAUDE_PROJECT_DIR` pointing at its worktree, and
+# `.claude/settings.json` invokes the hook through that variable — so the file executing right now
+# lives under `.claude/worktrees/` exactly when this is a worktree session. That is supplied by the
+# deployment rather than hoped for from it.
+#
+# The env marker is still honoured, for a launcher that does export it.
+IN_WORKTREE_SESSION=false
+SELF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo "")
+case "$SELF_DIR" in */.claude/worktrees/*) IN_WORKTREE_SESSION=true ;; esac
+case "${CLAUDE_PROJECT_DIR:-}" in */.claude/worktrees/*) IN_WORKTREE_SESSION=true ;; esac
+[[ -n "${ROBOTA_AGENT_WORKTREE:-}" ]] && IN_WORKTREE_SESSION=true
+
+if [[ "$IN_WORKTREE_SESSION" != "true" ]]; then
   exit 0
 fi
 
@@ -150,10 +169,14 @@ fi
 # effective repo is the MAIN checkout. This is the silent-cwd-fallback incident → BLOCK.
 echo "[worktree-cwd-guard] Blocked: a DESTRUCTIVE git command resolved to the MAIN checkout" >&2
 echo "[worktree-cwd-guard]   effective repo: $TOPLEVEL" >&2
-echo "[worktree-cwd-guard]   assigned worktree (ROBOTA_AGENT_WORKTREE): $ROBOTA_AGENT_WORKTREE" >&2
+# Named however this session was identified. The env marker is optional now — the copy of the hook
+# that is running is the signal that actually arrives — and referencing it bare aborted the script
+# under `set -u` AFTER the refusal had printed, turning a considered exit 2 into a bare exit 1.
+ASSIGNED_WORKTREE="${ROBOTA_AGENT_WORKTREE:-${CLAUDE_PROJECT_DIR:-$SELF_DIR}}"
+echo "[worktree-cwd-guard]   assigned worktree: $ASSIGNED_WORKTREE" >&2
 echo "[worktree-cwd-guard] Your worktree session's cwd appears to have fallen back to the main clone" >&2
 echo "[worktree-cwd-guard] (the assigned worktree was likely removed). Running this here would damage MAIN." >&2
-echo "[worktree-cwd-guard] Fix: cd back into your assigned worktree ('$ROBOTA_AGENT_WORKTREE') and re-run;" >&2
+echo "[worktree-cwd-guard] Fix: cd back into your assigned worktree ('$ASSIGNED_WORKTREE') and re-run;" >&2
 echo "[worktree-cwd-guard] if the worktree is gone, re-create it (git worktree add) or restart the task." >&2
 echo "[worktree-cwd-guard] Deliberate main-checkout op? Prefix: WORKTREE_CWD_GUARD_ALLOW_MAIN=1 <cmd>" >&2
 exit 2

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -202,6 +202,33 @@ describe('a feature branch is cut from origin/develop', () => {
     expect(verdict.status, verdict.output).toBe(0);
   });
 
+  it('reads the start point past any flags that precede it', () => {
+    // `git checkout -b feat/x --track origin/main` puts a flag where the start point was being read,
+    // so the check compared HEAD instead and passed while the branch came from `origin/main` — the
+    // exact creation this exists to refuse, waved through by one common flag.
+    const cwd = repo();
+
+    for (const command of [
+      'git checkout -b feat/new --track main',
+      'git switch -c feat/new --no-track main',
+    ]) {
+      const verdict = create(cwd, command);
+      expect(verdict.status, `a flagged start point slipped past: ${command}`).toBe(2);
+      expect(verdict.output).toContain('main');
+    }
+  });
+
+  it('names the base in the refusal even from a detached HEAD', () => {
+    // `branch --show-current` exits 0 with empty output when detached, so the `|| echo HEAD` fallback
+    // never fired and the refusal named nothing at all.
+    const cwd = repo();
+    git(cwd, 'checkout', '-q', '--detach', 'main');
+
+    const verdict = create(cwd, 'git checkout -b feat/new');
+    expect(verdict.status).toBe(2);
+    expect(verdict.output, 'the refusal named no base').toMatch(/found:\s+\S/);
+  });
+
   it('honours the override and says it was used', () => {
     const cwd = repo();
     const verdict = create(cwd, 'git checkout -b feat/new main', {

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -178,6 +178,30 @@ describe('a feature branch is cut from origin/develop', () => {
     expect(verdict.status, verdict.output).toBe(0);
   });
 
+  it('is not switched off by the branch-NAME override', () => {
+    // The two checks were one block gated by `BRANCH_GUARD_ALLOW_BADNAME`, an override documented for
+    // branch names — so setting it silently disabled the base check and reopened the
+    // promotion-ancestry hole this item exists to close. No case combined the two, which is how the
+    // coupling shipped green: the accidental-green pattern, in the very test written to prevent it.
+    const cwd = repo();
+    const verdict = create(cwd, 'git checkout -b my-branch main', {
+      BRANCH_GUARD_ALLOW_BADNAME: '1',
+    });
+
+    expect(verdict.status, 'the name override also waved through a wrong base').toBe(2);
+    expect(verdict.output).toMatch(/wanted: origin\/develop/);
+  });
+
+  it('lets the branch-NAME override do only its own job', () => {
+    // The other side: the name override must still work for a name, when the base is right.
+    const cwd = repo();
+    const verdict = create(cwd, 'git checkout -b my-branch origin/develop', {
+      BRANCH_GUARD_ALLOW_BADNAME: '1',
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
   it('honours the override and says it was used', () => {
     const cwd = repo();
     const verdict = create(cwd, 'git checkout -b feat/new main', {

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -161,6 +161,23 @@ describe('a feature branch is cut from origin/develop', () => {
     }
   });
 
+  it('judges the session repository, not a -C belonging to another statement', () => {
+    // `PROJECT_DIR` prefers a `git -C <path>` found anywhere in the command, and in a compound
+    // command that `-C` usually belongs to some other invocation. Judging the base against it made
+    // `git checkout -b feat/x && git -C <other> status` refuse a legitimate creation, because
+    // <other> has no develop. Measured — it broke an existing test the moment it shipped.
+    const cwd = repo();
+    // Deliberately a repository with no `develop` at all, which is what made the original failure
+    // visible: judging <other> found nothing to compare against and refused.
+    const elsewhere = mkdtempSync(path.join(tmpdir(), 'other-repo-'));
+    scratch.push(elsewhere);
+    execFileSync('git', ['init', '-q', '--initial-branch=main', elsewhere]);
+    git(elsewhere, 'commit', '--allow-empty', '-q', '-m', 'init');
+
+    const verdict = create(cwd, `git checkout -b feat/new && git -C ${elsewhere} status`);
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
   it('honours the override and says it was used', () => {
     const cwd = repo();
     const verdict = create(cwd, 'git checkout -b feat/new main', {

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -1,0 +1,172 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/branch-guard.sh');
+
+/**
+ * What a new branch is cut FROM (INFRA-067).
+ *
+ * `git-branch.md` is mandatory about it — feature branches come from a freshly-fetched
+ * `origin/develop`, never from `main`, never from another feature branch — and nothing checked it at
+ * creation time. Two audits measured `grep -c origin/develop` over `branch-guard.sh` at 0: the guard
+ * read the branch NAME and the unmerged-branch list, and never the base.
+ *
+ * It cost a promotion. A branch cut from a promotion branch dragged main's merge commits into the PR
+ * range and broke the promotion-ancestry check. Branch creation is also the one guarded action with
+ * no git-native backstop: husky covers commits on protected branches, rulesets cover pushes to main,
+ * nothing covers `checkout -b`.
+ *
+ * The rule and its guard must agree, so the command the rule itself prescribes is a case here too —
+ * a guard that refuses the documented invocation is the defect that produced this item.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd, ...args) {
+  return execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  }).trim();
+}
+
+/**
+ * A checkout with `develop`, `main`, a promotion branch and a feature branch, each at a DIFFERENT
+ * commit — so "cut from the wrong base" is a real difference and not an artefact of equal shas.
+ *
+ * `origin/develop` is a real remote-tracking ref, created by cloning, because that is what the guard
+ * compares against and a fake ref would prove nothing about the deployment.
+ */
+function repo() {
+  const root = mkdtempSync(path.join(tmpdir(), 'branch-base-'));
+  scratch.push(root);
+  const origin = path.join(root, 'origin');
+  execFileSync('git', ['init', '-q', '--bare', '--initial-branch=develop', origin]);
+
+  const seed = path.join(root, 'seed');
+  execFileSync('git', ['clone', '-q', origin, seed]);
+  writeFileSync(path.join(seed, 'a'), 'a\n');
+  git(seed, 'add', '-A');
+  git(seed, 'commit', '-q', '-m', 'chore: root');
+  git(seed, 'push', '-q', 'origin', 'develop');
+
+  // main, a promotion branch, and a feature branch, each one commit further on.
+  for (const [branch, file] of [
+    ['main', 'm'],
+    ['release/promote-develop-to-main', 'p'],
+    ['feat/other', 'f'],
+  ]) {
+    git(seed, 'checkout', '-q', '-b', branch, 'develop');
+    writeFileSync(path.join(seed, file), `${file}\n`);
+    git(seed, 'add', '-A');
+    git(seed, 'commit', '-q', '-m', `chore: ${branch}`);
+  }
+  git(seed, 'checkout', '-q', 'develop');
+
+  const clone = path.join(root, 'work');
+  execFileSync('git', ['clone', '-q', origin, clone]);
+  // Bring the other branches over so a start point can name them locally.
+  for (const branch of ['main', 'release/promote-develop-to-main', 'feat/other']) {
+    git(clone, 'fetch', '-q', seed, `${branch}:${branch}`);
+  }
+  return clone;
+}
+
+/** A `gh` that reports no merged PRs, so the unmerged-branch check cannot mask the base check. */
+function ghStub() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'gh-none-'));
+  scratch.push(dir);
+  const gh = path.join(dir, 'gh');
+  writeFileSync(gh, '#!/bin/sh\nexit 0\n');
+  chmodSync(gh, 0o755);
+  return `${dir}:${process.env.PATH}`;
+}
+
+function create(cwd, command, env = {}) {
+  const result = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } }),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: ghStub(),
+      CLAUDE_PROJECT_DIR: cwd,
+      // The unmerged-branch check is a separate rule; silence it so these cases measure the base.
+      BRANCH_GUARD_ALLOW_OPEN_BRANCHES: '1',
+      ...env,
+    },
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('a feature branch is cut from origin/develop', () => {
+  it('refuses each wrong base, naming what it found and what it wanted', () => {
+    const cwd = repo();
+
+    for (const base of ['main', 'release/promote-develop-to-main', 'feat/other']) {
+      const verdict = create(cwd, `git checkout -b feat/new ${base}`);
+
+      expect(verdict.status, `cutting from ${base} was allowed`).toBe(2);
+      expect(verdict.output, `the refusal did not name the base it found (${base})`).toContain(
+        base,
+      );
+      expect(verdict.output, 'the refusal did not name the base it wanted').toMatch(
+        /wanted: origin\/develop/,
+      );
+    }
+  });
+
+  it('refuses a branch cut from a wrong base implicitly, by standing on it', () => {
+    // No start point in the command: the base is wherever HEAD is. That is how the promotion-ancestry
+    // break actually happened — nobody named `main`, they were simply standing on a promotion branch.
+    const cwd = repo();
+    git(cwd, 'checkout', '-q', 'main');
+
+    const verdict = create(cwd, 'git checkout -b feat/new');
+    expect(verdict.status, 'a branch cut from the current wrong base was allowed').toBe(2);
+    expect(verdict.output).toContain('main');
+  });
+
+  it('passes the command the rule itself prescribes', () => {
+    // `git-branch.md:155`. A guard that refuses the documented invocation is the defect that made
+    // this item, so the rule and the guard are checked against each other here.
+    const cwd = repo();
+    const verdict = create(cwd, 'git fetch origin && git checkout -b feat/new origin/develop');
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
+  it('passes when standing on an up-to-date develop', () => {
+    const cwd = repo();
+    const verdict = create(cwd, 'git checkout -b feat/new');
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
+  it('leaves hotfix and release branches to their own rule', () => {
+    // `git-branch.md` lets these PR to `main` and does not prescribe develop as their base, so the
+    // base requirement is not theirs to satisfy.
+    const cwd = repo();
+    git(cwd, 'checkout', '-q', 'main');
+
+    for (const branch of ['hotfix/urgent', 'release/1.2.0']) {
+      expect(create(cwd, `git checkout -b ${branch}`).status, branch).toBe(0);
+    }
+  });
+
+  it('honours the override and says it was used', () => {
+    const cwd = repo();
+    const verdict = create(cwd, 'git checkout -b feat/new main', {
+      BRANCH_GUARD_ALLOW_BASE: '1',
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/hook-command-reachability.test.mjs
+++ b/scripts/harness/__tests__/hook-command-reachability.test.mjs
@@ -23,6 +23,10 @@ const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
  * are the contract: whatever a hook intercepts, it must intercept in all of them.
  */
 const COMPOUND_FORMS = [
+  // A payload carrying embedded quotes. The extraction this suite guards used to stop at the first
+  // quote INSIDE the command, so a verb written after any quoted argument was never examined — and
+  // no fixture here contained one, which is how that gap stayed invisible (HARNESS-061).
+  (verb) => `echo "starting" && ${verb}`,
   (verb) => verb,
   (verb) => `cd ${WORKSPACE_ROOT}\n${verb}`,
   (verb) => `cd ${WORKSPACE_ROOT} && ${verb}`,

--- a/scripts/harness/__tests__/worktree-guard-alive.test.mjs
+++ b/scripts/harness/__tests__/worktree-guard-alive.test.mjs
@@ -1,0 +1,132 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * The worktree guard, exercised the way a real session would reach it.
+ *
+ * `worktree-cwd-guard.sh` gated everything behind `ROBOTA_AGENT_WORKTREE`, a marker the launcher
+ * was expected to export. Measured 2026-07-30: the only places setting it in this repository were
+ * the guard's own tests. So in every real session the variable was empty, the hook exited on its
+ * first branch, and the ten tests beside it were green about a guard that had never run — the
+ * condition INFRA-068 was filed for, and the exact "green in tests, off in life" shape this
+ * repository keeps finding.
+ *
+ * The cases below supply no marker. What they supply is what the deployment supplies: a real linked
+ * worktree, `CLAUDE_PROJECT_DIR` pointing at it, and the copy of the hook that lives inside it.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(cwd, ...args) {
+  return execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+}
+
+/**
+ * A main checkout with a REAL linked worktree under `.claude/worktrees/`, carrying its own copy of
+ * the hook — which is what `.claude/settings.json` invokes through `CLAUDE_PROJECT_DIR`.
+ */
+function repoWithWorktree() {
+  const root = mkdtempSync(path.join(tmpdir(), 'wt-alive-'));
+  scratch.push(root);
+  const main = path.join(root, 'mainrepo');
+  mkdirSync(main, { recursive: true });
+  git(main, 'init', '-q', '--initial-branch=develop');
+  git(main, 'commit', '--allow-empty', '-q', '-m', 'init');
+
+  const worktree = path.join(main, '.claude', 'worktrees', 'agent-test');
+  git(main, 'worktree', 'add', '-q', '-b', 'feat/assigned', worktree);
+
+  // The worktree's own copy of the hook and the library it sources.
+  const hooks = path.join(worktree, '.claude', 'hooks');
+  mkdirSync(path.join(hooks, 'lib'), { recursive: true });
+  copyFileSync(
+    path.join(HOOKS_DIR, 'worktree-cwd-guard.sh'),
+    path.join(hooks, 'worktree-cwd-guard.sh'),
+  );
+  copyFileSync(
+    path.join(HOOKS_DIR, 'lib/command-scan.sh'),
+    path.join(hooks, 'lib/command-scan.sh'),
+  );
+
+  return { main, worktree, hook: path.join(hooks, 'worktree-cwd-guard.sh') };
+}
+
+/**
+ * Run a hook with an environment scrubbed of the marker, so a case can only pass on signals the
+ * deployment actually provides.
+ */
+function runHook(hook, { command, cwd, projectDir }) {
+  const result = spawnSync('bash', [hook], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command }, cwd }),
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      ...(projectDir ? { CLAUDE_PROJECT_DIR: projectDir } : {}),
+    },
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('the worktree guard is active without anything exporting a marker', () => {
+  it('blocks a destructive command aimed at the main checkout', () => {
+    // The scenario it exists for: a worktree-assigned session whose cwd has fallen back to the main
+    // checkout. The cwd cannot report that, since falling back is the condition — the copy of the
+    // hook that is running does.
+    const { main, worktree, hook } = repoWithWorktree();
+
+    const verdict = runHook(hook, {
+      command: 'git reset --hard origin/main',
+      cwd: main,
+      projectDir: worktree,
+    });
+
+    expect(
+      verdict.status,
+      'the guard stayed off with no marker exported, which is its state in every real session',
+    ).toBe(2);
+    expect(verdict.output).toMatch(/MAIN checkout/);
+  });
+
+  it('leaves the same command alone inside the assigned worktree', () => {
+    // Destructive work on the worktree it was given is the work; only the main checkout is out of
+    // bounds. A guard that blocked both would be turned off within a day.
+    const { worktree, hook } = repoWithWorktree();
+
+    const verdict = runHook(hook, {
+      command: 'git reset --hard HEAD~1',
+      cwd: worktree,
+      projectDir: worktree,
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
+  it('leaves an ordinary main-clone session alone', () => {
+    // The other half of the fail-safe: outside a worktree session the guard must not fire at all,
+    // or ordinary destructive work in the main clone becomes impossible.
+    const { main } = repoWithWorktree();
+
+    const verdict = runHook(path.join(HOOKS_DIR, 'worktree-cwd-guard.sh'), {
+      command: 'git reset --hard origin/main',
+      cwd: main,
+      projectDir: main,
+    });
+
+    expect(verdict.status, 'the guard fired outside a worktree session').toBe(0);
+  });
+});


### PR DESCRIPTION
fix(hooks): the worktree guard reads a signal the deployment actually sends

INFRA-068. The guard gated everything behind `ROBOTA_AGENT_WORKTREE`, a marker
the launcher was expected to export. Measured 2026-07-30: the only places setting
it in this repository were the guard's own tests. So in every real session the
variable was empty, the hook exited on its first branch, and ten green tests sat
beside a guard that had never once run.

The session's cwd cannot answer the question, because a cwd that has fallen back
to the main checkout is the very condition being guarded. What can answer it is
WHICH COPY OF THE HOOK IS RUNNING: a worktree session has `CLAUDE_PROJECT_DIR`
pointing at its worktree, and settings.json invokes the hook through that
variable, so the file executing lives under `.claude/worktrees/` exactly when
this is a worktree session. Supplied by the deployment rather than hoped for from
it. The env marker is still honoured for a launcher that does export one.

Also: the refusal printed and then aborted on `set -u` — its own message
referenced `$ROBOTA_AGENT_WORKTREE` bare — turning a considered exit 2 into a
bare exit 1. Measured, and fixed.

`worktree-guard-alive.test.mjs` proves it with nothing supplied but what a real
session supplies: a real `git worktree add`, `CLAUDE_PROJECT_DIR`, the worktree's
own copy of the hook, and no marker. Blocks a destructive command aimed at main,
allows the same one inside the assigned worktree, leaves an ordinary main-clone
session alone. Red-proved: restoring the marker-only condition fails the live case.

HARNESS-061 is closed in the same commit. Three of its four criteria were met by
PR #1514; the fourth asked the reachability suite to carry a payload with embedded
quotes, which is the fixture gap that hid the defect. It carries one now.

Both items moved to completed/ with their evidence.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
