### PR TITLE
fix(harness): the red-proof gate can see the layer it is meant to guard

### DIFF
--- a/.agents/backlog/INFRA-071-red-proof-gate-cannot-see-the-harness.md
+++ b/.agents/backlog/INFRA-071-red-proof-gate-cannot-see-the-harness.md
@@ -86,14 +86,51 @@ re-running the executing test is the same operation vitest already performs for 
 
 This is correctness-critical code in a gate, so it is worth doing deliberately rather than quickly.
 
+## What the implementation found (2026-07-31)
+
+**The gate had never once reverse-applied anything.** `reverseApply` read the diff through a helper
+that `.trim()`s its output, so the patch reached `git apply -R` without its final newline and git
+rejected it as corrupt — "patch broke at line 60". Twelve CI runs, zero verdicts: the widening is
+what made the line reachable, and reaching it is what exposed this. It was never a `packages/*/src`
+problem versus a hooks problem — the mutation step was broken for every subject alike.
+
+**The third acceptance bullet below was written on a false premise, and the replay disproves it.**
+Both candidate ranges were replayed through the widened gate in a detached worktree:
+
+| Range                  | Verdict        | Case that fails when the fix is reversed          |
+| ---------------------- | -------------- | ------------------------------------------------- |
+| `2ac10f251..b1f46acf3` | `red-proof-ok` | `post-tool-format > … outside the formatted set`  |
+| `b1f46acf3..c08e0dbd6` | `red-proof-ok` | `post-tool-format > … project directory is unset` |
+
+Those verdicts are CORRECT. Each range's changed test file does contain a case that fails on the
+reversed hook, so the range is red-proved whatever else is true of its other cases.
+
+The four misses are a **different defect class**, and reverse-apply cannot reach them by
+construction:
+
+- `hooks-have-execution-coverage` — the logic under test lives inside the test file. There is no
+  source to reverse.
+- the two guard-clause cases — the hooks they name (`spec-first-gate`, `task-tracking`) were not
+  changed in the range, so there is no pair.
+- the extension-filter case — the hook did change, and the case does fail reversed, but for the
+  wrong reason (the reversed hook crashes before the filter). The gate reads pass/fail; it cannot
+  read WHY.
+
+Reverse-apply answers "does this test depend on the fix?". All four failed a different question:
+"does this test REACH the behavior it names?" — the third of PROC-003's three questions, at
+case granularity. That needs a mutation/coverage floor, not this one. Filed as INFRA-072 rather than
+stretched into this item, because widening this gate to cover it would mean judging a test by its
+reason for failing, which pass/fail output does not carry.
+
 ## Done when
 
 - A `fix:` PR touching `scripts/harness/**` with a changed test produces a verdict, not a SKIP —
   proven on a real pair from this window.
 - A `fix:` PR touching `.claude/hooks/**` with a test that executes the hook produces a verdict,
   proven the same way.
-- At least one of the four accidental-greens listed above is replayed through the widened gate and
-  comes back `ACCIDENTAL_GREEN` — the floor must be shown catching what review caught, not merely
-  running.
+- ~~At least one of the four accidental-greens listed above is replayed through the widened gate and
+  comes back `ACCIDENTAL_GREEN`.~~ **Retracted on measurement — see above.** Replaced by: the hook
+  subject reaches `ACCIDENTAL_GREEN` through the orchestrator, pinned by a fixture, and the four
+  misses are re-filed under the floor that can actually catch them.
 - The SKIP reasons remain distinguishable from a clean verdict in the log, so the next promotion
   audit can tell "examined and clean" from "examined nothing".

--- a/.agents/backlog/INFRA-072-a-test-that-does-not-reach-what-it-names.md
+++ b/.agents/backlog/INFRA-072-a-test-that-does-not-reach-what-it-names.md
@@ -7,6 +7,7 @@ type: INFRA
 area: scripts/harness
 created: 2026-07-31
 depends_on: [INFRA-071]
+issue: https://github.com/woojubb/robota/issues/1537
 ---
 
 # INFRA-072 — the defect class reverse-apply cannot reach
@@ -36,7 +37,7 @@ third question — "is it reached?" — asked one level down, of a test case rat
   case that fails for an unrelated crash is indistinguishable from one that fails on its assertion.
 - `hooks-have-execution-coverage` (PROC-003) asks whether a hook is executed by ANY test. It says
   nothing about whether a given case reaches a given branch — and it was itself one of the four.
-- File-granularity masking: a changed test FILE is red-proved by any one of its cases failing, so a
+- File-granularity masking (the test-side face of [INFRA-073](INFRA-073-one-verdict-for-an-aggregate.md)): a changed test FILE is red-proved by any one of its cases failing, so a
   vacuous case beside a genuine one is invisible. Measured on `2ac10f251..b1f46acf3`.
 
 ## Directions, none chosen yet

--- a/.agents/backlog/INFRA-072-a-test-that-does-not-reach-what-it-names.md
+++ b/.agents/backlog/INFRA-072-a-test-that-does-not-reach-what-it-names.md
@@ -1,0 +1,62 @@
+---
+title: 'INFRA-072: a test that passes without reaching the behavior it names'
+status: todo
+priority: high
+urgency: next
+type: INFRA
+area: scripts/harness
+created: 2026-07-31
+depends_on: [INFRA-071]
+---
+
+# INFRA-072 — the defect class reverse-apply cannot reach
+
+## Problem
+
+INFRA-071 widened the accidental-green gate to `.claude/hooks/**` and `scripts/harness/**`, and in
+doing so measured something worth its own item: **the four accidental-greens that motivated it are
+not the class that gate catches.**
+
+`check-regression-red-proof` asks one question — _does this test depend on the fix?_ — by reversing
+the source and re-running. All four misses passed that question and failed a different one:
+
+| Test                              | Failed question                                                      |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `hooks-have-execution-coverage`   | logic under test is IN the test file — nothing to reverse            |
+| `remaining-hooks-run` (two hooks) | the hooks named were not changed — no pair exists                    |
+| `remaining-hooks-run` (extension) | fails reversed, but for the wrong reason (crashes before the filter) |
+| `remaining-hooks-run` (unset var) | asserted an exit code both paths share                               |
+
+The shared shape: **the test never reaches the behavior its own name claims.** It is PROC-003's
+third question — "is it reached?" — asked one level down, of a test case rather than of a guard.
+
+## Why the existing floors do not cover it
+
+- `check-regression-red-proof` (HARNESS-041) reads pass/fail. It cannot read WHY a test failed, so a
+  case that fails for an unrelated crash is indistinguishable from one that fails on its assertion.
+- `hooks-have-execution-coverage` (PROC-003) asks whether a hook is executed by ANY test. It says
+  nothing about whether a given case reaches a given branch — and it was itself one of the four.
+- File-granularity masking: a changed test FILE is red-proved by any one of its cases failing, so a
+  vacuous case beside a genuine one is invisible. Measured on `2ac10f251..b1f46acf3`.
+
+## Directions, none chosen yet
+
+1. **Per-case granularity.** Require at least one case ADDED in the range to fail on the reversed
+   source, not merely any case in the file. Cheap; catches the masking half; still blind to "fails
+   for the wrong reason".
+2. **Mutation at the branch level.** Delete/negate the branch the test names and require that case
+   to fail. Strongest, and directly answers "does it reach it" — but needs a way to name the branch,
+   which for a shell hook is not obvious.
+3. **Coverage delta per case.** Run the case with coverage and assert the named branch executed.
+   Precise for `.mjs`/`.ts`; `bash` needs its own instrumentation (`BASH_XTRACEFD`), which is
+   feasible but new machinery.
+
+Pick after INFRA-071 has produced a few real verdicts, so the choice is made against measured
+behavior rather than in the abstract.
+
+## Done when
+
+- A vacuous case — one that passes whether or not the behavior it names exists — fails a mechanical
+  check, demonstrated by replaying at least one of the four above.
+- The check distinguishes "this case reached the behavior" from "this file contains some case that
+  failed", since the second is what already passes today.

--- a/.agents/backlog/INFRA-073-one-verdict-for-an-aggregate.md
+++ b/.agents/backlog/INFRA-073-one-verdict-for-an-aggregate.md
@@ -1,0 +1,69 @@
+---
+title: 'INFRA-073: the red-proof gate reports one verdict for an aggregate, so a pass hides inside a fail'
+status: todo
+priority: high
+urgency: soon
+type: INFRA
+area: scripts/harness
+created: 2026-07-31
+depends_on: []
+issue: https://github.com/woojubb/robota/issues/1536
+---
+
+# INFRA-073 — the unit the gate judges is not the unit the defect lives in
+
+## Problem
+
+`check-regression-red-proof` reverses a range's source changes, re-runs the changed tests, and emits
+**one verdict per subject**. `classifyVitestOutcome` returns `assertion-fail` if ANY deciding test
+fails, and `assertion-fail` means `RED_PROOF_OK`.
+
+So when a `fix:` range touches two sources with their tests, a genuine red proof in one produces
+`RED_PROOF_OK` for both — even when the other's test is accidental-green. The defect the gate exists
+to catch, occurring across files instead of within one.
+
+This is not a consequence of INFRA-071's widening. Aggregation was there from the first version: a
+`packages/x/src` range changing five source files and five tests had the identical hole. The widening
+made subjects coarser (`.claude/hooks` and `scripts/harness` are whole directories, not packages), so
+it made the hole easier to hit and easier to see. It did not create it.
+
+## Measured
+
+Replaying `2ac10f251..b1f46acf3` through the widened gate returns `red-proof-ok` for `.claude/hooks`.
+Three hooks were reversed together; exactly one test failed
+(`post-tool-format > … outside the formatted set`). The other two hooks' cases passed reversed and
+the verdict said nothing about them.
+
+## Root
+
+The gate judges an **aggregate** and reports a **scalar**. Any pass hides inside any fail. Every
+granularity complaint against this gate is the same statement at a different level:
+
+- **This item** — subject-level vs source-file-level, for the code under test.
+- **[INFRA-072](INFRA-072-a-test-that-does-not-reach-what-it-names.md)** — file-level vs case-level,
+  for the tests doing the proving.
+
+They should be decided together, because a fix that splits one and not the other leaves the same
+shape one level down.
+
+## Direction
+
+Reverse and judge **per source file**: for each changed source, reverse only it, run the tests that
+exercise it, classify, and let the worst verdict carry — reporting each source's verdict rather than
+one for the set. The cost is one vitest run per changed source instead of one per pair, which is why
+it is a design decision and not a patch.
+
+## Containment in force
+
+`check-regression-red-proof.mjs` carries a comment at the aggregation point naming this item. The
+gate is ADVISORY (`REGRESSION_RED_PROOF_ENFORCE` is unset), so the aggregation cannot currently
+approve anything on its own — that is what makes containment acceptable rather than a hold on a
+required check. **This item must be resolved before the gate is promoted to enforcing** (INFRA-046),
+because at that point an aggregate verdict starts deciding merges.
+
+## Done when
+
+- Each changed source in a range receives its own verdict, and the log shows them separately.
+- A range where one source is red-proved and another is accidental-green reports `ACCIDENTAL_GREEN`,
+  proven by replaying `2ac10f251..b1f46acf3`.
+- Decided jointly with INFRA-072, or with a written reason for deciding them apart.

--- a/.agents/backlog/INFRA-074-the-spawn-relation-is-not-tied-to-its-argument.md
+++ b/.agents/backlog/INFRA-074-the-spawn-relation-is-not-tied-to-its-argument.md
@@ -1,0 +1,59 @@
+---
+title: 'INFRA-074: the spawn relation names a hook and spawns a shell, without tying one to the other'
+status: todo
+priority: high
+urgency: soon
+type: INFRA
+area: scripts/harness
+created: 2026-07-31
+depends_on: []
+issue: https://github.com/woojubb/robota/issues/1540
+---
+
+# INFRA-074 — a grep-level relation that now decides a verdict
+
+## Problem
+
+`testExecutesHook` answers "does this test execute this hook?" with two independent checks: the
+hook's basename appears in the comment-stripped text, AND the file spawns `bash` somewhere. Nothing
+ties the spawn to the name.
+
+So a test that names hook A in real code — a string it reads, a path it asserts on — while spawning
+`bash` for hook B is counted as executing A.
+
+## Why it matters more than it did
+
+The relation was written for `hooks-have-execution-coverage`, an advisory floor whose worst outcome
+was a message about a hook nobody runs. Its own docstring called it "structural rather than exact …
+a grep-level floor by design", and that was a fair trade for what it decided.
+
+INFRA-071 gave it a second job: for a `.claude/hooks` subject it now picks `decidingTests` — the
+tests whose pass/fail sets `RED_PROOF_OK` or `ACCIDENTAL_GREEN`. A misclassified bystander can now
+supply a verdict about a hook it never ran. The imprecision did not change; the consequence did.
+
+## Why a narrower match is not the fix
+
+Already tried and rejected on evidence: requiring the name inside a `path.join(...)` missed every
+test that passes the basename to a helper which joins it (`run('some-hook.sh', …)`) — those tests
+run the hook just as truly. Any pattern strict enough to tie name to spawn by text alone will keep
+rediscovering that, because the binding is a value flowing through a call, not a lexical adjacency.
+
+Doing it properly means reading the call graph: which argument reaches which spawn. That is a
+different kind of analysis from what this file does today, which is why it is a decision rather than
+a patch.
+
+## Containment in force
+
+The relation's docstring names this item and states the changed consequence. The gate is ADVISORY
+(`REGRESSION_RED_PROOF_ENFORCE` unset), so a misclassification approves nothing today.
+
+**Must be resolved before the gate is promoted to enforcing (INFRA-046)** — the same gate as
+[INFRA-073](INFRA-073-one-verdict-for-an-aggregate.md), and for the same reason: at that point these
+verdicts start deciding merges.
+
+## Done when
+
+- The relation ties a hook's name to the spawn that receives it, or states in the verdict that it
+  could not and returns INCONCLUSIVE instead of guessing.
+- A test naming one hook while spawning another is not counted as executing the first, proven by a
+  case that fails on today's implementation.

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -42,6 +42,10 @@ describe('HARNESS-041 file classification', () => {
     expect(pkgOf('scripts/harness/__tests__/x.test.mjs')).toBe('scripts/harness');
     expect(pkgOf('.claude/hooks/branch-guard.sh')).toBe('.claude/hooks');
     expect(pkgOf('.claude/hooks/lib/command-scan.sh')).toBe('.claude/hooks');
+    // Documentation is not source. Under the old `packages/*/src` scope this could not arise;
+    // scoping a whole directory means a docs-and-test range would otherwise manufacture a pair
+    // whose only possible verdict is noise — reversing prose proves nothing.
+    expect(pkgOf('scripts/harness/README.md')).toBeNull();
     // Not every file under `.claude/` is a guard; only the shell hooks are red-provable this way.
     expect(pkgOf('.claude/settings.json')).toBeNull();
   });

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -398,6 +398,41 @@ describe('HARNESS-041 orchestrator fixtures', () => {
     expect(verdict).toBe(VERDICT.ACCIDENTAL_GREEN);
   });
 
+  it('hook pair: an unrelated harness test cannot supply the failure', async () => {
+    // Adoption pulls every changed harness test into the hook subject as a CANDIDATE. If all of
+    // them were then run and judged, a sibling test that happens to be failing for its own reasons
+    // would supply the red proof, and a hook whose test is vacuous would be waved through as
+    // `red-proof-ok` — this gate's own failure mode, reintroduced by the widening that was supposed
+    // to close it. Only the tests that actually execute the reversed hook may decide.
+    const spawner = 'scripts/harness/__tests__/runs-the-hook.test.mjs';
+    const bystander = 'scripts/harness/__tests__/unrelated.test.mjs';
+    const sources = {
+      [abs(spawner)]: `spawnSync('bash', [path.join(HOOKS_DIR, 'some-hook.sh')]);`,
+      [abs(bystander)]: `expect(somethingElse).toBe(1);`,
+    };
+    let ran = null;
+
+    const { verdict } = await runRegressionRedProof(
+      baseIo({
+        changedFiles: ['.claude/hooks/some-hook.sh', spawner, bystander],
+        readText: (p) => sources[p] ?? '',
+        fileExists: () => true,
+        runVitest: (_pkg, testFiles) => {
+          ran = testFiles;
+          return {
+            testResults: [
+              { name: abs(spawner), assertionResults: [{ status: 'passed' }] },
+              { name: abs(bystander), assertionResults: [{ status: 'failed' }] },
+            ],
+          };
+        },
+      }),
+    );
+
+    expect(ran, 'a test that does not run the hook was handed the verdict').toEqual([spawner]);
+    expect(verdict).toBe(VERDICT.ACCIDENTAL_GREEN);
+  });
+
   it('hook pair: a test that only NAMES the hook never mutates the tree', async () => {
     // The other half. Reversing a hook a test does not run would blame it for a failure it had no
     // part in, so the guard has to hold — and it has to hold without touching the working tree.

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -385,7 +385,7 @@ describe('HARNESS-041 orchestrator fixtures', () => {
     const hook = '.claude/hooks/some-hook.sh';
     return baseIo({
       changedFiles: [hook, testFile],
-      readText: () => `spawnSync('bash', [path.join(HOOKS_DIR, 'some-hook.sh')]);`,
+      readText: () => "spawnSync('bash', ['/repo/.claude/hooks/some-hook.sh']);",
       fileExists: () => true,
       ...overrides,
     });
@@ -418,7 +418,7 @@ describe('HARNESS-041 orchestrator fixtures', () => {
     const spawner = 'scripts/harness/__tests__/runs-the-hook.test.mjs';
     const bystander = 'scripts/harness/__tests__/unrelated.test.mjs';
     const sources = {
-      [abs(spawner)]: `spawnSync('bash', [path.join(HOOKS_DIR, 'some-hook.sh')]);`,
+      [abs(spawner)]: "spawnSync('bash', ['/repo/.claude/hooks/some-hook.sh']);",
       [abs(bystander)]: `expect(somethingElse).toBe(1);`,
     };
     let ran = null;

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -7,6 +7,7 @@ import {
   classifyChanges,
   classifyVitestOutcome,
   decidePairVerdict,
+  defaultReverseApply,
   isDefectFixRange,
   isSourceFile,
   isTestFile,
@@ -17,19 +18,71 @@ import {
   relativeSpecifiers,
   resolveRelativeImport,
   runRegressionRedProof,
+  testExecutesHook,
 } from '../check-regression-red-proof.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const abs = (rel) => path.resolve(WORKSPACE_ROOT, rel);
 
 describe('HARNESS-041 file classification', () => {
-  it('pkgOf extracts the package/app root for src files only', () => {
+  it('pkgOf extracts the package/app root for src files', () => {
     expect(pkgOf('packages/agent-transport-tui/src/CjkTextInput.tsx')).toBe(
       'packages/agent-transport-tui',
     );
     expect(pkgOf('apps/agent-app/src/main.ts')).toBe('apps/agent-app');
     expect(pkgOf('packages/foo/docs/SPEC.md')).toBeNull();
-    expect(pkgOf('scripts/harness/x.mjs')).toBeNull();
+  });
+
+  it('pkgOf also covers the harness and the hooks (INFRA-071)', () => {
+    // This assertion used to read `scripts/harness/x.mjs` → null, which pinned the defect as a
+    // contract: the gate could not see the layer holding every scan, every floor and every guard.
+    // Measured over PRs #1525-#1530 — twelve CI runs, zero verdicts — while human review caught
+    // four accidental-green tests in that same window, all under `scripts/harness/__tests__/`.
+    expect(pkgOf('scripts/harness/x.mjs')).toBe('scripts/harness');
+    expect(pkgOf('scripts/harness/__tests__/x.test.mjs')).toBe('scripts/harness');
+    expect(pkgOf('.claude/hooks/branch-guard.sh')).toBe('.claude/hooks');
+    expect(pkgOf('.claude/hooks/lib/command-scan.sh')).toBe('.claude/hooks');
+    // Not every file under `.claude/` is a guard; only the shell hooks are red-provable this way.
+    expect(pkgOf('.claude/settings.json')).toBeNull();
+  });
+
+  it('pairs a changed hook with the harness test that runs it', () => {
+    // A hook's tests live in the harness suite, not beside it, so grouping strictly by path put
+    // them in different subjects and they could never pair. Adoption is what makes the pair exist.
+    const byPkg = classifyChanges([
+      '.claude/hooks/branch-guard.sh',
+      'scripts/harness/__tests__/branch-base-at-creation.test.mjs',
+    ]);
+    const hooks = byPkg.get('.claude/hooks');
+
+    expect(hooks.source).toContain('.claude/hooks/branch-guard.sh');
+    expect(hooks.test, 'the hook found no test to red-prove it against').toContain(
+      'scripts/harness/__tests__/branch-base-at-creation.test.mjs',
+    );
+  });
+
+  it('adopts nothing when no hook changed', () => {
+    // The adoption must not invent a subject: a harness-only change stays a harness change.
+    const byPkg = classifyChanges([
+      'scripts/harness/x.mjs',
+      'scripts/harness/__tests__/x.test.mjs',
+    ]);
+
+    expect(byPkg.has('.claude/hooks')).toBe(false);
+    expect(byPkg.get('scripts/harness').source).toEqual(['scripts/harness/x.mjs']);
+  });
+
+  it('testExecutesHook counts a spawn, not a mention', () => {
+    // The relation that stands in for the import graph when the source is a shell script. A hook
+    // named in a COMMENT is described, not run — the distinction this gate exists to make, and one
+    // an earlier version of this same rule got wrong in the coverage floor beside it.
+    const spawns = "run('branch-guard.sh');\nspawnSync('bash', [hook]);";
+    const mentions = "// branch-guard.sh is discussed here\nspawnSync('bash', [other]);";
+    const noSpawn = "const p = 'branch-guard.sh';";
+
+    expect(testExecutesHook(spawns, '.claude/hooks/branch-guard.sh')).toBe(true);
+    expect(testExecutesHook(mentions, '.claude/hooks/branch-guard.sh')).toBe(false);
+    expect(testExecutesHook(noSpawn, '.claude/hooks/branch-guard.sh')).toBe(false);
   });
 
   it('isTestFile / isSourceFile split correctly', () => {
@@ -305,6 +358,80 @@ describe('HARNESS-041 orchestrator fixtures', () => {
       baseIo({ changedFiles: ['packages/x/src/target.ts'] }), // source only
     );
     expect(verdict).toBe(VERDICT.SKIPPED_NO_PAIR);
+  });
+
+  // ── The hook subject, end to end through the orchestrator (INFRA-071) ────────────────────────
+  //
+  // A hook is never in a module graph, so before this the C3 check answered "not imported" for
+  // every hook pair and the gate returned INCONCLUSIVE — a SKIP wearing another name. These two
+  // fixtures pin both halves of the relation that replaces it.
+  function hookIo(overrides = {}) {
+    const testFile = 'scripts/harness/__tests__/some-hook.test.mjs';
+    const hook = '.claude/hooks/some-hook.sh';
+    return baseIo({
+      changedFiles: [hook, testFile],
+      readText: () => `spawnSync('bash', [path.join(HOOKS_DIR, 'some-hook.sh')]);`,
+      fileExists: () => true,
+      ...overrides,
+    });
+  }
+
+  it('hook pair: the test spawns it and still passes reversed → ACCIDENTAL_GREEN', async () => {
+    const { verdict, decisions } = await runRegressionRedProof(
+      hookIo({
+        runVitest: () => ({
+          testResults: [
+            {
+              name: abs('scripts/harness/__tests__/some-hook.test.mjs'),
+              assertionResults: [{ status: 'passed' }],
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(decisions[0].pkg).toBe('.claude/hooks');
+    expect(verdict).toBe(VERDICT.ACCIDENTAL_GREEN);
+  });
+
+  it('hook pair: a test that only NAMES the hook never mutates the tree', async () => {
+    // The other half. Reversing a hook a test does not run would blame it for a failure it had no
+    // part in, so the guard has to hold — and it has to hold without touching the working tree.
+    let mutated = false;
+    const { verdict, decisions } = await runRegressionRedProof(
+      hookIo({
+        readText: () => `// some-hook.sh is described here, and run nowhere\nexpect(1).toBe(1);`,
+        reverseApply: () => {
+          mutated = true;
+        },
+      }),
+    );
+
+    expect(verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(decisions[0].importsReversedFile).toBe(false);
+    expect(mutated).toBe(false);
+  });
+
+  it('hands git a byte-exact patch, final newline included', () => {
+    // The defect that made every verdict impossible. The diff was read through the trimming helper,
+    // so the patch reached `git apply -R` without its final newline and git rejected it as corrupt —
+    // "patch broke at line 60". The gate never got past this line, which is why twelve CI runs
+    // produced zero verdicts and nobody could tell a clean examination from no examination at all.
+    const diff = 'diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n';
+    let received = null;
+    defaultReverseApply(
+      'BASE',
+      ['x'],
+      () => diff,
+      (_cmd, _args, opts) => {
+        received = opts.input;
+      },
+    );
+
+    expect(received, 'the patch was altered on its way to git').toBe(diff);
+    expect(received.endsWith('\n'), 'the final newline was stripped — git calls that corrupt').toBe(
+      true,
+    );
   });
 
   it('restores the tree even when vitest throws', async () => {

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -87,6 +87,17 @@ describe('HARNESS-041 file classification', () => {
     expect(testExecutesHook(spawns, '.claude/hooks/branch-guard.sh')).toBe(true);
     expect(testExecutesHook(mentions, '.claude/hooks/branch-guard.sh')).toBe(false);
     expect(testExecutesHook(noSpawn, '.claude/hooks/branch-guard.sh')).toBe(false);
+
+    // Both halves must read the same text. Stripping comments for the NAME while matching the
+    // spawn against the raw source lets a documented example — the hook named in real code, the
+    // spawn shown in a comment — count as execution. Since this now picks which tests may set the
+    // verdict, that bystander could decide a hook it never runs.
+    const documented = [
+      "const hook = 'branch-guard.sh';",
+      "// e.g. spawnSync('bash', [hook])",
+      'expect(hook).toBeTruthy();',
+    ].join('\n');
+    expect(testExecutesHook(documented, '.claude/hooks/branch-guard.sh')).toBe(false);
   });
 
   it('isTestFile / isSourceFile split correctly', () => {

--- a/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
+++ b/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
@@ -3,6 +3,8 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { testExecutesHook } from '../check-regression-red-proof.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
 const TESTS_DIR = import.meta.dirname;
@@ -36,27 +38,21 @@ const TEST_SOURCES = readdirSync(TESTS_DIR)
   .map((name) => ({ name, text: readFileSync(path.join(TESTS_DIR, name), 'utf8') }));
 
 /**
- * Does `source` execute `hook`?
+ * Does `source` execute `hook`? The rule is owned by `testExecutesHook`, not restated here.
  *
- * The distinction that matters is between a hook NAMED IN PROSE and one named as a value. Matching
- * the name anywhere in the text counted a comment as coverage — the described-but-not-reached
- * failure this floor exists to close, reproduced inside the floor. So comments are stripped first,
- * and the name must survive that, in a file that spawns a shell.
+ * It lived in this file first, and the red-proof gate needed the same relation once it learned to
+ * see hooks (INFRA-071) — a shell script is never in a module graph, so "the test SPAWNS it" is
+ * what stands in for the import graph there. Two copies of a rule this exact is two things that
+ * drift, and the drift would be silent in both directions: this floor and that gate would disagree
+ * about whether a hook is covered while both stayed green.
  *
- * Requiring the name inside a `path.join(...)` was tried and was too narrow: a test that passes the
- * name to a helper which joins it — `run('some-hook.sh', …)` — is running it just as truly.
- *
- * Still structural rather than exact: a file that spawns one hook and names another in a string it
- * never uses would pass. Tying a spawn to its argument needs the call graph, and this is a
- * grep-level floor by design — stated rather than implied.
+ * What the shared rule claims, and does not: a hook NAMED IN PROSE is described, not run, so
+ * comments are stripped before the name is looked for. It stays structural rather than exact — a
+ * file that spawns one hook and names another in a string it never uses would pass. Tying a spawn
+ * to its argument needs the call graph, and this is a grep-level floor by design.
  */
-function withoutComments(text) {
-  return text.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
-}
-
 function executesHook(source, hook) {
-  if (!withoutComments(source.text).includes(hook)) return false;
-  return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(source.text);
+  return testExecutesHook(source.text, hook);
 }
 
 describe('every hook is executed by a test, not merely described by one', () => {

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -403,6 +403,16 @@ export async function runRegressionRedProof(io = {}) {
       importsReversedFile = srcAbs.some((s) => graph.has(s));
     }
 
+    // CONTAINMENT — INFRA-073. Every source in the pair is reversed together and judged by one
+    // outcome, and `assertion-fail` (any deciding test failing) reads as RED_PROOF_OK. So a range
+    // touching two sources reports the proof of one as the proof of both, and an accidental-green
+    // sibling passes unseen. That aggregation predates the INFRA-071 widening — a `packages/x/src`
+    // range with five sources had the same hole — so it is not repaired here: the fix is to reverse
+    // and judge PER SOURCE, which changes what the gate judges and costs one vitest run per source.
+    //
+    // Held rather than patched because the gate is advisory (`REGRESSION_RED_PROOF_ENFORCE` unset),
+    // so an aggregate verdict approves nothing today. INFRA-073 must be resolved BEFORE the gate is
+    // promoted to enforcing (INFRA-046), when it would start deciding merges.
     let outcome = null;
     if (importsReversedFile) {
       reverseApply(pair.source);

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -109,7 +109,10 @@ export function testExecutesHook(testText, hookPath) {
     .replace(/\/\*[\s\S]*?\*\//g, ' ')
     .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
   if (!withoutComments.includes(base)) return false;
-  return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(testText);
+  // The SAME text for both halves. Matching the spawn against the raw source let a documented
+  // example — the hook named in real code, the spawn shown in a comment — count as execution, which
+  // is the described-but-not-reached shape this function exists to reject, inside the function.
+  return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(withoutComments);
 }
 
 /** Packages that changed BOTH source and test — the only ones this v1 can red-prove. */

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -35,10 +35,25 @@ export const VERDICT = Object.freeze({
 
 // ── Pure: file classification ─────────────────────────────────────────────────────────────────────
 
-/** Package/app root key for a repo-relative path, or null if not under a package/app `src`. */
+/** The subject whose tests live in the harness suite rather than beside it. */
+export const HOOK_SUBJECT = '.claude/hooks';
+/** The harness itself — scans, floors and their tests. */
+export const HARNESS_SUBJECT = 'scripts/harness';
+
+/**
+ * The subject a repo-relative path belongs to, or null when nothing red-proves it.
+ *
+ * It matched `packages|apps/*​/src/` and nothing else, which made the gate blind to every guard in
+ * the repository. Measured over PRs #1525–#1530: twelve CI runs, zero verdicts, nine of them
+ * `no same-package pair` — while human review caught four accidental-green tests in that same
+ * window, all of them under `scripts/harness/__tests__/` (INFRA-071).
+ */
 export function pkgOf(filePath) {
   const m = filePath.match(/^((?:packages|apps)\/[^/]+)\/src\//);
-  return m ? m[1] : null;
+  if (m) return m[1];
+  if (filePath.startsWith(`${HARNESS_SUBJECT}/`)) return HARNESS_SUBJECT;
+  if (/^\.claude\/hooks\/.*\.sh$/.test(filePath)) return HOOK_SUBJECT;
+  return null;
 }
 
 export function isTestFile(filePath) {
@@ -63,7 +78,34 @@ export function classifyChanges(changedFiles) {
     if (isTestFile(f)) byPkg.get(pkg).test.push(f);
     else byPkg.get(pkg).source.push(f);
   }
+
+  // A hook's tests do not live beside it — they live in the harness suite, because that is where a
+  // test that SPAWNS a shell script belongs. Grouping strictly by path therefore put a changed hook
+  // and the test that runs it in different subjects, and they could never form a pair. The harness
+  // tests are adopted as candidates here; whether any of them actually exercises the changed hook is
+  // the relation check's job, and an unrelated one yields INCONCLUSIVE rather than a false verdict.
+  const hooks = byPkg.get(HOOK_SUBJECT);
+  const harness = byPkg.get(HARNESS_SUBJECT);
+  if (hooks?.source.length && harness?.test.length) {
+    hooks.test = [...new Set([...hooks.test, ...harness.test])];
+  }
   return byPkg;
+}
+
+/**
+ * Does this test EXECUTE this hook? The relation that stands in for the import graph when the
+ * changed source is a shell script, which is never in one.
+ *
+ * Comments are stripped first: a hook named only in prose is described, not run — the
+ * described-but-not-reached distinction this gate exists to make.
+ */
+export function testExecutesHook(testText, hookPath) {
+  const base = hookPath.split('/').pop();
+  const withoutComments = String(testText ?? '')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+  if (!withoutComments.includes(base)) return false;
+  return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(testText);
 }
 
 /** Packages that changed BOTH source and test — the only ones this v1 can red-prove. */
@@ -224,7 +266,28 @@ export function reachableRelativeGraph(
 // ── Impure orchestrator ─────────────────────────────────────────────────────────────────────────────
 
 function git(args, opts = {}) {
-  return execFileSync('git', args, { cwd: WORKSPACE_ROOT, encoding: 'utf8', ...opts }).trim();
+  return gitRaw(args, opts).trim();
+}
+
+/** Byte-exact git output. Anything fed back to git (a patch) must come through here, not `git`. */
+function gitRaw(args, opts = {}) {
+  return execFileSync('git', args, { cwd: WORKSPACE_ROOT, encoding: 'utf8', ...opts });
+}
+
+/**
+ * Reverse the range's changes to `srcPaths` — the mutation the whole gate is built around.
+ *
+ * The patch must be BYTE-EXACT. `git()` trims, and a patch missing its final newline is one
+ * `git apply` rejects as corrupt — so every reverse-apply threw, and the gate reported nothing but
+ * SKIPs and orchestration errors for its entire life (twelve CI runs, zero verdicts). Nothing
+ * caught it because reaching this line requires a qualifying pair, and until INFRA-071 widened
+ * `pkgOf` the subjects that produce pairs were nearly never touched by a `fix:` range.
+ *
+ * The seams are injected so the byte-exactness is assertable without a repository to mutate.
+ */
+export function defaultReverseApply(base, srcPaths, readDiff = gitRaw, exec = execFileSync) {
+  const patch = readDiff(['diff', `${base}..HEAD`, '--', ...srcPaths]);
+  exec('git', ['apply', '-R'], { cwd: WORKSPACE_ROOT, input: patch });
 }
 
 function mergeBase(ref = 'origin/develop') {
@@ -279,12 +342,7 @@ export async function runRegressionRedProof(io = {}) {
   const fileExists = io.fileExists ?? existsSync;
   const isDirty =
     io.isDirty ?? ((paths) => git(['status', '--porcelain', '--', ...paths]).length > 0);
-  const reverseApply =
-    io.reverseApply ??
-    ((srcPaths) => {
-      const patch = git(['diff', `${base}..HEAD`, '--', ...srcPaths]);
-      execFileSync('git', ['apply', '-R'], { cwd: WORKSPACE_ROOT, input: patch });
-    });
+  const reverseApply = io.reverseApply ?? ((srcPaths) => defaultReverseApply(base, srcPaths));
   const restore = io.restore ?? ((srcPaths) => git(['checkout', '--', ...srcPaths]));
   const runVitest = io.runVitest ?? defaultRunVitest;
 
@@ -306,12 +364,30 @@ export async function runRegressionRedProof(io = {}) {
       continue;
     }
 
-    // C3 — is any reversed source file in the changed test's relative-import graph?
-    const pkgAbsRoot = path.resolve(WORKSPACE_ROOT, pair.pkg);
+    // C3 — is the reversed source actually what the changed test exercises?
+    //
+    // Two relations, because two kinds of source. A module is reached through the test's import
+    // graph. A shell script never appears in one, so for a hook the relation is that the test
+    // SPAWNS it — which is the same question asked of the thing it can be asked of. Using the
+    // import graph for both would return INCONCLUSIVE for every hook, a SKIP by another name.
     const testAbs = pair.test.map((t) => path.resolve(WORKSPACE_ROOT, t));
-    const graph = reachableRelativeGraph(testAbs, pkgAbsRoot, readText, fileExists);
-    const srcAbs = pair.source.map((s) => path.resolve(WORKSPACE_ROOT, s));
-    const importsReversedFile = srcAbs.some((s) => graph.has(s));
+    let importsReversedFile;
+    if (pair.pkg === HOOK_SUBJECT) {
+      importsReversedFile = testAbs.some((t) => {
+        let text;
+        try {
+          text = readText(t);
+        } catch {
+          return false; // unreadable — cannot claim it exercises anything
+        }
+        return pair.source.some((src) => testExecutesHook(text, src));
+      });
+    } else {
+      const pkgAbsRoot = path.resolve(WORKSPACE_ROOT, pair.pkg);
+      const graph = reachableRelativeGraph(testAbs, pkgAbsRoot, readText, fileExists);
+      const srcAbs = pair.source.map((s) => path.resolve(WORKSPACE_ROOT, s));
+      importsReversedFile = srcAbs.some((s) => graph.has(s));
+    }
 
     let outcome = null;
     if (importsReversedFile) {
@@ -335,13 +411,27 @@ export async function runRegressionRedProof(io = {}) {
 }
 
 function defaultRunVitest(pkg, testFiles) {
-  const rel = testFiles.map((f) => path.relative(path.join(WORKSPACE_ROOT, pkg), f));
+  // `--filter ./<pkg>` only resolves for a workspace package. The harness and the hooks are neither,
+  // and their tests run from the repository root, so the invocation follows the subject rather than
+  // assuming every subject is a package.
+  const isWorkspacePackage = /^(?:packages|apps)\//.test(pkg);
+  const args = isWorkspacePackage
+    ? [
+        '--filter',
+        `./${pkg}`,
+        'exec',
+        'vitest',
+        'run',
+        '--reporter=json',
+        ...testFiles.map((f) => path.relative(path.join(WORKSPACE_ROOT, pkg), f)),
+      ]
+    : ['exec', 'vitest', 'run', '--reporter=json', ...testFiles];
   try {
-    const out = execFileSync(
-      'pnpm',
-      ['--filter', `./${pkg}`, 'exec', 'vitest', 'run', '--reporter=json', ...rel],
-      { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
-    );
+    const out = execFileSync('pnpm', args, {
+      cwd: WORKSPACE_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     return JSON.parse(extractJson(out));
   } catch (err) {
     // vitest exits non-zero on failure; its JSON is still on stdout.

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -376,16 +376,23 @@ export async function runRegressionRedProof(io = {}) {
     // import graph for both would return INCONCLUSIVE for every hook, a SKIP by another name.
     const testAbs = pair.test.map((t) => path.resolve(WORKSPACE_ROOT, t));
     let importsReversedFile;
+    // Which tests may decide the verdict. For a hook subject this is NOT every changed test:
+    // adoption pulls in the whole changed harness suite as candidates, and if all of them were run
+    // and judged, a sibling failing for its own reasons would supply the red proof while the hook's
+    // own vacuous test passed — this gate's failure mode, reintroduced by the widening meant to
+    // close it. Only the tests that execute the reversed hook are run, and only they are judged.
+    let decidingTests = pair.test;
     if (pair.pkg === HOOK_SUBJECT) {
-      importsReversedFile = testAbs.some((t) => {
+      decidingTests = pair.test.filter((t, i) => {
         let text;
         try {
-          text = readText(t);
+          text = readText(testAbs[i]);
         } catch {
           return false; // unreadable — cannot claim it exercises anything
         }
         return pair.source.some((src) => testExecutesHook(text, src));
       });
+      importsReversedFile = decidingTests.length > 0;
     } else {
       const pkgAbsRoot = path.resolve(WORKSPACE_ROOT, pair.pkg);
       const graph = reachableRelativeGraph(testAbs, pkgAbsRoot, readText, fileExists);
@@ -397,7 +404,7 @@ export async function runRegressionRedProof(io = {}) {
     if (importsReversedFile) {
       reverseApply(pair.source);
       try {
-        outcome = classifyVitestOutcome(await runVitest(pair.pkg, pair.test), pair.test);
+        outcome = classifyVitestOutcome(await runVitest(pair.pkg, decidingTests), decidingTests);
       } finally {
         restore(pair.source);
       }

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -102,6 +102,15 @@ export function classifyChanges(changedFiles) {
  *
  * Comments are stripped first: a hook named only in prose is described, not run — the
  * described-but-not-reached distinction this gate exists to make.
+ *
+ * CONTAINMENT — INFRA-074. The two halves are independent: the name must appear, and the file must
+ * spawn a shell, but nothing ties the spawn to the name. A test naming hook A in real code while
+ * spawning hook B counts as executing A. That imprecision was a fair trade when this only decided an
+ * advisory coverage message; it now picks `decidingTests`, so a bystander can supply a verdict about
+ * a hook it never ran. Tying them needs the call graph — the binding is a value flowing through a
+ * call, not a lexical adjacency, and the narrower text patterns were already tried and were too
+ * narrow (a helper that joins the basename runs the hook just as truly). Held rather than patched
+ * because the gate is advisory; must be resolved before it is promoted to enforcing (INFRA-046).
  */
 export function testExecutesHook(testText, hookPath) {
   const base = hookPath.split('/').pop();

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -51,7 +51,11 @@ export const HARNESS_SUBJECT = 'scripts/harness';
 export function pkgOf(filePath) {
   const m = filePath.match(/^((?:packages|apps)\/[^/]+)\/src\//);
   if (m) return m[1];
-  if (filePath.startsWith(`${HARNESS_SUBJECT}/`)) return HARNESS_SUBJECT;
+  // Documentation is not source: reversing a `.md` and re-running a test proves nothing, and a
+  // docs-and-test range would otherwise manufacture a pair whose only possible verdict is noise.
+  // Under a `packages/*/src` scope this could not arise; under a whole directory it can.
+  if (filePath.startsWith(`${HARNESS_SUBJECT}/`))
+    return /\.mdx?$/.test(filePath) ? null : HARNESS_SUBJECT;
   if (/^\.claude\/hooks\/.*\.sh$/.test(filePath)) return HOOK_SUBJECT;
   return null;
 }


### PR DESCRIPTION
## What

`check-regression-red-proof` (HARNESS-041) catches a regression test that passes on the unfixed code. It decided what to examine with one expression matching `packages/*/src` and `apps/*/src`, so **`.claude/hooks/**` — every guard in the repository — and `scripts/harness/**` — every scan and every floor — were invisible to it.**

Measured over PRs #1525–#1530: twelve CI runs, **zero verdicts**. In that same window human review caught four accidental-green tests, all of them in that blind spot. The mechanical floor for exactly this defect was blind to every one.

## Why widening `pkgOf` alone would have changed nothing

- A `.sh` hook and the harness test that runs it live in different directories, so they never pair. The hook subject now **adopts** the changed harness tests as candidates.
- A shell script is never in a module graph, so the C3 import-graph check would answer "not imported" for every hook and return INCONCLUSIVE — a SKIP by another name. For that subject the relation becomes **"this test SPAWNS this hook"** (`testExecutesHook`, comments stripped: a hook named in prose is described, not run).

## The defect underneath

Reaching the mutation step is what exposed it. `reverseApply` read the diff through a helper that `.trim()`s, so the patch arrived at `git apply -R` **without its final newline** and git rejected it as corrupt — "patch broke at line 60". **Every reverse-apply had thrown since the gate was written.** The verdict count was zero because the mutation never happened, not because nothing qualified — and it was broken for `packages/*/src` just as completely.

## The acceptance bullet this retracts

INFRA-071 asked for one of the four accidental-greens to be replayed and come back `ACCIDENTAL_GREEN`. Both candidate ranges were replayed in a detached worktree:

| Range | Verdict | Case that fails when the fix is reversed |
| --- | --- | --- |
| `2ac10f251..b1f46acf3` | `red-proof-ok` | `post-tool-format > … outside the formatted set` |
| `b1f46acf3..c08e0dbd6` | `red-proof-ok` | `post-tool-format > … project directory is unset` |

**Those verdicts are correct.** Each range's changed test file does contain a case that genuinely fails on the reversed hook. The bullet was written on a false premise: reverse-apply answers *"does this test depend on the fix?"*, and all four misses failed a different question — *"does this test REACH the behavior it names?"* Three have no source to reverse at all; the fourth fails reversed for the wrong reason (the hook crashes before the branch under test), which pass/fail output cannot distinguish. Recorded with the measurement rather than quietly restated, and re-filed as **INFRA-072** with three candidate mechanisms and the reason none is chosen yet.

## Verification

- **Red-proved**: reverting the source fails all seven new cases; reintroducing the trim alone fails exactly the byte-exactness case; removing the doc exclusion fails exactly the classification case.
- 1666 harness tests green (112 files), 82 scans pass.
- Round A review before push: 2 findings (docs-as-source in the widened `pkgOf`; the spawn rule duplicated between the floor and the gate), both fixed in `d0e89820f`.

This PR is itself a `fix:` range with a `scripts/harness` source+test pair, so the widened gate should produce a live verdict on it rather than a SKIP — the first one it has ever emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso