### PR TITLE
feat(harness): nothing read .claude/settings.json — a hook could be wired to no event

### DIFF
--- a/.agents/backlog/INFRA-078-nothing-checks-hook-registration.md
+++ b/.agents/backlog/INFRA-078-nothing-checks-hook-registration.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-078: a hook can be wired to no event, or a matcher can name a deleted file, and everything stays green'
-status: todo
+status: in-progress
 priority: high
 urgency: now
 type: INFRA
@@ -48,3 +48,18 @@ form, not an exemption list, or the exemption becomes the hole.
 - Red-proved both ways against the current tree.
 - `revert-detect`'s indirect invocation is declared, so "unregistered" and "invoked by a sibling"
   are told apart mechanically rather than by memory.
+
+## Implemented (branch `feat/infra-078-hook-registration`)
+
+`scripts/harness/scan-hook-registration.mjs`, registered as `hook-registration`. Measured on this
+tree: **12 hook files, 6 matchers, 12 registrations**.
+
+Red-proved both ways before it was believed:
+
+- The undeclared unregistered hook — run against the real tree it named
+  `.claude/hooks/revert-detect.sh … carries no \`# invoked-by: <hook>.sh\` header`, exit 1. Adding
+  the verified declaration to `revert-detect.sh` turned it green.
+- The missing file — a matcher pointing at `deleted.sh` in a temp fixture reports
+  `registers \`deleted.sh\` for PreToolUse, but .claude/hooks/deleted.sh does not exist`.
+- Neither is accidentally green: reverse-applying rule A fails 4 tests, rule B fails its own test,
+  and the correctly-registered fixture plus the real tree pass with an empty findings list.

--- a/.claude/hooks/revert-detect.sh
+++ b/.claude/hooks/revert-detect.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Stop hook helper: collect rework/revert signals from transcript and git history.
+# invoked-by: eval-log-stop.sh
 #
 # LESSON-010: this hook fires on EVERY session Stop and re-scans the whole transcript, so a
 # naive append re-emits the same signal once per Stop (296k duplicate events by 2026-07).

--- a/scripts/harness/__tests__/scan-hook-registration.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-registration.test.mjs
@@ -254,3 +254,38 @@ describe('scan-hook-registration', () => {
     expect(matchersExamined).toBeGreaterThan(0);
   });
 });
+
+describe('a declaration is verified against an INVOCATION, not a mention', () => {
+  // The class this repository keeps meeting: a name present in a file is not the same as a file
+  // that runs it. `eval-log-stop.sh` really does `bash "$HOOK_DIR/revert-detect.sh"`; a comment
+  // saying "revert-detect.sh is related" would satisfy a substring test just as well, and then a
+  // hook nothing calls would carry a declaration that certified itself through a sibling's prose.
+  it('refuses a caller that only NAMES the declarer', () => {
+    const root = fixture({
+      settings: { hooks: { Stop: [{ hooks: [{ command: '.claude/hooks/caller.sh' }] }] } },
+      hooks: {
+        'caller.sh': '#!/bin/bash\n# related: helper.sh does the parsing\necho hi\n',
+        'helper.sh': '#!/bin/bash\n# invoked-by: caller.sh\necho hi\n',
+      },
+    });
+
+    const { findings } = collectHookRegistrationFindings(root);
+
+    expect(
+      findings.map((f) => String(f)),
+      'a mention in a comment certified a hook nothing runs',
+    ).toHaveLength(1);
+  });
+
+  it('accepts a caller that actually spawns it', () => {
+    const root = fixture({
+      settings: { hooks: { Stop: [{ hooks: [{ command: '.claude/hooks/caller.sh' }] }] } },
+      hooks: {
+        'caller.sh': '#!/bin/bash\nbash "$HOOK_DIR/helper.sh"\n',
+        'helper.sh': '#!/bin/bash\n# invoked-by: caller.sh\necho hi\n',
+      },
+    });
+
+    expect(collectHookRegistrationFindings(root).findings).toEqual([]);
+  });
+});

--- a/scripts/harness/__tests__/scan-hook-registration.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-registration.test.mjs
@@ -1,0 +1,256 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  collectHookRegistrationFindings,
+  declaredInvoker,
+  registeredHookFiles,
+} from '../scan-hook-registration.mjs';
+
+/**
+ * ACCEPTANCE CRITERION (written before the scan — INFRA-078).
+ *
+ * `hooks-have-execution-coverage` proves a hook CAN run. Nothing proved the DEPLOYMENT calls it, so
+ * both of these stayed green:
+ *
+ *   A. a `.claude/hooks/*.sh` file registered to no event — tested, executable, and never fired;
+ *   B. a matcher naming a hook file that does not exist — the event fires and nothing happens.
+ *
+ * The scan FAILS on A and on B, naming the offending file in the message.
+ *
+ * THE NUANCE, and the reason this is not a one-line glob diff. `revert-detect.sh` is legitimately
+ * registered nowhere: `eval-log-stop.sh` shells out to it. An exemption LIST would become the hole —
+ * the next unregistered hook gets appended to it and the floor is gone. So the exemption is a
+ * DECLARATION the hook itself carries, and the declaration is VERIFIED:
+ *
+ *   - an unregistered hook with no `# invoked-by:` header FAILS;
+ *   - a declared hook whose named caller does not exist FAILS;
+ *   - a declared hook whose named caller does not reference it FAILS (the claim is checked against
+ *     the caller's body, so a declaration cannot be self-certifying);
+ *   - a declaration chain that never lands on a registered hook FAILS (two hooks declaring each
+ *     other are both unreached, and each would otherwise excuse the other).
+ *
+ * WHAT MUST NOT FIRE, pinned as hard as what must. A correctly registered hook produces no finding,
+ * and `revert-detect.sh` with its declaration produces no finding — asserted against the REAL tree,
+ * not only fixtures, because a floor that fires on correct work is a floor someone switches off.
+ *
+ * FAIL-CLOSED. `.claude/hooks` or `.claude/settings.json` absent is an ERROR, never a pass, and a
+ * run that examined zero hooks or zero matchers is a finding rather than a green — "nothing was
+ * examined" must not be able to read as "everything is registered".
+ */
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A temp root with `.claude/settings.json` and `.claude/hooks/*.sh`. Never the real tree. */
+function fixture({ hooks = {}, settings } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), 'hook-registration-'));
+  scratch.push(root);
+  mkdirSync(path.join(root, '.claude/hooks'), { recursive: true });
+  for (const [name, body] of Object.entries(hooks)) {
+    writeFileSync(path.join(root, '.claude/hooks', name), body, 'utf8');
+  }
+  if (settings !== undefined) {
+    writeFileSync(path.join(root, '.claude/settings.json'), JSON.stringify(settings, null, 2));
+  }
+  return root;
+}
+
+/** The shape of a real registration: one event, one matcher, one command per hook file. */
+function settingsFor(event, matcher, files) {
+  return {
+    hooks: {
+      [event]: [
+        {
+          matcher,
+          hooks: files.map((f) => ({
+            type: 'command',
+            command: `"$CLAUDE_PROJECT_DIR"/.claude/hooks/${f}`,
+          })),
+        },
+      ],
+    },
+  };
+}
+
+const TRIVIAL = '#!/usr/bin/env bash\nexit 0\n';
+
+describe('scan-hook-registration', () => {
+  it('A. FAILS on a hook file that appears in no matcher', () => {
+    const root = fixture({
+      hooks: { 'wired.sh': TRIVIAL, 'orphan.sh': TRIVIAL },
+      settings: settingsFor('PreToolUse', 'Bash', ['wired.sh']),
+    });
+    const { findings } = collectHookRegistrationFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('orphan.sh');
+    expect(findings[0]).toContain('invoked-by');
+  });
+
+  it('B. FAILS on a matcher naming a hook file that does not exist', () => {
+    const root = fixture({
+      hooks: { 'wired.sh': TRIVIAL },
+      settings: settingsFor('PreToolUse', 'Bash', ['wired.sh', 'deleted.sh']),
+    });
+    const { findings } = collectHookRegistrationFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('deleted.sh');
+    expect(findings[0]).toContain('PreToolUse');
+  });
+
+  it('passes SILENTLY on a correctly registered hook', () => {
+    const root = fixture({
+      hooks: { 'wired.sh': TRIVIAL },
+      settings: settingsFor('PreToolUse', 'Bash', ['wired.sh']),
+    });
+    const { findings, hooksExamined, matchersExamined } = collectHookRegistrationFindings(root);
+    expect(findings).toEqual([]);
+    expect(hooksExamined).toBe(1);
+    expect(matchersExamined).toBe(1);
+  });
+
+  it('accepts an unregistered hook DECLARED as invoked by a registered sibling that calls it', () => {
+    const root = fixture({
+      hooks: {
+        'stop.sh': `#!/usr/bin/env bash\nbash "$HOOK_DIR/helper.sh"\n`,
+        'helper.sh': `#!/usr/bin/env bash\n# invoked-by: stop.sh\nexit 0\n`,
+      },
+      settings: settingsFor('Stop', '', ['stop.sh']),
+    });
+    expect(collectHookRegistrationFindings(root).findings).toEqual([]);
+  });
+
+  it('FAILS a declaration whose named caller does not reference it', () => {
+    const root = fixture({
+      hooks: {
+        'stop.sh': `#!/usr/bin/env bash\nexit 0\n`,
+        'helper.sh': `#!/usr/bin/env bash\n# invoked-by: stop.sh\nexit 0\n`,
+      },
+      settings: settingsFor('Stop', '', ['stop.sh']),
+    });
+    const { findings } = collectHookRegistrationFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('helper.sh');
+    expect(findings[0]).toContain('does not reference');
+  });
+
+  it('FAILS a declaration naming a caller that does not exist', () => {
+    const root = fixture({
+      hooks: {
+        'stop.sh': `#!/usr/bin/env bash\nexit 0\n`,
+        'helper.sh': `#!/usr/bin/env bash\n# invoked-by: gone.sh\nexit 0\n`,
+      },
+      settings: settingsFor('Stop', '', ['stop.sh']),
+    });
+    const { findings } = collectHookRegistrationFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toContain('gone.sh');
+    expect(findings[0]).toContain('does not exist');
+  });
+
+  it('FAILS a declaration chain that never reaches a registered hook', () => {
+    const root = fixture({
+      hooks: {
+        'wired.sh': TRIVIAL,
+        'a.sh': `#!/usr/bin/env bash\n# invoked-by: b.sh\nbash b.sh\n`,
+        'b.sh': `#!/usr/bin/env bash\n# invoked-by: a.sh\nbash a.sh\n`,
+      },
+      settings: settingsFor('Stop', '', ['wired.sh']),
+    });
+    const { findings } = collectHookRegistrationFindings(root);
+    expect(findings).toHaveLength(2);
+    expect(findings.join('\n')).toContain('never reaches a registered hook');
+  });
+
+  it('is a finding — not a pass — when zero hooks or zero matchers were examined', () => {
+    const noHooks = fixture({ hooks: {}, settings: settingsFor('Stop', '', []) });
+    const { findings } = collectHookRegistrationFindings(noHooks);
+    expect(findings.join('\n')).toContain('examined');
+  });
+
+  it('fails closed when .claude/hooks is absent', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'hook-registration-bare-'));
+    scratch.push(root);
+    mkdirSync(path.join(root, '.claude'), { recursive: true });
+    writeFileSync(path.join(root, '.claude/settings.json'), '{}');
+    expect(() => collectHookRegistrationFindings(root)).toThrow(/\.claude\/hooks/);
+  });
+
+  it('fails closed when .claude/settings.json is absent', () => {
+    const root = fixture({ hooks: { 'wired.sh': TRIVIAL } });
+    expect(() => collectHookRegistrationFindings(root)).toThrow(/settings\.json/);
+  });
+
+  it('reads every event and every matcher, not just the first', () => {
+    const root = fixture({
+      hooks: { 'a.sh': TRIVIAL, 'b.sh': TRIVIAL },
+      settings: {
+        hooks: {
+          PreToolUse: [
+            { matcher: 'Bash', hooks: [{ type: 'command', command: '.claude/hooks/a.sh' }] },
+          ],
+          Stop: [{ matcher: '', hooks: [{ type: 'command', command: '.claude/hooks/b.sh' }] }],
+        },
+      },
+    });
+    const { findings, matchersExamined } = collectHookRegistrationFindings(root);
+    expect(findings).toEqual([]);
+    expect(matchersExamined).toBe(2);
+  });
+
+  it('reads an argument-carrying command (task-tracking.sh start) as a registration', () => {
+    const root = fixture({
+      hooks: { 'task-tracking.sh': TRIVIAL },
+      settings: {
+        hooks: {
+          SessionStart: [
+            {
+              matcher: '',
+              hooks: [
+                {
+                  type: 'command',
+                  command: '"$CLAUDE_PROJECT_DIR"/.claude/hooks/task-tracking.sh start',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(collectHookRegistrationFindings(root).findings).toEqual([]);
+  });
+
+  describe('declaredInvoker', () => {
+    it('reads the header line', () => {
+      expect(declaredInvoker('#!/usr/bin/env bash\n# invoked-by: stop.sh\n')).toBe('stop.sh');
+    });
+    it('is null when absent', () => {
+      expect(declaredInvoker('#!/usr/bin/env bash\necho hi\n')).toBeNull();
+    });
+    it('does not read a mention buried deep in the body as a header', () => {
+      const body = '#!/usr/bin/env bash\n' + 'echo x\n'.repeat(40) + '# invoked-by: stop.sh\n';
+      expect(declaredInvoker(body)).toBeNull();
+    });
+  });
+
+  describe('registeredHookFiles', () => {
+    it('is empty for settings with no hooks block', () => {
+      expect(registeredHookFiles({}).files.size).toBe(0);
+    });
+  });
+
+  it('the REAL tree passes with nothing on the findings list', () => {
+    const { findings, hooksExamined, matchersExamined } =
+      collectHookRegistrationFindings(WORKSPACE_ROOT);
+    expect(findings).toEqual([]);
+    expect(hooksExamined).toBeGreaterThan(0);
+    expect(matchersExamined).toBeGreaterThan(0);
+  });
+});

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -101,6 +101,13 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/scan-orchestration-neutrality.mjs'],
   },
   { name: 'hook-catalog', command: ['node', 'scripts/harness/scan-hook-catalog.mjs'] },
+  {
+    // INFRA-078 — `hooks-have-execution-coverage` proves a hook CAN run; nothing read the file that
+    // decides whether the deployment CALLS it, so a hook registered to no event, and a matcher
+    // naming a deleted file, both stayed green.
+    name: 'hook-registration',
+    command: ['node', 'scripts/harness/scan-hook-registration.mjs'],
+  },
   { name: 'review-findings', command: ['node', 'scripts/harness/scan-review-findings.mjs'] },
   {
     name: 'review-token-supply',

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -345,6 +345,16 @@ export const MANDATORY_TREE_GUARDS = [
     why: 'the agent definitions are the set the map is checked against; with none, "every agent is listed" is true of nothing (the missing MAP was already an error — the missing SUBJECT was not)',
   },
   {
+    // INFRA-078. MEASURED on a bare root, not assumed: throws `.claude/hooks, .claude/settings.json
+    // missing`. Both sides are named because either alone is unjudgeable — a hooks directory with
+    // no settings file has no registrations to check, and settings with no hooks directory has no
+    // files to check them against.
+    file: 'scan-hook-registration.mjs',
+    finder: 'collectHookRegistrationFindings',
+    tree: '.claude/hooks and .claude/settings.json',
+    why: 'it compares the hook files against the matchers that call them; over a root with neither, "every hook is registered" is a claim about no hooks — which is the exact green this scan was written to end one level down',
+  },
+  {
     file: 'scan-spec-research.mjs',
     finder: 'collectSpecResearchFindings',
     tree: '.agents/spec-docs',

--- a/scripts/harness/scan-hook-registration.mjs
+++ b/scripts/harness/scan-hook-registration.mjs
@@ -112,6 +112,24 @@ export function registeredHookFiles(settings) {
 }
 
 /**
+ * Does `text` INVOKE `name`, rather than merely mention it?
+ *
+ * A substring test let a comment certify the declaration: `# related: helper.sh does the parsing` in
+ * the claimed caller was enough, and a hook nothing runs would then be excused by a sibling's prose.
+ * That is the described-but-not-reached shape this scan exists to close, occurring inside its own
+ * exemption path — so the reference has to look like a spawn: the name preceded by an interpreter or
+ * a source, after comments are stripped.
+ */
+function invokes(text, name) {
+  const withoutComments = String(text ?? '')
+    .split('\n')
+    .map((line) => line.replace(/(^|\s)#.*$/, '$1'))
+    .join('\n');
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:bash|sh|zsh|source|\\.)\\s[^\\n]{0,80}${escaped}`).test(withoutComments);
+}
+
+/**
  * Follow a hook's `invoked-by` chain until it reaches a registered hook.
  *
  * Returns `{ ok: true }`, or the reason it does not resolve. Cycle-terminated: `a` declaring `b`
@@ -134,7 +152,7 @@ function resolveDeclaration(name, { hookText, registered }) {
     if (!hookText.has(caller)) {
       return { ok: false, reason: `declares \`# invoked-by: ${caller}\`, which does not exist` };
     }
-    if (!hookText.get(caller).includes(current)) {
+    if (!invokes(hookText.get(caller), current)) {
       return {
         ok: false,
         reason: `declares \`# invoked-by: ${caller}\`, but ${caller} does not reference ${current}`,

--- a/scripts/harness/scan-hook-registration.mjs
+++ b/scripts/harness/scan-hook-registration.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+
+/**
+ * Hook REGISTRATION floor (INFRA-078) — `.claude/settings.json` was read by nothing.
+ *
+ * `hooks-have-execution-coverage` enumerates `.claude/hooks/*.sh` and requires a test to EXECUTE
+ * each one. Nothing enumerated the same directory against the file that decides whether the
+ * deployment ever CALLS them, so two states stayed green:
+ *
+ *   A. a hook exists, is tested, and is registered to no event — it never fires in a real session;
+ *   B. a matcher names a file that no longer exists — the event fires and nothing happens.
+ *
+ * MEASURED 2026-08-01 before this was written: the only assertion in the repository that read
+ * `settings.json` checked one fact — that `check-forbidden-patterns` is registered for `MultiEdit`
+ * (`hook-command-parsing.test.mjs:514`). Twelve hooks, eight matchers, one of them covered.
+ *
+ * This is PROC-003's third question — *is it reached?* — asked one step earlier than the execution
+ * floor asks it. That floor proves a hook CAN run; this one proves the deployment calls it.
+ *
+ * THE NUANCE, which is the whole difficulty. `revert-detect.sh` is registered to no event and is not
+ * dead: `eval-log-stop.sh` shells out to it. An exemption LIST is the obvious answer and the wrong
+ * one — the next unregistered hook is appended to it, nobody re-derives whether the entry is still
+ * true, and the exemption becomes the hole the floor was built to close. So the exemption is a
+ * DECLARATION the hook carries in its own header, and the declaration is CHECKED against the caller
+ * it names:
+ *
+ *     # invoked-by: eval-log-stop.sh
+ *
+ * An undeclared unregistered hook fails. A declared one whose named caller does not exist fails. A
+ * declared one whose named caller does not reference it fails — the claim is verified against the
+ * caller's body, so it cannot certify itself. And a chain of declarations that never lands on a
+ * registered hook fails, because two hooks declaring each other are both unreached while each
+ * excuses the other, which is the exemption list rebuilt out of headers.
+ *
+ * WHAT IT DOES NOT CLAIM. That a registered hook is CORRECT, or that its matcher names the events
+ * it ought to name — `settings.json` says `Edit|Write|MultiEdit` and nothing here knows whether that
+ * is the right set. That a hook reached only through a declared caller is reached on any particular
+ * run: `eval-log-stop.sh` guards its call with `[ -f … ]`, and a guard that is never true is
+ * invisible from here. Helper scripts under `.claude/hooks/lib/` are not hooks and are not
+ * enumerated — the glob is the same non-recursive `*.sh` the execution-coverage floor uses, so the
+ * two floors quantify over exactly the same set.
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { requireGovernedTree } from './governed-tree.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const HOOKS_DIR = '.claude/hooks';
+const SETTINGS_FILE = '.claude/settings.json';
+
+/** How far into a file a `# invoked-by:` line still counts as a HEADER rather than a remark. */
+const HEADER_LINES = 15;
+
+/**
+ * The hook file a declaration names, or null.
+ *
+ * Bounded to the header block on purpose. A mention anywhere in a 137-line script would let an
+ * incidental comment — or a line of documentation ABOUT this convention — silently excuse a hook
+ * nothing calls, which is the exemption list again, spelled differently.
+ */
+export function declaredInvoker(text) {
+  const header = String(text ?? '')
+    .split('\n')
+    .slice(0, HEADER_LINES);
+  for (const line of header) {
+    const match = /^#\s*invoked-by:\s*([A-Za-z0-9._-]+\.sh)\s*$/.exec(line.trim());
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Every `.claude/hooks/*.sh` basename named by a matcher, and how many matcher entries were read.
+ *
+ * The command is a shell string — `"$CLAUDE_PROJECT_DIR"/.claude/hooks/task-tracking.sh start` —
+ * so the file is extracted by path shape rather than by equality with a constructed string. Reading
+ * it as an exact path would have missed the two argument-carrying registrations on this tree and
+ * reported both hooks unregistered, and a floor that fires on correct work gets switched off.
+ *
+ * @returns {{files: Map<string, string[]>, matchers: number, registrations: number}}
+ *   files: hook basename → the events that register it.
+ */
+export function registeredHookFiles(settings) {
+  const files = new Map();
+  let matchers = 0;
+  let registrations = 0;
+  const hooks = settings?.hooks;
+  if (typeof hooks !== 'object' || hooks === null) return { files, matchers, registrations };
+
+  for (const [event, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      matchers += 1;
+      const commands = Array.isArray(entry?.hooks) ? entry.hooks : [];
+      for (const command of commands) {
+        const text = typeof command?.command === 'string' ? command.command : '';
+        for (const match of text.matchAll(/\.claude\/hooks\/([A-Za-z0-9._-]+\.sh)/g)) {
+          registrations += 1;
+          const existing = files.get(match[1]);
+          if (existing) existing.push(event);
+          else files.set(match[1], [event]);
+        }
+      }
+    }
+  }
+  return { files, matchers, registrations };
+}
+
+/**
+ * Follow a hook's `invoked-by` chain until it reaches a registered hook.
+ *
+ * Returns `{ ok: true }`, or the reason it does not resolve. Cycle-terminated: `a` declaring `b`
+ * while `b` declares `a` is not a resolution, it is two hooks nothing calls.
+ */
+function resolveDeclaration(name, { hookText, registered }) {
+  const seen = new Set([name]);
+  let current = name;
+  for (;;) {
+    const caller = declaredInvoker(hookText.get(current));
+    if (caller === null) {
+      return {
+        ok: false,
+        reason:
+          current === name
+            ? 'is registered to no event in .claude/settings.json and carries no `# invoked-by: <hook>.sh` header — it never fires'
+            : `is reached only through \`${current}\`, which is itself unregistered and undeclared`,
+      };
+    }
+    if (!hookText.has(caller)) {
+      return { ok: false, reason: `declares \`# invoked-by: ${caller}\`, which does not exist` };
+    }
+    if (!hookText.get(caller).includes(current)) {
+      return {
+        ok: false,
+        reason: `declares \`# invoked-by: ${caller}\`, but ${caller} does not reference ${current}`,
+      };
+    }
+    if (registered.has(caller)) return { ok: true };
+    if (seen.has(caller)) {
+      return {
+        ok: false,
+        reason: `has an \`invoked-by\` chain (${[...seen, caller].join(' → ')}) that never reaches a registered hook`,
+      };
+    }
+    seen.add(caller);
+    current = caller;
+  }
+}
+
+export function collectHookRegistrationFindings(root = WORKSPACE_ROOT) {
+  requireGovernedTree(root, [HOOKS_DIR, SETTINGS_FILE], {
+    scan: 'hook-registration',
+    why: 'The hook directory and the settings file are the two sides this scan compares; with either absent there is nothing to compare and no registration to verify.',
+  });
+
+  const findings = [];
+  const hooksDir = path.join(root, HOOKS_DIR);
+  const hookNames = readdirSync(hooksDir).filter((f) => f.endsWith('.sh'));
+  const hookText = new Map(
+    hookNames.map((name) => [name, readFileSync(path.join(hooksDir, name), 'utf8')]),
+  );
+
+  let settings;
+  try {
+    settings = JSON.parse(readFileSync(path.join(root, SETTINGS_FILE), 'utf8'));
+  } catch (error) {
+    // Not swallowed into a default: unreadable settings means the comparison did not happen, and
+    // the scan's own subject is a file that decides whether guards run at all.
+    throw new Error(`hook-registration: ${SETTINGS_FILE} is not valid JSON — ${error.message}`);
+  }
+
+  const { files: registered, matchers, registrations } = registeredHookFiles(settings);
+
+  // B. A matcher naming a file that is not there. The event fires, the command is not found, and
+  // the session carries on: the loudest possible no-op.
+  for (const [name, events] of registered) {
+    if (!hookText.has(name)) {
+      findings.push(
+        `${SETTINGS_FILE} registers \`${name}\` for ${events.join(', ')}, but ${HOOKS_DIR}/${name} does not exist — the event fires and nothing runs.`,
+      );
+    }
+  }
+
+  // A. A hook file no matcher names, minus the ones that declare — and prove — an indirect caller.
+  for (const name of hookNames) {
+    if (registered.has(name)) continue;
+    const resolved = resolveDeclaration(name, { hookText, registered });
+    if (!resolved.ok) findings.push(`${HOOKS_DIR}/${name} ${resolved.reason}.`);
+  }
+
+  // A run that examined nothing must not read as a run that found nothing. `requireGovernedTree`
+  // covers the directory's absence; an EMPTY directory, or a settings file with no matcher, is the
+  // same vacuity one level in.
+  if (hookNames.length === 0) {
+    findings.push(`${HOOKS_DIR} contains no *.sh — 0 hooks examined, which is not 0 findings.`);
+  }
+  if (matchers === 0) {
+    findings.push(
+      `${SETTINGS_FILE} declares no matcher — 0 matchers examined, so no hook in ${HOOKS_DIR} is reached by this deployment.`,
+    );
+  }
+
+  return { findings, hooksExamined: hookNames.length, matchersExamined: matchers, registrations };
+}
+
+export function main() {
+  const { findings, hooksExamined, matchersExamined, registrations } =
+    collectHookRegistrationFindings();
+
+  if (findings.length > 0) {
+    console.error('hook-registration scan: FINDINGS');
+    for (const f of findings) console.error('  - ' + f);
+    console.error(
+      `\nExamined ${hooksExamined} hook file(s) against ${matchersExamined} matcher(s) ` +
+        `(${registrations} registration(s)) in ${SETTINGS_FILE}.\n` +
+        'Fix: register the hook under the event it belongs to, delete it, or — if a sibling hook ' +
+        'invokes it — add a `# invoked-by: <that-hook>.sh` header line, which is verified against ' +
+        "that hook's body.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `hook-registration scan passed: ${hooksExamined} hook file(s), ${matchersExamined} matcher(s), ` +
+      `${registrations} registration(s) — every hook is reached and every matcher resolves.`,
+  );
+  process.exit(0);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
**INFRA-078** (#1552).

## The hole

`hooks-have-execution-coverage` enumerates `.claude/hooks/*.sh` and requires a test to **execute** each one. Nothing enumerated the same directory against `.claude/settings.json`. So a hook could exist, be tested, and be **registered to no event** — never firing in a real session, with every gate green. A matcher could equally name a **deleted file**: the event fires and nothing runs.

This is PROC-003's third question — *is it reached?* — one step earlier than the existing floor asks it. That one proves a hook **can** run; this proves the deployment actually calls it.

## Red-proved against the REAL tree, not a fixture

`revert-detect.sh` (137 lines) was genuinely registered nowhere:

```
hook-registration scan: FINDINGS
  - .claude/hooks/revert-detect.sh is registered to no event in .claude/settings.json and
    carries no `# invoked-by: <hook>.sh` header — it never fires.

Examined 12 hook file(s) against 6 matcher(s) (12 registration(s)).   EXIT=1
```

It is not dead — `eval-log-stop.sh` shells out to it. Adding the **verified** declaration is what turned the live tree green.

## The exemption is a declaration, not a list

A list would become the hole. A hook declares `# invoked-by: <caller>.sh`, and the scan checks the claim against the caller. Four ways a declaration fails: no header; the caller does not exist; the caller does not run it; the chain never lands on a registered hook (two hooks declaring each other are both unreached, and each would otherwise excuse the other).

## What my review of the implementation caught

The declaration was verified by **substring**, so a comment sufficed — `# related: helper.sh does the parsing` certified a hook nothing runs, through a sibling's prose. **The described-but-not-reached shape, inside the exemption path of the scan built to close it** — the third time today a floor reproduced its own class, and the reason each gets a case that fails on the unfixed form before it lands.

It now requires a spawn: the name preceded by an interpreter or a source, comments stripped. Both directions pinned; the live declaration re-verified against the real tree.

## Not predicted by the item

Registering a scan takes **two** files, not one: `scan-guard-scope-fail-closed`'s classification-completeness rule catches any new registered scan that is in neither `MANDATORY_TREE_GUARDS` nor `PENDING_CLASSIFICATION`, and `harness:scan` cannot pass without the entry. Also, `task-tracking.sh start|stop` means exact-path matching would have reported two correctly-registered hooks as unregistered — the extractor reads by path shape, with a case pinning it.

## Verification

- 19 tests in the new file; zero hooks or zero matchers is a **finding**, not a pass; `requireGovernedTree` throws on an absent tree, measured on a bare root.
- Reverse-applying each rule fails its own tests; restoring passes.
- 84 scans (was 83); `dist` and `doc-examples` fail only for lack of a built tree, same as baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso