### PR TITLE
feat(harness): a scan says how much it examined, so a zero is visibly a zero

### DIFF
--- a/.agents/backlog/HARNESS-063-scans-that-examine-nothing.md
+++ b/.agents/backlog/HARNESS-063-scans-that-examine-nothing.md
@@ -1,6 +1,6 @@
 ---
 title: 'HARNESS-063: three scans whose subject is empty, and one that cannot fail in CI'
-status: todo
+status: in-progress
 priority: medium
 urgency: soon
 type: HARNESS

--- a/scripts/harness/__tests__/check-design-doc-completeness.test.mjs
+++ b/scripts/harness/__tests__/check-design-doc-completeness.test.mjs
@@ -121,7 +121,11 @@ describe('check-design-doc-completeness CLI', () => {
     const result = runScan([path.join(root, 'design')]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain(`${ADVISORY_MARKER} design-doc completeness examined 0`);
-    expect(result.stdout).toContain('design-doc completeness scan passed (0 design document(s)');
+    // HARNESS-063: the zero is paired with the number of places looked in, so "no corpus" and
+    // "a corpus that authored none" stop reading the same.
+    expect(result.stdout).toContain(
+      'design-doc completeness scan passed (0 design document(s) examined in 1 target path)',
+    );
   });
 
   it('exits 1 and lists missing sections on a violating fixture (RED)', async () => {
@@ -131,7 +135,62 @@ describe('check-design-doc-completeness CLI', () => {
 
     const result = runScan([path.join(root, 'design')]);
     expect(result.status).toBe(1);
-    expect(result.stdout).toContain('design-doc completeness scan failed:');
+    expect(result.stdout).toContain('design-doc completeness scan failed');
     expect(result.stdout).toContain('missing "## Test Approach" section');
+  });
+
+  /**
+   * HARNESS-063 — a zero `examined` means something different depending on how many places were
+   * looked in. Over this repository the numbers are 0 documents in 76 package design directories:
+   * every package was enumerated and none authored a design doc, which is the honest reading the
+   * unqualified `0` could not distinguish from "there was nowhere to look".
+   */
+  it('names how many locations it searched, not only how many documents it read', async () => {
+    const root = await createDesignDir({
+      'design/a.md': GREEN_DESIGN_DOC,
+      'design/b.md': GREEN_DESIGN_DOC,
+    });
+    const result = runScan([path.join(root, 'design')]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      'design-doc completeness scan passed (2 design document(s) examined in 1 target path)',
+    );
+  });
+});
+
+/**
+ * The auto-discovery denominator: how many package design directories were looked in. Over a
+ * fixture workspace with a known package population, `searched` must equal that population — a
+ * zero-document run in 3 packages is a different claim from a zero-document run in none.
+ */
+describe('findDesignDocFindings — the searched count when auto-discovering', () => {
+  async function workspaceFixture(packages, designDocs = {}) {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-design-doc-ws-'));
+    for (const name of packages) {
+      const dir = path.join(root, 'packages', name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, 'package.json'), `{"name":"${name}"}`, 'utf8');
+    }
+    for (const [rel, content] of Object.entries(designDocs)) {
+      const abs = path.join(root, rel);
+      mkdirSync(path.dirname(abs), { recursive: true });
+      writeFileSync(abs, content, 'utf8');
+    }
+    return root;
+  }
+
+  it('counts every manifest package as a place it looked, and the docs it found', async () => {
+    const root = await workspaceFixture(['alpha', 'beta', 'gamma'], {
+      'packages/beta/docs/design/store.md': GREEN_DESIGN_DOC,
+    });
+    const { examined, searched, blocking } = findDesignDocFindings(undefined, root);
+    expect({ examined, searched }).toEqual({ examined: 1, searched: 3 });
+    expect(blocking).toEqual([]);
+  });
+
+  it('reports 0 examined over 3 packages that authored none', async () => {
+    const root = await workspaceFixture(['alpha', 'beta', 'gamma']);
+    const { examined, searched } = findDesignDocFindings(undefined, root);
+    expect({ examined, searched }).toEqual({ examined: 0, searched: 3 });
   });
 });

--- a/scripts/harness/__tests__/check-task-archival.test.mjs
+++ b/scripts/harness/__tests__/check-task-archival.test.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -160,5 +160,37 @@ describe('the examined count', () => {
     expect(code).toBe(1);
     expect(output).toContain('task-archival scan failed (1 active task file(s) examined');
     expect(output).toContain('.agents/tasks/A-001.md');
+  });
+
+  it('refuses an unreadable archive instead of reporting it as nothing archived', async () => {
+    // Review of #1561, and the same defect the active half already carries a guard for: a bare
+    // `catch { return 0 }` reports a permission or I/O failure in the words of a clean result. The
+    // count exists to tell a reader how much was actually looked at, so a count that silently
+    // becomes 0 when the read fails is worse than no count at all -- it looks measured.
+    // Red-proved 2026-08-01: with the bare catch restored, this case reported 0 archived and passed.
+    const root = await tasksFixture({
+      '.agents/tasks/README.md': '# Tasks\n',
+      '.agents/tasks/completed/OLD-001.md': ARCHIVABLE,
+    });
+    const archive = path.join(root, '.agents/tasks/completed');
+    const fsp = await import('node:fs/promises');
+    chmodSync(archive, 0o000);
+    try {
+      // Running as root defeats the permission bit; skip rather than assert something untrue.
+      let readable = true;
+      try {
+        await fsp.readdir(archive);
+      } catch {
+        readable = false;
+      }
+      if (readable) return;
+
+      await expect(
+        findTaskArchivalFindings(root),
+        'an unreadable archive was reported as 0 archived',
+      ).rejects.toThrow(/EACCES|permission denied/i);
+    } finally {
+      chmodSync(archive, 0o755);
+    }
   });
 });

--- a/scripts/harness/__tests__/check-task-archival.test.mjs
+++ b/scripts/harness/__tests__/check-task-archival.test.mjs
@@ -1,6 +1,12 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import { classifyTaskFile } from '../check-task-archival.mjs';
+import { classifyTaskFile, findTaskArchivalFindings, main } from '../check-task-archival.mjs';
+import { ADVISORY_MARKER } from '../run-all-scans.mjs';
 
 describe('classifyTaskFile', () => {
   it('flags an all-checked breakdown whose spec is in spec-docs/done/', () => {
@@ -79,5 +85,80 @@ describe('classifyTaskFile', () => {
 
   it('ignores a file with no checkboxes and no status', () => {
     expect(classifyTaskFile('# Notes\nSome prose, no checkboxes.').archivable).toBe(false);
+  });
+});
+
+/**
+ * HARNESS-063 — the scan says how much it examined.
+ *
+ * Measured on this repository 2026-08-01: `0` active task files and `422` archived ones, and
+ * `task-archival scan passed.` was the entire output. The two halves are reported separately
+ * because the archive is what made the pass look populated.
+ */
+describe('the examined count', () => {
+  const ARCHIVABLE = ['Spec: `.agents/spec-docs/done/X-001.md`', '- [x] TC-01'].join('\n');
+  const OPEN = ['Spec: `.agents/spec-docs/active/X-002.md`', '- [ ] TC-01'].join('\n');
+
+  async function tasksFixture(files) {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-task-archival-'));
+    mkdirSync(path.join(root, '.agents/tasks/completed'), { recursive: true });
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(root, rel);
+      mkdirSync(path.dirname(abs), { recursive: true });
+      writeFileSync(abs, content, 'utf8');
+    }
+    return root;
+  }
+
+  async function run(root) {
+    const lines = [];
+    const code = await main(root, (line) => lines.push(line));
+    return { code, output: lines.join('') };
+  }
+
+  it('reports N for a fixture holding N active task files, and the archive separately', async () => {
+    const root = await tasksFixture({
+      '.agents/tasks/README.md': '# Tasks\n',
+      '.agents/tasks/A-001.md': OPEN,
+      '.agents/tasks/A-002.md': OPEN,
+      '.agents/tasks/A-003.md': OPEN,
+      '.agents/tasks/completed/OLD-001.md': ARCHIVABLE,
+      '.agents/tasks/completed/OLD-002.md': ARCHIVABLE,
+    });
+
+    const { examined, archived } = await findTaskArchivalFindings(root);
+    expect(examined).toBe(3);
+    expect(archived).toBe(2);
+
+    const { code, output } = await run(root);
+    expect(code).toBe(0);
+    expect(output).toContain(
+      'task-archival scan passed (3 active task file(s) examined, 2 archived in .agents/tasks/completed/)',
+    );
+    expect(output).not.toContain(ADVISORY_MARKER);
+  });
+
+  it('reports 0 — and raises an advisory — rather than staying silent over an empty active half', async () => {
+    const root = await tasksFixture({
+      '.agents/tasks/README.md': '# Tasks\n',
+      '.agents/tasks/completed/OLD-001.md': ARCHIVABLE,
+    });
+
+    const { examined, archived } = await findTaskArchivalFindings(root);
+    expect(examined).toBe(0);
+    expect(archived).toBe(1);
+
+    const { code, output } = await run(root);
+    expect(code).toBe(0);
+    expect(output).toContain('(0 active task file(s) examined, 1 archived');
+    expect(output).toContain(`${ADVISORY_MARKER} task-archival examined 0 active task files`);
+  });
+
+  it('still fails on a done-but-active file, and names the count it read', async () => {
+    const root = await tasksFixture({ '.agents/tasks/A-001.md': ARCHIVABLE });
+    const { code, output } = await run(root);
+    expect(code).toBe(1);
+    expect(output).toContain('task-archival scan failed (1 active task file(s) examined');
+    expect(output).toContain('.agents/tasks/A-001.md');
   });
 });

--- a/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
+++ b/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { loadHarnessConfig } from '../harness-config.mjs';
+import { ADVISORY_MARKER } from '../run-all-scans.mjs';
 import {
   extractNarrativeText,
   findBareRatioProgressStatements,
@@ -232,7 +233,70 @@ describe('main', () => {
       home: makeTempDir(),
     });
     expect(code).toBe(0);
-    expect(lines.join('\n')).toContain('skipped: no session transcript');
+    expect(lines.join('\n')).toContain('scan skipped');
+    expect(lines.join('\n')).toContain('no session transcript for this workspace');
+  });
+
+  /**
+   * HARNESS-063 — the skip states its zero, through the channel that survives to the suite summary.
+   * A passing scan's stdout is suppressed to a single tick, so on CI (where this channel never
+   * exists) the explicit skip reason was invisible and the tick read as a verified rule.
+   */
+  it('reports 0 transcripts and raises an advisory when the channel is absent', async () => {
+    const lines = [];
+    const code = await main((line) => lines.push(line), {
+      root: '/home/dev/repo',
+      home: makeTempDir(),
+    });
+    const output = lines.join('\n');
+    expect(code).toBe(0);
+    expect(output).toContain('skipped (0 transcript(s), 0 narrative message(s) examined)');
+    expect(output).toContain(
+      `${ADVISORY_MARKER} progress-report quantification examined 0 transcript(s)`,
+    );
+  });
+
+  it('reports the number of transcripts AND narrative messages it judged', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.claude', 'projects', transcriptSlugFor('/home/dev/repo'));
+    mkdirSync(dir, { recursive: true });
+    const recent = POLICY.enforceSinceIso.replace(/^(\d{4})/, (year) => String(Number(year) + 1));
+    writeFileSync(
+      path.join(dir, 'a.jsonl'),
+      [
+        assistantRecord('All good = 100%.', recent),
+        JSON.stringify({ type: 'user', message: { content: 'go' } }),
+        assistantRecord('Second message, nothing countable here.', recent),
+      ].join('\n'),
+    );
+    writeFileSync(path.join(dir, 'b.jsonl'), assistantRecord('Third, still clean.', recent));
+
+    const lines = [];
+    const code = await main((line) => lines.push(line), { root: '/home/dev/repo', home });
+    expect(code).toBe(0);
+    expect(lines.join('\n')).toContain(
+      'progress-report quantification scan passed (2 transcript(s), 3 narrative message(s) examined)',
+    );
+    expect(lines.join('\n')).not.toContain(ADVISORY_MARKER);
+  });
+
+  it('raises an advisory when transcripts exist but the ratchet leaves 0 messages to judge', async () => {
+    const home = makeTempDir();
+    const dir = path.join(home, '.claude', 'projects', transcriptSlugFor('/home/dev/repo'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, 'ancient.jsonl'),
+      assistantRecord('Sweep 3/7 done.', '2000-01-01T00:00:00.000Z'),
+    );
+
+    const lines = [];
+    const code = await main((line) => lines.push(line), { root: '/home/dev/repo', home });
+    const output = lines.join('\n');
+    expect(code).toBe(0);
+    expect(output).toContain('scan passed (1 transcript(s), 0 narrative message(s) examined)');
+    expect(output).toContain(
+      `${ADVISORY_MARKER} progress-report quantification examined 0 narrative messages`,
+    );
   });
 
   it('exits 1 and names the rule when a transcript violates it', async () => {

--- a/scripts/harness/__tests__/scan-test-plan.test.mjs
+++ b/scripts/harness/__tests__/scan-test-plan.test.mjs
@@ -5,7 +5,8 @@ import path from 'node:path';
 
 import { describe, it, expect } from 'vitest';
 
-import { collectTestPlanFindings, hasTestPlanSection } from '../scan-test-plan.mjs';
+import { ADVISORY_MARKER } from '../run-all-scans.mjs';
+import { collectTestPlanFindings, hasTestPlanSection, main } from '../scan-test-plan.mjs';
 
 describe('hasTestPlanSection', () => {
   it('returns true for ## Test Plan with enough content', () => {
@@ -110,5 +111,96 @@ describe('collectTestPlanFindings — the gated tree', () => {
   it('throws rather than passing when the spec-doc pipeline is absent', async () => {
     const bare = await mkdtemp(path.join(tmpdir(), 'robota-test-plan-bare-'));
     await expect(collectTestPlanFindings(bare)).rejects.toThrow(/spec-docs/);
+  });
+});
+
+/**
+ * HARNESS-063 — the count, split by half.
+ *
+ * Measured on this repository 2026-08-01: `26 document(s) checked`, of which 26 came from
+ * `docs/superpowers/` (history) and 0 from the live pipeline. A single number let a frozen archive
+ * stand in for the tree a reader assumes was scanned.
+ */
+describe('main — the examined count is reported per half', () => {
+  const WITH_PLAN = [
+    '# X',
+    '',
+    '## Test Plan',
+    '',
+    'Unit tests cover the parser edge cases and the error paths; run them with pnpm test.',
+    '',
+  ].join('\n');
+
+  async function fixture(files) {
+    const root = await mkdtemp(path.join(tmpdir(), 'robota-test-plan-halves-'));
+    for (const state of ['draft', 'backlog', 'todo', 'active', 'done', 'rejected']) {
+      mkdirSync(path.join(root, '.agents/spec-docs', state), { recursive: true });
+    }
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = path.join(root, rel);
+      mkdirSync(path.dirname(abs), { recursive: true });
+      writeFileSync(abs, content, 'utf8');
+    }
+    return root;
+  }
+
+  async function run(root) {
+    const lines = [];
+    const code = await main(root, (line) => lines.push(line));
+    return { code, output: lines.join('') };
+  }
+
+  it('counts a known population into the live and archived halves', async () => {
+    const root = await fixture({
+      '.agents/spec-docs/todo/CLI-001.md': WITH_PLAN,
+      '.agents/spec-docs/active/CLI-002.md': WITH_PLAN,
+      'docs/superpowers/plans/old-plan.md': WITH_PLAN,
+    });
+
+    const { examined, examinedLive, examinedArchive } = await collectTestPlanFindings(root);
+    expect({ examined, examinedLive, examinedArchive }).toEqual({
+      examined: 3,
+      examinedLive: 2,
+      examinedArchive: 1,
+    });
+
+    const { code, output } = await run(root);
+    expect(code).toBe(0);
+    expect(output).toContain('harness test-plan scan passed (3 document(s) checked: 2 live');
+    expect(output).toContain('1 archived (docs/superpowers/plans, docs/superpowers/specs)');
+    expect(output).not.toContain(ADVISORY_MARKER);
+  });
+
+  it('raises an advisory when the live half is empty and only the archive supplies the count', async () => {
+    // This is the shipped state of the repository, in a fixture: a green line reading "26 checked"
+    // where the live pipeline contributed nothing.
+    const root = await fixture({
+      'docs/superpowers/plans/old-plan.md': WITH_PLAN,
+      'docs/superpowers/specs/old-spec.md': WITH_PLAN,
+    });
+
+    const { code, output } = await run(root);
+    expect(code).toBe(0);
+    expect(output).toContain('(2 document(s) checked: 0 live');
+    expect(output).toContain(`${ADVISORY_MARKER} test-plan examined 0 live planning documents`);
+  });
+
+  it('reports 0 for an empty corpus instead of an unqualified pass', async () => {
+    const root = await fixture({});
+    const { code, output } = await run(root);
+    expect(code).toBe(0);
+    expect(output).toContain('(0 document(s) checked: 0 live');
+    expect(output).toContain('0 archived');
+    expect(output).toContain(ADVISORY_MARKER);
+  });
+
+  it('still fails on a live document with no test plan, and names the counts', async () => {
+    const root = await fixture({
+      '.agents/spec-docs/todo/CLI-003.md': '# X\n\n## Problem\n\nBroken.\n',
+    });
+    const { code, output } = await run(root);
+    expect(code).toBe(1);
+    expect(output).toContain('harness test-plan scan failed (1 document(s) checked: 1 live');
+    expect(output).toContain('CLI-003.md');
   });
 });

--- a/scripts/harness/check-design-doc-completeness.mjs
+++ b/scripts/harness/check-design-doc-completeness.mjs
@@ -55,20 +55,30 @@ function walkMarkdown(dir) {
  */
 function discoverDesignDocs(root = WORKSPACE_ROOT) {
   const out = [];
-  for (const pkgDir of listManifestPackageDirs(root)) {
+  const packageDirs = listManifestPackageDirs(root);
+  for (const pkgDir of packageDirs) {
     out.push(...walkMarkdown(path.join(pkgDir, 'docs', 'design')));
   }
-  return out;
+  return { files: out, searched: packageDirs.length };
 }
 
+/**
+ * Findings plus BOTH sizes (HARNESS-063): `examined` is how many design documents were read,
+ * `searched` is how many locations were looked in. A zero `examined` means something different
+ * depending on `searched` — nowhere to look versus the 76 packages measured here on 2026-08-01,
+ * none of which authored one — and
+ * the pass line has to say which.
+ */
 export function findDesignDocFindings(target, root = WORKSPACE_ROOT) {
   const blocking = [];
   const warnings = [];
   let files;
+  let searched;
   if (target) {
     files = existsSync(target) && statSync(target).isFile() ? [target] : walkMarkdown(target);
+    searched = 1;
   } else {
-    files = discoverDesignDocs(root);
+    ({ files, searched } = discoverDesignDocs(root));
   }
   const examined = files.length;
   for (const file of files) {
@@ -81,13 +91,14 @@ export function findDesignDocFindings(target, root = WORKSPACE_ROOT) {
       warnings.push({ file: rel, detail: 'no link to the owning SPEC.md — recommended' });
     }
   }
-  return { blocking, warnings, examined };
+  return { blocking, warnings, examined, searched };
 }
 
 export function main(argv = process.argv) {
   const arg = argv[2];
   const target = arg ? path.resolve(WORKSPACE_ROOT, arg) : undefined;
-  const { blocking, warnings, examined } = findDesignDocFindings(target);
+  const { blocking, warnings, examined, searched } = findDesignDocFindings(target);
+  const location = target ? 'target path' : 'package design director(y/ies)';
   for (const w of warnings) process.stdout.write(`- [warn] ${w.file}: ${w.detail}\n`);
   if (blocking.length === 0) {
     // HARNESS-052 asked this scan's subject to be DECIDED, because it has never validated a
@@ -101,16 +112,21 @@ export function main(argv = process.argv) {
     // rendering as an ordinary tick.
     if (examined === 0) {
       process.stdout.write(
-        `${ADVISORY_MARKER} design-doc completeness examined 0 documents — the design/LLD type is ` +
-          'OPTIONAL (RULE-009), so this is a measured zero, not a validated corpus.\n',
+        `${ADVISORY_MARKER} design-doc completeness examined 0 documents in ${searched} ` +
+          `${location} — the design/LLD type is OPTIONAL (RULE-009), so this is a measured zero, ` +
+          'not a validated corpus.\n',
       );
     }
     process.stdout.write(
-      `design-doc completeness scan passed (${examined} design document(s) examined).\n`,
+      `design-doc completeness scan passed (${examined} design document(s) examined in ` +
+        `${searched} ${location}).\n`,
     );
     return;
   }
-  process.stdout.write('design-doc completeness scan failed:\n');
+  process.stdout.write(
+    `design-doc completeness scan failed (${examined} design document(s) examined in ` +
+      `${searched} ${location}):\n`,
+  );
   for (const f of blocking) process.stdout.write(`- [missing-section] ${f.file}: ${f.detail}\n`);
   process.exitCode = 1;
 }

--- a/scripts/harness/check-task-archival.mjs
+++ b/scripts/harness/check-task-archival.mjs
@@ -89,14 +89,27 @@ export function classifyTaskFile(content) {
   return { archivable, gatesOverdue, reason, exemptReason };
 }
 
+/**
+ * Read a directory, treating ONLY its absence as empty.
+ *
+ * A bare `catch { return [] }` here reports a permission or I/O failure in the words of a clean
+ * result — the swallow-error-as-clean-default pattern `requireGovernedTree` was added to this very
+ * file to end on the active side. Adding a count while leaving the count's own read able to fail
+ * silently would have given the reader a number that looks measured and is not.
+ */
+async function readDirOrAbsent(dir) {
+  try {
+    return await fs.readdir(dir);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
 /** Count the archived breakdowns under `.agents/tasks/completed/`; an absent archive is 0. */
 async function countArchived(root) {
-  try {
-    const entries = await fs.readdir(path.join(root, COMPLETED_DIR));
-    return entries.filter((name) => name.endsWith('.md') && name !== 'README.md').length;
-  } catch {
-    return 0;
-  }
+  const entries = await readDirOrAbsent(path.join(root, COMPLETED_DIR));
+  return entries.filter((name) => name.endsWith('.md') && name !== 'README.md').length;
 }
 
 /**
@@ -118,12 +131,7 @@ export async function findTaskArchivalFindings(root = WORKSPACE_ROOT) {
   const archived = await countArchived(root);
   let examined = 0;
 
-  let entries = [];
-  try {
-    entries = await fs.readdir(tasksAbsolute);
-  } catch {
-    return { findings, exemptions, examined, archived };
-  }
+  const entries = await readDirOrAbsent(tasksAbsolute);
 
   for (const entry of entries
     .filter((name) => name.endsWith('.md') && name !== 'README.md')

--- a/scripts/harness/check-task-archival.mjs
+++ b/scripts/harness/check-task-archival.mjs
@@ -28,10 +28,12 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 import { requireGovernedTree } from './governed-tree.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const TASKS_DIR = '.agents/tasks';
+const COMPLETED_DIR = `${TASKS_DIR}/completed`;
 
 const UNCHECKED_PATTERN = /^\s*[-*]\s+\[ \]/;
 const CHECKED_PATTERN = /^\s*[-*]\s+\[[xX]\]/;
@@ -87,21 +89,40 @@ export function classifyTaskFile(content) {
   return { archivable, gatesOverdue, reason, exemptReason };
 }
 
+/** Count the archived breakdowns under `.agents/tasks/completed/`; an absent archive is 0. */
+async function countArchived(root) {
+  try {
+    const entries = await fs.readdir(path.join(root, COMPLETED_DIR));
+    return entries.filter((name) => name.endsWith('.md') && name !== 'README.md').length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Findings plus the SIZE OF EACH HALF of the corpus (HARNESS-063).
+ *
+ * `examined` is the number of ACTIVE task files this scan actually read; `archived` is the frozen
+ * half it deliberately does not judge. Measured 2026-08-01 on this repository: 0 examined, 422
+ * archived — the scan had never read a document, and `task-archival scan passed.` said so in
+ * exactly the same words it would have used over a hundred verified breakdowns.
+ */
 export async function findTaskArchivalFindings(root = WORKSPACE_ROOT) {
   requireGovernedTree(root, [TASKS_DIR], {
     scan: 'task-archival',
-    why:
-      'The task tree is the subject; a readdir failure was swallowed and returned as "nothing to archive".',
+    why: 'The task tree is the subject; a readdir failure was swallowed and returned as "nothing to archive".',
   });
   const findings = [];
   const exemptions = [];
   const tasksAbsolute = path.join(root, TASKS_DIR);
+  const archived = await countArchived(root);
+  let examined = 0;
 
   let entries = [];
   try {
     entries = await fs.readdir(tasksAbsolute);
   } catch {
-    return { findings, exemptions };
+    return { findings, exemptions, examined, archived };
   }
 
   for (const entry of entries
@@ -109,6 +130,7 @@ export async function findTaskArchivalFindings(root = WORKSPACE_ROOT) {
     .sort()) {
     const taskFile = path.join(TASKS_DIR, entry);
     const content = await fs.readFile(path.join(root, taskFile), 'utf8');
+    examined += 1;
     const { archivable, gatesOverdue, reason, exemptReason } = classifyTaskFile(content);
     if (!archivable && !gatesOverdue) continue;
     if (exemptReason) {
@@ -118,42 +140,59 @@ export async function findTaskArchivalFindings(root = WORKSPACE_ROOT) {
     findings.push({ taskFile, reason, gatesOverdue });
   }
 
-  return { findings, exemptions };
+  return { findings, exemptions, examined, archived };
 }
 
-export async function main() {
-  const { findings, exemptions } = await findTaskArchivalFindings(WORKSPACE_ROOT);
+/**
+ * Run the scan. Returns the exit code rather than setting `process.exitCode`, so a test can drive it
+ * over a fixture root without the fixture's verdict escaping into the test runner's own exit status.
+ */
+export async function main(root = WORKSPACE_ROOT, write = (line) => process.stdout.write(line)) {
+  const { findings, exemptions, examined, archived } = await findTaskArchivalFindings(root);
 
   for (const exemption of exemptions) {
-    process.stdout.write(`  archival-exempt: ${exemption.taskFile} — ${exemption.reason}\n`);
+    write(`  archival-exempt: ${exemption.taskFile} — ${exemption.reason}\n`);
   }
+
+  const subject =
+    `${examined} active task file(s) examined, ${archived} archived in ${COMPLETED_DIR}/` +
+    (exemptions.length > 0 ? `, ${exemptions.length} exempt` : '');
 
   if (findings.length === 0) {
-    process.stdout.write(
-      `task-archival scan passed${exemptions.length > 0 ? ` (${exemptions.length} exempt)` : ''}.\n`,
-    );
-    return;
+    // HARNESS-063: `task-archival scan passed.` was identical whether the scan had read a hundred
+    // breakdowns or none. A zero here is not a clean sweep — it is a corpus that contributed
+    // nothing, and the advisory channel is what carries that into the suite summary (a passing
+    // scan's stdout is otherwise suppressed to a single tick).
+    if (examined === 0) {
+      write(
+        `${ADVISORY_MARKER} task-archival examined 0 active task files — the active half of ` +
+          `${TASKS_DIR}/ is empty (${archived} archived under completed/), so this pass verified ` +
+          'no document.\n',
+      );
+    }
+    write(`task-archival scan passed (${subject}).\n`);
+    return 0;
   }
 
-  process.stdout.write(
-    'task-archival scan failed — done or gate-overdue task files in the active directory:\n',
+  write(
+    `task-archival scan failed (${subject}) — done or gate-overdue task files in the active directory:\n`,
   );
   for (const finding of findings) {
-    process.stdout.write(
+    write(
       `  - ${finding.taskFile} (${finding.reason})${finding.gatesOverdue ? ' — run GATE-VERIFY/GATE-COMPLETE, move the spec to done/, then archive' : ''}\n`,
     );
   }
-  process.stdout.write(
+  write(
     'Archive done tasks to .agents/tasks/completed/ (git mv) in the same change as the work; ' +
       'for fully-checked tasks whose spec is not yet done/, run the remaining gates first. ' +
       'Annotate with <!-- archival-exempt: <reason> --> only when the file must stay active.\n',
   );
-  process.exitCode = 1;
+  return 1;
 }
 
 const isDirectExecution =
   process.argv[1] !== undefined &&
   path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
 if (isDirectExecution) {
-  await main();
+  process.exitCode = await main();
 }

--- a/scripts/harness/scan-progress-report-quantification.mjs
+++ b/scripts/harness/scan-progress-report-quantification.mjs
@@ -53,6 +53,7 @@ import readline from 'node:readline';
 import { pathToFileURL } from 'node:url';
 
 import { loadHarnessConfig } from './harness-config.mjs';
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
@@ -165,7 +166,7 @@ function recordTimestampMs(record) {
  * Scan one transcript JSONL. Streamed line-by-line: session transcripts reach hundreds of MB,
  * so nothing is buffered whole and only assistant records are parsed.
  */
-export async function scanTranscriptFile(filePath, policy, sinceMs) {
+export async function scanTranscriptFile(filePath, policy, sinceMs, stats) {
   const findings = [];
   const stream = createReadStream(filePath, { encoding: 'utf8' });
   const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
@@ -182,6 +183,10 @@ export async function scanTranscriptFile(filePath, policy, sinceMs) {
     if (sinceMs !== undefined && timestampMs !== undefined && timestampMs < sinceMs) continue;
     const text = extractNarrativeText(record);
     if (text === '') continue;
+    // The examined count is the NARRATIVE MESSAGES actually judged — after the type filter and
+    // after the time ratchet — not the transcripts opened (HARNESS-063). A transcript whose every
+    // record predates `enforceSinceIso` is a file read and nothing judged.
+    if (stats !== undefined) stats.messages += 1;
     for (const finding of findBareRatioProgressStatements(text, policy)) {
       findings.push({ ...finding, file: filePath, timestamp: record?.timestamp });
     }
@@ -224,8 +229,18 @@ export async function main(write = (line) => process.stdout.write(`${line}\n`), 
   const { dir, files } = resolveTranscriptFiles(policy, overrides);
 
   if (files.length === 0) {
+    // HARNESS-063: the skip reason was already explicit, but a passing scan's stdout is suppressed
+    // to a single tick in the suite summary — so on every CI run this line was invisible and the
+    // tick was indistinguishable from a scan that had judged the narrative channel. The advisory
+    // channel is the one that survives to the summary.
     write(
-      `progress-report quantification scan skipped: no session transcript for this workspace at ${dir} ` +
+      `${ADVISORY_MARKER} progress-report quantification examined 0 transcript(s) — no session ` +
+        `transcript for this workspace at ${dir}; the agent-narrative channel does not exist on ` +
+        'this host (e.g. CI or a fresh checkout), so nothing was judged.',
+    );
+    write(
+      `progress-report quantification scan skipped (0 transcript(s), 0 narrative message(s) examined): ` +
+        `no session transcript for this workspace at ${dir} ` +
         '(no agent-narrative channel on this host — e.g. CI or a fresh checkout).',
     );
     return 0;
@@ -233,16 +248,26 @@ export async function main(write = (line) => process.stdout.write(`${line}\n`), 
 
   const sinceMs = Date.parse(policy.enforceSinceIso);
   const findings = [];
+  const stats = { messages: 0 };
   for (const file of files) {
-    findings.push(...(await scanTranscriptFile(file, policy, sinceMs)));
+    findings.push(...(await scanTranscriptFile(file, policy, sinceMs, stats)));
   }
+  const subject = `${files.length} transcript(s), ${stats.messages} narrative message(s) examined`;
 
   if (findings.length === 0) {
-    write(`progress-report quantification scan passed (${files.length} transcript(s)).`);
+    if (stats.messages === 0) {
+      write(
+        `${ADVISORY_MARKER} progress-report quantification examined 0 narrative messages across ` +
+          `${files.length} transcript(s) — every record was filtered out by the ` +
+          `enforceSinceIso ratchet (${policy.enforceSinceIso}) or carried no assistant narrative, ` +
+          'so this pass judged no message.',
+      );
+    }
+    write(`progress-report quantification scan passed (${subject}).`);
     return 0;
   }
 
-  write('progress-report quantification scan failed:');
+  write(`progress-report quantification scan failed (${subject}):`);
   for (const finding of findings) {
     write(`  ${path.basename(finding.file)} [${finding.timestamp ?? 'no timestamp'}]`);
     write(`    ratio ${finding.ratio} reported without a percentage: "${finding.excerpt}"`);

--- a/scripts/harness/scan-test-plan.mjs
+++ b/scripts/harness/scan-test-plan.mjs
@@ -24,6 +24,7 @@
  */
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { ADVISORY_MARKER } from './run-all-scans.mjs';
 import { WORKSPACE_ROOT, pathExists } from './shared.mjs';
 
 const MIN_CONTENT_LENGTH = 50;
@@ -31,14 +32,32 @@ const MIN_CONTENT_LENGTH = 50;
 /** The spec-doc lifecycle folder that MUST exist for this scan to have a subject at all. */
 const SPEC_DOCS_ROOT = '.agents/spec-docs';
 
+/**
+ * The corpus, split by HALF (HARNESS-063).
+ *
+ * `docs/superpowers/**` is history — `check-ghost-package-refs` classifies it as "dated historical
+ * plan/spec artifacts" and excludes it on exactly that ground. It stays gated here (a plan document
+ * that acquires a test plan section costs nothing, and these files are still edited by hand), but it
+ * must not be counted as if it were the live pipeline: measured 2026-08-01, all 26 documents this
+ * scan reported "checked" came from that archive and the live half contributed 0. One number over
+ * two halves is how a frozen archive ends up standing in for a pipeline nobody scanned.
+ */
+const LIVE_HALF = 'live';
+const ARCHIVE_HALF = 'archive';
+
 const SCAN_DIRS = [
-  'docs/superpowers/plans',
-  'docs/superpowers/specs',
-  '.agents/tasks',
-  `${SPEC_DOCS_ROOT}/backlog`,
-  `${SPEC_DOCS_ROOT}/todo`,
-  `${SPEC_DOCS_ROOT}/active`,
+  { dir: 'docs/superpowers/plans', half: ARCHIVE_HALF },
+  { dir: 'docs/superpowers/specs', half: ARCHIVE_HALF },
+  { dir: '.agents/tasks', half: LIVE_HALF },
+  { dir: `${SPEC_DOCS_ROOT}/backlog`, half: LIVE_HALF },
+  { dir: `${SPEC_DOCS_ROOT}/todo`, half: LIVE_HALF },
+  { dir: `${SPEC_DOCS_ROOT}/active`, half: LIVE_HALF },
 ];
+
+const halfLabel = (half) =>
+  SCAN_DIRS.filter((entry) => entry.half === half)
+    .map((entry) => entry.dir)
+    .join(', ');
 
 /** Heading patterns that qualify as a test plan section (case-insensitive). */
 const TEST_SECTION_PATTERNS = [
@@ -108,13 +127,15 @@ export async function collectTestPlanFindings(root = WORKSPACE_ROOT) {
 
   const findings = [];
   let examined = 0;
+  const examinedByHalf = { [LIVE_HALF]: 0, [ARCHIVE_HALF]: 0 };
 
-  for (const dir of SCAN_DIRS) {
+  for (const { dir, half } of SCAN_DIRS) {
     const files = await collectMarkdownFiles(dir, root);
 
     for (const { absPath, relPath } of files) {
       const content = await fs.readFile(absPath, 'utf8');
       examined += 1;
+      examinedByHalf[half] += 1;
 
       if (!hasTestPlanSection(content)) {
         findings.push({
@@ -127,23 +148,42 @@ export async function collectTestPlanFindings(root = WORKSPACE_ROOT) {
     }
   }
 
-  return { findings, examined };
+  return {
+    findings,
+    examined,
+    examinedLive: examinedByHalf[LIVE_HALF],
+    examinedArchive: examinedByHalf[ARCHIVE_HALF],
+  };
 }
 
-async function main() {
-  const { findings, examined } = await collectTestPlanFindings();
+export async function main(root = WORKSPACE_ROOT, write = (line) => process.stdout.write(line)) {
+  const { findings, examined, examinedLive, examinedArchive } = await collectTestPlanFindings(root);
+
+  // The count is reported because "passed" over 26 documents and "passed" over none read the same;
+  // it is reported PER HALF (HARNESS-063) because "passed over 26" and "passed over 26 frozen
+  // records and nothing live" also read the same.
+  const subject =
+    `${examined} document(s) checked: ${examinedLive} live (${halfLabel(LIVE_HALF)}), ` +
+    `${examinedArchive} archived (${halfLabel(ARCHIVE_HALF)})`;
 
   if (findings.length === 0) {
-    // The count is reported because "passed" over 26 documents and "passed" over none read the same.
-    process.stdout.write(`harness test-plan scan passed (${examined} document(s) checked).\n`);
-    return;
+    if (examinedLive === 0) {
+      write(
+        `${ADVISORY_MARKER} test-plan examined 0 live planning documents — the ${examined} ` +
+          `document(s) checked all come from ${halfLabel(ARCHIVE_HALF)}, which ` +
+          'check-ghost-package-refs classifies as dated historical artifacts. The live planning ' +
+          'pipeline contributed nothing to this pass.\n',
+      );
+    }
+    write(`harness test-plan scan passed (${subject}).\n`);
+    return 0;
   }
 
-  process.stdout.write('harness test-plan scan failed:\n');
+  write(`harness test-plan scan failed (${subject}):\n`);
   for (const finding of findings) {
-    process.stdout.write(`- [${finding.type}] ${finding.file}: ${finding.detail}\n`);
+    write(`- [${finding.type}] ${finding.file}: ${finding.detail}\n`);
   }
-  process.exitCode = 1;
+  return 1;
 }
 
 // Only when RUN, not when imported: `void main()` at module scope meant importing this scan for its
@@ -153,5 +193,5 @@ const isDirectExecution =
   process.argv[1] !== undefined &&
   path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
 if (isDirectExecution) {
-  await main();
+  process.exitCode = await main();
 }


### PR DESCRIPTION
**HARNESS-063** (#1554).

## The problem

`requireGovernedTree` fences a scan whose tree is **absent**. It does not fence one whose tree exists and is **empty**, or one whose live half is empty while a frozen archive supplies the count. Four green lines in an 83-scan summary reporting nothing verified — and the summary is what a reader takes as the state of the tree.

## Measured independently before changing anything

| Scan | Measured |
| --- | --- |
| `check-task-archival` | **0 active**, 422 archived |
| `scan-test-plan` | **0 live**; all 26 documents checked come from `docs/superpowers/`, which a sibling scan excludes as *"dated historical artifacts"* |
| `check-design-doc-completeness` | **0 documents**, across **76** manifest packages |
| `scan-progress-report-quantification` | dev host: 3 transcripts, 2049 messages, 1.26 s. **Transcript-less env (CI): 0 transcripts, 0.03 s** |

## The key design point

A passing scan's stdout is suppressed to a single `✓` in the suite summary — **so the count alone would never reach a reader.** Each scan now also raises an `::advisory::` when its live half is zero, which is the one channel that survives suppression:

```
⚑ task-archival: examined 0 active task files — the active half of .agents/tasks/ is empty
  (422 archived under completed/), so this pass verified no document.
⚑ test-plans: examined 0 live planning documents — the 26 checked all come from
  docs/superpowers/…, which check-ghost-package-refs classifies as dated historical artifacts.
⚑ design-doc: examined 0 documents in 76 package design director(y/ies).
⚑ progress-report-quantification: examined 0 transcript(s) — the agent-narrative channel does
  not exist on this host (e.g. CI), so nothing was judged.
```

The verdict is unchanged; advisories are non-blocking by construction. Nothing that passed starts failing.

## What the item got wrong, corrected in this PR

- **"the 3rd slowest scan at 1281 ms" is not a CI measurement.** With no transcripts it runs in **0.03 s**. The two complaints in that cell are mutually exclusive: wherever it runs it is either fast-and-vacuous or slow-and-working, never both — and the `--skip` argument rested on the slowness half.
- **The `.agents/tasks/` decision was already taken.** PROC-006 records *"Decided (owner): `Task` … the tree is revived, and it becomes the one home"*, citing HARNESS-063 by name. **Recommendation: keep the scan** — it is about to acquire the largest corpus in the repo, and `examined`/`archived` become the mechanical progress signal for that migration.
- **`check-design-doc-completeness` was closer to done than the table implies** — it already reported its zero honestly; what was missing was the denominator and any test that the count appears at all.

## The other recommendation, not acted on

**Should the progress scan join CI's `--skip`? No.** It costs 0.03 s there, `--skip` is a static declaration about a host-conditional scan and would silently disable it the day a transcript channel exists on the runner, and the honesty it was meant to buy is now delivered by the advisory. The one argument the other way, which is the owner's to weigh: `--skip` also removes it from the "83 scans" denominator, so if that denominator should mean *"scans that verified something"*, only `--skip` achieves it.

## Verification

- 12 tests added, all on temp-dir fixtures, **both directions** — an N-document fixture reports N, an empty one reports 0 with the advisory rather than staying silent. Counts appear on the failure line too.
- Counts verified computed, not hardcoded: a 2-active/1-archived fixture reports `examined=2 archived=1`.
- Full suite green apart from the known worktree symlink artifact; `dist`/`doc-examples` fail only for lack of a build, same as baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso