### PR TITLE
feat(harness): a hook no test runs fails the build

### DIFF
--- a/.agents/backlog/PROC-003-registered-is-not-reached.md
+++ b/.agents/backlog/PROC-003-registered-is-not-reached.md
@@ -75,3 +75,34 @@ all pass 1 and 2 and fail 3.
 
 `#1510` and `#1514` already close the anchoring class for hooks, and `#1513` makes three scans'
 findings visible. Two audit passes proposed items for those; they are struck rather than duplicated.
+
+## Progress (2026-07-30)
+
+**Criterion 1 — the three questions are in the rule: DONE.** `enforcement-architecture.md` now
+carries them as the contract for adding a guard, with the three measured failures that produced the
+third one (`pre-push-check`'s `^` anchor, `worktree-cwd-guard`'s unexported marker, `verify-like-ci`'s
+absent caller).
+
+**Criterion 2 — a new guard cannot land without a case that runs it: PARTLY DONE, and the part that
+is mechanical is stated.** `hooks-have-execution-coverage` fails when any `.claude/hooks/*.sh` is
+executed by no test. It found four on its first run — `memory-mirror-reminder`, `post-tool-format`,
+`spec-first-gate`, `task-tracking` — described by nothing and run by nothing; all four now have
+execution cases, and giving `post-tool-format` its first one immediately surfaced a `set -u` crash on
+an unset `CLAUDE_PROJECT_DIR`.
+
+What the floor deliberately does not claim is the harder half: that the environment a case supplies
+is one a real session supplies. `worktree-cwd-guard` passed ten tests that ran it — with a marker
+only those tests set. The rule asks each case to state which signal it depends on and who sends it,
+and that remains judgement rather than a check.
+
+**Criterion 3 — child items closed or consciously deferred:**
+
+| Child                                                | State                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------- |
+| INFRA-067 (branch base at creation)                  | closed 2026-07-30                                       |
+| INFRA-068 (worktree guard dead)                      | closed 2026-07-30                                       |
+| HARNESS-061 (hooks see part of the command)          | closed 2026-07-30                                       |
+| INFRA-066 (required checks runnable locally)         | OPEN — the ruleset-declaration mechanism does not exist |
+| HARNESS-057 (a scan reports the size of its subject) | OPEN                                                    |
+
+This item stays open on INFRA-066 and HARNESS-057, and on the judgement half of criterion 2.

--- a/.agents/rules/enforcement-architecture.md
+++ b/.agents/rules/enforcement-architecture.md
@@ -83,3 +83,28 @@ On a guardian FAIL the orchestrator rewinds. Two shapes, both already in the rep
 4. Reuse the `backlog-pipeline` / `backlog-gate-guard` shape: an orchestrator that only routes, a worker
    that only produces, a guardian that only judges. Add a tier only when a phase owns its own ordering
    (see the nesting note above) — never to make a step more likely to run.
+
+## Three questions a guard must answer (PROC-003)
+
+In this order. The first two were already asked here; the third is what four independent audits added.
+
+1. **Can it fail?** — a check with no failing input is a check that has never been run.
+   (`scan-main-required-checks`, INFRA-055.)
+2. **Does it check the right thing?** — a check that fires on the wrong subject is not a weaker check,
+   it is a different one. (`.agents/memory/check-validity-two-axes.md`.)
+3. **Is it REACHED — by the real invocation, in the real environment?**
+
+A test that supplies the condition itself, an entry point nothing calls, and a matcher no real command
+hits all pass 1 and 2 and fail 3. Each has been measured here:
+
+- `pre-push-check` matched with a `^` anchor while every command begins `cd <repo> && …`, so every push
+  in a long session bypassed it silently (#1510).
+- `worktree-cwd-guard` gated on `ROBOTA_AGENT_WORKTREE`, exported by nothing but its own tests, so it
+  exited on its first line in every real session while ten tests stayed green (INFRA-068).
+- `verify-like-ci` named itself the CI-equivalent entry point and was invoked by nothing (INFRA-069).
+
+So a guard lands with a case that RUNS it as a real invocation would, supplying only what a real
+session supplies. `hooks-have-execution-coverage` is the mechanical floor for question 3 in
+`.claude/hooks/`: a hook no test executes fails it. Whether the environment a case supplies is one a
+real session has remains judgement — state, beside the case, which signal it depends on and who sends
+it.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -378,7 +378,7 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
   # `-C` target and the delete name follow. Pulling it straight out of the masked string returned
   # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
   NEW_BRANCH=$(hook_match_extract "$COMMAND_EXEC" \
-    '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+' || true)
+    '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+' || true)
   # --- the base the branch is cut from (INFRA-067) ---------------------------------------------
   #
   # `git-branch.md` is mandatory about this: feature branches are created from a freshly-fetched
@@ -402,7 +402,7 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # instead and passed while the branch came from `origin/main` — the exact creation this exists to
     # refuse, waved through by one common flag.
     START_POINT=$(hook_match_extract "$COMMAND_EXEC" \
-      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t]+[ \t]+|-[^ \t]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t]+[ \t]+)*-[bBcC][ \t]+[^ \t]+[ \t]+(-[^ \t]+[ \t]+)*' || true)
+      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+[^ \t\n]+[ \t]+(-[^ \t\n]+[ \t]+)*' || true)
     # A start point is a git ref, and the token holding it may be glued to what follows.
     #
     # Blanking the whole token whenever it contained an operator was worse than the bug it replaced:

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -447,7 +447,7 @@ hook_verb_scan() {
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 hook_git_c_path() {
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t\n]+[ \t]+)*-C[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+'
 }
 
 # The branch a remote-delete would remove, in either spelling the guard recognises.
@@ -471,10 +471,10 @@ hook_deleted_branch() {
   fi
 
   # `git push <remote> --delete <branch>` and `git push <remote> :<branch>`.
-  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t\n]+[ \t]+(--delete[ \t]+|:)')
+  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)')
   [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
 
   # `git push --delete <remote> <branch>` — git accepts the flag before the remote, and the guard
   # never did. Pre-existing rather than new, but a delete this misses is a delete it permits.
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t\n]+[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t]+[ \t]+'
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -445,9 +445,15 @@ hook_verb_scan() {
   hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v ERE="" -v VRE="" "$HOOK_SCAN_AWK"
 }
 
+# Token classes here exclude the newline as well as space and tab. That matters in `branch-guard.sh`,
+# where a name token ran greedily across a line break and read the next line's first word as a base —
+# measured, and fixed there with a test. Here it is CONSISTENCY, not a fix: every multi-line form was
+# tried against these expressions and none extracts anything different, because each requires
+# `[ \t]+` right after a token and a newline never satisfies that. Recorded as unproven rather than
+# dressed in a test that would pass either way.
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 hook_git_c_path() {
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t\n]+[ \t]+)*-C[ \t]+'
 }
 
 # The branch a remote-delete would remove, in either spelling the guard recognises.
@@ -471,10 +477,10 @@ hook_deleted_branch() {
   fi
 
   # `git push <remote> --delete <branch>` and `git push <remote> :<branch>`.
-  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)')
+  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t\n]+[ \t]+(--delete[ \t]+|:)')
   [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
 
   # `git push --delete <remote> <branch>` — git accepts the flag before the remote, and the guard
   # never did. Pre-existing rather than new, but a delete this misses is a delete it permits.
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t]+[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t\n]+[ \t]+'
 }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -447,7 +447,7 @@ hook_verb_scan() {
 
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 hook_git_c_path() {
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t]+[ \t]+)*-C[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t\n]+[ \t]+)*-C[ \t]+'
 }
 
 # The branch a remote-delete would remove, in either spelling the guard recognises.
@@ -471,10 +471,10 @@ hook_deleted_branch() {
   fi
 
   # `git push <remote> --delete <branch>` and `git push <remote> :<branch>`.
-  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t]+[ \t]+(--delete[ \t]+|:)')
+  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t\n]+[ \t]+(--delete[ \t]+|:)')
   [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
 
   # `git push --delete <remote> <branch>` — git accepts the flag before the remote, and the guard
   # never did. Pre-existing rather than new, but a delete this misses is a delete it permits.
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t]+[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t\n]+[ \t]+'
 }

--- a/.claude/hooks/post-tool-format.sh
+++ b/.claude/hooks/post-tool-format.sh
@@ -20,15 +20,23 @@ if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Only format files within the project directory.
+# Without a project directory this hook cannot tell what is in scope, and it must not guess.
 #
-# `${CLAUDE_PROJECT_DIR:-}`, not a bare reference: under `set -u` an unset variable aborts the hook
-# here, and the tool host does not guarantee it. Found by giving this hook its first execution test
-# (PROC-003's third question) — it had never been run by anything but a live session, where the
-# variable happens to be present. With it unset the comparison simply matches nothing, which is the
-# fail-safe direction for a formatter.
+# It bare-referenced `$CLAUDE_PROJECT_DIR` under `set -u`, so an unset variable aborted the hook —
+# found by giving it its first execution test (PROC-003's third question); it had only ever run in a
+# live session, where the variable happens to be present. The first attempt at a fix wrote
+# `"${CLAUDE_PROJECT_DIR:-}"/*` and claimed that matched nothing. It does the opposite: unset, the
+# pattern reduces to `/*`, and `*` in a case pattern matches `/` too — so it matches nearly every
+# absolute path, widening scope while the comment said it narrowed it. And `cd "$CLAUDE_PROJECT_DIR"`
+# four lines down still aborted anyway, so the crash simply moved.
+#
+# Nothing to scope means nothing to format.
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  exit 0
+fi
+
 case "$FILE_PATH" in
-  "${CLAUDE_PROJECT_DIR:-}"/*) ;;
+  "$CLAUDE_PROJECT_DIR"/*) ;;
   *) exit 0 ;;
 esac
 

--- a/.claude/hooks/post-tool-format.sh
+++ b/.claude/hooks/post-tool-format.sh
@@ -20,9 +20,15 @@ if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Only format files within the project directory
+# Only format files within the project directory.
+#
+# `${CLAUDE_PROJECT_DIR:-}`, not a bare reference: under `set -u` an unset variable aborts the hook
+# here, and the tool host does not guarantee it. Found by giving this hook its first execution test
+# (PROC-003's third question) — it had never been run by anything but a live session, where the
+# variable happens to be present. With it unset the comparison simply matches nothing, which is the
+# fail-safe direction for a formatter.
 case "$FILE_PATH" in
-  "$CLAUDE_PROJECT_DIR"/*) ;;
+  "${CLAUDE_PROJECT_DIR:-}"/*) ;;
   *) exit 0 ;;
 esac
 

--- a/scripts/harness/__tests__/branch-base-at-creation.test.mjs
+++ b/scripts/harness/__tests__/branch-base-at-creation.test.mjs
@@ -229,6 +229,17 @@ describe('a feature branch is cut from origin/develop', () => {
     expect(verdict.output, 'the refusal named no base').toMatch(/found:\s+\S/);
   });
 
+  it('stops at the end of the line, not at the end of the command', () => {
+    // `[^ \\t]` excludes space and tab but INCLUDES a newline, so the branch-name token ran greedily
+    // across the line break and swallowed the next line's first word — `git checkout -b feat/x` on
+    // one line and `git status --porcelain` on the next had `status` read as the base. Measured in
+    // practice: it refused the creation of the branch this fix lives on, twice in one session.
+    const cwd = repo();
+    const verdict = create(cwd, 'git checkout -b feat/new\ngit status --porcelain');
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
   it('honours the override written INLINE, the way it is documented', () => {
     // The distinction this hook spends nine lines explaining: an inline `VAR=1 git …` is set in the
     // TOOL's shell and never reaches the hook process, so an override read only as `${VAR:-0}` does

--- a/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
+++ b/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
@@ -38,12 +38,24 @@ const TEST_SOURCES = readdirSync(TESTS_DIR)
 /**
  * Does `source` execute `hook`?
  *
- * Deliberately structural rather than clever: the file must name the hook AND hand a path to a
- * spawned shell. Naming it in a comment, or asserting over its source text, is not running it —
- * which is exactly the distinction this floor exists to draw.
+ * The distinction that matters is between a hook NAMED IN PROSE and one named as a value. Matching
+ * the name anywhere in the text counted a comment as coverage — the described-but-not-reached
+ * failure this floor exists to close, reproduced inside the floor. So comments are stripped first,
+ * and the name must survive that, in a file that spawns a shell.
+ *
+ * Requiring the name inside a `path.join(...)` was tried and was too narrow: a test that passes the
+ * name to a helper which joins it — `run('some-hook.sh', …)` — is running it just as truly.
+ *
+ * Still structural rather than exact: a file that spawns one hook and names another in a string it
+ * never uses would pass. Tying a spawn to its argument needs the call graph, and this is a
+ * grep-level floor by design — stated rather than implied.
  */
+function withoutComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
 function executesHook(source, hook) {
-  if (!source.text.includes(hook)) return false;
+  if (!withoutComments(source.text).includes(hook)) return false;
   return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(source.text);
 }
 

--- a/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
+++ b/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
@@ -1,0 +1,71 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+const TESTS_DIR = import.meta.dirname;
+
+/**
+ * The mechanical floor for the third question a guard must answer (PROC-003): **is it reached?**
+ *
+ * `enforcement-architecture.md` already required every guardian to have a mechanical floor, and
+ * `.claude/hooks/` was the one layer without one. What that cost, measured:
+ *
+ * - `pre-push-check` matched with a `^` anchor while every command begins `cd <repo> && …`, so every
+ *   push in a long session bypassed it silently.
+ * - `worktree-cwd-guard` gated on an environment marker exported by nothing but its own tests, so it
+ *   exited on its first line in every real session — with ten green tests beside it.
+ * - `merge-gate` shipped with a reachability probe and no test of what it DECIDED, so a gate looking
+ *   for a reviewer nobody uses would have passed.
+ *
+ * This asks the smallest question that catches the shape: does any test EXECUTE this hook? A hook
+ * nobody runs is a hook nobody has checked, whatever else is asserted about its source.
+ *
+ * What it deliberately does not claim: that the environment a case supplies is one a real session
+ * supplies. That stays judgement, and the rule asks for it to be stated beside the case.
+ */
+const SHELL_HOOKS = readdirSync(HOOKS_DIR)
+  .filter((name) => name.endsWith('.sh'))
+  .sort();
+
+/** Test sources, read once. A hook is "executed" if a test spawns bash on its path. */
+const TEST_SOURCES = readdirSync(TESTS_DIR)
+  .filter((name) => name.endsWith('.test.mjs'))
+  .map((name) => ({ name, text: readFileSync(path.join(TESTS_DIR, name), 'utf8') }));
+
+/**
+ * Does `source` execute `hook`?
+ *
+ * Deliberately structural rather than clever: the file must name the hook AND hand a path to a
+ * spawned shell. Naming it in a comment, or asserting over its source text, is not running it —
+ * which is exactly the distinction this floor exists to draw.
+ */
+function executesHook(source, hook) {
+  if (!source.text.includes(hook)) return false;
+  return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(source.text);
+}
+
+describe('every hook is executed by a test, not merely described by one', () => {
+  it('finds hooks and tests to check', () => {
+    // Fail closed: a moved directory would make every assertion below pass over nothing.
+    expect(SHELL_HOOKS.length).toBeGreaterThan(0);
+    expect(TEST_SOURCES.length).toBeGreaterThan(0);
+  });
+
+  for (const hook of SHELL_HOOKS) {
+    it(`${hook} is run by at least one test`, () => {
+      const runners = TEST_SOURCES.filter((source) => executesHook(source, hook)).map(
+        (s) => s.name,
+      );
+
+      expect(
+        runners.length,
+        `No test executes ${hook}. A hook nobody runs is a hook nobody has checked — the shape that ` +
+          'left `worktree-cwd-guard` off in every real session with ten green tests beside it. Add a ' +
+          'case that spawns it with a payload, and state which signal it depends on and who sends it.',
+      ).toBeGreaterThan(0);
+    });
+  }
+});

--- a/scripts/harness/__tests__/remaining-hooks-run.test.mjs
+++ b/scripts/harness/__tests__/remaining-hooks-run.test.mjs
@@ -80,6 +80,33 @@ describe('post-tool-format', () => {
     expect(verdict.status, verdict.output).toBe(0);
   });
 
+  it('does nothing at all when the project directory is unset', () => {
+    // The case neither earlier test reached: the variable unset AND a real file with a formatted
+    // extension. A nonexistent path and a `.txt` both exit before the scoping check, so both stayed
+    // green whether or not the bare `$CLAUDE_PROJECT_DIR` crash existed — and it did, twice: once in
+    // the scoping pattern and again at the `cd` four lines below it.
+    //
+    // Without a project directory the hook cannot tell what is in scope. `\"${CLAUDE_PROJECT_DIR:-}\"/*`
+    // does not fail safe either — unset, it reduces to `/*`, which matches nearly every absolute
+    // path. So it does nothing.
+    const dir = scratchDir('post-format-unset-');
+    const file = path.join(dir, 'thing.ts');
+    writeFileSync(file, 'const a = 1\n');
+
+    const result = spawnSync('bash', [path.join(HOOKS_DIR, 'post-tool-format.sh')], {
+      input: JSON.stringify({ tool_input: { file_path: file } }),
+      encoding: 'utf8',
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(([k]) => k !== 'CLAUDE_PROJECT_DIR'),
+      ),
+    });
+
+    expect(result.status ?? 1, `${result.stdout ?? ''}${result.stderr ?? ''}`).toBe(0);
+    expect(`${result.stderr ?? ''}`, 'it crashed instead of standing down').not.toMatch(
+      /unbound variable|바인딩 해제/,
+    );
+  });
+
   it('does nothing for a file outside the formatted set', () => {
     const dir = scratchDir('post-format-');
     const file = path.join(dir, 'notes.txt');

--- a/scripts/harness/__tests__/remaining-hooks-run.test.mjs
+++ b/scripts/harness/__tests__/remaining-hooks-run.test.mjs
@@ -1,0 +1,141 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * Execution coverage for the four hooks that had none.
+ *
+ * `hooks-have-execution-coverage` — the mechanical floor for PROC-003's third question, "is it
+ * reached?" — found these on its first run: `memory-mirror-reminder`, `post-tool-format`,
+ * `spec-first-gate` and `task-tracking` were described by no test and executed by none. That is the
+ * shape that left `worktree-cwd-guard` switched off in every real session with ten green tests
+ * beside it, so a hook nobody runs is a hook nobody has checked.
+ *
+ * Each case below states which signal the hook depends on and who sends it, because the floor
+ * cannot judge that and the rule asks for it in writing.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchDir(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+}
+
+function run(hook, { input, env = {}, cwd = WORKSPACE_ROOT } = {}) {
+  const result = spawnSync('bash', [path.join(HOOKS_DIR, hook)], {
+    input,
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
+
+describe('memory-mirror-reminder', () => {
+  // Signal: the PostToolUse payload's `tool_input.file_path`, sent by the tool host on every
+  // Write/Edit. Nothing else is required, so a case supplies only that.
+  it('reminds on a write outside the in-repo memory', () => {
+    const verdict = run('memory-mirror-reminder.sh', {
+      input: JSON.stringify({ tool_input: { file_path: '/home/u/.claude/memory/thing.md' } }),
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(verdict.output.trim().length, 'the reminder said nothing at all').toBeGreaterThan(0);
+  });
+
+  it('stays silent on a write INTO the in-repo memory', () => {
+    // The compliant case is the whole point: a reminder that fires on the compliant path is one
+    // everybody learns to ignore.
+    const verdict = run('memory-mirror-reminder.sh', {
+      input: JSON.stringify({ tool_input: { file_path: '/repo/.agents/memory/thing.md' } }),
+    });
+
+    expect(verdict.status).toBe(0);
+    expect(verdict.output.trim()).toBe('');
+  });
+});
+
+describe('post-tool-format', () => {
+  // Signal: `tool_input.file_path` again, and the file must EXIST — the hook formats what was just
+  // written. A path that does not exist is the ordinary case for a deleted or moved file.
+  it('does nothing for a file that is not there', () => {
+    const verdict = run('post-tool-format.sh', {
+      input: JSON.stringify({ tool_input: { file_path: '/nonexistent/nowhere.ts' } }),
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+
+  it('does nothing for a file outside the formatted set', () => {
+    const dir = scratchDir('post-format-');
+    const file = path.join(dir, 'notes.txt');
+    writeFileSync(file, 'plain text\n');
+
+    const verdict = run('post-tool-format.sh', {
+      input: JSON.stringify({ tool_input: { file_path: file } }),
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+});
+
+describe('spec-first-gate', () => {
+  // Signal: the UserPromptSubmit payload's `prompt`. The gate reads intent from the text, so the
+  // cases are two prompts — one that states implementation intent without a spec reference, and one
+  // that carries no such intent at all.
+  it('says nothing when the prompt states no implementation intent', () => {
+    const verdict = run('spec-first-gate.sh', {
+      input: JSON.stringify({ prompt: 'what does this package do?' }),
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(verdict.output.trim()).toBe('');
+  });
+
+  it('says nothing on an empty prompt', () => {
+    const verdict = run('spec-first-gate.sh', { input: JSON.stringify({ prompt: '' }) });
+
+    expect(verdict.status).toBe(0);
+    expect(verdict.output.trim()).toBe('');
+  });
+});
+
+describe('task-tracking', () => {
+  // Signals: the `start`/`stop` mode argument, and a tasks directory under CLAUDE_PROJECT_DIR. Both
+  // come from the deployment — the mode from `.claude/settings.json`, the directory from the repo.
+  it('refuses a mode it does not handle, and says so', () => {
+    // Invoked with no mode it is not a no-op — it is a misuse, and the hook names the two it takes.
+    const verdict = run('task-tracking.sh', { input: '{}' });
+
+    expect(verdict.status, verdict.output).not.toBe(0);
+    expect(verdict.output).toMatch(/Usage: task-tracking\.sh <start\|stop>/);
+  });
+
+  it('does nothing when there is no tasks directory', () => {
+    const dir = scratchDir('task-tracking-');
+    mkdirSync(path.join(dir, '.claude'), { recursive: true });
+
+    const result = spawnSync('bash', [path.join(HOOKS_DIR, 'task-tracking.sh'), 'start'], {
+      input: '{}',
+      encoding: 'utf8',
+      cwd: dir,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+    });
+
+    expect(result.status ?? 1, `${result.stdout ?? ''}${result.stderr ?? ''}`).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/remaining-hooks-run.test.mjs
+++ b/scripts/harness/__tests__/remaining-hooks-run.test.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -107,16 +107,37 @@ describe('post-tool-format', () => {
     );
   });
 
-  it('does nothing for a file outside the formatted set', () => {
-    const dir = scratchDir('post-format-');
-    const file = path.join(dir, 'notes.txt');
-    writeFileSync(file, 'plain text\n');
+  it('reaches the extension filter, and the filter decides', () => {
+    // This case asserted exit 0 for a `.txt` without setting CLAUDE_PROJECT_DIR — so the new
+    // stand-down guard exited first and the extension filter was never reached. Deleting that filter
+    // entirely would have left the test green: the described-but-not-reached shape, in the file
+    // written to close it.
+    //
+    // `npx` is stubbed to leave a marker, so "the filter let it through" is observable rather than
+    // inferred from an exit code both paths share.
+    const dir = scratchDir('post-format-filter-');
+    const bin = scratchDir('npx-stub-');
+    const marker = path.join(dir, 'npx-ran');
+    writeFileSync(path.join(bin, 'npx'), `#!/bin/sh\necho "$@" >> ${JSON.stringify(marker)}\n`);
+    chmodSync(path.join(bin, 'npx'), 0o755);
 
-    const verdict = run('post-tool-format.sh', {
-      input: JSON.stringify({ tool_input: { file_path: file } }),
-    });
+    const formatted = path.join(dir, 'thing.ts');
+    const ignored = path.join(dir, 'notes.txt');
+    writeFileSync(formatted, 'const a = 1\n');
+    writeFileSync(ignored, 'plain text\n');
 
-    expect(verdict.status, verdict.output).toBe(0);
+    const call = (file) =>
+      spawnSync('bash', [path.join(HOOKS_DIR, 'post-tool-format.sh')], {
+        input: JSON.stringify({ tool_input: { file_path: file } }),
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, CLAUDE_PROJECT_DIR: dir },
+      });
+
+    expect(call(ignored).status ?? 1).toBe(0);
+    expect(existsSync(marker), 'an unsupported extension was handed to the formatter').toBe(false);
+
+    expect(call(formatted).status ?? 1).toBe(0);
+    expect(existsSync(marker), 'a supported extension never reached the formatter').toBe(true);
   });
 });
 

--- a/scripts/harness/__tests__/remaining-hooks-run.test.mjs
+++ b/scripts/harness/__tests__/remaining-hooks-run.test.mjs
@@ -143,8 +143,31 @@ describe('post-tool-format', () => {
 
 describe('spec-first-gate', () => {
   // Signal: the UserPromptSubmit payload's `prompt`. The gate reads intent from the text, so the
-  // cases are two prompts — one that states implementation intent without a spec reference, and one
-  // that carries no such intent at all.
+  // cases are prompts.
+  it('injects the gate when a prompt states implementation intent without a spec', () => {
+    // The case the earlier pair claimed and did not reach: both of those took the silent path, so
+    // breaking the intent match or deleting the SPEC-GATE block entirely would have left them green.
+    const verdict = run('spec-first-gate.sh', {
+      input: JSON.stringify({ prompt: 'implement the retry queue for the worker' }),
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(verdict.output, 'the gate said nothing about implementation intent').toMatch(
+      /SPEC-GATE/,
+    );
+  });
+
+  it('stays quiet when the prompt already refers to a spec', () => {
+    // The other half of the same branch: a prompt that names a spec has already done what the gate
+    // asks for, and a gate that fires anyway is one people learn to scroll past.
+    const verdict = run('spec-first-gate.sh', {
+      input: JSON.stringify({ prompt: 'implement the retry queue per its spec-doc' }),
+    });
+
+    expect(verdict.status).toBe(0);
+    expect(verdict.output.trim()).toBe('');
+  });
+
   it('says nothing when the prompt states no implementation intent', () => {
     const verdict = run('spec-first-gate.sh', {
       input: JSON.stringify({ prompt: 'what does this package do?' }),
@@ -165,6 +188,46 @@ describe('spec-first-gate', () => {
 describe('task-tracking', () => {
   // Signals: the `start`/`stop` mode argument, and a tasks directory under CLAUDE_PROJECT_DIR. Both
   // come from the deployment — the mode from `.claude/settings.json`, the directory from the repo.
+  function repoWithTasks(files) {
+    const dir = scratchDir('task-tracking-');
+    const tasks = path.join(dir, '.agents', 'tasks');
+    mkdirSync(tasks, { recursive: true });
+    for (const [name, body] of Object.entries(files)) {
+      writeFileSync(path.join(tasks, name), body);
+    }
+    return dir;
+  }
+
+  function track(dir, mode) {
+    const result = spawnSync('bash', [path.join(HOOKS_DIR, 'task-tracking.sh'), mode], {
+      input: '{}',
+      encoding: 'utf8',
+      cwd: dir,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
+    });
+    return {
+      status: result.status ?? 1,
+      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    };
+  }
+
+  it('classifies what is in the directory, open from finished', () => {
+    // The hook's actual job, which the guard-clause cases never reached. It lists both, and the
+    // classification is the content: an unchecked box is open work, `status: completed` is work that
+    // needs archiving. Asserting only that a name appears would pass with the classifier deleted.
+    const dir = repoWithTasks({
+      'TASK-1.md': '# One\n\n- [ ] still to do\n',
+      'TASK-2.md': '# Two\n\nstatus: completed\n\n- [ ] leftover\n',
+    });
+    const verdict = track(dir, 'start');
+
+    expect(verdict.output, 'the open task went unmentioned').toMatch(/TASK-1/);
+    expect(verdict.output, 'the open task was called finished').not.toMatch(/TASK-1\.md — DONE/);
+    expect(verdict.output, 'a finished task was not marked for archival').toMatch(
+      /TASK-2\.md — DONE/,
+    );
+  });
+
   it('refuses a mode it does not handle, and says so', () => {
     // Invoked with no mode it is not a no-op — it is a misuse, and the hook names the two it takes.
     const verdict = run('task-tracking.sh', { input: '{}' });
@@ -174,16 +237,9 @@ describe('task-tracking', () => {
   });
 
   it('does nothing when there is no tasks directory', () => {
-    const dir = scratchDir('task-tracking-');
+    const dir = scratchDir('task-tracking-empty-');
     mkdirSync(path.join(dir, '.claude'), { recursive: true });
 
-    const result = spawnSync('bash', [path.join(HOOKS_DIR, 'task-tracking.sh'), 'start'], {
-      input: '{}',
-      encoding: 'utf8',
-      cwd: dir,
-      env: { ...process.env, CLAUDE_PROJECT_DIR: dir },
-    });
-
-    expect(result.status ?? 1, `${result.stdout ?? ''}${result.stderr ?? ''}`).toBe(0);
+    expect(track(dir, 'start').status).toBe(0);
   });
 });


### PR DESCRIPTION
PROC-003's third question — is the guard REACHED, by the real invocation, in the real environment — now has a mechanical floor in the one layer that had none. `enforcement-architecture.md` already required every guardian to have one, and `.claude/hooks/` was the exception. The three questions are written into that rule with the failures that produced the third: a `^`-anchored matcher no real command hit, a marker exported by nothing, an entry point nothing called.

`hooks-have-execution-coverage` fails when any `.claude/hooks/*.sh` is executed by no test. It found four on its first run — `memory-mirror-reminder`, `post-tool-format`, `spec-first-gate`, `task-tracking` — run by nothing at all. All four have execution cases now, each stating which signal it depends on and who sends it, because the floor cannot judge that and the rule asks for it in writing.

Giving `post-tool-format` its first execution surfaced a real defect immediately: `$CLAUDE_PROJECT_DIR` bare under `set -u`, in TWO places. Without a project directory the hook now does nothing, because it cannot tell what is in scope — and `"${CLAUDE_PROJECT_DIR:-}"/*` does not fail safe either, since unset it reduces to `/*` and matches nearly every absolute path.

Also fixes a defect this session hit twice in practice: `[^ \t]` excludes space and tab but INCLUDES a newline, so a branch-name token ran greedily across the line break and read the next line's first word as the base — refusing the creation of the branch this fix lives on. Eight classes corrected in `branch-guard.sh`, where it was measured; the three in `command-scan.sh` are aligned for consistency with the reasoning recorded beside them, after measuring that no multi-line form distinguishes the two spellings there.

Review rounds on this PR found three accidental-greens in my own tests, each now red-proved: the coverage floor counted a comment as coverage, the unset-variable case never reached the crash, and the extension-filter case never reached the filter.
