### PR TITLE
fix(hooks): one positional reading for every override, and one that never worked

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -80,18 +80,43 @@ override_given() {
   return 1
 }
 
+# A quote and a backtick are boundaries too: a KEPT region — `bash -c "git push"`, or a backtick
+# subshell — puts one immediately before the verb, and without them the region survived masking and
+# still matched nothing. Quoted payloads are masked before this runs, so this cannot resurrect the
+# false positive it sits beside.
+GITPFX='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
+# Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
+# read as a merge and `git commit-tree` as a commit — false positives that, now that the leading
+# match is loose, would block ordinary read-only work on a protected branch. It also covers the verb
+# ending a line (`git commit\ngit push`), which a bare `(\s|$)` misses.
+GITEND='([^-[:alnum:]_]|$)'
+# Tolerate flags between the subcommand and the create flag (e.g. `git checkout -q -b x`, which
+# previously slipped past the create-guard entirely). `-B`/`-C` are the force-create spellings and
+# create a branch just as much as `-b`/`-c` do.
+#
+# ONE expression per action, read by BOTH the detector below and the override check above it.
+# Review of #1559 found the override carrying its own hand-written copies, forked in both
+# directions at once: no trailing boundary, so `git merge-base` excused a real `git merge`; and no
+# room for an intervening flag, so the documented `git checkout -q -b x` stopped registering. A
+# second spelling of "what counts as this action" is a second answer waiting to disagree, and here
+# it disagreed the moment it was written.
+RE_COMMIT="${GITPFX}commit${GITEND}"
+RE_PUSH="${GITPFX}push${GITEND}"
+RE_MERGE="${GITPFX}merge${GITEND}"
+RE_CREATE="${GITPFX}(checkout\s+(-\S+\s+)*-[bB]|switch\s+(-\S+\s+)*-[cC])${GITEND}"
+RE_GH_API="(^|[;&|({\"'\`]|[[:space:]])[[:space:]]*gh[[:space:]]+api${GITEND}"
+
 # Each override is bound to the command it excuses, so a decoy statement cannot stand in for it.
-CREATE_RE='(git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c))'
-override_given BRANCH_GUARD_ALLOW_DELETE '(git[[:space:]]+push|gh[[:space:]]+api)' && BRANCH_GUARD_ALLOW_DELETE=1
-override_given BRANCH_GUARD_ALLOW_OPEN_BRANCHES "$CREATE_RE" && BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
-override_given BRANCH_GUARD_ALLOW_BADNAME "$CREATE_RE" && BRANCH_GUARD_ALLOW_BADNAME=1
+override_given BRANCH_GUARD_ALLOW_DELETE "($RE_PUSH|$RE_GH_API)" && BRANCH_GUARD_ALLOW_DELETE=1
+override_given BRANCH_GUARD_ALLOW_OPEN_BRANCHES "$RE_CREATE" && BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
+override_given BRANCH_GUARD_ALLOW_BADNAME "$RE_CREATE" && BRANCH_GUARD_ALLOW_BADNAME=1
 # The base override belongs in this block for the reason the paragraph above gives: an inline
 # `VAR=1 git …` is set in the TOOL's shell and never reaches this process, so reading it only as
 # `${VAR:-0}` means the documented form does nothing.
-override_given BRANCH_GUARD_ALLOW_BASE "$CREATE_RE" && BRANCH_GUARD_ALLOW_BASE=1
+override_given BRANCH_GUARD_ALLOW_BASE "$RE_CREATE" && BRANCH_GUARD_ALLOW_BASE=1
 # MAIN_MERGE was the one still read ONLY from this process's environment, which means the form
 # git-branch.md documents could never work, for the two most dangerous operations the guard covers.
-override_given BRANCH_GUARD_ALLOW_MAIN_MERGE '(git[[:space:]]+(push|merge))' && BRANCH_GUARD_ALLOW_MAIN_MERGE=1
+override_given BRANCH_GUARD_ALLOW_MAIN_MERGE "($RE_PUSH|$RE_MERGE)" && BRANCH_GUARD_ALLOW_MAIN_MERGE=1
 
 # Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
 # a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),
@@ -145,24 +170,10 @@ IS_GH_DELETE_BRANCH=false
 # inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
 # quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
 
-# A quote and a backtick are boundaries too: a KEPT region — `bash -c "git push"`, or a backtick
-# subshell — puts one immediately before the verb, and without them the region survived masking and
-# still matched nothing. Quoted payloads are masked before this runs, so this cannot resurrect the
-# false positive it sits beside.
-GITPFX='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+\s+)*git\s+((-C|-c)\s+\S+\s+)*'
-# Trailing boundary: anything that is not a word character or `-`. `\b` alone let `git merge-base`
-# read as a merge and `git commit-tree` as a commit — false positives that, now that the leading
-# match is loose, would block ordinary read-only work on a protected branch. It also covers the verb
-# ending a line (`git commit\ngit push`), which a bare `(\s|$)` misses.
-GITEND='([^-[:alnum:]_]|$)'
-echo "$COMMAND_VERBS" | grep -qE "${GITPFX}commit${GITEND}" && IS_COMMIT=true
-echo "$COMMAND_VERBS" | grep -qE "${GITPFX}push${GITEND}" && IS_PUSH=true
-echo "$COMMAND_VERBS" | grep -qE "${GITPFX}merge${GITEND}" && IS_MERGE=true
-# Tolerate flags between the subcommand and the create flag (e.g. `git checkout -q -b x`, which
-# previously slipped past the create-guard entirely). `-B`/`-C` are the force-create spellings and
-# create a branch just as much as `-b`/`-c` do.
-echo "$COMMAND_VERBS" | grep -qE "${GITPFX}checkout\s+(-\S+\s+)*-[bB]${GITEND}" && IS_BRANCH_CREATE=true
-echo "$COMMAND_VERBS" | grep -qE "${GITPFX}switch\s+(-\S+\s+)*-[cC]${GITEND}" && IS_BRANCH_CREATE=true
+echo "$COMMAND_VERBS" | grep -qE "$RE_COMMIT" && IS_COMMIT=true
+echo "$COMMAND_VERBS" | grep -qE "$RE_PUSH" && IS_PUSH=true
+echo "$COMMAND_VERBS" | grep -qE "$RE_MERGE" && IS_MERGE=true
+echo "$COMMAND_VERBS" | grep -qE "$RE_CREATE" && IS_BRANCH_CREATE=true
 # `gh pr merge --delete-branch` is banned (git-branch.md): it once deleted the
 # develop integration branch. Match ONLY when --delete-branch is an actual argument
 # of a `gh pr merge` invocation — strip shell comments first, then require the flag

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -67,17 +67,43 @@ override_given() {
   # set the flag globally and the real push went unchecked. The sibling guard met this exact attack
   # and split on separators to close it; porting the anchoring without the scoping left the hole
   # open here. (INFRA-076)
+  #
+  # And "one statement carries it" is still not the question. The action detection below is a set of
+  # booleans over the WHOLE command, so a single global flag answered for every guarded statement:
+  #   BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git merge develop ; git push origin main
+  # is a correctly-overridden merge followed by a push to main that nobody overrode, and it passed.
+  # Making a previously-dead override live over whole-command detection is what opened that one.
+  #
+  # The question is whether EVERY statement carrying this action carries the override — the
+  # invariant the sibling guard already states as DESTRUCTIVE_STATEMENTS == OVERRIDDEN_STATEMENTS.
+  # Requiring "no sibling exists" instead would refuse correctly-overridden work, which is how a
+  # guard earns being switched off.
+  #
+  # CONTAINED, INFRA-079 (#1563). This closes the coarseness in the OVERRIDE reading. It does not
+  # close the coarseness in the ACTION reading, which is a second face of the same defect: the
+  # detection booleans below are still computed over the whole command, and NEW_BRANCH / START_POINT
+  # / DELETE_BRANCH_NAME are still single values taken from the FIRST match anywhere, because
+  # `hook_match_extract` uses awk `match()`. So a command with two branch creations has its second
+  # judged by nothing — measured, with no override token involved and reproducing on develop:
+  #   git checkout -b feat/x develop ; git checkout -b feat/y main    -> exit 0 (wrong base unjudged)
+  #   git checkout -b feat/ok ; git checkout -b BAD_NAME              -> exit 0 (bad name unjudged)
+  # Closing those needs an aligned per-statement split in lib/command-scan.sh, which is a library
+  # change and not this function's subject. Do not add a third override reading here; the remaining
+  # hole is not in the override.
+  #
   # No pipeline: a `while` on the right of a pipe runs in a SUBSHELL, so its exit status says
   # nothing about what it found. The statements are split into a variable first and read from a
   # here-string, which keeps the loop in this shell.
-  local statements stmt
+  local statements stmt guarded=0 overridden=0
   statements=$(printf '%s\n' "$COMMAND_VERBS" | sed -E 's/(\|\||&&|[;&|])/\n/g')
   while IFS= read -r stmt; do
-    printf '%s' "$stmt" | grep -qE "^[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$token=1[[:space:]]" || continue
     printf '%s' "$stmt" | grep -qE "$verb_re" || continue
-    return 0
+    guarded=$((guarded + 1))
+    if printf '%s' "$stmt" | grep -qE "^[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$token=1[[:space:]]"; then
+      overridden=$((overridden + 1))
+    fi
   done <<< "$statements"
-  return 1
+  [[ "$guarded" -gt 0 && "$overridden" -eq "$guarded" ]]
 }
 
 # A quote and a backtick are boundaries too: a KEPT region — `bash -c "git push"`, or a backtick

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -50,23 +50,33 @@ COMMAND_EXEC=$(hook_executable_part "$COMMAND")
 # because branch names and `-C` paths are routinely quoted.
 COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 
-if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_DELETE=1([[:space:]]|$)'; then
-  BRANCH_GUARD_ALLOW_DELETE=1
-fi
-if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1([[:space:]]|$)'; then
-  BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
-fi
-if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BADNAME=1([[:space:]]|$)'; then
-  BRANCH_GUARD_ALLOW_BADNAME=1
-fi
+# One reading for all five, and it is POSITIONAL. Read as a token anywhere, an unquoted mention
+# disarmed the guard — `git commit -m X BRANCH_GUARD_ALLOW_DELETE=1 && git push origin --delete
+# develop` — the same shape fixed in worktree-cwd-guard and not ported here because these were
+# documented as loose. Measured before narrowing them: every documented usage is already the prefix
+# form, and git-branch.md says "inline in the same command". There was no loose usage to break.
+#
+# An override is given TO a command, so it must prefix one. `ALLOW=1 git …`, optionally behind other
+# assignments, and nowhere else. (INFRA-076)
+override_given() {
+  printf '%s' "$COMMAND_VERBS" |
+    grep -qE "(^|[;&|]|&&)[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$1=1[[:space:]]+([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*(git|gh)[[:space:]]"
+}
+
+override_given BRANCH_GUARD_ALLOW_DELETE && BRANCH_GUARD_ALLOW_DELETE=1
+override_given BRANCH_GUARD_ALLOW_OPEN_BRANCHES && BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
+override_given BRANCH_GUARD_ALLOW_BADNAME && BRANCH_GUARD_ALLOW_BADNAME=1
 # The base override belongs in this block for the reason the paragraph above gives: an inline
 # `VAR=1 git …` is set in the TOOL's shell and never reaches this process, so reading it only as
 # `${VAR:-0}` means the documented form does nothing. It was added as a plain env read, and the test
 # for it injected the variable through the hook's own environment — hiding the very distinction this
 # file spends nine lines explaining.
-if printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[[:space:];&])BRANCH_GUARD_ALLOW_BASE=1([[:space:]]|$)'; then
-  BRANCH_GUARD_ALLOW_BASE=1
-fi
+override_given BRANCH_GUARD_ALLOW_BASE && BRANCH_GUARD_ALLOW_BASE=1
+# MAIN_MERGE was the one still read ONLY from this process's environment, which means the form
+# git-branch.md documents — `BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git push …` — could never work, for the
+# two most dangerous operations the guard covers. An operator following the printed instruction was
+# refused. It reads the command string now, by the same positional rule as the rest.
+override_given BRANCH_GUARD_ALLOW_MAIN_MERGE && BRANCH_GUARD_ALLOW_MAIN_MERGE=1
 
 # Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
 # a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -59,24 +59,39 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # An override is given TO a command, so it must prefix one. `ALLOW=1 git …`, optionally behind other
 # assignments, and nowhere else. (INFRA-076)
 override_given() {
-  printf '%s' "$COMMAND_VERBS" |
-    grep -qE "(^|[;&|]|&&)[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$1=1[[:space:]]+([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*(git|gh)[[:space:]]"
+  local token="$1" verb_re="$2"
+  # Statement by statement, and the override must prefix THE STATEMENT THAT CARRIES THE COMMAND it
+  # overrides. Anchoring it to "some git call anywhere on the line" is not enough: a decoy in front
+  # turns it into a skeleton key —
+  #   BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git status; git push origin main
+  # set the flag globally and the real push went unchecked. The sibling guard met this exact attack
+  # and split on separators to close it; porting the anchoring without the scoping left the hole
+  # open here. (INFRA-076)
+  # No pipeline: a `while` on the right of a pipe runs in a SUBSHELL, so its exit status says
+  # nothing about what it found. The statements are split into a variable first and read from a
+  # here-string, which keeps the loop in this shell.
+  local statements stmt
+  statements=$(printf '%s\n' "$COMMAND_VERBS" | sed -E 's/(\|\||&&|[;&|])/\n/g')
+  while IFS= read -r stmt; do
+    printf '%s' "$stmt" | grep -qE "^[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$token=1[[:space:]]" || continue
+    printf '%s' "$stmt" | grep -qE "$verb_re" || continue
+    return 0
+  done <<< "$statements"
+  return 1
 }
 
-override_given BRANCH_GUARD_ALLOW_DELETE && BRANCH_GUARD_ALLOW_DELETE=1
-override_given BRANCH_GUARD_ALLOW_OPEN_BRANCHES && BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
-override_given BRANCH_GUARD_ALLOW_BADNAME && BRANCH_GUARD_ALLOW_BADNAME=1
+# Each override is bound to the command it excuses, so a decoy statement cannot stand in for it.
+CREATE_RE='(git[[:space:]]+(checkout[[:space:]]+-b|switch[[:space:]]+-c))'
+override_given BRANCH_GUARD_ALLOW_DELETE '(git[[:space:]]+push|gh[[:space:]]+api)' && BRANCH_GUARD_ALLOW_DELETE=1
+override_given BRANCH_GUARD_ALLOW_OPEN_BRANCHES "$CREATE_RE" && BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
+override_given BRANCH_GUARD_ALLOW_BADNAME "$CREATE_RE" && BRANCH_GUARD_ALLOW_BADNAME=1
 # The base override belongs in this block for the reason the paragraph above gives: an inline
 # `VAR=1 git …` is set in the TOOL's shell and never reaches this process, so reading it only as
-# `${VAR:-0}` means the documented form does nothing. It was added as a plain env read, and the test
-# for it injected the variable through the hook's own environment — hiding the very distinction this
-# file spends nine lines explaining.
-override_given BRANCH_GUARD_ALLOW_BASE && BRANCH_GUARD_ALLOW_BASE=1
+# `${VAR:-0}` means the documented form does nothing.
+override_given BRANCH_GUARD_ALLOW_BASE "$CREATE_RE" && BRANCH_GUARD_ALLOW_BASE=1
 # MAIN_MERGE was the one still read ONLY from this process's environment, which means the form
-# git-branch.md documents — `BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git push …` — could never work, for the
-# two most dangerous operations the guard covers. An operator following the printed instruction was
-# refused. It reads the command string now, by the same positional rule as the rest.
-override_given BRANCH_GUARD_ALLOW_MAIN_MERGE && BRANCH_GUARD_ALLOW_MAIN_MERGE=1
+# git-branch.md documents could never work, for the two most dangerous operations the guard covers.
+override_given BRANCH_GUARD_ALLOW_MAIN_MERGE '(git[[:space:]]+(push|merge))' && BRANCH_GUARD_ALLOW_MAIN_MERGE=1
 
 # Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
 # a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -82,6 +82,45 @@ describe('a push is a push to every guard that reads the command', () => {
   });
 });
 
+describe('every branch-guard override is given, not merely mentioned', () => {
+  // INFRA-076. The four `BRANCH_GUARD_ALLOW_*` tokens were read as a token ANYWHERE in the masked
+  // command, so an unquoted mention disarmed them — the shape fixed in the sibling guard and never
+  // ported here, because these were DOCUMENTED as loose.
+  //
+  // Measured before changing them: every documented usage is already the prefix form, and
+  // `git-branch.md` says "inline in the same command". There was no loose usage to break.
+  const OVERRIDES = [
+    // On a feature branch: the protected-branch push rule would otherwise fire first and the case
+    // would prove nothing about the delete override.
+    {
+      token: 'BRANCH_GUARD_ALLOW_DELETE',
+      guarded: 'git push origin --delete feat/gone',
+      on: 'feat/probe',
+    },
+    { token: 'BRANCH_GUARD_ALLOW_MAIN_MERGE', guarded: 'git merge develop', on: 'main' },
+    { token: 'BRANCH_GUARD_ALLOW_BADNAME', guarded: 'git checkout -b BAD_NAME', on: 'develop' },
+  ];
+
+  for (const { token, guarded, on } of OVERRIDES) {
+    it(`${token} fires, resists a mention, and yields to the prefix`, () => {
+      // Three ways in one case, so the fixture proves itself. Asserting only "the mention was
+      // blocked" passes whenever the guard blocks for ANY reason — including a fixture that never
+      // reached the check at all, which is the accidental-green shape this suite exists against.
+      const dir = scratchRepo(on);
+      const bare = run('branch-guard.sh', guarded, dir);
+      const mention = run('branch-guard.sh', `echo ${token}=1 ; ${guarded}`, dir);
+      const prefix = run('branch-guard.sh', `${token}=1 ${guarded}`, dir);
+
+      expect(
+        bare.status,
+        `the guard never fired here, so this case proves nothing: ${bare.output}`,
+      ).not.toBe(0);
+      expect(mention.status, `a bare mention of ${token} disarmed the guard`).not.toBe(0);
+      expect(prefix.status, `the documented prefix form was refused: ${prefix.output}`).toBe(0);
+    });
+  }
+});
+
 describe('an override must be given, not merely mentioned', () => {
   function worktreeRun(command) {
     const dir = scratchRepo('feat/probe');

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -267,3 +267,59 @@ describe('an override names an action, not a string that contains one', () => {
     ).not.toBe(0);
   });
 });
+
+describe('an override covers the statements it was given to, and no others', () => {
+  // Depth verdict on #1559. The override became statement-scoped; the ACTION detection did not.
+  // `IS_PUSH`/`IS_MERGE`/`IS_BRANCH_CREATE` are booleans over the WHOLE command, and the decision
+  // at the bottom reads one global override flag — so one overridden statement answered for every
+  // sibling statement of any guarded kind.
+  //
+  // The sibling guard reached the correct shape first and this file did not take it: count the
+  // guarded statements, count the overridden ones, and honour the override only when every guarded
+  // statement carries it (worktree-cwd-guard.sh, "DESTRUCTIVE_STATEMENTS == OVERRIDDEN_STATEMENTS").
+
+  it('an overridden statement does not excuse an un-overridden sibling', () => {
+    const cases = [
+      {
+        on: 'main',
+        // Measured as newly reachable ON THIS BRANCH: develop refuses it only because the inline
+        // form of this token was dead there. Making a dead override live over whole-command
+        // detection is what opened it.
+        command: 'BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git merge develop ; git push origin main',
+        control: 'git push origin main',
+      },
+      {
+        on: 'develop',
+        // The delete path, whose own comment records that it once closed an unmerged PR.
+        command:
+          'BRANCH_GUARD_ALLOW_DELETE=1 git push origin --delete scratch-1 ; git push origin --delete develop',
+        control: 'git push origin --delete develop',
+      },
+    ];
+    for (const { on, command, control } of cases) {
+      const bare = scratchRepo(on);
+      expect(
+        run('branch-guard.sh', control, bare).status,
+        `the control is not blocked, so the case proves nothing: ${control}`,
+      ).not.toBe(0);
+
+      const dir = scratchRepo(on);
+      expect(
+        run('branch-guard.sh', command, dir).status,
+        `one overridden statement excused an un-overridden sibling: ${command}`,
+      ).not.toBe(0);
+    }
+  });
+
+  it('an override still covers a command whose guarded statements all carry it', () => {
+    // The other direction, and the reason the rule is "every guarded statement carries it" rather
+    // than "no sibling exists": a guard that refuses correctly-overridden work gets switched off.
+    const dir = scratchRepo('main');
+    const { status, output } = run(
+      'branch-guard.sh',
+      'BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git merge develop ; BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git push origin main',
+      dir,
+    );
+    expect(status, `a fully-overridden command was refused: ${output}`).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -101,6 +101,31 @@ describe('every branch-guard override is given, not merely mentioned', () => {
     { token: 'BRANCH_GUARD_ALLOW_BADNAME', guarded: 'git checkout -b BAD_NAME', on: 'develop' },
   ];
 
+  it('an override on a harmless command does not excuse the guarded one', () => {
+    // The decoy, ported from the sibling guard where it was already fixed and measured. Anchoring
+    // the token to "some git call" is not enough: it must prefix the statement that carries the
+    // command being overridden, or a `git status` in front becomes a skeleton key for the line.
+    //
+    // Reported as a PoC on this PR: `BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git status; git push origin
+    // main` set the flag globally and the real push went unchecked.
+    const decoys = [
+      { on: 'main', command: 'BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git status; git push origin main' },
+      { on: 'main', command: 'BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git log -1 && git merge develop' },
+      {
+        on: 'develop',
+        command: 'BRANCH_GUARD_ALLOW_BADNAME=1 git status; git checkout -b BAD_NAME',
+      },
+    ];
+
+    for (const { on, command } of decoys) {
+      const dir = scratchRepo(on);
+      expect(
+        run('branch-guard.sh', command, dir).status,
+        `an override on a harmless command excused: ${command}`,
+      ).not.toBe(0);
+    }
+  });
+
   for (const { token, guarded, on } of OVERRIDES) {
     it(`${token} fires, resists a mention, and yields to the prefix`, () => {
       // Three ways in one case, so the fixture proves itself. Asserting only "the mention was

--- a/scripts/harness/__tests__/hook-boundary-parity.test.mjs
+++ b/scripts/harness/__tests__/hook-boundary-parity.test.mjs
@@ -207,3 +207,63 @@ describe('an override must be given, not merely mentioned', () => {
     }
   });
 });
+
+describe('an override names an action, not a string that contains one', () => {
+  // Review of #1559, both halves reproduced on a scratch repo before the fix. `override_given`'s
+  // verb patterns were written fresh instead of reusing the ones the file already uses to DETECT
+  // each action, so they forked in both directions at once: too loose at the end (no trailing
+  // boundary, so `merge-base` read as `merge`) and too strict in the middle (no room for an
+  // intervening flag, so the documented `git checkout -q -b x` stopped registering).
+  //
+  // The fork is the defect. One expression per action now serves both the detector and the
+  // override, which is why these two cases sit together.
+
+  it('a substring of the guarded verb does not excuse the guarded verb', () => {
+    const decoys = [
+      {
+        on: 'main',
+        command: 'BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git merge-base develop main ; git merge develop',
+      },
+      {
+        on: 'main',
+        command: 'BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git commit-tree -h ; git push origin main',
+      },
+      {
+        on: 'develop',
+        command: 'BRANCH_GUARD_ALLOW_BADNAME=1 git checkout -bogus ; git checkout -b BAD_NAME',
+      },
+    ];
+    for (const { on, command } of decoys) {
+      const dir = scratchRepo(on);
+      expect(
+        run('branch-guard.sh', command, dir).status,
+        `a read-only plumbing command stood in for the guarded one: ${command}`,
+      ).not.toBe(0);
+    }
+  });
+
+  it('the documented override still registers with the flags git actually accepts', () => {
+    // Fails CLOSED, so nothing was at risk — but a guard that refuses a form its own rule document
+    // tells people to use is a guard people learn to route around.
+    const allowed = [
+      { on: 'develop', command: 'BRANCH_GUARD_ALLOW_BADNAME=1 git checkout -q -b BAD_NAME' },
+      { on: 'develop', command: 'BRANCH_GUARD_ALLOW_BADNAME=1 git checkout -B BAD_NAME' },
+      { on: 'develop', command: 'BRANCH_GUARD_ALLOW_BADNAME=1 git switch -C BAD_NAME' },
+    ];
+    for (const { on, command } of allowed) {
+      const dir = scratchRepo(on);
+      const { status, output } = run('branch-guard.sh', command, dir);
+      expect(status, `the documented override was refused: ${output}`).toBe(0);
+    }
+  });
+
+  it('proves the cases above are not vacuous', () => {
+    // Without this, `not.toBe(0)` above passes when the guard blocks for ANY reason, and `toBe(0)`
+    // passes when the guard never fires at all.
+    const dir = scratchRepo('develop');
+    expect(
+      run('branch-guard.sh', 'git checkout -q -b BAD_NAME', dir).status,
+      'the guard does not fire on the bare command, so the override cases prove nothing',
+    ).not.toBe(0);
+  });
+});


### PR DESCRIPTION
**INFRA-076** (#1548) — decided on measurement, and a second defect found while testing it.

## The decision, and why its stated cost is zero

The item offered three options; option 1 (anchor all four) carried the objection *"breaks any established loose usage"*.

**Measured before changing anything: there is none.** `git-branch.md` says the override goes "**inline in the same command**" and shows `BRANCH_GUARD_ALLOW_DELETE=1 git push origin --delete <name>`. Every documented usage is the prefix form; every use in practice is that shape.

So anchoring costs nothing and ends two conventions living side by side — three hooks already anchored, one did not. All five now share **one positional reading**: the token prefixes the command it overrides, optionally behind other assignments, and nowhere else.

## The second defect, opposite in polarity

`BRANCH_GUARD_ALLOW_MAIN_MERGE` was read **only** from the hook's own environment:

```sh
if [[ "$IS_MERGE" == "true" && "${BRANCH_GUARD_ALLOW_MAIN_MERGE:-0}" != "1" ]]; then
```

But `VAR=1 cmd` sets the variable in the **tool's** shell, which never reaches this process. So the form the rule documents **could not work at all** — for the two most dangerous operations the guard covers: pushing to `main` and merging into `main`. An operator following the printed instruction was refused.

INFRA-076 was about a mention that disarms too easily; this was an override that could not be given at all. Same subject, and the same fix covers both.

## The fixtures had to prove themselves

Each case asserts **three ways in one fixture**:

1. the guard **fires** here at all — without this the case proves nothing;
2. a bare mention does **not** disarm it;
3. the documented prefix **does**.

The first version asserted only (2). It passed on **three of four** overrides — including where the guard was blocking for an unrelated reason and the case never reached the check. That is the accidental-green shape, caught by making each case validate its own premise rather than by reading it.

## Verification

- 1798 harness tests green (119 files), 83 scans pass.
- The delete case runs on a feature branch on purpose: on `main` the protected-branch push rule fires first and the case would say nothing about the delete override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso