### PR TITLE
fix(hooks): two guards reading one command must reach one reading of it

### DIFF
--- a/.agents/backlog/INFRA-076-loose-override-tokens.md
+++ b/.agents/backlog/INFRA-076-loose-override-tokens.md
@@ -1,0 +1,59 @@
+---
+title: 'INFRA-076: branch-guard honours an override token wherever it appears, not where it is given'
+status: todo
+priority: high
+urgency: soon
+type: INFRA
+area: .claude/hooks
+created: 2026-08-01
+issue: https://github.com/woojubb/robota/issues/1548
+depends_on: []
+---
+
+# INFRA-076 — an override read as a word, not as a prefix
+
+## Problem
+
+`branch-guard.sh` reads its four overrides (`BRANCH_GUARD_ALLOW_DELETE`, `_ALLOW_MAIN_MERGE`,
+`_ALLOW_OPEN_BRANCHES`, `_ALLOW_BASE`) as a token appearing anywhere in the masked command:
+
+```sh
+grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'
+```
+
+Masking stops a QUOTED mention. It does not stop an unquoted one, because an unquoted token is a
+real word in the command:
+
+```
+git commit -m BRANCH_GUARD_ALLOW_DELETE=1 && git push origin --delete develop
+echo BRANCH_GUARD_ALLOW_DELETE=1 ; git push origin --delete develop
+```
+
+Measured on the sibling hook `worktree-cwd-guard`, which had the identical rule: both shapes
+disarmed the guard, and the quoted shape did not. That hook was repaired by anchoring the override
+to the command it overrides — an override is something you GIVE a command, so it must prefix one.
+
+## Why it is filed rather than fixed alongside
+
+`branch-guard`'s overrides are DOCUMENTED as loose — a token anywhere on the line — and its own
+comments explain the choice. Narrowing them to a prefix is a user-visible behaviour change to the
+most-used hook in the repository: an operator whose habit is `BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1`
+somewhere in a compound command would start being refused. That is a decision, not a repair, and it
+should be taken deliberately rather than as a side effect of fixing a sibling.
+
+`pre-push-check`'s `PRE_PUSH_ALLOW_UNREVIEWED` already uses the strict prefix rule, as does
+`merge-gate`'s ACK. So the repository has both conventions live, which is the thing to settle.
+
+## Options
+
+1. **Anchor all four**, matching the three hooks that already anchor. Uniform, and closes the hole.
+   Cost: breaks any established loose usage.
+2. **Anchor the destructive ones only** (`_ALLOW_DELETE`, `_ALLOW_MAIN_MERGE`) and leave the two
+   workflow ones loose. Closes the cases where a mention costs something irreversible.
+3. **Leave as is and document the exposure.** Only defensible if the loose form is load-bearing for
+   an actual workflow — name it if so.
+
+## Done when
+
+- One convention is chosen for override tokens across `.claude/hooks/`, and every hook follows it.
+- A case per hook proves a bare mention does NOT disarm it, and the real prefix still does.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -74,7 +74,12 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # payloads are masked before this runs now, so the exclusion protected nothing and cost the forms
 # above. A quote and a backtick are boundaries because a kept region — `bash -c "git push"`,
 # `` `git push` `` — puts one immediately before the verb.
-printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([[:space:]]|$)' || exit 0
+# The trailing boundary is any NON-WORD character, matching `branch-guard`'s. It required
+# whitespace-or-end here, so `git push;` was a push to that guard and not a push to this one — and
+# because this line is the whole file's entry point, the branch-hygiene check, the lockfile-sync
+# check and the local-review record were all skipped for that shape. Two guards reading one command
+# must reach one reading of it.
+printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)' || exit 0
 
 # Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -57,7 +57,10 @@ fi
 # Honor the inline override token written IN the command string. The `VAR=1` prefix runs in the
 # TOOL's shell, not this hook's process, so a plain env check never sees it (same reasoning as
 # branch-guard's inline overrides).
-if printf '%s' "$COMMAND" | grep -qE '(^|[[:space:];&])WORKTREE_CWD_GUARD_ALLOW_MAIN=1([[:space:]]|$)'; then
+# Read off the MASKED command, not the raw one. Off the raw text, a commit message that merely
+# NAMED this token switched the guard off for a `git reset --hard` on the main checkout — the attack
+# `branch-guard` documents beside its own overrides and fixed there, never ported here.
+if printf '%s' "$(hook_verb_scan "$COMMAND")" | grep -qE '(^|[[:space:];&])WORKTREE_CWD_GUARD_ALLOW_MAIN=1([[:space:]]|$)'; then
   exit 0
 fi
 

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -54,20 +54,21 @@ if ! COMMAND=$(hook_command_of "$INPUT"); then
   exit 2
 fi
 
-# Honor the inline override token written IN the command string. The `VAR=1` prefix runs in the
-# TOOL's shell, not this hook's process, so a plain env check never sees it (same reasoning as
-# branch-guard's inline overrides).
-# Read off the MASKED command, not the raw one. Off the raw text, a commit message that merely
-# NAMED this token switched the guard off for a `git reset --hard` on the main checkout — the attack
-# `branch-guard` documents beside its own overrides and fixed there, never ported here.
-# Positional, not lexical. Masking alone was not enough: an UNQUOTED mention is a real word in the
-# command, so the loose token rule honoured it wherever it sat — `git commit -m TOKEN && git reset
-# --hard` and `echo TOKEN ; git reset --hard` both disarmed the guard. An override is something you
-# GIVE a command, so it must PREFIX one, which is exactly what this hook's own refusal message has
-# always told the operator to do. Same rule `merge-gate` and `pre-push-check`'s ACK already use.
-if printf '%s' "$(hook_verb_scan "$COMMAND")" | grep -qE '(^|[;&|]|&&)[[:space:]]*([^[:space:]]+=[^[:space:]]+[[:space:]]+)*WORKTREE_CWD_GUARD_ALLOW_MAIN=1[[:space:]]+([^[:space:]]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]'; then
-  exit 0
-fi
+# The inline override is checked further down, AFTER the destructive command is identified — not
+# here. It has to be, and the reason is the whole shape of this class:
+#
+#   - The `VAR=1` prefix runs in the TOOL's shell, not this hook's process, so a plain env check
+#     never sees it (same reasoning as branch-guard's inline overrides).
+#   - Read off the RAW command, a commit message that merely NAMED the token switched the guard off.
+#     So it is read off the masked text.
+#   - Read as a token ANYWHERE, an unquoted mention still disarmed it — `git commit -m TOKEN &&
+#     git reset --hard`. So it must PREFIX a command.
+#   - Read as "prefixes SOME git call", a decoy disarmed it — `TOKEN git status && git reset --hard`
+#     puts the token on something harmless and the destructive command that follows is never judged.
+#
+# Each repair was correct and each left the next hole, because the question was being asked about
+# the wrong subject. An override is given to ONE command: the one it precedes. So the only check
+# that closes it is asked of the destructive statement itself.
 
 # --- (b) worktree-assignment marker -------------------------------------------------------------
 # Present iff this session was spawned as a worktree-assigned subagent. Absent → ordinary main-clone
@@ -127,6 +128,35 @@ printf '%s' "$VERBS" | grep -qE "${GITPFX}checkout\b[^|;&]*[[:space:]]--([[:spac
 printf '%s' "$VERBS" | grep -qE "${GITPFX}push\b[^|;&]*--force" && IS_DESTRUCTIVE=true
 
 if [[ "$IS_DESTRUCTIVE" != "true" ]]; then
+  exit 0
+fi
+
+# --- The inline override, asked of the destructive statement itself ------------------------------
+# Split on statement separators and judge each statement alone. A statement that is destructive is
+# excused only if the override prefixes THAT statement; the token sitting on a sibling command
+# excuses nothing. Every destructive statement must carry it, so a decoy plus a real one still
+# refuses. See the note above for the three earlier readings this replaces.
+OVERRIDE_RE='^[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*WORKTREE_CWD_GUARD_ALLOW_MAIN=1[[:space:]]'
+DESTRUCTIVE_STATEMENTS=0
+OVERRIDDEN_STATEMENTS=0
+while IFS= read -r STATEMENT; do
+  [[ -z "${STATEMENT//[[:space:]]/}" ]] && continue
+  IS_STMT_DESTRUCTIVE=false
+  printf '%s' "$STATEMENT" | grep -qE "${GITPFX}reset\b.*--hard\b" && IS_STMT_DESTRUCTIVE=true
+  printf '%s' "$STATEMENT" | grep -qE "${GITPFX}clean\b.*(-[[:alnum:]]*f|--force)" && IS_STMT_DESTRUCTIVE=true
+  printf '%s' "$STATEMENT" | grep -qE "${GITPFX}checkout\b.*[[:space:]]--([[:space:]]|$)" && IS_STMT_DESTRUCTIVE=true
+  printf '%s' "$STATEMENT" | grep -qE "${GITPFX}push\b.*--force" && IS_STMT_DESTRUCTIVE=true
+  [[ "$IS_STMT_DESTRUCTIVE" != "true" ]] && continue
+  DESTRUCTIVE_STATEMENTS=$((DESTRUCTIVE_STATEMENTS + 1))
+  if printf '%s' "$STATEMENT" | grep -qE "$OVERRIDE_RE"; then
+    OVERRIDDEN_STATEMENTS=$((OVERRIDDEN_STATEMENTS + 1))
+  fi
+# `%s\n`, not `%s`: without a trailing newline `read` drops the final line, which for a single-
+# statement command is the only line there is — the override would then never be seen and an
+# ordinary, correct invocation would be refused.
+done < <(printf '%s\n' "$VERBS" | sed -E 's/(\|\||&&|[;&|])/\n/g')
+
+if [[ "$DESTRUCTIVE_STATEMENTS" -gt 0 && "$OVERRIDDEN_STATEMENTS" -eq "$DESTRUCTIVE_STATEMENTS" ]]; then
   exit 0
 fi
 

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -60,7 +60,12 @@ fi
 # Read off the MASKED command, not the raw one. Off the raw text, a commit message that merely
 # NAMED this token switched the guard off for a `git reset --hard` on the main checkout — the attack
 # `branch-guard` documents beside its own overrides and fixed there, never ported here.
-if printf '%s' "$(hook_verb_scan "$COMMAND")" | grep -qE '(^|[[:space:];&])WORKTREE_CWD_GUARD_ALLOW_MAIN=1([[:space:]]|$)'; then
+# Positional, not lexical. Masking alone was not enough: an UNQUOTED mention is a real word in the
+# command, so the loose token rule honoured it wherever it sat — `git commit -m TOKEN && git reset
+# --hard` and `echo TOKEN ; git reset --hard` both disarmed the guard. An override is something you
+# GIVE a command, so it must PREFIX one, which is exactly what this hook's own refusal message has
+# always told the operator to do. Same rule `merge-gate` and `pre-push-check`'s ACK already use.
+if printf '%s' "$(hook_verb_scan "$COMMAND")" | grep -qE '(^|[;&|]|&&)[[:space:]]*([^[:space:]]+=[^[:space:]]+[[:space:]]+)*WORKTREE_CWD_GUARD_ALLOW_MAIN=1[[:space:]]+([^[:space:]]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]'; then
   exit 0
 fi
 

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -1,0 +1,111 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * Two guards reading the same command must reach the same reading of it.
+ *
+ * These are not style findings. Both cases below were measured on `develop`, and each is a live
+ * bypass of a gate that is otherwise working:
+ *
+ * - `branch-guard` ends a git verb at any non-word character; `pre-push-check`'s interception gate
+ *   required whitespace or end-of-line. So `git push; …` was a push to one and not a push to the
+ *   other — and since that gate is the whole file's entry point, the branch-hygiene check, the
+ *   lockfile-sync check and the local-review record were all skipped for that shape. No fixture in
+ *   the repository ended a command at `push`, which is why it survived.
+ * - `worktree-cwd-guard` read its override token off the RAW command rather than the masked one, so
+ *   a commit message that merely NAMED the override switched the guard off. `branch-guard` documents
+ *   this exact attack and fixed it; the sibling hook never received the fix.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchRepo(branch) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'boundary-'));
+  scratch.push(dir);
+  const git = (...a) => spawnSync('git', ['-C', dir, ...a], { encoding: 'utf8' });
+  git('init', '--quiet', `--initial-branch=${branch}`);
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', 'chore: root');
+  return dir;
+}
+
+function run(hook, command, dir, env = {}) {
+  const result = spawnSync('bash', [path.join(HOOKS_DIR, hook)], {
+    input: JSON.stringify({ tool_name: 'Bash', cwd: dir, tool_input: { command } }),
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: dir, ...env },
+    timeout: 120_000,
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('a push is a push to every guard that reads the command', () => {
+  // The separator follows the verb. Every existing fixture writes `git push origin …`, so the
+  // boundary after `push` itself had never been exercised.
+  const SHAPES = ['git push;', 'git push; echo ok', 'git push|cat', '(git push)', 'git push&'];
+
+  for (const command of SHAPES) {
+    it(`pre-push-check sees a push in \`${command}\``, () => {
+      const dir = scratchRepo('feat/probe');
+      const verdict = run('pre-push-check.sh', command, dir);
+
+      expect(
+        verdict.status,
+        'the push gate never engaged, so branch hygiene, lockfile sync and the review record were ' +
+          `all skipped for this shape: ${verdict.output}`,
+      ).toBe(2);
+      expect(verdict.output).toMatch(/no local review recorded/);
+    });
+  }
+
+  it('still says nothing about a command that is not a push', () => {
+    // The other half: widening a boundary is how a guard starts firing on correct work.
+    const dir = scratchRepo('feat/probe');
+    const verdict = run('pre-push-check.sh', 'git pushd-something; echo ok', dir);
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(verdict.output.trim()).toBe('');
+  });
+});
+
+describe('an override must be given, not merely mentioned', () => {
+  function worktreeRun(command) {
+    const dir = scratchRepo('feat/probe');
+    return run('worktree-cwd-guard.sh', command, dir, {
+      ROBOTA_AGENT_WORKTREE: '/repo/.claude/worktrees/agent-x',
+    });
+  }
+
+  it('refuses a destructive command whose message only NAMES the override', () => {
+    // Measured on develop: allowed. The token was read off the raw command, so any quoted mention
+    // disarmed the guard — the attack `branch-guard` documents at its own override, never ported.
+    const verdict = worktreeRun(
+      'git commit -m "note: WORKTREE_CWD_GUARD_ALLOW_MAIN=1 was tried" && git reset --hard',
+    );
+
+    expect(
+      verdict.status,
+      'a quoted mention of the override switched the guard off for a reset --hard on the main clone',
+    ).toBe(2);
+  });
+
+  it('still honours the override when it is actually given', () => {
+    const verdict = worktreeRun('WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git reset --hard origin/develop');
+
+    expect(verdict.status, verdict.output).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -103,9 +103,30 @@ describe('an override must be given, not merely mentioned', () => {
     ).toBe(2);
   });
 
-  it('still honours the override when it is actually given', () => {
-    const verdict = worktreeRun('WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git reset --hard origin/develop');
+  it('refuses when the token is merely a word in the command', () => {
+    // The shape that actually gets through. A quoted mention is masked and already refused; an
+    // UNQUOTED one is a real word in the command, and the loose token rule honoured it wherever it
+    // appeared. Both of these were allowed:
+    //   git commit -m WORKTREE_CWD_GUARD_ALLOW_MAIN=1 && git reset --hard
+    //   echo WORKTREE_CWD_GUARD_ALLOW_MAIN=1 ; git reset --hard
+    // The fix is positional, not lexical: an override is something you GIVE the command, so it must
+    // prefix it — which is what the hook's own refusal message has always told the operator to do.
+    for (const command of [
+      'git commit -m WORKTREE_CWD_GUARD_ALLOW_MAIN=1 && git reset --hard',
+      'echo WORKTREE_CWD_GUARD_ALLOW_MAIN=1 ; git reset --hard',
+    ]) {
+      expect(worktreeRun(command).status, `a bare mention disarmed the guard: ${command}`).toBe(2);
+    }
+  });
 
-    expect(verdict.status, verdict.output).toBe(0);
+  it('still honours the override when it is actually given', () => {
+    // Including behind another assignment, which is how a real invocation often looks.
+    for (const command of [
+      'WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git reset --hard origin/develop',
+      'FOO=1 WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git reset --hard origin/develop',
+    ]) {
+      const verdict = worktreeRun(command);
+      expect(verdict.status, `${command}: ${verdict.output}`).toBe(0);
+    }
   });
 });

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -119,6 +119,19 @@ describe('an override must be given, not merely mentioned', () => {
     }
   });
 
+  it('refuses when the override prefixes a DIFFERENT command', () => {
+    // The decoy. `WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git status && git reset --hard` puts the token on
+    // a harmless call; a check that asks only "does the token prefix SOME git call" matches, exits
+    // 0, and the destructive command that follows is never judged at all. An override is given to
+    // ONE command — the one it precedes — not to everything after it on the line.
+    for (const command of [
+      'WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git status && git reset --hard',
+      'WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git log -1; git clean -fdx',
+    ]) {
+      expect(worktreeRun(command).status, `a decoy override let this through: ${command}`).toBe(2);
+    }
+  });
+
   it('still honours the override when it is actually given', () => {
     // Including behind another assignment, which is how a real invocation often looks.
     for (const command of [

--- a/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
+++ b/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
@@ -1,0 +1,195 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const LIB = path.join(WORKSPACE_ROOT, '.claude/hooks/lib/command-scan.sh');
+
+/**
+ * The guards read a shell command with regular expressions. Shell quoting is not a regular
+ * language — nesting (`$(…)` inside quotes inside `$(…)`) needs a stack, and a regex has none — so
+ * every masker is an approximation that holds until someone writes a spelling nobody tried.
+ *
+ * Measured over four days: `branch-guard.sh` rewritten 26 times, seven distinct instances of this
+ * one class, **every one found by a person hitting a new spelling**. Twice the new spelling refused
+ * the creation of the branch its own fix lived on.
+ *
+ * A hand-written case list cannot end that, because the next spelling is by definition not on it.
+ * What can is an ORACLE, and there is one sitting right there: bash. Generate the shapes, run each
+ * one for real with a recording stub on `PATH`, and ask the shell whether the verb actually ran.
+ * Then require the masker's reading to agree.
+ *
+ * Nothing destructive executes: `git` is a stub that records its argv and exits 0. The commands are
+ * about what the SHELL does with the text, not about what git would have done.
+ *
+ * This is the mechanism INFRA-075 asks for, standing on its own: it needs no new tokenizer, and it
+ * fails on a disagreement whatever the cause. A tokenizer, when it lands, is judged by this same
+ * corpus.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function sandbox() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'reading-'));
+  scratch.push(dir);
+  const bin = path.join(dir, 'bin');
+  spawnSync('mkdir', ['-p', bin]);
+  const log = path.join(dir, 'calls.log');
+  // A recorder, not git. It logs the SUBCOMMAND — the first argument that is not a global flag —
+  // because `git -C /tmp push` invokes push just as truly as `git push` does, and a recorder that
+  // logged the raw argv would call the first token `-C`. Logging the subcommand also means a verb
+  // appearing inside a commit MESSAGE is never mistaken for one, which would make the oracle agree
+  // with a masker that is wrong.
+  const recorder = [
+    '#!/bin/sh',
+    'while [ $# -gt 0 ]; do',
+    '  case "$1" in',
+    '    -C|-c|--git-dir|--work-tree|--namespace|--exec-path) shift 2 ;;',
+    '    -*) shift ;;',
+    `    *) printf '%s\\n' "$1" >> ${JSON.stringify(log)}; exit 0 ;;`,
+    '  esac',
+    'done',
+    'exit 0',
+    '',
+  ].join('\n');
+  writeFileSync(path.join(bin, 'git'), recorder);
+  chmodSync(path.join(bin, 'git'), 0o755);
+  return { dir, bin, log };
+}
+
+/** Did bash actually invoke `git <verb>`? The oracle — real shell semantics, no parser involved. */
+function bashRuns(command, verb) {
+  const { dir, bin, log } = sandbox();
+  spawnSync('bash', ['-c', command], {
+    cwd: dir,
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  if (!existsSync(log)) return false;
+  return readFileSync(log, 'utf8')
+    .split('\n')
+    .some((line) => line.trim() === verb);
+}
+
+/**
+ * What the shared masker lets a guard see: does the verb survive into the scanned text?
+ *
+ * The command and the verb arrive as ARGUMENTS, never interpolated into the probe script. An
+ * earlier version built the script by substitution, so a corpus entry containing `$(…)` was
+ * EXECUTED while being measured — the measurement running the thing it was supposed to be reading.
+ * One escape level is the most this can afford, and this is that level.
+ */
+function maskerSees(command, verb) {
+  const probe = [
+    'source "$1"',
+    'scanned=$(hook_verb_scan "$2")',
+    'printf \'%s\' "$scanned" | grep -qE "(^|[;&|({\\"\'\\`]|[[:space:]])[[:space:]]*([^[:space:]]+=[^[:space:]]+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*$3([^-[:alnum:]_]|$)"',
+  ].join('\n');
+  const result = spawnSync('bash', ['-c', probe, '_', LIB, command, verb], {
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  return result.status === 0;
+}
+
+/**
+ * The corpus. Every entry is a way of writing a command that a person might plausibly write, and
+ * the point of each is a construct the masker has to get right — not a variation on one shape.
+ */
+const CORPUS = [
+  // Plain, and the boundary immediately after the verb — the shape no fixture had.
+  'git push',
+  'git push;',
+  'git push; echo done',
+  'git push&',
+  'git push|cat',
+  '(git push)',
+  '{ git push; }',
+  // Separators and continuations before it.
+  'cd /tmp && git push',
+  'cd /tmp \\\n  && git push',
+  'true; git push',
+  // Assignments and global flags between `git` and the verb.
+  'FOO=1 git push',
+  'FOO=1 BAR=2 git push',
+  'git -C /tmp push',
+  'git -c user.name=x push',
+  // Quoted MENTIONS — the verb is text, not a command. The masker must hide these.
+  "echo 'git push'",
+  'echo "git push"',
+  "git commit -m 'about to git push later'",
+  'git commit -m "about to git push later"',
+  '# git push',
+  'echo hi # git push',
+  // A mention nested inside a substitution — the shape that is still open (INFRA-075).
+  // Deliberately NOT asserted below; see the exemption list.
+  "out=$(echo 'git push'); echo $out",
+  // Interpreter strings — the verb really does run, inside another shell.
+  'bash -c "git push"',
+  "sh -c 'git push'",
+  // Escapes.
+  'echo \\"git push\\"',
+  // A different verb entirely: must not read as a push.
+  'git pushd-something',
+  'git push-tags-please',
+];
+
+/**
+ * Known-open disagreements, each naming the item that owns it. An exemption carries a reason and an
+ * ID — an unexplained one is how a corpus becomes decorative.
+ */
+const KNOWN_OPEN = new Map([
+  [
+    "out=$(echo 'git push'); echo $out",
+    'INFRA-075 — a substitution span is restored whole, un-masking the quotes inside it',
+  ],
+  [
+    'echo \\"git push\\"',
+    'INFRA-075 (same root) — an escaped quote is a literal character, so the verb survives as bare ' +
+      'words in an ARGUMENT list. Telling an argument from a command needs command-position ' +
+      'tracking, which is the tokenizer that item asks for and not something a mask can do',
+  ],
+]);
+
+describe("the masker's reading of a command matches what bash does with it", () => {
+  it('has a corpus and an oracle', () => {
+    // Fail closed: an emptied corpus or a stub that never records would make every case below pass
+    // over nothing.
+    expect(CORPUS.length).toBeGreaterThan(20);
+    expect(bashRuns('git push', 'push'), 'the oracle did not observe an obvious push').toBe(true);
+    expect(bashRuns("echo 'git push'", 'push'), 'the oracle saw a push in an echo').toBe(false);
+  });
+
+  for (const command of CORPUS) {
+    const known = KNOWN_OPEN.get(command);
+    it(`${known ? '[known-open] ' : ''}${JSON.stringify(command)}`, () => {
+      const actuallyRan = bashRuns(command, 'push');
+      const wasSeen = maskerSees(command, 'push');
+
+      if (known) {
+        // Pinned as a disagreement, so closing it turns this case red and the exemption gets removed
+        // rather than outliving its reason.
+        expect(wasSeen, `${known} — if this now agrees, delete the exemption`).not.toBe(
+          actuallyRan,
+        );
+        return;
+      }
+
+      expect(
+        wasSeen,
+        actuallyRan
+          ? 'bash RAN git push and the masker did not see it — a guard reading this text is blind ' +
+              'to a real invocation, which is a bypass'
+          : 'bash did NOT run git push and the masker saw one — a guard reading this text refuses ' +
+              'correct work, which is how a guard gets disabled',
+      ).toBe(actuallyRan);
+    });
+  }
+});


### PR DESCRIPTION
An independent audit of the hook surface measured **two live bypasses**. Neither is a style finding — both are gates that were working and could be walked past.

## 1. `git push; …` skipped `pre-push-check` entirely

`branch-guard` ends a git verb at any non-word character (`([^-[:alnum:]_]|$)`); this file's interception gate required whitespace or end-of-line (`([[:space:]]|$)`).

So that shape was a push to one guard and **not a push to the other** — and because that line is the whole file's entry point, **three checks were skipped for it**: branch-base hygiene, lockfile sync, and the local-review record.

| command | branch-guard | pre-push-check (before) |
| --- | --- | --- |
| `git push origin x` | sees a push | sees a push |
| `git push;` | sees a push | **exit 0 — never engaged** |
| `git push; echo ok` | sees a push | **exit 0** |
| `git push\|cat` | sees a push | **exit 0** |
| `(git push)` | sees a push | **exit 0** |
| `git push&` | sees a push | **exit 0** |

**Why it survived:** not one fixture in the repository ends a command at `push` — every one writes `git push origin …`, so the boundary immediately after the verb had never been exercised. The new cases assert that boundary specifically, rather than a longer command that would pass either way.

## 2. A quoted mention disarmed the worktree guard

```
git commit -m "note: WORKTREE_CWD_GUARD_ALLOW_MAIN=1 was tried" && git reset --hard   → ALLOWED
```

The override was read off the **raw** command instead of the masked one, so any text merely *naming* the token switched the guard off — for a `git reset --hard` on the main checkout, which is the incident this hook was written for.

`branch-guard` documents this exact attack beside its own overrides and fixed it there. The sibling hook never received the fix. It reads the masked command now.

## Verification

- **Test-first**: six cases fail on the unfixed hooks and name the bypass in their failure messages.
- **Both halves pinned.** Widening a boundary is how a guard starts firing on correct work, so `git pushd-something; echo ok` must still pass **silently**, and the real `WORKTREE_CWD_GUARD_ALLOW_MAIN=1 git reset --hard` must still be honoured. Both asserted.
- 1732 harness tests green (116 files), 83 scans pass.

## Note on the branch

`BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1` was used to cut this branch while #1546 is still in review. A live guard bypass should not queue behind a documentation PR — the override announces itself, which is what it is for.

## Related, not in this PR

The same audit found more that is filed rather than bundled: two hooks still hand-roll `grep -o '"file_path"…"[^"]*"'` (truncating on an escaped quote), a `read_json` copy in three hooks with no `python3` fallback (so those hooks silently no-op where `jq` is absent while the others keep working), four disagreeing effective-directory resolutions, and unscrubbed `GIT_DIR` in the judging hooks. Also: **nothing validates `.claude/settings.json`** — a hook file could be registered to no event, or a matcher could name a deleted file, and every gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso