### PR TITLE
fix(hooks): a quote that opens inside a substitution is the substitution's

### DIFF
--- a/.agents/backlog/INFRA-075-substitution-span-restores-its-own-quotes.md
+++ b/.agents/backlog/INFRA-075-substitution-span-restores-its-own-quotes.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-075: restoring a command-substitution span un-masks the quotes inside it'
-status: todo
+status: in-progress
 priority: high
 urgency: now
 type: INFRA
@@ -75,6 +75,31 @@ person who is blocked by a quoted mention knows in one search that it is known a
 one-line fix.
 
 `BRANCH_GUARD_ALLOW_*` overrides remain the operator's way past it, and they announce themselves.
+
+## Resolved (2026-08-01) — the first half
+
+The restore pass now keeps a quote that OPENED INSIDE the span. The first pass already masked such a
+region correctly; the second pass was taking it back wholesale. Recording the index where each
+enclosing quote opened is enough to tell the two cases apart:
+
+- a quote opened BEFORE the span was context the substitution overrides → restore it;
+- a quote opened INSIDE the span belongs to the substitution → it stands.
+
+Measured, both directions:
+
+```
+out=$(printf 'x git commit -m y' | bash h.sh); echo done   → exit 0   (was BLOCKED)
+git commit -m real            (on develop)                 → exit 2   (unchanged)
+out="$(git commit -m x)"                                    → still seen as a commit
+```
+
+The differential corpus removed its own exemption for this case, because the exemption was pinned as
+a DISAGREEMENT — closing it turned the case red until the exemption was deleted. That is the property
+that keeps an exemption from outliving its reason.
+
+**Still open: the second half.** `echo \"git push\"` — an escaped quote is a literal character, so the
+verb survives as bare words in an ARGUMENT list, and the masker has no notion of command position.
+That needs the tokenizer this item asks for; masking cannot reach it. The corpus still pins it.
 
 ## Done when
 

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -358,6 +358,11 @@ HOOK_SCAN_AWK='
       } else {
         m[i] = keep ? c : "\001"
         if (q == "\047") { sq[i] = 1 }
+        # Where the enclosing quote OPENED. A substitution restores its span, and a quote that
+        # opened INSIDE that span must survive the restore while one opened outside it must not.
+        # Without this index the restore could only take everything back, which un-masked the
+        # quotes the pass above had just masked. See INFRA-075.
+        qopen[i] = openq
       }
     }
 
@@ -381,12 +386,23 @@ HOOK_SCAN_AWK='
           if (cj == "(") { depth++ } else if (cj == ")") { depth--; if (depth == 0) { break } }
         }
         stop = (j <= len) ? j : len
-        for (k = i; k <= stop; k++) { m[k] = substr(s, k, 1) }
+        for (k = i; k <= stop; k++) {
+          # Restore the span, but NOT a region quoted inside it. A double-quoted substitution runs,
+          # so it must come back; a substitution whose own argument is quoted runs an echo over a
+          # payload, and restoring that raw read the payload as a command. The test is where the
+          # enclosing quote OPENED: before the span, the mask came from context the substitution
+          # overrides; inside it, the quote belongs to the substitution and stands.
+          if (qopen[k] != "" && qopen[k] >= i && qopen[k] <= stop) { continue }
+          m[k] = substr(s, k, 1)
+        }
         i = stop
       } else if (substr(s, i, 1) == "`") {
         for (j = i + 1; j <= len; j++) { if (substr(s, j, 1) == "`") { break } }
         stop = (j <= len) ? j : len
-        for (k = i; k <= stop; k++) { m[k] = substr(s, k, 1) }
+        for (k = i; k <= stop; k++) {
+          if (qopen[k] != "" && qopen[k] >= i && qopen[k] <= stop) { continue }
+          m[k] = substr(s, k, 1)
+        }
         i = stop
       }
     }

--- a/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
+++ b/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
@@ -128,8 +128,9 @@ const CORPUS = [
   'git commit -m "about to git push later"',
   '# git push',
   'echo hi # git push',
-  // A mention nested inside a substitution — the shape that is still open (INFRA-075).
-  // Deliberately NOT asserted below; see the exemption list.
+  // A mention nested inside a substitution. Open until 2026-08-01, when the restore pass learned to
+  // keep a quote that opens INSIDE the span; the exemption was removed because this case went green,
+  // which is what pinning a disagreement AS a disagreement buys.
   "out=$(echo 'git push'); echo $out",
   // Interpreter strings — the verb really does run, inside another shell.
   'bash -c "git push"',
@@ -146,10 +147,6 @@ const CORPUS = [
  * ID — an unexplained one is how a corpus becomes decorative.
  */
 const KNOWN_OPEN = new Map([
-  [
-    "out=$(echo 'git push'); echo $out",
-    'INFRA-075 — a substitution span is restored whole, un-masking the quotes inside it',
-  ],
   [
     'echo \\"git push\\"',
     'INFRA-075 (same root) — an escaped quote is a literal character, so the verb survives as bare ' +


### PR DESCRIPTION
**INFRA-075** (#1542), first half — the FOUNDATIONAL finding held under containment since this morning, now resolved.

## The reproduction, closed

```
out=$(printf 'x git commit -m y' | bash h.sh); echo done   →  exit 0   (was BLOCKED)
printf 'x git commit -m y' | bash h.sh                     →  exit 0   (unchanged)
git commit -m real            (on develop)                 →  exit 2   (unchanged)
```

Nothing in the first command commits anything. The verb sat inside a single-quoted argument — exactly what the masker exists to neutralise, and it **did** neutralise it. The second pass then restored the substitution span wholesale and took the masking back with it.

## The fix is a distinction, not a wider pattern

Both of these must keep working, and they pull opposite ways:

| command | must read as |
| --- | --- |
| `"$(git commit)"` | a real commit — expansion happens inside double quotes, so the substitution runs |
| `$(echo 'git push')` | not a push — the substitution runs an `echo` whose argument is a quoted payload |

The first pass now records **where each enclosing quote opened**, and the restore uses it:

- a quote opened **before** the span was context the substitution overrides → restore it;
- a quote opened **inside** the span belongs to the substitution → it stands.

## The corpus deleted its own exemption

This case was pinned in `hook-reading-matches-bash.test.mjs` as a **disagreement**, not skipped. So closing it turned that case **red** until the exemption was removed — which is precisely what keeps an exemption from outliving its reason, and why it was written that way.

## Still open, and still pinned

`echo \"git push\"` — an escaped quote is a literal character, so the verb survives as bare words in an **argument list**, and the masker has no notion of command position. That needs the tokenizer INFRA-075 asks for; no masking rule reaches it. The corpus keeps the pin, with the reason.

## Verification

- 27/27 in the bash-differential corpus, which judges the masker against **what bash actually does** rather than against a case list.
- 1795 harness tests green (119 files), 83 scans pass.
- Both halves measured directly against `branch-guard`: the nested mention passes, a real commit on a protected branch still refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso