### PR TITLE
docs(backlog): the accidental-green gate never runs where accidental greens happen

### DIFF
--- a/.agents/backlog/INFRA-046-promote-advisory-gates.md
+++ b/.agents/backlog/INFRA-046-promote-advisory-gates.md
@@ -139,3 +139,44 @@ A four-way recurrence audit measured what these two floors are currently worth:
 So the repository has a built, tested floor for its accidental-green class and **nothing can fail on
 it**. The change is two environment variables and moving two contexts to required — the smallest
 mechanical prevention on the whole audit's list, against a class with confirmed recurrence.
+
+## Promotion Audit 2026-07-31 — NOT PROMOTED (neither flag flipped)
+
+**Evidence window.** The 12 most recent successful `ci.yml` runs (2026-07-30, PRs #1525–#1530 and
+their promotion runs). Every one of them post-dates both gates.
+
+**Result: no verdict was produced at all.** Not one run reached a decision to evaluate for false
+positives.
+
+| Verdict                                       | Runs |
+| --------------------------------------------- | ---- |
+| `RED_PROOF_OK`                                | 0    |
+| `ACCIDENTAL_GREEN`                            | 0    |
+| `INCONCLUSIVE`                                | 0    |
+| `SKIPPED: no same-package (source+test) pair` | 9    |
+| `SKIPPED: range has no fix: commit`           | 1    |
+| no verdict line (promotion runs)              | 2    |
+
+**Why.** `pkgOf` in `check-regression-red-proof.mjs` matches
+`^((?:packages|apps)/[^/]+)/src/` and nothing else. The gate therefore cannot see:
+
+- `.claude/hooks/**` — every guard in the repository
+- `scripts/harness/**` and `scripts/harness/__tests__/**` — every scan, floor and their tests
+
+Confirmed by executing `classifyChanges` over a file list drawn from these PRs: a
+`packages/agent-core/src` pair qualifies; `.claude/hooks/branch-guard.sh` with
+`scripts/harness/__tests__/branch-base-at-creation.test.mjs` yields nothing.
+
+**Why that matters more than the tally.** The gate exists to catch a regression test that passes on
+the unfixed code. During this same window human review caught FOUR such tests, all of them mine, all
+in `scripts/harness/__tests__/` — a coverage floor that counted a comment as coverage, an
+unset-variable case that never reached the crash it named, an extension-filter case that never
+reached the filter, and two hook cases that exercised only guard clauses. The mechanical floor for
+that exact defect was blind to every one of them.
+
+So the promotion criterion — N=10 code-PRs with zero false-positive verdicts — cannot be satisfied by
+work in this area, not because the gate is accurate but because it never runs. Promoting on a tally
+of zero verdicts would make a required check that is required to do nothing.
+
+**Blocked on:** INFRA-071 (widen the gate's subject to the harness and hook layer). Re-run this audit
+once verdicts exist.

--- a/.agents/backlog/INFRA-046-promote-advisory-gates.md
+++ b/.agents/backlog/INFRA-046-promote-advisory-gates.md
@@ -5,7 +5,7 @@ created: 2026-07-25
 priority: high
 urgency: now
 area: .github/workflows/ci.yml, repo rulesets
-depends_on: []
+depends_on: [INFRA-071]
 ---
 
 # INFRA-046: advisory→required gate promotion

--- a/.agents/backlog/INFRA-071-red-proof-gate-cannot-see-the-harness.md
+++ b/.agents/backlog/INFRA-071-red-proof-gate-cannot-see-the-harness.md
@@ -1,0 +1,74 @@
+---
+title: 'INFRA-071: the accidental-green gate cannot see the layer where accidental greens keep happening'
+status: todo
+priority: high
+urgency: now
+type: INFRA
+area: scripts/harness
+created: 2026-07-31
+depends_on: []
+---
+
+# INFRA-071 — the red-proof gate is scoped to `packages/*/src` and nothing else
+
+## Problem
+
+`check-regression-red-proof.mjs` (HARNESS-041) exists to catch a regression test that passes on the
+unfixed code. It decides what to examine with one expression:
+
+```js
+export function pkgOf(filePath) {
+  const m = filePath.match(/^((?:packages|apps)\/[^/]+)\/src\//);
+  return m ? m[1] : null;
+}
+```
+
+Everything outside `packages/*/src/` and `apps/*/src/` is invisible to it. That excludes:
+
+- `.claude/hooks/**` — every guard in the repository
+- `scripts/harness/**` and `scripts/harness/__tests__/**` — every scan, every floor, and their tests
+
+## What it has cost
+
+Measured over PRs #1525–#1530 (2026-07-30): twelve successful CI runs, **zero verdicts**. Nine
+skipped with `no same-package (source+test) pair`, one with `range has no fix: commit`, two produced
+no verdict line at all.
+
+In that same window human review caught **four accidental-green tests**, every one of them in
+`scripts/harness/__tests__/`:
+
+| Test                              | What it asserted                      | What it missed                            |
+| --------------------------------- | ------------------------------------- | ----------------------------------------- |
+| `hooks-have-execution-coverage`   | a hook name appears in a test file    | a name in a COMMENT counted as coverage   |
+| `remaining-hooks-run` (unset var) | exit 0 on a missing path and a `.txt` | never reached the `set -u` crash it named |
+| `remaining-hooks-run` (extension) | exit 0 for a `.txt`                   | never reached the extension filter        |
+| `remaining-hooks-run` (two hooks) | guard clauses returned 0              | never ran the hooks' actual logic         |
+
+The mechanical floor for exactly this defect was blind to all four. They were found by a reviewer
+reading the diff, which is the thing the floor is supposed to make unnecessary.
+
+This also blocks INFRA-046: the promotion criterion is N code-PRs with zero false-positive verdicts,
+and a gate that never produces a verdict can accumulate that tally forever without meaning anything.
+
+## Proposed direction
+
+Widen the subject to the layers that carry guards, and pair them the way they are actually written:
+
+- `scripts/harness/x.mjs` ↔ `scripts/harness/__tests__/x.test.mjs`
+- `.claude/hooks/x.sh` ↔ any test that executes it (`hooks-have-execution-coverage` already computes
+  that relation and could export it)
+
+The reverse-apply mechanism should carry over unchanged for `.mjs`; a `.sh` hook is not transformed
+by vitest, so reverse-applying its hunks and re-running the executing test is the same operation.
+
+## Done when
+
+- A `fix:` PR touching `scripts/harness/**` with a changed test produces a verdict, not a SKIP —
+  proven on a real pair from this window.
+- A `fix:` PR touching `.claude/hooks/**` with a test that executes the hook produces a verdict,
+  proven the same way.
+- At least one of the four accidental-greens listed above is replayed through the widened gate and
+  comes back `ACCIDENTAL_GREEN` — the floor must be shown catching what review caught, not merely
+  running.
+- The SKIP reasons remain distinguishable from a clean verdict in the log, so the next promotion
+  audit can tell "examined and clean" from "examined nothing".


### PR DESCRIPTION
docs(backlog): the accidental-green gate never runs where accidental greens happen

INFRA-046 asks for N code-PRs with zero false-positive verdicts before promoting
`regression-red-proof` to blocking. Audited the 12 most recent successful CI runs
(PRs #1525–#1530): **zero verdicts**. Nine skipped with `no same-package
(source+test) pair`, one with `range has no fix: commit`, two produced no verdict
line at all.

The cause is one expression. `pkgOf` matches `^((?:packages|apps)/[^/]+)/src/`
and nothing else, so `.claude/hooks/**` — every guard in the repository — and
`scripts/harness/**` — every scan, floor and their tests — are invisible to it.
Confirmed by executing `classifyChanges` over a file list from these PRs.

What makes that worth filing rather than noting: during the same window human
review caught FOUR accidental-green tests, all of them mine, all in
`scripts/harness/__tests__/`. The mechanical floor for exactly that defect was
blind to every one. They were found by a reviewer reading the diff, which is the
work the floor exists to remove.

So promotion stays blocked, and not because the gate is inaccurate — because a
tally of zero verdicts would make a required check that is required to do
nothing. INFRA-071 files the scope gap, with the four missed tests as its
acceptance evidence: the widened gate has to come back ACCIDENTAL_GREEN on at
least one of them, not merely run.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z
