### PR TITLE
feat(rules): a helper's limits are re-judged where the consequences change

### DIFF
--- a/.agents/rules/helper-limits.md
+++ b/.agents/rules/helper-limits.md
@@ -1,0 +1,54 @@
+# Helper Limits — re-judged at every consumer whose consequences differ
+
+Mandatory. Parent: [index.md](index.md) § Process Sub-Rules.
+
+A shared function's documented limits were judged against what its FIRST consumer did with the
+answer. That judgement is not a property of the function. It is a property of the pair.
+
+When a second consumer arrives whose consequences are heavier, **the function does not change** — so
+nothing in the diff signals anything, and review sees a reuse, which reads as good practice. The
+defect is invisible in the code and shows up only in behaviour, usually much later.
+
+Two instances, measured in one session:
+
+- `git()` trimmed its output. Right for a sha; wrong for a patch. Reused to produce the input to
+  `git apply -R`, it stripped the final newline, git called every patch corrupt, and the red-proof
+  gate's mutation step threw for its entire life — twelve CI runs, zero verdicts, no error anyone saw.
+- `testExecutesHook` was a grep-level relation for an ADVISORY coverage floor whose own docstring
+  called it "structural rather than exact". Reused to pick which tests may set a red-proof VERDICT,
+  the same imprecision can hand a verdict to a test that never ran the hook (INFRA-074).
+
+## The rule
+
+**Before reusing a helper in a context with different consequences, re-judge its stated limits at
+the new call site, and record the answer there.**
+
+Three outcomes, and only three:
+
+1. **They hold** — say why, at the call site. One line.
+2. **They do not hold** — narrow the helper, or use a different one.
+3. **They do not hold and the mismatch is being held** — a labelled containment naming a root item,
+   per [finding-depth.md](finding-depth.md). Never an unlabelled hold.
+
+The point is not the comment. It is that the question is ASKED where the consequences are known,
+which is the only place it can be answered. The author of the helper could not have answered it:
+the second consumer did not exist yet.
+
+## Where it is enforced
+
+`scan-helper-limits` (`pnpm harness:scan`). A helper declares its limits with a `@limits <statement>`
+line in the docblock attached to its export; every module importing a `@limits` function must carry
+`// LIMITS <name>: <why they hold here>` — or a containment naming a root item.
+
+Declaring is **opt-in**, deliberately: requiring every helper to be annotated would be satisfied by
+boilerplate and would say nothing. Once declared, acknowledgement is not optional.
+
+Anti-rot, the convention `allow-fake` and `allow-fallback` already use: a `@limits` with no
+statement and a `LIMITS <name>:` with no reason both FAIL. A marker that says nothing stops being
+read, and then the floor is decorative.
+
+## What this rule does not say
+
+It does not say helpers should not be reused — reuse is how a codebase stays one thing. It does not
+ask for the limits to be eliminated; an approximate relation is often exactly right for what rides
+on it. It asks only that the trade be re-made by whoever changes what rides on it.

--- a/.agents/rules/index.md
+++ b/.agents/rules/index.md
@@ -33,4 +33,5 @@ All rules are mandatory and non-negotiable. Domain-specific rules live in
 | [backlog-execution.md](backlog-execution.md)   | Backlog recommendation gates, user execution test scenario gates, initiative PRs                           |
 | [operational.md](operational.md)               | No fallback policy, idea capture, feature documentation, API boundary & lifecycle                          |
 | [finding-depth.md](finding-depth.md)         | A review finding is classified LOCAL or FOUNDATIONAL before it is fixed; a foundational one is filed, not patched |
+| [helper-limits.md](helper-limits.md)           | A helper's stated limits are re-judged at every consumer whose consequences differ           |
 | [learning-loop.md](learning-loop.md)           | Lesson capture, contract-before-automation, and mechanical enforcement preference                          |

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -21,6 +21,9 @@ import {
   testExecutesHook,
 } from '../check-regression-red-proof.mjs';
 
+// LIMITS testExecutesHook: they hold here — this file TESTS the relation, so its imprecision is
+// the subject rather than a dependency. Nothing here rides on the answer being exact.
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const abs = (rel) => path.resolve(WORKSPACE_ROOT, rel);
 

--- a/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
+++ b/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
@@ -5,6 +5,11 @@ import { describe, expect, it } from 'vitest';
 
 import { testExecutesHook } from '../check-regression-red-proof.mjs';
 
+// LIMITS testExecutesHook: they hold here. This floor's whole output is a message naming a hook
+// no test runs, so an approximate relation costs a false reassurance at worst — which is the
+// consequence class the relation was written against. The gate that reuses it to pick which tests
+// may SET a verdict is a different consumer, and holds the mismatch under INFRA-074.
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
 const TESTS_DIR = import.meta.dirname;

--- a/scripts/harness/__tests__/scan-helper-limits.test.mjs
+++ b/scripts/harness/__tests__/scan-helper-limits.test.mjs
@@ -136,8 +136,10 @@ describe('a @limits helper is acknowledged where it is consumed', () => {
     // twelve-green-runs-zero-verdicts shape, in the floor written because of it.
     const { findings, examined } = analyze({
       'scripts/harness/drifted.mjs': [
-        '/** @limits written in a shape the parser no longer recognises */',
-        'export const notAFunction = () => {};',
+        '/**',
+        ' * @limits written where nothing the parser recognises follows it.',
+        ' */',
+        'const notExported = 1;',
       ].join('\n'),
     });
 
@@ -162,6 +164,42 @@ describe('a @limits helper is acknowledged where it is consumed', () => {
     });
 
     expect(findings, 'an import of a different module was judged against these limits').toEqual([]);
+  });
+
+  it('reads a tag from every shape an export is written in', () => {
+    // One shape was recognised: a multi-line docblock followed by `export function`. A single-line
+    // docblock, an `export async function`, or an arrow assigned to an `export const` all registered
+    // as nothing — and because the drift check counted tags across the WHOLE scan, one parsing
+    // correctly elsewhere kept each specific miss invisible. Invisible in the code, visible only in
+    // behaviour: the class this tool exists to catch, inside the tool.
+    const shapes = [
+      ['/** @limits one-liner. */', 'export function a() {}'].join('\n'),
+      ['/**', ' * @limits async.', ' */', 'export async function b() {}'].join('\n'),
+      ['/**', ' * @limits arrow.', ' */', 'export const c = (x) => x;'].join('\n'),
+    ];
+
+    expect(shapes.map((t) => taggedFunctions(t).map((f) => f.name))).toEqual([['a'], ['b'], ['c']]);
+  });
+
+  it('flags a file whose tag text the parser could not read, even when others parse', () => {
+    // Per FILE, not per run. A global count is satisfied by any one tag anywhere, which is what let
+    // the shapes above go missing without a sound.
+    const { findings } = analyze({
+      'scripts/harness/ok.mjs': [
+        '/**',
+        ' * @limits parsed fine.',
+        ' */',
+        'export function parsed() {}',
+      ].join('\n'),
+      'scripts/harness/unread.mjs': [
+        '/**',
+        ' * @limits declared, but nothing the parser recognises follows it.',
+        ' */',
+        'const notExported = 1;',
+      ].join('\n'),
+    });
+
+    expect(findings.map((f) => f.file)).toContain('scripts/harness/unread.mjs');
   });
 
   it('reads imports and acknowledgements as written', () => {

--- a/scripts/harness/__tests__/scan-helper-limits.test.mjs
+++ b/scripts/harness/__tests__/scan-helper-limits.test.mjs
@@ -129,6 +129,41 @@ describe('a @limits helper is acknowledged where it is consumed', () => {
     expect(taggedFunctions(text)).toEqual([]);
   });
 
+  it('refuses when tags exist in the text but the parser matched none', () => {
+    // Fail-closed against parser drift. Declaring is opt-in, so `examined: 0` is legitimate while
+    // nobody has tagged anything — but zero matches while the tag string IS present in the subject
+    // means the reader broke, and a reader that reads nothing reports a clean sweep. That is the
+    // twelve-green-runs-zero-verdicts shape, in the floor written because of it.
+    const { findings, examined } = analyze({
+      'scripts/harness/drifted.mjs': [
+        '/** @limits written in a shape the parser no longer recognises */',
+        'export const notAFunction = () => {};',
+      ].join('\n'),
+    });
+
+    expect(examined).toBe(0);
+    expect(findings.map((f) => f.message).join(' ')).toMatch(/matched none|parser/i);
+  });
+
+  it('does not credit an acknowledgement to a same-named export from elsewhere', () => {
+    // `analyze`, `main`, `walk` are ordinary names in this directory. Resolving an owner by NAME
+    // alone means an unrelated import can demand the wrong file's limits, or an acknowledgement of
+    // an unrelated function can silently excuse the real one — the invisible-in-the-code failure
+    // this rule exists to catch, reproduced by its own enforcement.
+    const { findings } = analyze({
+      'scripts/harness/owner.mjs': [
+        '/**',
+        ' * @limits approximate.',
+        ' */',
+        'export function shared(x) { return x; }',
+      ].join('\n'),
+      'scripts/harness/other.mjs': 'export function shared(x) { return x; }',
+      'scripts/harness/consumer.mjs': "import { shared } from './other.mjs';",
+    });
+
+    expect(findings, 'an import of a different module was judged against these limits').toEqual([]);
+  });
+
   it('reads imports and acknowledgements as written', () => {
     expect(localImports("import { a, b as c } from './x.mjs';")).toEqual([
       { specifier: './x.mjs', names: ['a', 'b'] },
@@ -156,7 +191,13 @@ describe('the scan runs, and says what it examined', () => {
       { cwd: WORKSPACE_ROOT, encoding: 'utf8' },
     );
 
-    expect(`${result.stdout}${result.stderr}`).toMatch(/@limits-tagged function\(s\)/);
-    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    const out = `${result.stdout}${result.stderr}`;
+    const examined = Number(out.match(/helper-limits: (\d+) @limits-tagged/)?.[1] ?? -1);
+
+    // `toMatch(/@limits-tagged function\(s\)/)` alone matched "0 @limits-tagged function(s)" too, so
+    // the parser could stop matching anything and this case would stay green — an accidental-green
+    // regression test guarding the scan whose whole subject is defects that leave no signal.
+    expect(examined, 'the scan examined nothing and still reported success').toBeGreaterThan(0);
+    expect(result.status, out).toBe(0);
   });
 });

--- a/scripts/harness/__tests__/scan-helper-limits.test.mjs
+++ b/scripts/harness/__tests__/scan-helper-limits.test.mjs
@@ -202,6 +202,24 @@ describe('a @limits helper is acknowledged where it is consumed', () => {
     expect(findings.map((f) => f.file)).toContain('scripts/harness/unread.mjs');
   });
 
+  it('is loud, not silent, when a tag drifts away from its export', () => {
+    // Adjacency is required on purpose: tolerating a gap would let a MODULE docblock tag whatever
+    // export happens to follow it, which is a drifted tag naming limits that belong to something
+    // else. What matters is that breaking adjacency FAILS rather than passing quietly — the
+    // per-file reader check is what makes that true, and this pins it so it stays a guarantee
+    // rather than a coincidence.
+    const spaced = [
+      '/**',
+      ' * @limits separated from its export by a blank line.',
+      ' */',
+      '',
+      'export function spaced() {}',
+    ].join('\n');
+
+    expect(taggedFunctions(spaced)).toEqual([]);
+    expect(analyze({ 'scripts/harness/x.mjs': spaced }).findings).toHaveLength(1);
+  });
+
   it('reads imports and acknowledgements as written', () => {
     expect(localImports("import { a, b as c } from './x.mjs';")).toEqual([
       { specifier: './x.mjs', names: ['a', 'b'] },

--- a/scripts/harness/__tests__/scan-helper-limits.test.mjs
+++ b/scripts/harness/__tests__/scan-helper-limits.test.mjs
@@ -1,0 +1,156 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  acknowledgements,
+  analyze,
+  localImports,
+  taggedFunctions,
+} from '../scan-helper-limits.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+/**
+ * The floor for `helper-limits.md`: a helper's stated limits are re-judged at every consumer whose
+ * consequences differ.
+ *
+ * Measured, not hypothetical — two instances in one session. `git()` trimmed its output, which is
+ * right for a sha and wrong for a patch, and reused to feed `git apply -R` it broke every
+ * reverse-apply the red-proof gate ever attempted. `testExecutesHook` was a grep-level relation for
+ * an advisory floor, and reused to pick which tests may set a verdict, the same imprecision can hand
+ * a verdict to a test that never ran the hook.
+ *
+ * In both, the function did not change. Nothing in the diff signalled anything, and review saw a
+ * reuse, which reads as good practice.
+ */
+describe('a @limits helper is acknowledged where it is consumed', () => {
+  const OWNER = 'scripts/harness/owner.mjs';
+  const ownerText = [
+    '/**',
+    ' * Does the thing, roughly.',
+    ' * @limits grep-level: approximate, and only an advisory message rides on it.',
+    ' */',
+    'export function roughRelation(text) { return text.length > 0; }',
+  ].join('\n');
+
+  it('flags a consumer that imports it without asking the question', () => {
+    // The failure this exists to catch: the import is the whole diff, and it reads as reuse.
+    const { findings } = analyze({
+      [OWNER]: ownerText,
+      'scripts/harness/consumer.mjs': "import { roughRelation } from './owner.mjs';\nroughRelation('x');",
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toBe('scripts/harness/consumer.mjs');
+    expect(findings[0].message).toMatch(/roughRelation/);
+  });
+
+  it('accepts a consumer that states why they hold', () => {
+    const { findings } = analyze({
+      [OWNER]: ownerText,
+      'scripts/harness/consumer.mjs': [
+        "import { roughRelation } from './owner.mjs';",
+        '// LIMITS roughRelation: only a log line rides on this, so approximate is enough.',
+        "roughRelation('x');",
+      ].join('\n'),
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('accepts a containment when they do NOT hold', () => {
+    // The honest second answer. `finding-depth.md` allows a labelled hold; what it does not allow
+    // is the question going unasked, which is what an unannotated import is.
+    const { findings } = analyze({
+      [OWNER]: ownerText,
+      'scripts/harness/gate.mjs': [
+        "import { roughRelation } from './owner.mjs';",
+        '// LIMITS roughRelation: CONTAINMENT — INFRA-074, held until the gate becomes enforcing.',
+      ].join('\n'),
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('does not ask the declaring module to acknowledge itself', () => {
+    const { findings } = analyze({ [OWNER]: ownerText });
+
+    expect(findings).toEqual([]);
+  });
+
+  it('rejects a tag that states nothing, and an acknowledgement with no reason', () => {
+    // Anti-rot, the convention `allow-fake` and `allow-fallback` already use: a marker that says
+    // nothing is a marker that stops being read, and then the floor is decorative.
+    const { findings } = analyze({
+      'scripts/harness/empty.mjs': [
+        '/**',
+        ' * @limits',
+        ' */',
+        'export function bare() {}',
+      ].join('\n'),
+      'scripts/harness/user.mjs': [
+        "import { bare } from './empty.mjs';",
+        '// LIMITS bare:',
+      ].join('\n'),
+    });
+
+    expect(findings.map((f) => f.message).join(' ')).toMatch(/states nothing/);
+    expect(findings.map((f) => f.message).join(' ')).toMatch(/no reason/);
+  });
+
+  it('reads the tag only from the docblock attached to the export', () => {
+    // A `@limits` line floating anywhere in the file would let the tag drift away from what it
+    // describes, and a drifted tag is worse than none: it names limits that belong to something else.
+    const floating = ['// @limits this belongs to nothing', 'export function untagged() {}'].join(
+      '\n',
+    );
+
+    expect(taggedFunctions(floating)).toEqual([]);
+  });
+
+  it('does not adopt a `@limits` the file merely talks about', () => {
+    // Found by running it: a lazy block starting at the MODULE docblock ran past it and reached the
+    // first documented export, so this scan's own contract prose — which necessarily writes out
+    // `@limits` — tagged an unrelated function. A tag that drifts names limits belonging to
+    // something else, which is worse than no tag at all.
+    const text = [
+      '/**',
+      ' * This module explains the @limits convention in prose.',
+      ' */',
+      '',
+      '/**',
+      ' * Unrelated, and untagged.',
+      ' */',
+      'export function innocent() {}',
+    ].join('\n');
+
+    expect(taggedFunctions(text)).toEqual([]);
+  });
+
+  it('reads imports and acknowledgements as written', () => {
+    expect(localImports("import { a, b as c } from './x.mjs';")).toEqual([
+      { specifier: './x.mjs', names: ['a', 'b'] },
+    ]);
+    // Not a local module: a package import has no declaring file here to carry limits.
+    expect(localImports("import { z } from 'node:path';")).toEqual([]);
+    expect(acknowledgements('// LIMITS foo: because.')).toEqual([{ name: 'foo', reason: 'because.' }]);
+    expect(acknowledgements(' * LIMITS foo: inside a docblock.')).toHaveLength(1);
+  });
+});
+
+describe('the scan runs, and says what it examined', () => {
+  it('reports the tagged-function count rather than a bare pass', () => {
+    // A run that examined nothing must not read as a clean sweep. The repository has been burned by
+    // exactly that: twelve green CI runs of a gate that produced no verdict at all.
+    const result = spawnSync(
+      'node',
+      [path.join(WORKSPACE_ROOT, 'scripts/harness/scan-helper-limits.mjs')],
+      { cwd: WORKSPACE_ROOT, encoding: 'utf8' },
+    );
+
+    expect(`${result.stdout}${result.stderr}`).toMatch(/@limits-tagged function\(s\)/);
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/scan-helper-limits.test.mjs
+++ b/scripts/harness/__tests__/scan-helper-limits.test.mjs
@@ -133,6 +133,12 @@ describe('a @limits helper is acknowledged where it is consumed', () => {
     expect(localImports("import { a, b as c } from './x.mjs';")).toEqual([
       { specifier: './x.mjs', names: ['a', 'b'] },
     ]);
+    // A default beside the named ones, and a double-quoted specifier. Neither is common here —
+    // prettier settles the quotes — but a floor that MISSES a consumer fails silently, which is the
+    // "invisible in the code" shape this rule exists to catch, occurring inside its own enforcement.
+    expect(localImports('import owner, { a } from "./x.mjs";')).toEqual([
+      { specifier: './x.mjs', names: ['a'] },
+    ]);
     // Not a local module: a package import has no declaring file here to carry limits.
     expect(localImports("import { z } from 'node:path';")).toEqual([]);
     expect(acknowledgements('// LIMITS foo: because.')).toEqual([{ name: 'foo', reason: 'because.' }]);

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -111,6 +111,9 @@ export function classifyChanges(changedFiles) {
  * call, not a lexical adjacency, and the narrower text patterns were already tried and were too
  * narrow (a helper that joins the basename runs the hook just as truly). Held rather than patched
  * because the gate is advisory; must be resolved before it is promoted to enforcing (INFRA-046).
+ *
+ * @limits basename-only, and the spawn is not tied to the name (INFRA-074) — approximate enough for
+ * an advisory message, not for anything that decides on its own.
  */
 export function testExecutesHook(testText, hookPath) {
   const base = hookPath.split('/').pop();

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -228,6 +228,7 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/scan-legacy-typescript.mjs'],
   },
   { name: 'no-fake-in-src', command: ['node', 'scripts/harness/scan-no-fake-in-src.mjs'] },
+  { name: 'helper-limits', command: ['node', 'scripts/harness/scan-helper-limits.mjs'] },
   {
     // HARNESS-052 — the audited "success over work it did not do" shape wearing a test: an
     // assertion that no implementation of the code under test could fail.

--- a/scripts/harness/scan-helper-limits.mjs
+++ b/scripts/harness/scan-helper-limits.mjs
@@ -79,7 +79,10 @@ export function taggedFunctions(text) {
 /** Local module specifiers imported by `text`, with the names taken from each. */
 export function localImports(text) {
   const out = [];
-  const re = /(?:^|\n)import\s*\{([^}]*)\}\s*from\s*'(\.[^']*)'/g;
+  // A default binding may precede the braces, and the specifier may be quoted either way. Neither
+  // is common here — prettier settles the quotes — but a floor that MISSES a consumer fails
+  // silently, which is the invisible-in-the-code shape this whole rule exists to catch.
+  const re = /(?:^|\n)import\s+(?:[A-Za-z0-9_$]+\s*,\s*)?\{([^}]*)\}\s*from\s*['"](\.[^'"]*)['"]/g;
   for (const m of text.matchAll(re)) {
     const names = m[1]
       .split(',')

--- a/scripts/harness/scan-helper-limits.mjs
+++ b/scripts/harness/scan-helper-limits.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Mechanical floor for [helper-limits.md](../../.agents/rules/helper-limits.md): a helper's stated
+ * limits are re-judged at every consumer whose consequences differ.
+ *
+ * ## The class this fences
+ *
+ * A shared function's documented limits were judged against what its FIRST consumer did with the
+ * answer. When a second consumer arrives with heavier consequences, the function does not change —
+ * so nothing in the diff signals anything, and review sees a reuse, which reads as good practice.
+ * The defect is invisible in the code and appears only in behaviour. Two instances, one session:
+ *
+ * - `git()` trimmed its output, which is right for a sha and wrong for a patch. Reused to produce
+ *   the input to `git apply -R`, it stripped the final newline and git called every patch corrupt —
+ *   so the red-proof gate's mutation step threw for its entire life (twelve CI runs, zero verdicts).
+ * - `testExecutesHook` was written as a grep-level relation for an ADVISORY coverage floor, whose
+ *   own docstring called it "structural rather than exact". Reused to pick which tests may set a
+ *   red-proof VERDICT, the same imprecision can hand a verdict to a test that never ran the hook
+ *   (INFRA-074).
+ *
+ * ## The contract
+ *
+ * An exported function may declare its limits with a `@limits <statement>` line in its docblock.
+ * Doing so is opt-in — this floor does not demand that every helper be annotated, because a blanket
+ * requirement would be satisfied by boilerplate and would say nothing.
+ *
+ * What it does demand: **every module that imports a `@limits` function carries an acknowledgement**
+ * naming it —
+ *
+ *     // LIMITS testExecutesHook: only an advisory message rides on this, so approximate is enough.
+ *
+ * or, when they do NOT hold and the mismatch is being held rather than fixed, a containment naming a
+ * root item (`finding-depth.md`):
+ *
+ *     // LIMITS testExecutesHook: CONTAINMENT — INFRA-074, held until the gate becomes enforcing.
+ *
+ * The point is not the comment. It is that the question was ASKED at the site where the consequences
+ * are known, which is the only place it can be answered.
+ *
+ * ## Anti-rot
+ *
+ * A `@limits` tag with no statement, and a `LIMITS <name>:` with no reason, both FAIL — the same
+ * convention `allow-fake` and `allow-fallback` use. A marker that says nothing is a marker that
+ * stops being read.
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** Subjects scanned. Shell hooks have no import graph, so this is the JS side of the harness. */
+export const SUBJECT_DIRS = ['scripts/harness'];
+
+/** Every `@limits`-tagged exported function in `text`, as `{ name, statement }`. */
+export function taggedFunctions(text) {
+  const found = [];
+  // A docblock immediately preceding an `export function`. Deliberately positional: a `@limits` line
+  // floating anywhere in a file would let the tag drift away from what it describes.
+  // Anchored at line start, and that is not cosmetic: a fixture inside a string literal — which is
+  // what a test of this very scan is full of — otherwise reads as a real declaration. Real code
+  // declares its exports in column zero; quoted text never does.
+  // The block may not run past a `*/`: without that, a lazy match starting at the module docblock
+  // swallows everything down to the first documented export and adopts any `@limits` the file
+  // merely TALKS about — including this one's own contract prose.
+  const re = /(?:^|\n)\/\*\*\n((?:(?!\*\/)[\s\S])*?)\n \*\/\nexport function ([A-Za-z0-9_$]+)/g;
+  for (const m of text.matchAll(re)) {
+    const [, block, name] = m;
+    const tag = block.match(/@limits[ \t]*(.*)/);
+    if (!tag) continue;
+    found.push({ name, statement: tag[1].trim() });
+  }
+  return found;
+}
+
+/** Local module specifiers imported by `text`, with the names taken from each. */
+export function localImports(text) {
+  const out = [];
+  const re = /(?:^|\n)import\s*\{([^}]*)\}\s*from\s*'(\.[^']*)'/g;
+  for (const m of text.matchAll(re)) {
+    const names = m[1]
+      .split(',')
+      .map((s) => s.trim().split(/\s+as\s+/)[0].trim())
+      .filter(Boolean);
+    out.push({ specifier: m[2], names });
+  }
+  return out;
+}
+
+/** Acknowledgements present in `text`, as `{ name, reason }` — comment-scoped, like `allow-fake`. */
+export function acknowledgements(text) {
+  const out = [];
+  for (const m of text.matchAll(
+    /(?:^|\n)[ \t]*(?:\/\/|\*)[ \t]*LIMITS[ \t]+([A-Za-z0-9_$]+)[ \t]*:(.*)/g,
+  )) {
+    out.push({ name: m[1], reason: m[2].trim() });
+  }
+  return out;
+}
+
+/**
+ * The whole decision, over a `{ [repoRelativePath]: text }` map — pure, so the contract is testable
+ * without a tree to walk.
+ */
+export function analyze(files) {
+  const findings = [];
+  const tagged = new Map(); // absolute-ish module path → [{name, statement}]
+
+  for (const [file, text] of Object.entries(files)) {
+    const fns = taggedFunctions(text);
+    if (fns.length > 0) tagged.set(file, fns);
+    for (const fn of fns) {
+      if (fn.statement === '') {
+        findings.push({
+          file,
+          message: `@limits on ${fn.name} states nothing — a marker that says nothing stops being read`,
+        });
+      }
+    }
+  }
+
+  const nameToOwner = new Map();
+  for (const [file, fns] of tagged) for (const fn of fns) nameToOwner.set(fn.name, file);
+
+  for (const [file, text] of Object.entries(files)) {
+    const acked = acknowledgements(text);
+    for (const ack of acked) {
+      if (ack.reason === '') {
+        findings.push({
+          file,
+          message: `LIMITS ${ack.name} carries no reason — say why they hold here, or name the containment`,
+        });
+      }
+    }
+    const ackedNames = new Set(acked.map((a) => a.name));
+
+    for (const imp of localImports(text)) {
+      for (const name of imp.names) {
+        const owner = nameToOwner.get(name);
+        // Only the declaring module's own name counts: a same-named export elsewhere is a different
+        // function, and the file that DECLARES it needs no acknowledgement of itself.
+        if (!owner || owner === file) continue;
+        if (!ackedNames.has(name)) {
+          findings.push({
+            file,
+            message:
+              `imports ${name}, whose limits are declared in ${owner}, without acknowledging them. ` +
+              `Add \`// LIMITS ${name}: <why they hold here>\` — or, if they do not hold, a ` +
+              'containment naming a root item.',
+          });
+        }
+      }
+    }
+  }
+
+  return { findings, examined: nameToOwner.size };
+}
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (full.endsWith('.mjs')) out.push(full);
+  }
+  return out;
+}
+
+function main() {
+  const files = {};
+  for (const rel of SUBJECT_DIRS) {
+    for (const full of walk(path.join(WORKSPACE_ROOT, rel))) {
+      files[path.relative(WORKSPACE_ROOT, full)] = readFileSync(full, 'utf8');
+    }
+  }
+
+  const { findings, examined } = analyze(files);
+
+  // Measured, never silent: a run that examined nothing is reported as such rather than reading as
+  // a clean sweep — the distinction between "examined and clean" and "examined nothing".
+  console.log(
+    `helper-limits: ${examined} @limits-tagged function(s) across ${Object.keys(files).length} file(s).`,
+  );
+  if (findings.length === 0) {
+    process.exit(0);
+  }
+  for (const f of findings) console.error(`✗ ${f.file}: ${f.message}`);
+  console.error(
+    `\nhelper-limits: ${findings.length} finding(s). A helper's limits were judged against its ` +
+      "first consumer's consequences; a consumer with different consequences has to judge them again.",
+  );
+  process.exit(1);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/harness/scan-helper-limits.mjs
+++ b/scripts/harness/scan-helper-limits.mjs
@@ -26,7 +26,12 @@
  * requirement would be satisfied by boilerplate and would say nothing.
  *
  * What it does demand: **every module that imports a `@limits` function carries an acknowledgement**
- * naming it —
+ * naming it. The acknowledgement is MODULE-scoped, not line-scoped — unlike `allow-fake`, which sits
+ * on the flagged line. That is a deliberate granularity choice and a weaker guarantee, stated rather
+ * than implied: an acknowledgement written for one call site covers a heavier one added later in the
+ * same file. Tying it to a call site needs the call graph, which is the same boundary
+ * `testExecutesHook` runs into.
+ *
  *
  *     // LIMITS testExecutesHook: only an advisory message rides on this, so approximate is enough.
  *
@@ -55,22 +60,41 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 /** Subjects scanned. Shell hooks have no import graph, so this is the JS side of the harness. */
 export const SUBJECT_DIRS = ['scripts/harness'];
 
+/**
+ * A tag in TAG POSITION — opening the docblock, or first on a continuation line. The token written
+ * mid-sentence (as this file's own prose must write it) is a mention, not a declaration; matching it
+ * anywhere made this scanner tag its own parser, and made every fixture string in its test read as a
+ * drifted tag.
+ */
+const TAG_RE = /(?:(?:^|\n)[ \t]*\/\*\*|\n[ \t]*\*)[ \t]*@limits[ \t]*([^\n*]*)/;
+
 /** Every `@limits`-tagged exported function in `text`, as `{ name, statement }`. */
 export function taggedFunctions(text) {
   const found = [];
-  // A docblock immediately preceding an `export function`. Deliberately positional: a `@limits` line
-  // floating anywhere in a file would let the tag drift away from what it describes.
   // Anchored at line start, and that is not cosmetic: a fixture inside a string literal — which is
   // what a test of this very scan is full of — otherwise reads as a real declaration. Real code
   // declares its exports in column zero; quoted text never does.
+  //
   // The block may not run past a `*/`: without that, a lazy match starting at the module docblock
   // swallows everything down to the first documented export and adopts any `@limits` the file
   // merely TALKS about — including this one's own contract prose.
-  const re = /(?:^|\n)\/\*\*\n((?:(?!\*\/)[\s\S])*?)\n \*\/\nexport function ([A-Za-z0-9_$]+)/g;
+  //
+  // Every shape an export is written in, not one. Recognising only `/**\n…\n */\nexport function`
+  // silently missed a single-line docblock, an `export async function`, and an arrow assigned to an
+  // `export const` — invisible in the code, visible only in behaviour, which is the class this tool
+  // exists to catch.
+  const decl = String.raw`export\s+(?:async\s+)?(?:function\s+([A-Za-z0-9_$]+)|const\s+([A-Za-z0-9_$]+)\s*=)`;
+  const re = new RegExp(
+    String.raw`(?:^|\n)\/\*\*((?:(?!\*\/)[\s\S])*?)\*\/[ \t]*\n` + decl,
+    'g',
+  );
   for (const m of text.matchAll(re)) {
-    const [, block, name] = m;
-    const tag = block.match(/@limits[ \t]*(.*)/);
-    if (!tag) continue;
+    const block = m[1];
+    const name = m[2] ?? m[3];
+    // The opener is put back before testing: TAG_RE requires tag POSITION, and for a one-line
+    // docblock the position is immediately after `/**`, which the capture does not include.
+    const tag = `/**${block}`.match(TAG_RE);
+    if (!tag || !name) continue;
     found.push({ name, statement: tag[1].trim() });
   }
   return found;
@@ -93,7 +117,7 @@ export function localImports(text) {
   return out;
 }
 
-/** Acknowledgements present in `text`, as `{ name, reason }` — comment-scoped, like `allow-fake`. */
+/** Acknowledgements present in `text`, as `{ name, reason }` — module-scoped (see the header). */
 export function acknowledgements(text) {
   const out = [];
   for (const m of text.matchAll(
@@ -168,16 +192,19 @@ export function analyze(files) {
   // nobody has tagged anything — but zero matches while the tag string IS present in the subject
   // means the READER broke, and a reader that reads nothing reports a clean sweep. That is the
   // twelve-green-runs-zero-verdicts shape, in the floor written because of it.
-  if (taggedCount === 0) {
-    const withTagText = Object.keys(files).filter((f) => files[f].includes('@limits'));
-    if (withTagText.length > 0) {
-      findings.push({
-        file: withTagText[0],
-        message:
-          `the text contains @limits in ${withTagText.length} file(s) and the parser matched none — ` +
-          'the reader has drifted, and a reader that reads nothing reports a clean sweep',
-      });
-    }
+  // Per FILE, not per run. A global count is satisfied by any one tag anywhere, which is exactly
+  // what let whole export shapes go missing without a sound: one file parsing correctly kept every
+  // other file's miss invisible. Declaring is opt-in, so a file with no tag TEXT is silent; a file
+  // whose text carries the tag and from which nothing parsed means the reader drifted.
+  for (const [file, text] of Object.entries(files)) {
+    if (!TAG_RE.test(text)) continue;
+    if (taggedFunctions(text).length > 0) continue;
+    findings.push({
+      file,
+      message:
+        'the text carries @limits and the parser read none of it — the reader has drifted, and a ' +
+        'reader that reads nothing reports a clean sweep',
+    });
   }
 
   return { findings, examined: taggedCount };

--- a/scripts/harness/scan-helper-limits.mjs
+++ b/scripts/harness/scan-helper-limits.mjs
@@ -125,8 +125,13 @@ export function analyze(files) {
     }
   }
 
-  const nameToOwner = new Map();
-  for (const [file, fns] of tagged) for (const fn of fns) nameToOwner.set(fn.name, file);
+  // Keyed by MODULE and name, not by name alone. `analyze`, `main` and `walk` are ordinary names in
+  // this directory; resolving an owner by name would let an unrelated import demand the wrong file's
+  // limits, or let an acknowledgement of an unrelated function silently excuse the real one — the
+  // invisible-in-the-code failure this rule exists to catch, reproduced by its own enforcement.
+  const ownerHas = new Set();
+  for (const [file, fns] of tagged) for (const fn of fns) ownerHas.add(`${file}\u0000${fn.name}`);
+  const taggedCount = ownerHas.size;
 
   for (const [file, text] of Object.entries(files)) {
     const acked = acknowledgements(text);
@@ -141,11 +146,11 @@ export function analyze(files) {
     const ackedNames = new Set(acked.map((a) => a.name));
 
     for (const imp of localImports(text)) {
+      const owner = resolveSpecifier(file, imp.specifier);
       for (const name of imp.names) {
-        const owner = nameToOwner.get(name);
         // Only the declaring module's own name counts: a same-named export elsewhere is a different
         // function, and the file that DECLARES it needs no acknowledgement of itself.
-        if (!owner || owner === file) continue;
+        if (!owner || owner === file || !ownerHas.has(`${owner}\u0000${name}`)) continue;
         if (!ackedNames.has(name)) {
           findings.push({
             file,
@@ -159,7 +164,29 @@ export function analyze(files) {
     }
   }
 
-  return { findings, examined: nameToOwner.size };
+  // Fail-closed against parser drift. Declaring is opt-in, so examining nothing is legitimate while
+  // nobody has tagged anything — but zero matches while the tag string IS present in the subject
+  // means the READER broke, and a reader that reads nothing reports a clean sweep. That is the
+  // twelve-green-runs-zero-verdicts shape, in the floor written because of it.
+  if (taggedCount === 0) {
+    const withTagText = Object.keys(files).filter((f) => files[f].includes('@limits'));
+    if (withTagText.length > 0) {
+      findings.push({
+        file: withTagText[0],
+        message:
+          `the text contains @limits in ${withTagText.length} file(s) and the parser matched none — ` +
+          'the reader has drifted, and a reader that reads nothing reports a clean sweep',
+      });
+    }
+  }
+
+  return { findings, examined: taggedCount };
+}
+
+/** A relative specifier resolved to a repo-relative module path, or null when it is not local. */
+export function resolveSpecifier(fromFile, specifier) {
+  if (!specifier.startsWith('.')) return null;
+  return path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), specifier));
 }
 
 function walk(dir, out = []) {

--- a/scripts/harness/scan-helper-limits.mjs
+++ b/scripts/harness/scan-helper-limits.mjs
@@ -43,6 +43,14 @@
  * The point is not the comment. It is that the question was ASKED at the site where the consequences
  * are known, which is the only place it can be answered.
  *
+ * ## Known gaps, stated rather than implied
+ *
+ * A namespace import (`import * as owner from './owner.mjs'; owner.tagged()`) is not detected:
+ * the binding that matters is a property access, not an imported name. Nothing in this tree uses
+ * one for a tagged function today. Adjacency between the docblock and its export is required, and
+ * a gap is caught by the per-file reader check below rather than passing quietly — tolerating the
+ * gap would let a module docblock tag whatever export followed it.
+ *
  * ## Anti-rot
  *
  * A `@limits` tag with no statement, and a `LIMITS <name>:` with no reason, both FAIL — the same


### PR DESCRIPTION
## The class

A shared function's documented limits were judged against what its **first** consumer did with the answer. That judgement is a property of the pair, not of the function.

When a second consumer arrives whose consequences are heavier, **the function does not change** — so nothing in the diff signals anything, and review sees a reuse, which reads as good practice. The defect is invisible in the code and shows up only in behaviour, usually much later.

## Two instances, measured in one session

| Helper | Judged against | Reused for | What it cost |
| --- | --- | --- | --- |
| `git()` — trims its output | a sha, where trimming is right | producing the input to `git apply -R` | the final newline stripped, every patch "corrupt", the red-proof gate's mutation step threw for its **entire life** — twelve CI runs, zero verdicts, no error anyone saw |
| `testExecutesHook` — grep-level, "structural rather than exact" | an **advisory** coverage message | picking which tests may set a red-proof **verdict** | the same imprecision can hand a verdict to a test that never ran the hook (INFRA-074, #1540) |

## What landed

**RULE** `.agents/rules/helper-limits.md` — before reusing a helper where the consequences differ, re-judge its stated limits at the new call site and record the answer. Three outcomes, only three: they hold (say why), they do not (narrow it or use something else), or the mismatch is **held** under a labelled containment naming a root item (`finding-depth.md`, #1539). The helper's author could not have answered this — the second consumer did not exist yet.

**FLOOR** `scripts/harness/scan-helper-limits.mjs`, registered in `harness:scan` (82 → 83 scans). A helper declares its limits with `@limits <statement>` on the docblock attached to its export; every module importing it must carry `// LIMITS <name>: <why they hold here>`.

- **Declaring is opt-in**, deliberately — a blanket requirement would be met by boilerplate and would say nothing.
- **Acknowledging is not optional** once declared.
- **Anti-rot** follows `allow-fake` / `allow-fallback`: an empty tag, or a `LIMITS <name>:` with no reason, both FAIL.
- The scan **reports what it examined** (`N @limits-tagged function(s) across M file(s)`), so a run that examined nothing cannot read as a clean sweep.

## Proved against the pre-fix state

Seeded on the instance the lesson came from. Removing the acknowledgement from the coverage floor makes the scan **fail** with the exact message; restoring it makes it **pass**. That is the state the repo was actually in when the defect was introduced.

Two defects were found **by running it**, both fixed and pinned with cases:

- a fixture inside a string literal was read as a real declaration — the scan of a scan is full of them, and the repo's other scans state that string literals must not match;
- the module docblock's own contract prose (which necessarily writes `@limits`) was adopted as a tag on an unrelated export. A tag that drifts names limits belonging to something else, which is worse than no tag.

## Verification

- 9 tests in `scan-helper-limits.test.mjs` green; 1676 harness tests green.
- 83 scans pass. Two scans (`dist`, `doc-examples`) need a built tree and were not run in this worktree; they run with a build in CI.

Lesson processed per `lesson-to-harness` steps 3–9 (normalize → tier A → mechanism → prove it catches the incident), with the candidate approved before institutionalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso