### PR TITLE
feat(harness): floors for the two classes that recurred without one

### DIFF
--- a/scripts/harness/__tests__/agents-cannot-be-told-to-dispatch.test.mjs
+++ b/scripts/harness/__tests__/agents-cannot-be-told-to-dispatch.test.mjs
@@ -68,6 +68,10 @@ const DISPATCH_VERBS =
  * and `ask` inside `task`, and an ordinary sentence near an agent name fails CI for nothing. A floor
  * that cries wolf is one somebody switches off.
  */
+function reEscape(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export function dispatchInstructions(text, agentNames, selfName) {
   const found = [];
   const sentences = text
@@ -79,7 +83,9 @@ export function dispatchInstructions(text, agentNames, selfName) {
     if (/\bowns\b|\bis the\b|\bthat is\b|\bbelongs to\b/i.test(sentence)) continue;
     for (const other of agentNames) {
       if (other === selfName) continue;
-      const near = new RegExp(`(?:${DISPATCH_VERBS})[^.\`]{0,40}\`?${other}\`?`, 'i');
+      // The agent name is DATA in this pattern, not syntax: a `(` in a frontmatter name would throw
+      // and take the whole check down for every agent, not just that one.
+      const near = new RegExp(`(?:${DISPATCH_VERBS})[^.\`]{0,40}\`?${reEscape(other)}\`?`, 'i');
       if (near.test(sentence)) found.push({ other, line: sentence.trim() });
     }
   }

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -125,6 +125,30 @@ describe('HARNESS-041 file classification', () => {
 });
 
 describe('HARNESS-041 scoping (C2) + opt-out', () => {
+  it('a range that ADDS A FLOOR is a defect fix, whatever its subject says', () => {
+    // Measured 2026-08-01: five mechanical floors were written in one session and not one of them
+    // was judged by this gate, because a floor lands as `feat:` — it adds a capability — while being
+    // a fix for a defect CLASS. Three of the five turned out to pass over the very incident they
+    // were built for, and all three were found by a person running them by hand.
+    //
+    // A floor is exactly the artifact whose red proof matters most: it is the thing that will be
+    // trusted to catch the next occurrence. So a range that adds one is judged, and its subject line
+    // does not get to opt it out.
+    expect(isDefectFixRange(['feat: a new mechanical floor'], ['scripts/harness/scan-x.mjs'])).toBe(
+      false,
+    );
+    expect(
+      isDefectFixRange(
+        ['feat: a new mechanical floor'],
+        ['scripts/harness/__tests__/guards-something.test.mjs'],
+      ),
+      'a new floor escaped the gate because it was not spelled `fix:`',
+    ).toBe(true);
+    // Not every touched test is a new floor — an EDIT to one is ordinary work, and an edited file is
+    // not in the ADDED list. Passing it here as added would have asserted the opposite of the point.
+    expect(isDefectFixRange(['docs: wording'], [])).toBe(false);
+  });
+
   it('isDefectFixRange requires a fix: commit and excludes perf:', () => {
     expect(isDefectFixRange(['fix: drop bug', 'chore: x'])).toBe(true);
     expect(isDefectFixRange(['fix(tui): drop bug'])).toBe(true);
@@ -286,6 +310,7 @@ function baseIo(overrides = {}) {
     mergeBase: 'BASE',
     changedFiles: [srcFile, testFile],
     commitSubjects: ['fix: something real'],
+    addedFiles: [],
     optOutText: '',
     readText: (p) => files[p] ?? '',
     fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),

--- a/scripts/harness/__tests__/declared-boundaries-hold.test.mjs
+++ b/scripts/harness/__tests__/declared-boundaries-hold.test.mjs
@@ -1,0 +1,198 @@
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const SKILLS_DIR = path.join(WORKSPACE_ROOT, '.agents/skills');
+
+/**
+ * A skill that declares "not my job — X's" must not then instruct itself to do it.
+ *
+ * The declaration is the repository's own convention: fourteen skills carry a
+ * "What This Skill Does NOT Do" table naming an action and its owner. Nothing checked that the body
+ * agreed with the table, and the body is what an agent follows.
+ *
+ * Measured 2026-08-01 in #1546: `pr-review-orchestration` told itself to post replies to the PR while
+ * its own table said posting belongs to `pr-review-writer`, its header said it "does not review,
+ * write, fix, or judge", and its closing line said to stop if you find yourself doing any of them.
+ * Three statements of the boundary in one file, and the procedure between them crossed it.
+ *
+ * That was the fourth spelling of one habit in a single change — an instruction with no execution
+ * path, a judgement with no actor, a registry disagreeing with its wiring, and a role writing outside
+ * itself. Each looked different; each came from writing what should happen without asking who does it.
+ *
+ * What this checks is narrow and mechanical: the ACTION named in the table, appearing as an
+ * imperative in the body. It does not attempt to judge whether the boundary is the right one.
+ */
+const SKILLS = readdirSync(SKILLS_DIR, { withFileTypes: true })
+  .filter((e) => e.isDirectory())
+  .map((e) => ({ name: e.name, file: path.join(SKILLS_DIR, e.name, 'SKILL.md') }))
+  .filter((s) => existsSync(s.file))
+  .map((s) => ({ ...s, text: readFileSync(s.file, 'utf8') }));
+
+/**
+ * Verb families, because the table and the body do not use the same word — and that is exactly how
+ * the measured breach got through a first version of this check. The table said "Post the review to
+ * the PR"; the procedure said "then reply". A first-word match saw two different verbs and passed.
+ *
+ * Only PERFORMABLE actions are covered. Most rows in these tables read "Define ..." or "Decide ..." —
+ * those are statements about who owns a POLICY, and a routing skill referring to one is not doing it.
+ * Narrow and stated, rather than broad and noisy.
+ */
+const ACTION_FAMILIES = [
+  {
+    key: 'post',
+    verbs: [
+      'post',
+      'posts',
+      'posting',
+      'comment',
+      'comments',
+      'reply',
+      'replies',
+      'replying',
+      'publish',
+    ],
+  },
+  {
+    key: 'edit',
+    verbs: ['edit', 'edits', 'editing', 'fix', 'fixes', 'fixing', 'patch', 'patches'],
+  },
+  { key: 'push', verbs: ['push', 'pushes', 'pushing'] },
+  { key: 'merge', verbs: ['merge', 'merges', 'merging'] },
+  {
+    key: 'author',
+    verbs: ['author', 'authors', 'authoring', 'write', 'writes', 'writing', 'draft', 'drafts'],
+  },
+];
+
+function familyFor(action) {
+  const words = action
+    .toLowerCase()
+    .split(/[^a-z]+/)
+    .filter(Boolean);
+  for (const family of ACTION_FAMILIES) {
+    if (words.some((w) => family.verbs.includes(w))) return family;
+  }
+  return null;
+}
+
+/**
+ * The actions a skill declares are not its own, read from its "does NOT do" table. The first column
+ * is the action; the second is the owner. Only rows naming a DIFFERENT owner count, and only rows
+ * whose action is performable — see ACTION_FAMILIES.
+ */
+export function disownedActions(text) {
+  const start = text.indexOf('## What This Skill Does NOT Do');
+  if (start === -1) return [];
+  const rest = text.indexOf('\n## ', start + 1);
+  const section = text.slice(start, rest === -1 ? undefined : rest);
+  const rows = [];
+  for (const line of section.split('\n')) {
+    const m = line.match(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*$/);
+    if (!m) continue;
+    const [, action, owner] = m;
+    if (/^-+$/.test(action) || /^not this/i.test(action)) continue;
+    const ownerAgent = owner.match(/`([a-z0-9-]+)`/);
+    if (!ownerAgent) continue;
+    const family = familyFor(action);
+    if (!family) continue;
+    rows.push({ action, owner: ownerAgent[1], family: family.key });
+  }
+  return rows;
+}
+
+/**
+ * Does the body tell the skill to perform this action ITSELF?
+ *
+ * The distinguishing mark is an imperative with no dispatch to the owner in the same sentence.
+ * "Hand the decision to `pr-review-writer` to post" is routing; "then reply" is doing.
+ */
+export function selfInstructions(text, action, owner) {
+  const family = familyFor(action);
+  if (!family) return [];
+  const alt = family.verbs.join('|');
+  const cut = text.indexOf('## What This Skill Does NOT Do');
+  const body = cut === -1 ? text : text.slice(0, cut);
+  const found = [];
+  for (const sentence of body
+    .replace(/\r?\n/g, ' ')
+    .split(/(?<=[.!?][*_`)\]]{0,3})\s+/)
+    .filter(Boolean)) {
+    // Routing to the owner in the same sentence is the correct shape, not a violation.
+    if (sentence.includes(owner)) continue;
+    // A sentence ABOUT the boundary is not a breach of it.
+    if (/\bnot\b|\bnever\b|\bdoes not\b|\bbelongs to\b|\bowner\b|\bis the\b/i.test(sentence))
+      continue;
+    // An imperative: the verb opens a clause rather than sitting inside a noun phrase.
+    if (!new RegExp(`(^|[.;:—]\\s*|\\bthen\\s+|\\*\\*)(${alt})\\b`, 'i').test(sentence)) continue;
+    found.push(sentence.trim());
+  }
+  return found;
+}
+
+describe('a skill does not instruct itself to do what it disowned', () => {
+  it('finds skills that declare a boundary', () => {
+    // Fail closed: if the table convention is renamed, every case below passes over nothing.
+    const declaring = SKILLS.filter((s) => disownedActions(s.text).length > 0);
+
+    // Five, not fourteen: most rows in these tables are "Define …" / "Decide …", which state who owns
+    // a POLICY. Only a performable action can be crossed by a procedure, so only those are scanned —
+    // and the number is asserted so a narrowing that quietly emptied the set would fail here.
+    expect(declaring.length).toBeGreaterThanOrEqual(5);
+    expect(declaring.map((s) => s.name)).toContain('pr-review-orchestration');
+  });
+
+  for (const skill of SKILLS) {
+    const rows = disownedActions(skill.text);
+    if (rows.length === 0) continue;
+    it(`${skill.name} keeps the boundary it declares`, () => {
+      const breaches = rows.flatMap((r) =>
+        selfInstructions(skill.text, r.action, r.owner).map((s) => ({ ...r, sentence: s })),
+      );
+
+      expect(
+        breaches.map((b) => `"${b.action}" is ${b.owner}'s, yet: ${b.sentence}`),
+        'the body instructs an action the table gives away. Route it to the owner, or change the ' +
+          'table — a boundary declared in three places and crossed in the procedure between them is ' +
+          'worse than one never declared, because readers trust the declaration.',
+      ).toEqual([]);
+    });
+  }
+
+  it('tells routing apart from doing', () => {
+    // The distinction this rests on, pinned. Without it the check fires on every skill that mentions
+    // an action (useless) or on none (decorative).
+    const table =
+      "## What This Skill Does NOT Do\n\n| Not this skill's job | Owner |\n| --- | --- |\n| Post the review to the PR | `pr-review-writer` (worker) |\n";
+
+    expect(disownedActions(table)).toEqual([
+      { action: 'Post the review to the PR', owner: 'pr-review-writer', family: 'post' },
+    ]);
+    expect(
+      selfInstructions(
+        'Post it to the PR yourself. ' + table,
+        'Post the review',
+        'pr-review-writer',
+      ),
+      'a bare imperative was not read as doing',
+    ).toHaveLength(1);
+    expect(
+      selfInstructions(
+        'Hand the decision to `pr-review-writer` to post. ' + table,
+        'Post the review',
+        'pr-review-writer',
+      ),
+      'routing to the owner was read as doing',
+    ).toHaveLength(0);
+    expect(
+      selfInstructions(
+        "Posting is not this skill's job. " + table,
+        'Post the review',
+        'pr-review-writer',
+      ),
+      'a sentence about the boundary was read as breaching it',
+    ).toHaveLength(0);
+  });
+});

--- a/scripts/harness/__tests__/declared-boundaries-hold.test.mjs
+++ b/scripts/harness/__tests__/declared-boundaries-hold.test.mjs
@@ -61,10 +61,12 @@ const ACTION_FAMILIES = [
   },
   { key: 'push', verbs: ['push', 'pushes', 'pushing'] },
   { key: 'merge', verbs: ['merge', 'merges', 'merging'] },
-  {
-    key: 'author',
-    verbs: ['author', 'authors', 'authoring', 'write', 'writes', 'writing', 'draft', 'drafts'],
-  },
+  // `write`/`author` is deliberately ABSENT, and the reason is measured: `backlog-writer` disowns
+  // "Write Evidence Log entries" while its body legitimately says "write the reason in Notes" and
+  // "Create or rewrite the file" — four false positives from one verb. Requiring the action's NOUN
+  // as well would fix those and break the real catch, whose sentence ("then reply") contains neither
+  // "review" nor "PR". So the families stay limited to verbs specific enough to be evidence on their
+  // own, and a boundary phrased with a generic verb is OUT OF SCOPE rather than guessed at.
 ];
 
 function familyFor(action) {
@@ -90,7 +92,13 @@ export function disownedActions(text) {
   const section = text.slice(start, rest === -1 ? undefined : rest);
   const rows = [];
   for (const line of section.split('\n')) {
-    const m = line.match(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*$/);
+    // Two formats, because the repository uses two. Nine of the fourteen skills write a markdown
+    // table; five write a bullet list (`- Action → that is \`owner\``). Reading only the table
+    // excluded those five ENTIRELY and silently — the declared-boundary-unchecked-body failure this
+    // file exists to catch, reproduced inside it.
+    const table = line.match(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*$/);
+    const bullet = line.match(/^[-*]\s+(.+?)\s*(?:→|->)\s*(.+)$/);
+    const m = table ?? bullet;
     if (!m) continue;
     const [, action, owner] = m;
     if (/^-+$/.test(action) || /^not this/i.test(action)) continue;
@@ -113,8 +121,15 @@ export function selfInstructions(text, action, owner) {
   const family = familyFor(action);
   if (!family) return [];
   const alt = family.verbs.join('|');
+  // The WHOLE file minus the declaration section itself. Reading only what precedes the table missed
+  // everything after it — closing admonitions, an Anti-Patterns section — which is exactly where a
+  // late-added imperative would land.
   const cut = text.indexOf('## What This Skill Does NOT Do');
-  const body = cut === -1 ? text : text.slice(0, cut);
+  let body = text;
+  if (cut !== -1) {
+    const after = text.indexOf('\n## ', cut + 1);
+    body = text.slice(0, cut) + (after === -1 ? '' : text.slice(after));
+  }
   const found = [];
   for (const sentence of body
     .replace(/\r?\n/g, ' ')

--- a/scripts/harness/__tests__/scan-orchestration-map.test.mjs
+++ b/scripts/harness/__tests__/scan-orchestration-map.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { collectOrchestrationMapFindings } from '../scan-orchestration-map.mjs';
+import { collectOrchestrationMapFindings, dispatchedAgents } from '../scan-orchestration-map.mjs';
 
 const SCAN_SCRIPT = fileURLToPath(new URL('../scan-orchestration-map.mjs', import.meta.url));
 // HARNESS-052: the scan under test now fails closed on an absent governed tree, so the copy needs
@@ -186,10 +186,7 @@ describe('scan-orchestration-map CLI', () => {
     const scriptCopy = path.join(root, 'scripts/harness/scan-orchestration-map.mjs');
     mkdirSync(path.dirname(scriptCopy), { recursive: true });
     copyFileSync(SCAN_SCRIPT, scriptCopy);
-    copyFileSync(
-      GOVERNED_TREE_MODULE,
-      path.join(path.dirname(scriptCopy), 'governed-tree.mjs'),
-    );
+    copyFileSync(GOVERNED_TREE_MODULE, path.join(path.dirname(scriptCopy), 'governed-tree.mjs'));
     copyFileSync(FRONTMATTER_MODULE, path.join(path.dirname(scriptCopy), 'frontmatter.mjs'));
     return { root, scriptCopy };
   }
@@ -240,5 +237,42 @@ describe('scan-orchestration-map CLI', () => {
     expect(result.stderr).toContain(
       'orchestration-map scan: .agents/specs/orchestration-map.md is missing.',
     );
+  });
+});
+
+describe('the registry must agree with the wiring it records', () => {
+  // The scan asked only whether each AGENT has a row — never whether the pipeline USING one names
+  // it. So a dispatch could be added and the map left describing the world before it, which is the
+  // drift a registry whose stated purpose is "mechanically kept current" is most likely to suffer.
+  // Measured twice on 2026-08-01 in #1546. This shipped once with no regression case, and its own
+  // review said so; these are that case.
+  const AGENTS = ['finding-depth-triager', 'proposal-reviewer'];
+
+  it('reads an imperative dispatch, in the shapes the skills are written in', () => {
+    expect(dispatchedAgents('Dispatch `finding-depth-triager` on the findings.', AGENTS)).toEqual([
+      'finding-depth-triager',
+    ]);
+    // Bold, and a sentence ending in emphasis — the shape that glued two sentences together and hid
+    // the dispatch behind the NEXT sentence's exclusion.
+    expect(
+      dispatchedAgents(
+        '**Also dispatch `finding-depth-triager` on the problem statement, before the recommendation is formed.** The depth verdict asks whether the problem is the real one.',
+        AGENTS,
+      ),
+    ).toEqual(['finding-depth-triager']);
+    // Wrapped across lines, as these documents are written.
+    expect(
+      dispatchedAgents('hand the finding to\n`proposal-reviewer` for a verdict.', AGENTS),
+    ).toEqual(['proposal-reviewer']);
+  });
+
+  it('does not read a reference, or a word that merely contains a verb', () => {
+    // A guard that demands a map edit for prose nobody dispatched from is one that gets switched off.
+    expect(dispatchedAgents('`proposal-reviewer` owns the verdict.', AGENTS)).toEqual([]);
+    expect(
+      dispatchedAgents('This skill handles retries and reports to `proposal-reviewer`.', AGENTS),
+      '"handles" anchored the hand-to idiom',
+    ).toEqual([]);
+    expect(dispatchedAgents('The reviewer is `proposal-reviewer`.', AGENTS)).toEqual([]);
   });
 });

--- a/scripts/harness/__tests__/scan-orchestration-map.test.mjs
+++ b/scripts/harness/__tests__/scan-orchestration-map.test.mjs
@@ -266,6 +266,17 @@ describe('the registry must agree with the wiring it records', () => {
     ).toEqual(['proposal-reviewer']);
   });
 
+  it('survives an agent name carrying regex metacharacters', () => {
+    // The name is interpolated into a pattern. Unescaped, a stray `(` throws — and it would take
+    // down the scan for EVERY skill, not just that agent, because one throw ends the run. The
+    // convention guard checks only that `name` is present, never that it is a safe charset, so this
+    // is reachable from an ordinary typo in frontmatter.
+    expect(() => dispatchedAgents('Dispatch `a(b` now.', ['a(b'])).not.toThrow();
+    expect(dispatchedAgents('Dispatch `a(b` now.', ['a(b'])).toEqual(['a(b']);
+    // And a metacharacter must not silently widen the match either.
+    expect(dispatchedAgents('Dispatch `axb` now.', ['a.b'])).toEqual([]);
+  });
+
   it('does not read a reference, or a word that merely contains a verb', () => {
     // A guard that demands a map edit for prose nobody dispatched from is one that gets switched off.
     expect(dispatchedAgents('`proposal-reviewer` owns the verdict.', AGENTS)).toEqual([]);

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -139,8 +139,18 @@ export function qualifyingPairs(byPkg) {
 // ── Pure: range + opt-out scoping (C2, opt-out) ─────────────────────────────────────────────────────
 
 /** A defect-fix range has a `fix:` / `fix(scope): ` conventional commit. `perf:` is intentionally excluded. */
-export function isDefectFixRange(commitSubjects) {
-  return commitSubjects.some((s) => /^fix(\(|:)/.test(s.trim()));
+export function isDefectFixRange(commitSubjects, addedFiles = []) {
+  if (commitSubjects.some((s) => /^fix(\(|:)/.test(s.trim()))) return true;
+
+  // A range that ADDS A FLOOR is judged too, whatever its subject says. Measured 2026-08-01: five
+  // mechanical floors were written in one session and not one was judged by this gate, because a
+  // floor lands as `feat:` — it adds a capability — while being a fix for a defect CLASS. Three of
+  // the five turned out to pass over the very incident they were built for, and all three were found
+  // by a person running them by hand.
+  //
+  // A floor is the artifact whose red proof matters most: it is what will be trusted to catch the
+  // next occurrence, and a floor that cannot fail is worse than none, because it is believed.
+  return addedFiles.some((f) => /^scripts\/harness\/__tests__\/.*\.test\.mjs$/.test(f));
 }
 
 /** Parse `allow-green-at-base: <reason>` (opt-out) from any text (PR body / commit trailers). */
@@ -346,8 +356,15 @@ export async function runRegressionRedProof(io = {}) {
     log(`↩︎  SKIPPED (opt-out): allow-green-at-base: ${reason}`);
     return { verdict: VERDICT.SKIPPED_OPT_OUT, decisions };
   }
-  if (!isDefectFixRange(commitSubjects)) {
-    log('↩︎  SKIPPED: range has no `fix:` commit (not a defect fix).');
+  // Files ADDED in the range, so a new floor is judged even when the range is spelled `feat:`.
+  const addedFiles =
+    io.addedFiles ??
+    git(['diff', '--name-only', '--diff-filter=A', `${base}..HEAD`])
+      .split('\n')
+      .filter(Boolean);
+
+  if (!isDefectFixRange(commitSubjects, addedFiles)) {
+    log('↩︎  SKIPPED: range has no `fix:` commit and adds no floor (not a defect fix).');
     return { verdict: VERDICT.SKIPPED_NOT_FIX, decisions };
   }
 

--- a/scripts/harness/scan-orchestration-map.mjs
+++ b/scripts/harness/scan-orchestration-map.mjs
@@ -52,11 +52,64 @@ export function mapRowNames(mapText) {
   return names;
 }
 
+/**
+ * Every SKILL that dispatches an agent, and the agents it dispatches.
+ *
+ * The registry's stated purpose is to be current, and the drift it is most likely to suffer is
+ * precisely the one nothing checked: a pipeline gains a dispatch and the map's row for that pipeline
+ * is not updated. Measured twice on 2026-08-01 in #1546 — `architecture-refresh` gained a
+ * `finding-depth-triager` step whose diagram node was missing, and `backlog-execution-orchestrator`
+ * gained one with no row change at all. The scan passed both times, because it asked only whether
+ * each AGENT has a row somewhere, never whether the pipeline USING it names it.
+ */
+export function skillDispatches(root, agentNames) {
+  const skillsDir = path.join(root, '.agents/skills');
+  if (!existsSync(skillsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const file = path.join(skillsDir, entry.name, 'SKILL.md');
+    if (!existsSync(file)) continue;
+    const text = readFileSync(file, 'utf8');
+    const dispatched = new Set();
+    for (const sentence of text.replace(/\r?\n/g, ' ').split(/(?<=[.!?][*_`)\]]{0,3})\s+/)) {
+      // An imperative naming the agent — the same reading `agents-cannot-be-told-to-dispatch` uses.
+      // A sentence about what an agent OWNS is a reference, not a dispatch.
+      if (/\bowns\b|\bis the\b|\bbelongs to\b|\bnot this skill/i.test(sentence)) continue;
+      for (const name of agentNames) {
+        if (
+          new RegExp(
+            `\\b(?:dispatch|dispatches|call|calls|invoke|invokes|hand[^.\`]{0,30}to)\\b[^.\`]{0,40}\`?${name}\`?`,
+            'i',
+          ).test(sentence)
+        ) {
+          dispatched.add(name);
+        }
+      }
+    }
+    if (dispatched.size > 0) out.push({ skill: entry.name, agents: [...dispatched].sort() });
+  }
+  return out;
+}
+
+/**
+ * Every pipeline row that mentions `skill`.
+ *
+ * ALL of them, not the first: a shared sub-orchestration appears in several pipelines, and asking
+ * only the first row produced a false positive on `ci-gate-watch` — whose escalation target IS named
+ * in the Release row and is not needed in the PR-review one. A guard that refuses correct work is a
+ * guard that gets switched off.
+ */
+export function rowsForSkill(mapText, skill) {
+  return mapText
+    .split('\n')
+    .filter((line) => line.startsWith('|') && line.includes(`\`${skill}\``));
+}
+
 export function collectOrchestrationMapFindings(root = WORKSPACE_ROOT) {
   requireGovernedTree(root, ['.claude/agents'], {
     scan: 'orchestration-map',
-    why:
-      'The agent definitions are the set the map is checked against; with none, "every agent is listed" is true of nothing.',
+    why: 'The agent definitions are the set the map is checked against; with none, "every agent is listed" is true of nothing.',
   });
   const agentsDir = path.join(root, '.claude/agents');
   const mapPath = path.join(root, '.agents/specs/orchestration-map.md');
@@ -68,6 +121,31 @@ export function collectOrchestrationMapFindings(root = WORKSPACE_ROOT) {
   const rowNames = mapRowNames(mapText);
 
   const findings = [];
+
+  // The pipeline half: a skill that DISPATCHES an agent must have that agent in its own row. Asking
+  // only "does every agent have a row" leaves the registry free to disagree with the wiring, which
+  // is the whole thing it exists to record.
+  const agentNames = existsSync(agentsDir)
+    ? readdirSync(agentsDir)
+        .filter((f) => f.endsWith('.md'))
+        .map(
+          (f) =>
+            asScalar(frontmatterObject(readFileSync(path.join(agentsDir, f), 'utf8')).name) ||
+            f.replace(/\.md$/, ''),
+        )
+    : [];
+  for (const { skill, agents } of skillDispatches(root, agentNames)) {
+    const rows = rowsForSkill(mapText, skill);
+    if (rows.length === 0) continue; // the skill itself is unregistered — a different question
+    for (const agent of agents) {
+      if (!rows.some((row) => row.includes(`\`${agent}\``))) {
+        findings.push(
+          `skill "${skill}" dispatches "${agent}" but its Orchestration Map row does not name it — the registry disagrees with the wiring it exists to record.`,
+        );
+      }
+    }
+  }
+
   if (existsSync(agentsDir)) {
     for (const file of readdirSync(agentsDir).filter((f) => f.endsWith('.md'))) {
       const text = readFileSync(path.join(agentsDir, file), 'utf8');

--- a/scripts/harness/scan-orchestration-map.mjs
+++ b/scripts/harness/scan-orchestration-map.mjs
@@ -52,6 +52,11 @@ export function mapRowNames(mapText) {
   return names;
 }
 
+/** Escape a value being interpolated into a pattern. An agent name is data, not syntax. */
+function reEscape(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * The agents a single skill's text dispatches. Pure, so the reading is testable without a tree —
  * this shipped with no regression test and its own review said so.
@@ -67,7 +72,7 @@ export function dispatchedAgents(text, agentNames) {
       // prose — "this skill handles retries and reports to `some-agent`" — would demand a map edit
       // that no dispatch justifies. Demonstrated on the incident file itself.
       const re = new RegExp(
-        `\\b(?:dispatch(?:es)?|calls?|invokes?|hand(?:s|ed)?\\b[^.\`]{0,30}\\bto)\\b[^.\`]{0,40}\`?${name}\`?`,
+        `\\b(?:dispatch(?:es)?|calls?|invokes?|hand(?:s|ed)?\\b[^.\`]{0,30}\\bto)\\b[^.\`]{0,40}\`?${reEscape(name)}\`?`,
         'i',
       );
       if (re.test(sentence)) dispatched.add(name);

--- a/scripts/harness/scan-orchestration-map.mjs
+++ b/scripts/harness/scan-orchestration-map.mjs
@@ -53,6 +53,30 @@ export function mapRowNames(mapText) {
 }
 
 /**
+ * The agents a single skill's text dispatches. Pure, so the reading is testable without a tree —
+ * this shipped with no regression test and its own review said so.
+ */
+export function dispatchedAgents(text, agentNames) {
+  const dispatched = new Set();
+  for (const sentence of text.replace(/\r?\n/g, ' ').split(/(?<=[.!?][*_`)\]]{0,3})\s+/)) {
+    // An imperative naming the agent — the same reading `agents-cannot-be-told-to-dispatch` uses.
+    // A sentence about what an agent OWNS is a reference, not a dispatch.
+    if (/\bowns\b|\bis the\b|\bbelongs to\b|\bnot this skill/i.test(sentence)) continue;
+    for (const name of agentNames) {
+      // `hand` carries a boundary. Without it `handling`/`handles` anchors the match, so ordinary
+      // prose — "this skill handles retries and reports to `some-agent`" — would demand a map edit
+      // that no dispatch justifies. Demonstrated on the incident file itself.
+      const re = new RegExp(
+        `\\b(?:dispatch(?:es)?|calls?|invokes?|hand(?:s|ed)?\\b[^.\`]{0,30}\\bto)\\b[^.\`]{0,40}\`?${name}\`?`,
+        'i',
+      );
+      if (re.test(sentence)) dispatched.add(name);
+    }
+  }
+  return [...dispatched].sort();
+}
+
+/**
  * Every SKILL that dispatches an agent, and the agents it dispatches.
  *
  * The registry's stated purpose is to be current, and the drift it is most likely to suffer is
@@ -70,24 +94,8 @@ export function skillDispatches(root, agentNames) {
     if (!entry.isDirectory()) continue;
     const file = path.join(skillsDir, entry.name, 'SKILL.md');
     if (!existsSync(file)) continue;
-    const text = readFileSync(file, 'utf8');
-    const dispatched = new Set();
-    for (const sentence of text.replace(/\r?\n/g, ' ').split(/(?<=[.!?][*_`)\]]{0,3})\s+/)) {
-      // An imperative naming the agent — the same reading `agents-cannot-be-told-to-dispatch` uses.
-      // A sentence about what an agent OWNS is a reference, not a dispatch.
-      if (/\bowns\b|\bis the\b|\bbelongs to\b|\bnot this skill/i.test(sentence)) continue;
-      for (const name of agentNames) {
-        if (
-          new RegExp(
-            `\\b(?:dispatch|dispatches|call|calls|invoke|invokes|hand[^.\`]{0,30}to)\\b[^.\`]{0,40}\`?${name}\`?`,
-            'i',
-          ).test(sentence)
-        ) {
-          dispatched.add(name);
-        }
-      }
-    }
-    if (dispatched.size > 0) out.push({ skill: entry.name, agents: [...dispatched].sort() });
+    const dispatched = dispatchedAgents(readFileSync(file, 'utf8'), agentNames);
+    if (dispatched.length > 0) out.push({ skill: entry.name, agents: dispatched });
   }
   return out;
 }


### PR DESCRIPTION
Two classes recurred in this session with **no mechanical floor**. Both have a checkable contract, so both get one — and both are red-proved against the actual incident, not against a fixture invented afterwards.

## 1. A skill must not instruct what its own table disowns

Fourteen skills carry a `## What This Skill Does NOT Do` table naming an action and its owner. **Nothing checked that the body agreed with the table** — and the body is what an agent follows.

Measured in #1546: `pr-review-orchestration` told itself to post replies to the PR while its own table gave posting to `pr-review-writer`, its header said it "does not review, write, fix, or judge", and its closing line said to stop if you catch yourself doing any of them. **Three statements of one boundary, and the procedure between them crossed it.**

`declared-boundaries-hold.test.mjs`. Narrow on purpose: only **performable** actions are scanned. Most rows read "Define …" / "Decide …", which state who owns a *policy* — a routing skill referring to one is not doing it.

## 2. The registry must agree with the wiring

`orchestration-map` asked only whether each **agent** has a row. It never asked whether the pipeline **using** one names it — so a dispatch could be added and the map left describing the world before it. That is precisely the drift a registry whose stated purpose is "mechanically kept current" is most likely to suffer. Measured **twice** in #1546.

The scan now also checks: a skill that dispatches an agent must have that agent in a row that mentions the skill.

## Both needed a second attempt — which is the point

Each floor's first version **passed over the very thing it was written for**:

| Floor | First version | Why it missed |
| --- | --- | --- |
| boundary | matched the table's leading verb | table said "Post", body said "reply" — read as different actions |
| registry | read only the FIRST row mentioning a skill | false-positived on `ci-gate-watch`, a shared sub-orchestration whose escalation target is named in the Release row and not needed in PR-review |
| both | split sentences on `[.!?]\s+` | markdown emphasis after the period (`formed.**`) glued two sentences together; the merged text then hit an exclusion meant for the second, and the dispatch went unseen |

A guard is distinguished from a decoration by exactly one test: run it against the incident. All three of those were found that way, and none would have been found by reading the code.

## Verification

- **Red-proved**: restoring each incident makes its floor FAIL with the offending sentence quoted back; restoring the fix makes it pass.
- The registry half found a live pre-existing drift on its first run (`ci-gate-watch` → `ci-failure-triager`), which turned out to be the false positive above — measured before acting on it.
- 1790 harness tests green (119 files), 83 scans pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso