### PR TITLE
fix(harness): judge each source, so a proof of one is not a proof of all

### DIFF
--- a/.agents/backlog/INFRA-073-one-verdict-for-an-aggregate.md
+++ b/.agents/backlog/INFRA-073-one-verdict-for-an-aggregate.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-073: the red-proof gate reports one verdict for an aggregate, so a pass hides inside a fail'
-status: todo
+status: in-progress
 priority: high
 urgency: soon
 type: INFRA
@@ -53,6 +53,33 @@ exercise it, classify, and let the worst verdict carry — reporting each source
 one for the set. The cost is one vitest run per changed source instead of one per pair, which is why
 it is a design decision and not a patch.
 
+## Resolved (2026-08-01), and one acceptance line retracted on measurement
+
+Each changed source is now reversed alone, judged by the tests that exercise THAT source, and given
+its own verdict; the worst carries. The cost is one vitest run per changed source instead of one per
+pair — the reason this was a decision rather than a patch.
+
+Replaying `2ac10f251..b1f46acf3`, which is the range the problem was measured on:
+
+```
+before   3 sources -> 1 verdict    red-proof-ok
+after    .claude/hooks/branch-guard.sh     -> red-proof-ok   (assertion-fail)
+         .claude/hooks/lib/command-scan.sh -> inconclusive
+         .claude/hooks/post-tool-format.sh -> red-proof-ok   (assertion-fail)
+```
+
+**The Done-when line below asked for `ACCIDENTAL_GREEN` from that replay, and it does not come — the
+premise was wrong.** Both hooks with tests that exercise them are genuinely red-proved; the third
+source is a LIBRARY that no test spawns, so it is correctly INCONCLUSIVE. What the replay does prove
+is the thing the item is about: the aggregation is gone. A source nothing exercises used to be
+covered by its siblings' proof and is now visible as unjudged.
+
+The accidental-green-hidden-behind-a-proof case is covered directly instead, by a fixture that fails
+on the unfixed gate with the message `the sources were reversed together, so one proof covered both`.
+
+Expect more INCONCLUSIVE verdicts as a result. That is the honest reading of a source nothing
+exercises, and it is what the aggregate was hiding.
+
 ## Containment in force
 
 `check-regression-red-proof.mjs` carries a comment at the aggregation point naming this item. The
@@ -64,6 +91,7 @@ because at that point an aggregate verdict starts deciding merges.
 ## Done when
 
 - Each changed source in a range receives its own verdict, and the log shows them separately.
-- A range where one source is red-proved and another is accidental-green reports `ACCIDENTAL_GREEN`,
-  proven by replaying `2ac10f251..b1f46acf3`.
+- ~~A range where one source is red-proved and another is accidental-green reports
+  `ACCIDENTAL_GREEN`, proven by replaying `2ac10f251..b1f46acf3`.~~ **Retracted on measurement — that
+  range has no accidental-green source.** Replaced by a fixture that fails on the unfixed gate.
 - Decided jointly with INFRA-072, or with a written reason for deciding them apart.

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -490,6 +490,56 @@ describe('HARNESS-041 orchestrator fixtures', () => {
     expect(mutated).toBe(false);
   });
 
+  it('judges EACH source, so a proof of one is not a proof of both (INFRA-073)', () => {
+    // The aggregation this gate carried from its first version. Every source in a pair was reversed
+    // together and judged by ONE outcome, and `assertion-fail` — any deciding test failing — read as
+    // RED_PROOF_OK. So a range touching two sources reported the genuine proof of one as the proof
+    // of both, and an accidental-green sibling passed unseen: this gate's own defect class, across
+    // files instead of within one.
+    //
+    // Measured on `2ac10f251..b1f46acf3`: three hooks reversed together, exactly one test failing,
+    // verdict `red-proof-ok` — silent about the other two.
+    const a = 'packages/x/src/proved.ts';
+    const b = 'packages/x/src/unproved.ts';
+    const testA = 'packages/x/src/proved.test.ts';
+    const testB = 'packages/x/src/unproved.test.ts';
+    const files = {
+      [abs(testA)]: `import { t } from './proved.js';`,
+      [abs(testB)]: `import { u } from './unproved.js';`,
+      [abs(a)]: 'export const t = 1;',
+      [abs(b)]: 'export const u = 1;',
+    };
+    const reversed = [];
+
+    return runRegressionRedProof(
+      baseIo({
+        changedFiles: [a, b, testA, testB],
+        readText: (p) => files[p] ?? '',
+        fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+        reverseApply: (srcs) => reversed.push([...srcs]),
+        // `proved` has a test that fails when it is reversed; `unproved` does not.
+        runVitest: (_pkg, testFiles) => ({
+          testResults: testFiles.map((f) => ({
+            name: abs(f),
+            assertionResults: [{ status: f === testA ? 'failed' : 'passed' }],
+          })),
+        }),
+      }),
+    ).then(({ verdict, decisions }) => {
+      expect(
+        reversed.map((s) => s.length),
+        'the sources were reversed together, so one proof covered both',
+      ).toEqual([1, 1]);
+      expect(verdict, 'a genuinely red source hid an accidental-green sibling behind it').toBe(
+        VERDICT.ACCIDENTAL_GREEN,
+      );
+      expect(decisions.map((d) => `${d.source}:${d.verdict}`).sort()).toEqual([
+        `${a}:${VERDICT.RED_PROOF_OK}`,
+        `${b}:${VERDICT.ACCIDENTAL_GREEN}`,
+      ]);
+    });
+  });
+
   it('hands git a byte-exact patch, final newline included', () => {
     // The defect that made every verdict impossible. The diff was read through the trimming helper,
     // so the patch reached `git apply -R` without its final newline and git rejected it as corrupt —

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -407,57 +407,66 @@ export async function runRegressionRedProof(io = {}) {
     // SPAWNS it — which is the same question asked of the thing it can be asked of. Using the
     // import graph for both would return INCONCLUSIVE for every hook, a SKIP by another name.
     const testAbs = pair.test.map((t) => path.resolve(WORKSPACE_ROOT, t));
-    let importsReversedFile;
-    // Which tests may decide the verdict. For a hook subject this is NOT every changed test:
-    // adoption pulls in the whole changed harness suite as candidates, and if all of them were run
-    // and judged, a sibling failing for its own reasons would supply the red proof while the hook's
-    // own vacuous test passed — this gate's failure mode, reintroduced by the widening meant to
-    // close it. Only the tests that execute the reversed hook are run, and only they are judged.
-    let decidingTests = pair.test;
-    if (pair.pkg === HOOK_SUBJECT) {
-      decidingTests = pair.test.filter((t, i) => {
-        let text;
-        try {
-          text = readText(testAbs[i]);
-        } catch {
-          return false; // unreadable — cannot claim it exercises anything
-        }
-        return pair.source.some((src) => testExecutesHook(text, src));
-      });
-      importsReversedFile = decidingTests.length > 0;
-    } else {
-      const pkgAbsRoot = path.resolve(WORKSPACE_ROOT, pair.pkg);
-      const graph = reachableRelativeGraph(testAbs, pkgAbsRoot, readText, fileExists);
-      const srcAbs = pair.source.map((s) => path.resolve(WORKSPACE_ROOT, s));
-      importsReversedFile = srcAbs.some((s) => graph.has(s));
-    }
 
-    // CONTAINMENT — INFRA-073. Every source in the pair is reversed together and judged by one
-    // outcome, and `assertion-fail` (any deciding test failing) reads as RED_PROOF_OK. So a range
-    // touching two sources reports the proof of one as the proof of both, and an accidental-green
-    // sibling passes unseen. That aggregation predates the INFRA-071 widening — a `packages/x/src`
-    // range with five sources had the same hole — so it is not repaired here: the fix is to reverse
-    // and judge PER SOURCE, which changes what the gate judges and costs one vitest run per source.
+    // ONE SOURCE AT A TIME. Reversing a pair together and judging it by one outcome meant any
+    // deciding test failing read as RED_PROOF_OK for every source in the range — so a genuine proof
+    // of one was reported as the proof of all, and an accidental-green sibling passed unseen. This
+    // gate's own defect class, across files instead of within one, and it predated the widening that
+    // made it easy to hit: a `packages/x/src` range with five sources always had it.
     //
-    // Held rather than patched because the gate is advisory (`REGRESSION_RED_PROOF_ENFORCE` unset),
-    // so an aggregate verdict approves nothing today. INFRA-073 must be resolved BEFORE the gate is
-    // promoted to enforcing (INFRA-046), when it would start deciding merges.
-    let outcome = null;
-    if (importsReversedFile) {
-      reverseApply(pair.source);
-      try {
-        outcome = classifyVitestOutcome(await runVitest(pair.pkg, decidingTests), decidingTests);
-      } finally {
-        restore(pair.source);
-      }
-    }
+    // Measured on `2ac10f251..b1f46acf3` — three hooks reversed together, exactly one test failing,
+    // verdict `red-proof-ok`, silent about the other two.
+    //
+    // The cost is one vitest run per changed source instead of one per pair. That is what makes it a
+    // decision rather than a patch, and it is worth it: a verdict about a set is not a verdict about
+    // any member of it.
+    for (const source of pair.source) {
+      // Only the tests that exercise THIS source may judge it — the same relation as above, asked
+      // one source at a time.
+      const testsForSource =
+        pair.pkg === HOOK_SUBJECT
+          ? pair.test.filter((t, i) => {
+              let text;
+              try {
+                text = readText(testAbs[i]);
+              } catch {
+                return false;
+              }
+              return testExecutesHook(text, source);
+            })
+          : pair.test.filter((t, i) =>
+              // A module is reached through the test's import graph; a shell script never appears in
+              // one, which is why the two relations differ. Asked per test and per source, so a test
+              // that reaches a DIFFERENT source in the same range cannot judge this one.
+              reachableRelativeGraph(
+                [testAbs[i]],
+                path.resolve(WORKSPACE_ROOT, pair.pkg),
+                readText,
+                fileExists,
+              ).has(path.resolve(WORKSPACE_ROOT, source)),
+            );
 
-    const verdict = decidePairVerdict({ importsReversedFile, outcome });
-    decisions.push({ pkg: pair.pkg, verdict, outcome, importsReversedFile });
-    const icon =
-      verdict === VERDICT.RED_PROOF_OK ? '✅' : verdict === VERDICT.ACCIDENTAL_GREEN ? '❌' : '⚠︎';
-    log(`${icon}  ${pair.pkg}: ${verdict}${outcome ? ` (${outcome})` : ''}`);
-    if ((rank[verdict] ?? 0) > (rank[worst] ?? 0)) worst = verdict;
+      const exercised = testsForSource.length > 0;
+      let outcome = null;
+      if (exercised) {
+        reverseApply([source]);
+        try {
+          outcome = classifyVitestOutcome(
+            await runVitest(pair.pkg, testsForSource),
+            testsForSource,
+          );
+        } finally {
+          restore([source]);
+        }
+      }
+
+      const verdict = decidePairVerdict({ importsReversedFile: exercised, outcome });
+      decisions.push({ pkg: pair.pkg, source, verdict, outcome, importsReversedFile: exercised });
+      const icon =
+        verdict === VERDICT.RED_PROOF_OK ? '✅' : verdict === VERDICT.ACCIDENTAL_GREEN ? '❌' : '⚠︎';
+      log(`${icon}  ${source}: ${verdict}${outcome ? ` (${outcome})` : ''}`);
+      if ((rank[verdict] ?? 0) > (rank[worst] ?? 0)) worst = verdict;
+    }
   }
 
   return { verdict: worst, decisions };


### PR DESCRIPTION
**INFRA-073** (#1536) — held under containment since this morning, now resolved.

## The defect

Every source in a pair was reversed **together** and judged by **one** outcome, and `assertion-fail` — any deciding test failing — read as `RED_PROOF_OK`. So a range touching two sources reported the genuine proof of one as the proof of both, and an accidental-green sibling passed unseen.

This gate's own defect class, across files instead of within one. It predated the widening that made it easy to hit: a `packages/x/src` range with five sources always had it.

## The change

Each changed source is reversed **alone**, judged only by the tests that exercise **that** source, and given its own verdict. The worst carries. One vitest run per source instead of one per pair — the cost that made this a decision rather than a patch.

## Replaying the range it was measured on

`2ac10f251..b1f46acf3`:

```
before   3 sources → 1 verdict    red-proof-ok

after    .claude/hooks/branch-guard.sh      → red-proof-ok   (assertion-fail)
         .claude/hooks/lib/command-scan.sh  → inconclusive
         .claude/hooks/post-tool-format.sh  → red-proof-ok   (assertion-fail)
```

The third is a **library no test spawns** — correctly unjudged. It was covered by its siblings' proof before and is visible now.

## One acceptance line retracted, on measurement

The item asked for `ACCIDENTAL_GREEN` from that replay. **It does not come, because that range has no accidental-green source** — both hooks with tests that exercise them are genuinely red-proved. The premise was wrong, and it is recorded as retracted in the item rather than quietly restated.

The case it was standing in for is covered directly instead, by a fixture that fails on the unfixed gate with the message that names the defect:

```
the sources were reversed together, so one proof covered both:
  expected [ 2 ] to deeply equal [ 1, 1 ]
```

## Expect more INCONCLUSIVE

That is the honest reading of a source nothing exercises, and it is exactly what the aggregate was hiding. The gate is advisory, so this changes what it reports, not what it blocks.

## Verification

- Test-first; the acceptance case fails on the unfixed gate and names the defect.
- 1796 harness tests green (119 files), 83 scans pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso