### PR TITLE
chore(release): promote develop to main

### DIFF
--- a/.agents/backlog/INFRA-071-red-proof-gate-cannot-see-the-harness.md
+++ b/.agents/backlog/INFRA-071-red-proof-gate-cannot-see-the-harness.md
@@ -61,6 +61,31 @@ Widen the subject to the layers that carry guards, and pair them the way they ar
 The reverse-apply mechanism should carry over unchanged for `.mjs`; a `.sh` hook is not transformed
 by vitest, so reverse-applying its hunks and re-running the executing test is the same operation.
 
+## Design note (2026-07-31) — the obvious widening does not work
+
+Read the gate's mechanism before planning the change, and one thing it says is easy to miss:
+widening `pkgOf` to include `scripts/harness/` would catch **none of the four misses**.
+
+All four have `.claude/hooks/*.sh` as the code under test; only their TESTS live in
+`scripts/harness/__tests__/`. A `scripts/harness`-only widening pairs harness source with harness
+tests, and those four have no harness source at all — for
+`hooks-have-execution-coverage` the logic under test is inside the test file itself.
+
+So the change has two parts, and the second is the one that matters:
+
+1. **Grouping.** `classifyChanges` groups by `pkgOf`, so a `.sh` under `.claude/hooks/` and its test
+   under `scripts/harness/__tests__/` currently land in different groups and never form a pair. They
+   have to map to one subject.
+2. **`importsReversedFile`.** The C3 check walks relative imports from the test and asks whether any
+   reversed source is in that graph. A `.sh` is never in a module graph, so every hook pair would
+   return `INCONCLUSIVE` — a SKIP by another name. The relation that does hold is "this test SPAWNS
+   this hook", which `hooks-have-execution-coverage` already computes and could export.
+
+The reverse-apply half needs no change: bash reads a hook at spawn time, so reversing its hunks and
+re-running the executing test is the same operation vitest already performs for `src`.
+
+This is correctness-critical code in a gate, so it is worth doing deliberately rather than quickly.
+
 ## Done when
 
 - A `fix:` PR touching `scripts/harness/**` with a changed test produces a verdict, not a SKIP —


### PR DESCRIPTION
develop → main 승격. 릴리스 게이트를 PR 을 열기 전에 로컬에서 통과시켰다.

INFRA-071 설계 노트 — red-proof 게이트를 `scripts/harness/` 로 넓히는 자연스러운 첫 수는 이 항목이 등록된 accidental-green 4건을 **한 건도 잡지 못한다**. 넷 다 테스트만 하네스에 있고 대상 코드는 `.claude/hooks/*.sh` 이기 때문이다. 실제로 필요한 두 가지(그룹핑, 모듈 그래프 대신 spawn 관계)를 기록했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhJjnpqzCortHNB3h15h1Z