### PR TITLE
fix(hooks): the base override works inline, and a redirection is not a base

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -414,12 +414,19 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # recognised by its shape — `2>&1`, `>/dev/null` — instead of by containing an operator at all.
     # `git checkout -b feat/x 2>&1 | head` is an ordinary creation and must not be refused; that one
     # was measured, blocking the creation of the branch this check was fixed on.
+    # A redirection, in either direction, with or without a file-descriptor number: `2>&1`,
+    # `>/dev/null`, `3<file`, `<in`. Those are not start points at all.
+    #
+    # The descriptor and the operator must be ADJACENT. Written as the glob `[0-9]*'>'*` this read
+    # "a digit, then anything, then `>`" — so `2fa-base>/tmp/out.log` matched, and a real ref whose
+    # name begins with a digit was blanked and fell back to HEAD. The same fail-open this whole arm
+    # exists to prevent, reintroduced for every start point starting with a number. So the leading
+    # run of digits is stripped and the NEXT character decides.
+    START_POINT_AFTER_FD="${START_POINT#"${START_POINT%%[!0-9]*}"}"
+    case "$START_POINT_AFTER_FD" in '>'* | '<'*) START_POINT="" ;; esac
+
     case "$START_POINT" in
       -* | '') START_POINT="" ;;
-      # Both directions, and with or without a file-descriptor number: `2>&1`, `>/dev/null`,
-      # `3<file`, `<in`. Covering only the output side left `3<file` falling through to the
-      # truncation below, which kept the bare fd number `3` and refused a legitimate creation.
-      [0-9]*'>'* | [0-9]*'<'* | '>'* | '<'*) START_POINT="" ;;
       *) START_POINT="${START_POINT%%[\<\>\|\&\;]*}" ;;
     esac
 

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -403,13 +403,21 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # refuse, waved through by one common flag.
     START_POINT=$(hook_match_extract "$COMMAND_EXEC" \
       '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+(-[^ \t]+[ \t]+)*' || true)
-    # A start point is a git ref. A flag, a shell operator or a REDIRECTION is not one — and the
-    # redirection case is not hypothetical: `git checkout -b feat/x 2>&1 | head` had `2>&1` read as
-    # the base, which resolved to nothing and refused the creation. Measured while creating the very
-    # branch this fix lives on.
+    # A start point is a git ref, and the token holding it may be glued to what follows.
+    #
+    # Blanking the whole token whenever it contained an operator was worse than the bug it replaced:
+    # `git checkout -b feat/x main;` reads as one token `main;`, git cuts from `main`, and blanking
+    # it fell back to HEAD — so a base of `main` passed whenever HEAD happened to be develop. A
+    # fail-OPEN, where the version before it at least failed to resolve and refused.
+    #
+    # So the token is TRUNCATED at the first operator rather than discarded, and a redirection is
+    # recognised by its shape — `2>&1`, `>/dev/null` — instead of by containing an operator at all.
+    # `git checkout -b feat/x 2>&1 | head` is an ordinary creation and must not be refused; that one
+    # was measured, blocking the creation of the branch this check was fixed on.
     case "$START_POINT" in
       -* | '') START_POINT="" ;;
-      *[\<\>\|\&\;]*) START_POINT="" ;;
+      [0-9]*'>'* | '>'* | '<'*) START_POINT="" ;;
+      *) START_POINT="${START_POINT%%[\<\>\|\&\;]*}" ;;
     esac
 
     # The SESSION's repository, not `PROJECT_DIR`. `PROJECT_DIR` prefers a `git -C <path>` found

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -59,6 +59,14 @@ fi
 if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAME=1([[:space:]]|$)'; then
   BRANCH_GUARD_ALLOW_BADNAME=1
 fi
+# The base override belongs in this block for the reason the paragraph above gives: an inline
+# `VAR=1 git …` is set in the TOOL's shell and never reaches this process, so reading it only as
+# `${VAR:-0}` means the documented form does nothing. It was added as a plain env read, and the test
+# for it injected the variable through the hook's own environment — hiding the very distinction this
+# file spends nine lines explaining.
+if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BASE=1([[:space:]]|$)'; then
+  BRANCH_GUARD_ALLOW_BASE=1
+fi
 
 # Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
 # a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),
@@ -395,7 +403,14 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # refuse, waved through by one common flag.
     START_POINT=$(hook_match_extract "$COMMAND_EXEC" \
       '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+(-[^ \t]+[ \t]+)*' || true)
-    case "$START_POINT" in -* | '&'* | '|'* | ';'* | '') START_POINT="" ;; esac
+    # A start point is a git ref. A flag, a shell operator or a REDIRECTION is not one — and the
+    # redirection case is not hypothetical: `git checkout -b feat/x 2>&1 | head` had `2>&1` read as
+    # the base, which resolved to nothing and refused the creation. Measured while creating the very
+    # branch this fix lives on.
+    case "$START_POINT" in
+      -* | '') START_POINT="" ;;
+      *[\<\>\|\&\;]*) START_POINT="" ;;
+    esac
 
     # The SESSION's repository, not `PROJECT_DIR`. `PROJECT_DIR` prefers a `git -C <path>` found
     # anywhere in the command, and in a compound command that `-C` usually belongs to some other

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -416,7 +416,10 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # was measured, blocking the creation of the branch this check was fixed on.
     case "$START_POINT" in
       -* | '') START_POINT="" ;;
-      [0-9]*'>'* | '>'* | '<'*) START_POINT="" ;;
+      # Both directions, and with or without a file-descriptor number: `2>&1`, `>/dev/null`,
+      # `3<file`, `<in`. Covering only the output side left `3<file` falling through to the
+      # truncation below, which kept the bare fd number `3` and refused a legitimate creation.
+      [0-9]*'>'* | [0-9]*'<'* | '>'* | '<'*) START_POINT="" ;;
       *) START_POINT="${START_POINT%%[\<\>\|\&\;]*}" ;;
     esac
 

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -240,6 +240,24 @@ describe('a feature branch is cut from origin/develop', () => {
     expect(verdict.status, verdict.output).toBe(0);
   });
 
+  it('reads a base glued to the operator that follows it', () => {
+    // `git checkout -b feat/x main;` is one whitespace-separated token, `main;`, and git cuts from
+    // `main`. Blanking the token because it contained an operator fell back to HEAD, so a base of
+    // `main` passed whenever HEAD happened to be develop — a fail-OPEN, worse than the version
+    // before it, which at least failed to resolve and refused.
+    const cwd = repo();
+
+    for (const command of [
+      'git checkout -b feat/new main;',
+      'git checkout -b feat/new main&&true',
+      'git checkout -b feat/new main|cat',
+    ]) {
+      const verdict = create(cwd, command);
+      expect(verdict.status, `a glued base slipped past: ${command}`).toBe(2);
+      expect(verdict.output).toMatch(/found:\s+main\b/);
+    }
+  });
+
   it('does not read a redirection as a start point', () => {
     // `git checkout -b feat/x 2>&1 | head` had `2>&1` taken as the base, which resolved to nothing
     // and refused a perfectly ordinary creation. Measured in practice — it blocked the creation of

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -229,12 +229,36 @@ describe('a feature branch is cut from origin/develop', () => {
     expect(verdict.output, 'the refusal named no base').toMatch(/found:\s+\S/);
   });
 
-  it('honours the override and says it was used', () => {
+  it('honours the override written INLINE, the way it is documented', () => {
+    // The distinction this hook spends nine lines explaining: an inline `VAR=1 git …` is set in the
+    // TOOL's shell and never reaches the hook process, so an override read only as `${VAR:-0}` does
+    // nothing in its documented form. This case passes it inline, as a user would. Injecting it
+    // through the hook's environment — which the first version of this test did — hides exactly that.
     const cwd = repo();
-    const verdict = create(cwd, 'git checkout -b feat/new main', {
-      BRANCH_GUARD_ALLOW_BASE: '1',
-    });
+    const verdict = create(cwd, 'BRANCH_GUARD_ALLOW_BASE=1 git checkout -b feat/new main');
 
     expect(verdict.status, verdict.output).toBe(0);
+  });
+
+  it('does not read a redirection as a start point', () => {
+    // `git checkout -b feat/x 2>&1 | head` had `2>&1` taken as the base, which resolved to nothing
+    // and refused a perfectly ordinary creation. Measured in practice — it blocked the creation of
+    // the branch this fix was written on.
+    const cwd = repo();
+
+    for (const command of [
+      'git checkout -b feat/new 2>&1 | head -1',
+      'git checkout -b feat/new >/dev/null',
+      'git switch -c feat/new 2>/dev/null',
+    ]) {
+      const verdict = create(cwd, command);
+      expect(verdict.status, `a redirection was read as a base: ${command}`).toBe(0);
+    }
+  });
+
+  it('refuses the same creation without the override', () => {
+    // The other half, so the case above cannot pass because the check stopped working.
+    const cwd = repo();
+    expect(create(cwd, 'git checkout -b feat/new main').status).toBe(2);
   });
 });

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -274,6 +274,10 @@ describe('a feature branch is cut from origin/develop', () => {
       'git checkout -b feat/new 2>&1 | head -1',
       'git checkout -b feat/new >/dev/null',
       'git switch -c feat/new 2>/dev/null',
+      // The input side, with and without a descriptor number. Covering only `>` left `3<file`
+      // falling through to truncation, which kept the bare fd `3` and refused the creation.
+      'git checkout -b feat/new 3<file',
+      'git checkout -b feat/new <in',
     ]) {
       const verdict = create(cwd, command);
       expect(verdict.status, `a redirection was read as a base: ${command}`).toBe(0);

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -240,6 +240,19 @@ describe('a feature branch is cut from origin/develop', () => {
     expect(verdict.status, verdict.output).toBe(0);
   });
 
+  it('does not mistake a digit-named base for a file descriptor', () => {
+    // As a glob, `[0-9]*'>'*` reads "a digit, then anything, then `>`" — so `2fa-base>/tmp/out.log`
+    // matched and a real ref beginning with a digit was blanked, falling back to HEAD. The same
+    // fail-open the redirection arm exists to prevent, for every start point whose name starts with
+    // a number. The descriptor and the operator have to be adjacent.
+    const cwd = repo();
+    git(cwd, 'branch', '2fa-base', 'main');
+
+    const verdict = create(cwd, 'git checkout -b feat/new 2fa-base>/tmp/out.log');
+    expect(verdict.status, 'a digit-named base was read as a descriptor and skipped').toBe(2);
+    expect(verdict.output).toMatch(/found:\s+2fa-base \([0-9a-f]{9}\)/);
+  });
+
   it('reads a base glued to the operator that follows it', () => {
     // `git checkout -b feat/x main;` is one whitespace-separated token, `main;`, and git cuts from
     // `main`. Blanking the token because it contained an operator fell back to HEAD, so a base of

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -254,7 +254,13 @@ describe('a feature branch is cut from origin/develop', () => {
     ]) {
       const verdict = create(cwd, command);
       expect(verdict.status, `a glued base slipped past: ${command}`).toBe(2);
-      expect(verdict.output).toMatch(/found:\s+main\b/);
+      // The WRONG-BASE refusal, which prints a resolved sha — not the cannot-resolve one, which
+      // prints the raw token. Both exit 2 and both contain "found: main", so asserting on the
+      // status and the word alone passed whether or not the token was ever truncated. That is the
+      // difference this case exists to measure.
+      expect(verdict.output, `truncation did not happen for: ${command}`).toMatch(
+        /found:\s+main \([0-9a-f]{9}\)/,
+      );
     }
   });
 


### PR DESCRIPTION
fix(hooks): the base override works inline, and a redirection is not a base

[MUST] `BRANCH_GUARD_ALLOW_BASE=1 git checkout -b <name> <base>` did nothing. The
three older overrides are parsed out of the COMMAND string because an inline
`VAR=1 git …` is set in the tool's shell and never reaches this process — the hook
spends nine lines explaining exactly that — and the new override was added as a
plain `${VAR:-0}` read instead. Both `git-branch.md` and the hook's own refusal
message document the inline form, so the documented contract simply did not hold.

The test hid it: it injected the variable through `spawnSync`'s `env`, which is
the hook's own environment, not the command. Accidental green about the one
distinction this file exists to teach. It passes the override inline now, as a
user would, with the un-overridden case beside it so it cannot pass by the check
having stopped working.

Also, a redirection is not a start point. `git checkout -b feat/x 2>&1 | head`
had `2>&1` read as the base, which resolved to nothing and refused an ordinary
creation — measured in practice, blocking the creation of the branch this fix
lives on. Tokens carrying `< > | & ;` are rejected alongside flags.

Red-proved: removing the inline parse fails the override case; restoring the old
token filter fails the redirection case. 1630 harness tests green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
