### PR TITLE
feat(rules): re-plan withdraws the change, and the gate holds it to that

### DIFF
--- a/.agents/rules/finding-depth.md
+++ b/.agents/rules/finding-depth.md
@@ -35,6 +35,22 @@ Containment is permitted only when the change must land first, and only under al
 it is the smallest thing that keeps the tree honest, it introduces no new abstraction, and it names
 the root item's ID in both a code comment and the commit body. An unlabelled hold is a patch.
 
+**The disposition decides what happens to the change, and it is recorded, not narrated.**
+
+- **re-plan** — the change is WITHDRAWN or reduced. Comment the decision on the PR and CLOSE it. It
+  does not merge as it stands, and `merge-gate` refuses it: `record-local-review --disposition
+re-plan` is read at the merge, so the withdrawal is a state the machine holds rather than a
+  sentence someone wrote. Until that existed, `re-plan` was the only part of this rule with no
+  consequence — containment left a code comment and a commit body, and re-plan left a note.
+- **containment** — the change lands with the labelled hold above, and the PR stays open.
+
+**Closing on re-plan is not the same as closing on every foundational finding**, and the difference
+is measured. On 2026-08-01, three foundational verdicts were taken on two PRs; in all three the root
+predated the change and the change was independently correct. Closing them would have discarded a
+fix that gave a dead gate its first verdict in its entire life, and left two live guard bypasses
+standing while a tokenizer was written. A foundational finding says where the DEFECT is, not whether
+this change is worth keeping — those are different questions, and only the second decides the PR.
+
 **The label is a condition, not a courtesy.** A hold with no such comment is indistinguishable from
 having ignored the finding. It is also what lets the review loop converge: a foundational finding is
 not fixed, so the next round sees the same code and would raise it again. The comment at the site IS

--- a/.agents/skills/pr-review-orchestration/SKILL.md
+++ b/.agents/skills/pr-review-orchestration/SKILL.md
@@ -66,12 +66,11 @@ the judgement is the guardian's, the routing is this skill's, and neither does t
   `pnpm harness:review:record -- --findings 0 --foundational <ID>[,<ID>...] --disposition re-plan|containment`.
   The recorder refuses a foundational finding with no disposition, because the rule allows exactly two.
   - **containment** — the smallest hold, naming the item's ID in a code comment and the commit body. The
-    PR stays open.
+    PR stays open, and this is the branch that **returns to A1**: a containment is a change like any
+    other and the next round reads it. Push is A3's, and only once a round comes back zero.
   - **re-plan** — the change is withdrawn or reduced. Have `pr-review-writer` comment the decision on the
-    PR, then CLOSE it. `merge-gate` refuses the merge either way, so a withdrawal left open cannot land
-    by being forgotten.
-    Then **return to A1**: the containment is a change like any other, and the next round reads it.
-    Push is A3's, and only once a round comes back zero.
+    PR, then CLOSE it. There is nothing to return to A1 for. `merge-gate` refuses the merge regardless,
+    so a withdrawal left open cannot land by being forgotten.
 
 A loop that fixes every finding where it was reported converges just as cleanly as one that does not, which
 is why the depth question has to be asked before the fix rather than noticed afterwards.

--- a/.agents/skills/pr-review-orchestration/SKILL.md
+++ b/.agents/skills/pr-review-orchestration/SKILL.md
@@ -62,11 +62,16 @@ the judgement is the guardian's, the routing is this skill's, and neither does t
 - **UNDETERMINED** → not a pass. Obtain the specific thing the verdict names as missing, then re-run
   A1 on that finding. Treating it as LOCAL is how a guess enters the loop wearing a verdict's clothes.
 - **FOUNDATIONAL** → do NOT send it back into the fix loop. Route to `backlog-writer` for the root item,
-  register its GitHub issue, then take the disposition: **re-plan** (the change is withdrawn or reduced) or
-  **labelled containment** (the smallest hold, naming the item's ID in a code comment and the commit body).
-  Record the IDs with the round: `pnpm harness:review:record -- --findings 0 --foundational <ID>[,<ID>...]`.
-  Then **return to A1**: the containment is a change like any other, and the next round reads it.
-  Push is A3's, and only once a round comes back zero.
+  register its GitHub issue, then take the disposition and RECORD it:
+  `pnpm harness:review:record -- --findings 0 --foundational <ID>[,<ID>...] --disposition re-plan|containment`.
+  The recorder refuses a foundational finding with no disposition, because the rule allows exactly two.
+  - **containment** — the smallest hold, naming the item's ID in a code comment and the commit body. The
+    PR stays open.
+  - **re-plan** — the change is withdrawn or reduced. Have `pr-review-writer` comment the decision on the
+    PR, then CLOSE it. `merge-gate` refuses the merge either way, so a withdrawal left open cannot land
+    by being forgotten.
+    Then **return to A1**: the containment is a change like any other, and the next round reads it.
+    Push is A3's, and only once a round comes back zero.
 
 A loop that fixes every finding where it was reported converges just as cleanly as one that does not, which
 is why the depth question has to be asked before the fix rather than noticed afterwards.

--- a/.claude/hooks/merge-gate.sh
+++ b/.claude/hooks/merge-gate.sh
@@ -208,7 +208,17 @@ MERGE_CWD=$(hook_cwd_of "$INPUT" || true)
 if [[ -n "$MERGE_CWD" ]] && git -C "$MERGE_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   RECORD_DIR_FOR_MERGE="$MERGE_CWD"
 fi
-if command -v node >/dev/null 2>&1 && [[ -f "$RECORDER" ]] && git -C "$RECORD_DIR_FOR_MERGE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+# Fail closed when the recorder cannot be consulted at all, like every other unreadable state in
+# this file — a missing `jq`, a missing `gh`, an unreadable head date all refuse. Skipping silently
+# would make "I could not read the disposition" indistinguishable from "there is none", which is the
+# pair this hook is built not to conflate.
+if ! command -v node >/dev/null 2>&1 || [[ ! -f "$RECORDER" ]]; then
+  echo "[merge-gate] Blocked: cannot read the local round's disposition (node or the recorder is" >&2
+  echo "[merge-gate] missing), so whether this change was withdrawn is unknown. Override inline:" >&2
+  echo "[merge-gate] MERGE_GATE_ACK=1 gh pr merge $PR --merge" >&2
+  exit 2
+fi
+if git -C "$RECORD_DIR_FOR_MERGE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   if ! DISPOSITION_STATE=$(cd "$RECORD_DIR_FOR_MERGE" && node "$RECORDER" --merge-blocked 2>&1); then
     echo "[merge-gate] Blocked: ${DISPOSITION_STATE:-the local round withdrew this change}." >&2
     echo "[merge-gate] Comment the decision on the PR and close it, or record \`containment\` if the" >&2

--- a/.claude/hooks/merge-gate.sh
+++ b/.claude/hooks/merge-gate.sh
@@ -191,5 +191,31 @@ if [[ -z "$COUNT" ]]; then
   exit 2
 fi
 
+# The local round's DISPOSITION, for a foundational finding. `finding-depth.md` allows exactly two:
+# `containment` — the change lands with a labelled hold naming the root item — and `re-plan`, which
+# means the change is WITHDRAWN or reduced. Until this line existed, only one of them did anything:
+# containment left a code comment and a commit body, while re-plan was a word in a note that nothing
+# read, so a change recorded as withdrawn merged like any other. A disposition nothing acts on is a
+# decision with no actor.
+#
+# The verdict is the recorder's, not this hook's — same split as the review record itself.
+RECORDER="$(dirname "${BASH_SOURCE[0]}")/../../scripts/harness/record-local-review.mjs"
+# The checkout the merge is about — the hook payload's cwd when it names a work tree, else the
+# project dir. The recorder resolves its repository from the directory it RUNS in, so pointing it
+# at the wrong one would read another checkout's record while judging this one.
+RECORD_DIR_FOR_MERGE="${CLAUDE_PROJECT_DIR:-.}"
+MERGE_CWD=$(hook_cwd_of "$INPUT" || true)
+if [[ -n "$MERGE_CWD" ]] && git -C "$MERGE_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  RECORD_DIR_FOR_MERGE="$MERGE_CWD"
+fi
+if command -v node >/dev/null 2>&1 && [[ -f "$RECORDER" ]] && git -C "$RECORD_DIR_FOR_MERGE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if ! DISPOSITION_STATE=$(cd "$RECORD_DIR_FOR_MERGE" && node "$RECORDER" --merge-blocked 2>&1); then
+    echo "[merge-gate] Blocked: ${DISPOSITION_STATE:-the local round withdrew this change}." >&2
+    echo "[merge-gate] Comment the decision on the PR and close it, or record \`containment\` if the" >&2
+    echo "[merge-gate] change must land with a labelled hold. Deliberate exception: MERGE_GATE_ACK=1" >&2
+    exit 2
+  fi
+fi
+
 echo "[merge-gate] PR #$PR: CI CLEAN, review newer than head, ACTIONABLE FINDINGS: 0. READ IT." >&2
 exit 0

--- a/scripts/harness/__tests__/declared-options-have-a-reader.test.mjs
+++ b/scripts/harness/__tests__/declared-options-have-a-reader.test.mjs
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { DISPOSITIONS } from '../record-local-review.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+/**
+ * A rule that offers a choice must have somewhere for the choice to be RECORDED, and every option it
+ * names must be one that place accepts.
+ *
+ * Measured 2026-08-01. `finding-depth.md` offered two dispositions for a FOUNDATIONAL verdict and
+ * said "never a third option". One of them did something: `containment` left a code comment and a
+ * commit body carrying the root item's ID. The other, `re-plan` — the change is WITHDRAWN — was a
+ * word in a note that nothing read, so a change recorded as withdrawn merged like any other.
+ *
+ * That is a decision with no actor, and it had been sitting inside the rule written against exactly
+ * that shape. It was found by a person reading the rule, not by anything mechanical: the recorder had
+ * no disposition field at all, so there was nothing to disagree with.
+ *
+ * This is the disagreement. The rule's option list and the recorder's accepted set are read from
+ * their two sources and required to be the same set — so an option added to the prose with nowhere
+ * to record it fails, and so does a value the recorder accepts that the rule never sanctioned.
+ *
+ * What it does NOT claim: that each option then has a consequence. `re-plan` earns its keep because
+ * `merge-gate` refuses the merge, and that is held by its own case in `merge-gate-decision`. This
+ * check holds the earlier step — that the choice can be written down at all.
+ */
+const RULE = path.join(WORKSPACE_ROOT, '.agents/rules/finding-depth.md');
+
+/**
+ * The dispositions the rule names, read from the section that defines them.
+ *
+ * Scoped to that section on purpose: the same `- **name** —` shape carries the four VERDICTS earlier
+ * in the file, and a whole-file scan would conflate two vocabularies — which is the kind of quiet
+ * over-match that makes a floor fire on correct work.
+ */
+export function declaredDispositions(ruleText) {
+  const start = ruleText.indexOf('**The disposition decides');
+  if (start === -1) return [];
+  const rest = ruleText.slice(start);
+  const end = rest.indexOf('\n**');
+  const section = end === -1 ? rest : rest.slice(0, end);
+  return [...section.matchAll(/^- \*\*([a-z-]+)\*\*/gm)].map((m) => m[1]).sort();
+}
+
+describe('an option the rule offers has somewhere to be recorded', () => {
+  const ruleText = readFileSync(RULE, 'utf8');
+
+  it('finds the section it reads', () => {
+    // Fail closed: a renamed heading would make the comparison below pass over an empty list, which
+    // is the vacuity this whole file is about.
+    expect(declaredDispositions(ruleText).length).toBeGreaterThan(1);
+  });
+
+  it('the rule and the recorder name the same set', () => {
+    expect(
+      declaredDispositions(ruleText),
+      'the rule offers a disposition the recorder will not accept, or the recorder accepts one the ' +
+        'rule never sanctioned. An option with nowhere to be written down is a decision made in ' +
+        'prose and absent from anything that acts on it.',
+    ).toEqual([...DISPOSITIONS].sort());
+  });
+
+  it('reads the option list, and not the verdict list above it', () => {
+    // The distinction this rests on, pinned. `- **LOCAL** —` and friends use the identical shape a
+    // few paragraphs earlier; a whole-file match would return six names and compare two vocabularies
+    // as one.
+    expect(declaredDispositions(ruleText)).not.toContain('local');
+    expect(declaredDispositions(ruleText)).not.toContain('foundational');
+    expect(
+      declaredDispositions('nothing here'),
+      'a missing section returned options it could not have read',
+    ).toEqual([]);
+  });
+});

--- a/scripts/harness/__tests__/merge-gate-decision.test.mjs
+++ b/scripts/harness/__tests__/merge-gate-decision.test.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -274,5 +274,77 @@ describe('the merge gate decides on CI and on a current review', () => {
 
     expect(verdict.status).toBe(0);
     expect(verdict.output.trim()).toBe('');
+  });
+});
+
+describe('a re-planned change does not merge', () => {
+  // `finding-depth.md` allows two dispositions for a FOUNDATIONAL verdict, and until now only one
+  // of them did anything. `containment` had a code comment and a commit body carrying the root ID;
+  // `re-plan` — the change is WITHDRAWN or reduced — was a word in a note. A disposition nothing
+  // reads is a decision with no actor, which is the very shape the rule exists against.
+  //
+  // The gate refuses it now. Closing the PR is the tidy expression of a withdrawal; refusing the
+  // merge is the part a machine can hold.
+  /** A checkout whose recorded round took `disposition`, with everything else clean. */
+  function repoWithDisposition(disposition) {
+    const dir = mkdtempSync(path.join(tmpdir(), 'merge-disp-'));
+    scratch.push(dir);
+    const git = (...a) => spawnSync('git', ['-C', dir, ...a], { encoding: 'utf8' });
+    git('init', '--quiet', '--initial-branch=feat/probe');
+    git('config', 'user.email', 'harness@example.test');
+    git('config', 'user.name', 'Harness');
+    writeFileSync(path.join(dir, 'f'), 'x\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'chore: root');
+    const sha = spawnSync('git', ['-C', dir, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).stdout.trim();
+    mkdirSync(path.join(dir, '.agents/local-reviews'), { recursive: true });
+    writeFileSync(
+      path.join(dir, '.agents/local-reviews/feat%2Fprobe.json'),
+      JSON.stringify({
+        branch: 'feat/probe',
+        headSha: sha,
+        findings: 0,
+        foundational: ['INFRA-073'],
+        disposition,
+      }),
+    );
+    return dir;
+  }
+
+  function judgeIn(repo) {
+    const result = spawnSync('bash', [HOOK], {
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        cwd: repo,
+        tool_input: { command: 'gh pr merge 7 --merge' },
+      }),
+      cwd: repo,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: stubbedPath({
+          state: 'CLEAN',
+          headAt: '2026-01-01T00:00:00Z',
+          comments: [REVIEW('2026-01-02T00:00:00Z')],
+        }),
+        CLAUDE_PROJECT_DIR: repo,
+      },
+    });
+    return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+  }
+
+  it('refuses when the local record took the re-plan disposition', () => {
+    const verdict = judgeIn(repoWithDisposition('re-plan'));
+
+    expect(verdict.status, `a withdrawn change was allowed to merge: ${verdict.output}`).toBe(2);
+    expect(verdict.output).toMatch(/re-plan/);
+  });
+
+  it('allows a contained change, which is the other half of the same rule', () => {
+    const verdict = judgeIn(repoWithDisposition('containment'));
+
+    expect(verdict.status, `a labelled containment was refused: ${verdict.output}`).toBe(0);
   });
 });

--- a/scripts/harness/__tests__/merge-gate-decision.test.mjs
+++ b/scripts/harness/__tests__/merge-gate-decision.test.mjs
@@ -73,10 +73,18 @@ function stubbedPath({ state, comments = [], headAt }) {
 }
 
 function judge(world, command = 'cd /repo && gh pr merge 7 --merge') {
+  // An EMPTY scratch directory, not the real checkout. `CLAUDE_PROJECT_DIR` had no effect on this
+  // hook until it began reading the local review record; pointed at the workspace it would read the
+  // DEVELOPER'S own branch, HEAD and record — so a session that had recorded `--disposition
+  // re-plan`, which is the very workflow this suite covers, would see unrelated cases fail with
+  // exit 2. A test that depends on the machine it runs on is a test that will be believed wrongly.
+  const isolated = mkdtempSync(path.join(tmpdir(), 'merge-gate-cwd-'));
+  scratch.push(isolated);
   const result = spawnSync('bash', [HOOK], {
-    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command } }),
+    input: JSON.stringify({ tool_name: 'Bash', cwd: isolated, tool_input: { command } }),
+    cwd: isolated,
     encoding: 'utf8',
-    env: { ...process.env, PATH: stubbedPath(world), CLAUDE_PROJECT_DIR: WORKSPACE_ROOT },
+    env: { ...process.env, PATH: stubbedPath(world), CLAUDE_PROJECT_DIR: isolated },
   });
   return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
 }

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -531,6 +531,24 @@ describe('a foundational finding must name a root item that exists', () => {
     expect(recordIn(dir, ['--merge-blocked']).status, 'a contained change was refused').toBe(0);
   });
 
+  it('a detached HEAD has no record to consult, which is not a withdrawal', () => {
+    // Measured in CI, which local runs could not see: `actions/checkout` leaves a detached HEAD for
+    // a pull request, and the recorder refuses one because a record is keyed to a branch. The merge
+    // gate read that refusal as "this change was withdrawn" and blocked four passing cases.
+    //
+    // The two states a guard must never conflate, in the smallest possible form: "no record to
+    // consult" is not "recorded as withdrawn".
+    const dir = repoWithBacklog([]);
+    spawnSync('git', ['-C', dir, 'checkout', '--quiet', '--detach'], { encoding: 'utf8' });
+
+    const verdict = recordIn(dir, ['--merge-blocked']);
+
+    expect(
+      verdict.status ?? 1,
+      `a detached HEAD reported itself withdrawn: ${verdict.output}`,
+    ).toBe(0);
+  });
+
   it('refuses a flag it does not understand instead of ignoring it', () => {
     // `--note` (singular) was accepted by silence for as long as the recorder existed: the argument
     // parser skipped anything it did not recognise, so every note passed that way was dropped and

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -328,7 +328,14 @@ describe('a foundational finding must name a root item that exists', () => {
     // root item exists. So the recorder refuses rather than storing an unresolvable promise.
     const dir = repoWithBacklog(['INFRA-073']);
 
-    const verdict = recordIn(dir, ['--findings', '0', '--foundational', 'INFRA-999']);
+    const verdict = recordIn(dir, [
+      '--findings',
+      '0',
+      '--disposition',
+      'containment',
+      '--foundational',
+      'INFRA-999',
+    ]);
 
     expect(verdict.status, 'an unfiled root item was accepted').not.toBe(0);
     expect(verdict.output).toMatch(/INFRA-999/);
@@ -340,6 +347,8 @@ describe('a foundational finding must name a root item that exists', () => {
     const verdict = recordIn(dir, [
       '--findings',
       '0',
+      '--disposition',
+      'containment',
       '--foundational',
       'INFRA-073,PROC-004',
       '--notes',
@@ -361,7 +370,14 @@ describe('a foundational finding must name a root item that exists', () => {
     // most likely to teach someone to stop using the flag.
     const dir = repoWithBacklog(['ARCH-AUDIT-001', 'HARNESS-DIET-006']);
 
-    const verdict = recordIn(dir, ['--findings', '0', '--foundational', 'HARNESS-DIET-006']);
+    const verdict = recordIn(dir, [
+      '--findings',
+      '0',
+      '--disposition',
+      'containment',
+      '--foundational',
+      'HARNESS-DIET-006',
+    ]);
 
     expect(verdict.status, verdict.output).toBe(0);
   });
@@ -374,10 +390,14 @@ describe('a foundational finding must name a root item that exists', () => {
     mkdirSync(path.join(dir, '.agents/backlog'), { recursive: true });
     writeFileSync(path.join(dir, '.agents/backlog', 'INFRA-073.md'), '---\nstatus: todo\n---\n');
 
-    const result = spawnSync('node', [RECORDER, '--findings', '0', '--foundational', 'INFRA-073'], {
-      cwd: dir,
-      encoding: 'utf8',
-    });
+    const result = spawnSync(
+      'node',
+      [RECORDER, '--findings', '0', '--disposition', 'containment', '--foundational', 'INFRA-073'],
+      {
+        cwd: dir,
+        encoding: 'utf8',
+      },
+    );
 
     expect(result.status ?? 1, `${result.stdout ?? ''}${result.stderr ?? ''}`).toBe(0);
   });
@@ -396,14 +416,30 @@ describe('a foundational finding must name a root item that exists', () => {
 
     const ok = spawnSync(
       'node',
-      [RECORDER, '--findings', '0', '--foundational', 'SELFHOST-008-P5'],
+      [
+        RECORDER,
+        '--findings',
+        '0',
+        '--disposition',
+        'containment',
+        '--foundational',
+        'SELFHOST-008-P5',
+      ],
       { cwd: dir, encoding: 'utf8' },
     );
     expect(ok.status ?? 1, `${ok.stdout ?? ''}${ok.stderr ?? ''}`).toBe(0);
 
     const truncated = spawnSync(
       'node',
-      [RECORDER, '--findings', '0', '--foundational', 'SELFHOST-008'],
+      [
+        RECORDER,
+        '--findings',
+        '0',
+        '--disposition',
+        'containment',
+        '--foundational',
+        'SELFHOST-008',
+      ],
       { cwd: dir, encoding: 'utf8' },
     );
     expect(truncated.status ?? 1, 'an ID naming no file was accepted').not.toBe(0);
@@ -417,7 +453,7 @@ describe('a foundational finding must name a root item that exists', () => {
 
     const verdict = spawnSync(
       'node',
-      [RECORDER, '--findings', '0', '--foundational', 'INFRA-073'],
+      [RECORDER, '--findings', '0', '--disposition', 'containment', '--foundational', 'INFRA-073'],
       {
         cwd: dir,
         encoding: 'utf8',
@@ -428,6 +464,71 @@ describe('a foundational finding must name a root item that exists', () => {
     expect(`${verdict.stdout ?? ''}${verdict.stderr ?? ''}`).toMatch(
       /missing|not examined|examined/i,
     );
+  });
+
+  it('refuses a foundational finding with no disposition', () => {
+    // The rule allows exactly two — re-plan or labelled containment — and "never a third option".
+    // Recording the root item without saying which was taken leaves the decision made in prose and
+    // absent from anything that acts, which is the shape this whole rule exists against.
+    const dir = repoWithBacklog(['INFRA-073']);
+
+    const verdict = recordIn(dir, ['--findings', '0', '--foundational', 'INFRA-073']);
+
+    expect(verdict.status, 'a foundational verdict was recorded with no disposition').not.toBe(0);
+    expect(verdict.output).toMatch(/disposition/i);
+  });
+
+  it('stores the disposition, and only the two the rule allows', () => {
+    const dir = repoWithBacklog(['INFRA-073']);
+
+    expect(
+      recordIn(dir, [
+        '--findings',
+        '0',
+        '--foundational',
+        'INFRA-073',
+        '--disposition',
+        'sit-on-it',
+      ]).status,
+      'a third option was accepted',
+    ).not.toBe(0);
+
+    const ok = recordIn(dir, [
+      '--findings',
+      '0',
+      '--foundational',
+      'INFRA-073',
+      '--disposition',
+      're-plan',
+    ]);
+    expect(ok.status, ok.output).toBe(0);
+
+    const stored = JSON.parse(
+      readFileSync(recordPathFor('feat/probe', path.join(dir, '.agents/local-reviews')), 'utf8'),
+    );
+    expect(stored.disposition).toBe('re-plan');
+  });
+
+  it('reports that a re-planned change must not merge', () => {
+    // The half that was missing: `re-plan` means the change is WITHDRAWN, and until now that was a
+    // word in a note. A disposition nothing reads is a decision with no actor.
+    const dir = repoWithBacklog(['INFRA-073']);
+    recordIn(dir, ['--findings', '0', '--foundational', 'INFRA-073', '--disposition', 're-plan']);
+
+    const blocked = recordIn(dir, ['--merge-blocked']);
+    expect(blocked.status, 'a re-planned change reported itself mergeable').not.toBe(0);
+    expect(blocked.output).toMatch(/re-plan/);
+
+    // Containment is the other half, and it must NOT block — the change lands with a labelled hold.
+    recordIn(dir, [
+      '--findings',
+      '0',
+      '--foundational',
+      'INFRA-073',
+      '--disposition',
+      'containment',
+    ]);
+    expect(recordIn(dir, ['--merge-blocked']).status, 'a contained change was refused').toBe(0);
   });
 
   it('refuses a flag it does not understand instead of ignoring it', () => {

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -247,6 +247,21 @@ function main() {
   const branch = git(['branch', '--show-current'], root);
   const headSha = git(['rev-parse', 'HEAD'], root);
 
+  // Asked BEFORE the detached-HEAD refusal below, deliberately. `actions/checkout` leaves a
+  // detached HEAD for a pull request, and reading that refusal as an answer made the merge gate
+  // treat "no record to consult" as "recorded as withdrawn" — it blocked four passing cases in CI
+  // that every local run passed, because a local run is on a branch. The two states a guard must
+  // never conflate, in the smallest possible form.
+  if (args.mergeBlocked) {
+    if (!branch) process.exit(0);
+    const reason = mergeBlockReason(branch, headSha, recordDirFor(root));
+    if (reason) {
+      console.error(`record-local-review: ${reason}`);
+      process.exit(1);
+    }
+    process.exit(0);
+  }
+
   // A record is keyed by branch, so a detached HEAD has no key: every detached invocation would
   // share `.agents/local-reviews/.json` and satisfy the gate for every other. `pre-push-check` had
   // this guard and this file did not, which is exactly the split this file's docstring says it
@@ -257,15 +272,6 @@ function main() {
     );
     console.error('Check out the branch this commit belongs to and run it again.');
     process.exit(1);
-  }
-
-  if (args.mergeBlocked) {
-    const reason = mergeBlockReason(branch, headSha, recordDirFor(root));
-    if (reason) {
-      console.error(`record-local-review: ${reason}`);
-      process.exit(1);
-    }
-    process.exit(0);
   }
 
   if (args.show) {

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -147,6 +147,35 @@ export function reviewState(branch, headSha, dir = RECORD_DIR) {
   return { ok: true, reason: `reviewed at ${headSha.slice(0, 9)} — 0 findings` };
 }
 
+/**
+ * The two dispositions `finding-depth.md` allows for a FOUNDATIONAL verdict, and no third.
+ *
+ * `re-plan` means the change is WITHDRAWN or reduced; `containment` means it lands with a labelled
+ * hold. Until this was recorded, the choice lived in a note — a decision with no actor, which is the
+ * shape the rule itself exists against. Recorded, `re-plan` can be read by the merge gate.
+ */
+export const DISPOSITIONS = new Set(['re-plan', 'containment']);
+
+/** Why this branch must not merge at this commit, or null. */
+export function mergeBlockReason(branch, headSha, dir = RECORD_DIR) {
+  const file = recordPathFor(branch, dir);
+  if (!existsSync(file)) return null; // no record is pre-push's question, not this one
+  let stored;
+  try {
+    stored = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (stored.headSha !== headSha) return null;
+  if (stored.disposition !== 're-plan') return null;
+  const ids = (stored.foundational ?? []).join(', ') || 'a root item';
+  return (
+    `the review at ${headSha.slice(0, 9)} took the re-plan disposition on ${ids} — the change is ` +
+    'withdrawn or reduced, so it does not merge as it stands. Comment the decision on the PR and ' +
+    'close it, or record `containment` if the change must land with a labelled hold.'
+  );
+}
+
 /** Convenience predicate over {@link reviewState}. */
 export function isReviewed(branch, headSha, dir = RECORD_DIR) {
   return reviewState(branch, headSha, dir).ok;
@@ -178,9 +207,19 @@ export function resolveRootItems(ids, backlogDir) {
 }
 
 export function parseArgs(argv) {
-  const args = { findings: null, notes: '', show: false, foundational: [], unknown: [] };
+  const args = {
+    findings: null,
+    notes: '',
+    show: false,
+    mergeBlocked: false,
+    foundational: [],
+    disposition: '',
+    unknown: [],
+  };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--show') args.show = true;
+    else if (argv[i] === '--merge-blocked') args.mergeBlocked = true;
+    else if (argv[i] === '--disposition') args.disposition = String(argv[++i] ?? '').trim();
     else if (argv[i] === '--findings') args.findings = Number(argv[++i]);
     else if (argv[i] === '--notes') args.notes = String(argv[++i] ?? '');
     else if (argv[i] === '--foundational') {
@@ -220,6 +259,15 @@ function main() {
     process.exit(1);
   }
 
+  if (args.mergeBlocked) {
+    const reason = mergeBlockReason(branch, headSha, recordDirFor(root));
+    if (reason) {
+      console.error(`record-local-review: ${reason}`);
+      process.exit(1);
+    }
+    process.exit(0);
+  }
+
   if (args.show) {
     // The single owner of "is this commit reviewed". `pre-push-check` calls this and routes on the
     // exit code rather than re-parsing the record in bash — the duplicated-logic drift this whole
@@ -244,6 +292,21 @@ function main() {
       `record-local-review: ${args.findings} finding(s) still open — nothing to record yet.`,
     );
     console.error('Resolve them, review again, then record. The round is what saves the CI trip.');
+    process.exit(1);
+  }
+
+  if (args.foundational.length > 0 && !DISPOSITIONS.has(args.disposition)) {
+    console.error(
+      'record-local-review: a foundational finding needs --disposition re-plan|containment.',
+    );
+    console.error(
+      'The rule allows exactly those two and never a third. Recording the root item without saying ' +
+        'which was taken leaves the decision in prose and absent from anything that acts on it.',
+    );
+    process.exit(1);
+  }
+  if (args.disposition && !DISPOSITIONS.has(args.disposition)) {
+    console.error(`record-local-review: unknown disposition "${args.disposition}".`);
     process.exit(1);
   }
 
@@ -283,6 +346,7 @@ function main() {
     headSha,
     findings: 0,
     foundational: args.foundational,
+    disposition: args.disposition,
     notes: args.notes,
     reviewedAt: new Date().toISOString(),
   };

--- a/scripts/harness/record-local-review.mjs
+++ b/scripts/harness/record-local-review.mjs
@@ -164,7 +164,11 @@ export function mergeBlockReason(branch, headSha, dir = RECORD_DIR) {
   try {
     stored = JSON.parse(readFileSync(file, 'utf8'));
   } catch {
-    return null;
+    // Fail CLOSED, like `reviewState` twenty lines above: "an unreadable record is not a review".
+    // Returning null here would read a corrupted record that held `re-plan` as "no opinion" and let
+    // the merge through — the decision-with-no-actor this whole change exists to close, reappearing
+    // in the function that closes it.
+    return `the review record for ${branch} is unreadable, so whether this change was withdrawn cannot be told`;
   }
   if (stored.headSha !== headSha) return null;
   if (stored.disposition !== 're-plan') return null;


### PR DESCRIPTION
Owner proposal: on a FOUNDATIONAL verdict — file the issue, comment on the PR, **close it**. Adopted for the disposition it belongs to, with the reason for the distinction measured rather than argued.

## The hole the proposal found

`finding-depth.md` already allowed two dispositions, and **only one of them did anything**.

| disposition | what it did before |
| --- | --- |
| `containment` | left a code comment and a commit body carrying the root item's ID |
| `re-plan` — *the change is withdrawn or reduced* | **a word in a note that nothing read** |

So a change recorded as withdrawn merged like any other. A disposition nothing acts on is a decision with no actor — the shape this rule exists against, sitting inside the rule.

## What landed

- The recorder **refuses** a foundational finding with no disposition. The rule allows exactly two and never a third; recording the root item without saying which was taken leaves the decision in prose.
- The disposition is **stored**, and `merge-gate` reads it. A re-planned change **does not merge**.
- Comment-and-close is the tidy expression of a withdrawal; refusing the merge is the part that cannot be forgotten.

## Not adopted: closing on every foundational finding

Measured against the three foundational verdicts taken on 2026-08-01, across two PRs — **in all three the root predated the change, and the change was independently correct**:

| verdict | closing that PR would have |
| --- | --- |
| INFRA-073 (#1535) | discarded the fix that gave a dead gate its **first verdict in its entire life** — `reverseApply` had thrown since the gate was written |
| INFRA-074 (#1535) | same PR |
| INFRA-075 (#1547) | left **two live guard bypasses** standing while a tokenizer was written — and that PR's corpus is what made the root fixable at all |

A foundational finding says where the **defect** is. Whether this change is worth keeping is a different question, and only the second decides the PR.

## Verification

- **Test-first**, five cases: no disposition refused, a third option refused, the value stored, `re-plan` reported as unmergeable, `containment` explicitly **not** refused.
- Gate cases build a real checkout with a recorded round and run the hook against it — `re-plan` → exit 2 naming the disposition, `containment` → exit 0.
- The gate resolves the checkout from the payload's `cwd` before reading the record, for the same reason the recorder does: pointing it at the wrong one would judge this merge against another checkout's round.
- 1800 harness tests green (119 files), 83 scans pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso