### PR TITLE
fix(hooks): read the shell grammar with a stack, because quoting is not regular

### DIFF
--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -666,6 +666,15 @@ HOOK_SCAN_AWK='
 
     if (MODE == "mask") { print mask; exit }
 
+    # Where an unquoted VALUE ends. Whitespace and quotes were the whole list, so a value read
+    # out of a substitution came back wearing the paren that closed it: a nested
+    # `git push origin --delete develop` named the branch `develop)`, which matches no protected
+    # name, so the guard fell past the protected-branch check to the merged-PR one and refused a
+    # branch that does not exist. It still refused — but for the wrong reason and about the wrong
+    # branch, which is one name away from refusing nothing. Only visible once the tokenizer made
+    # substitution contents reachable at all; before that the value was masked and never read.
+    TERM = "[ \t\n\"\047)\140].*$"
+
     # Anchor in the mask, then search the ORIGINAL from that offset. Needed when the value sits
     # INSIDE a quoted argument — a `gh api` refs/heads URL nearly always does — where the mask
     # hides it. Reading the original from position zero instead is what let a decoy in a commit
@@ -675,7 +684,7 @@ HOOK_SCAN_AWK='
       rest = substr(s, RSTART)
       if (!match(rest, VRE)) { exit }
       v = substr(rest, RSTART + RLENGTH)
-      sub(/[ \t\n"\047].*$/, "", v)
+      sub(TERM, "", v)
       print v
       exit
     }
@@ -692,7 +701,7 @@ HOOK_SCAN_AWK='
       print (endq > 0 ? substr(s, p, endq - 1) : substr(s, p))
     } else {
       v = substr(s, p)
-      sub(/[ \t\n"\047].*$/, "", v)
+      sub(TERM, "", v)
       print v
     }
   }

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -492,6 +492,14 @@ HOOK_TOKENIZER_AWK='
       # ---- $((…)) : arithmetic, not a command, but substitutions inside it are ----
       if (k == "ARITH") {
         if (c == "\\") { m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; i += 2; continue }
+        # Arithmetic nests in arithmetic, and this was the ONE context that did not test for it
+        # before falling through to the two-character substitution test. `$(( $(( … )) ))` was
+        # therefore read as a command substitution whose content is a command, so the inner
+        # expression came back as visible command text. It fails in the refusing direction rather
+        # than the permitting one, but it is the same defect the rest of this file is a record of:
+        # a rule held in every context except one sibling.
+        if (c3 == "$((") { m[i] = "$"; m[i+1] = "("; m[i+2] = "("
+          sp++; kind[sp] = "ARITH"; fend[sp] = ""; fdep[sp] = 0; i += 3; continue }
         if (c2 == "$(") { m[i] = "$"; m[i+1] = "("
           sp++; kind[sp] = "CMD"; fend[sp] = ")"; fdep[sp] = 0; i += 2; continue }
         if (c == "\140") { m[i] = "\140"

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -255,6 +255,13 @@ hook_strip_comments() {
 }
 
 # What a guard should actually examine: the command with heredoc bodies and comments removed.
+#
+# This is the WEAKER of the two readings in this file, and callers that use both should know which
+# is which. It removes heredoc bodies and comments with the two line-oriented passes above and
+# leaves quoting alone; `hook_verb_scan` reads the same command by the grammar. Where they differ
+# the tokenizer is right, so a guard deciding whether a VERB is present must use `hook_verb_scan` —
+# this one is for the surrounding text a guard still needs to look at. Collapsing the two is a
+# caller-side change and is left to the item that owns those hooks.
 hook_executable_part() {
   printf '%s\n' "$1" | hook_strip_heredocs | hook_strip_comments
 }
@@ -299,6 +306,339 @@ hook_executable_part() {
 # because of the threat model: the commands guarded here are the agent's own, written plainly.
 HOOK_INTERPRETER_RE='(^|[ \t;&|(\n`])(([^ \t;&|(\n]*/)?(sh|bash|zsh|dash|ksh|tcsh|csh|ash|fish|mksh|busybox|python[0-9.]*|node|deno|bun|perl|ruby|php|awk|expect|tclsh|ssh)[ \t]+([^ \t;&|(\n"\047]+[ \t]+)*|eval[ \t]+)$'
 
+# The subset whose string argument is parsed AS SHELL. `python3 -c`, `node -e`, `perl -e` and
+# `awk` run a command too, but not a shell one, so reading their argument with shell quoting
+# rules would be an approximation of a DIFFERENT grammar — the exact mistake this file is a
+# record of. They stay on the list above, kept verbatim; only these are descended into.
+HOOK_SHELL_INTERPRETER_RE='(^|[ \t;&|(\n`])(([^ \t;&|(\n]*/)?(sh|bash|zsh|dash|ksh|tcsh|csh|ash|fish|mksh|busybox|ssh)[ \t]+([^ \t;&|(\n"\047]+[ \t]+)*|eval[ \t]+)$'
+
+# A tokenizer for the shell grammar, for the one question the guards ask: which characters of this
+# command will the shell EXECUTE, and which are data it will merely pass along?
+#
+# Why a tokenizer and not one more pass over the string.
+#
+# This file used to answer that with two linear passes: mask quoted regions, then restore
+# command-substitution spans. Both passes are regular, and shell quoting is not: `"$(printf 'x')"`
+# nests a single-quoted payload inside a substitution inside a double-quoted string, and deciding
+# what is data at the innermost level needs a stack. The restore pass had none, so it copied the
+# whole span back from the original, quoted payload included, and
+#
+#     out=$(printf 'x git commit -m y' | bash h.sh); echo done
+#
+# was refused as a commit (INFRA-075). Indexing where each quote OPENED closed that spelling and
+# opened its mirror: with the inner quotes now held masked, a genuine `a=$(echo "$(git commit)")`
+# stopped being seen at all — a real invocation invisible to every guard, which is a bypass, not a
+# nuisance. Measured on the differential corpus at the commit before this tokenizer existed: 177
+# of 197 shapes agreed with bash. Five of the twenty that did not were BYPASSES — bash ran the
+# push and no guard could see it — and the rest were refusals of correct work. With the grammar
+# read properly: 194 of 197, and every remaining disagreement is the one class named below.
+#
+# Four days of that class: `branch-guard.sh` rewritten 26 times, seven distinct instances, every one
+# found by a person hitting a new spelling and twice by a fix refusing the branch it lived on. The
+# repair is not a third pass. A substitution's content is itself a command and must be read by the
+# same rules that read the outer command — that is recursion, and the program below expresses it
+# as an explicit context stack, so the nesting depth is not bounded by the number of passes.
+#
+# What it models: single quotes, double quotes, ANSI-C `$'…'`, locale `$"…"`, backslash escapes and
+# the backslash-newline continuation, `#` comments, heredocs (`<<`, `<<-`, quoted and unquoted
+# delimiters) and herestrings, redirections, subshells, `${…}`, `$((…))`, `$(…)` and backtick
+# substitutions NESTED TO ANY DEPTH, and the string an interpreter is told to run.
+#
+# What it deliberately does NOT model, stated rather than discovered later: COMMAND POSITION. `echo
+# git push` names a verb the shell never runs as a command, and this tokenizer still shows it. To
+# hide it, the mask would have to drop every word that is not the first of a simple command — and
+# then `sudo git push`, `xargs git push`, `env git push`, `timeout 5 git push`, `command git push`
+# and every other exec-style wrapper not on some list would go unseen. That trade runs the wrong
+# way: an unmodelled wrapper is a silent BYPASS, while an argument read as a command is a refusal
+# that announces itself. The shapes this leaves unread are pinned as disagreements in
+# `scripts/harness/__tests__/hook-reading-matches-bash.test.mjs`, not hidden.
+#
+# The output is length-preserving, one character in for one character out, because `hook_match_*`
+# locates a verb in the mask and then reads its argument from the ORIGINAL at the same offset.
+# Executed text comes back as itself; data becomes \001; a quote that delimits a region the shell
+# will run becomes a space, so `git "push"` reads exactly as `git  push `.
+
+# The program defines awk FUNCTIONS only, and is concatenated ahead of the END block below, which
+# calls `tk_mask`. It is a separate variable because a parser and a set of field accessors are
+# different jobs, and because every awk invocation here needs the same one.
+#
+# No literal backtick and no literal apostrophe appears below. Both are load-bearing characters of
+# the grammar being parsed AND terminators of the single-quoted shell string carrying the program;
+# writing one directly is what left this file unparseable once, which blocks every guarded command
+# in the session. They are spelled \140 and \047.
+HOOK_TOKENIZER_AWK='
+  # A `#` opens a comment only where a word can begin.
+  function tk_wordstart(s, i) {
+    return (i == 1 || substr(s, i - 1, 1) ~ /[ \t\n;&|(]/)
+  }
+
+  # Characters that may end a heredoc delimiter word.
+  function tk_delimchar(c) {
+    return (c ~ /[A-Za-z0-9_.\/-]/)
+  }
+
+  # Fill m[1..length(s)] with the reading of s.
+  #
+  # Two interpreter lookbehinds, because the grammar this file knows is the SHELL grammar. SRE names
+  # the interpreters that parse their string argument AS SHELL — the shells themselves, `eval`, and
+  # `ssh` (a remote shell reads it) — and the tokenizer descends into those, which is what tells
+  # `bash -c "echo \047git commit\047"` from `bash -c "git commit"`. IRE names every interpreter,
+  # shell or not; a string run by `python3 -c` or `perl -e` is a command but NOT a shell command, so
+  # applying shell quoting to it would be a second approximation dressed as a parse. Those are kept
+  # verbatim, which over-reads (a mention inside python source still shows) — the direction that
+  # refuses work rather than the one that lets a `python3 -c "os.system(\047git push\047)"` through.
+  function tk_mask(s, m, IRE, SRE,
+                   len, i, j, w, c, c2, c3, nx, k, q, spaced, ch,
+                   sp, kind, fend, fdep, fterm, fdash, fquo,
+                   hn, hterm, hdash, hquo, dash, quoted, term, dc, eol, e, line, cand) {
+    len = length(s)
+
+    # Pre-fill with the original. Anything the loop somehow fails to visit therefore stays VISIBLE:
+    # a guard that over-reads refuses work and is argued with, a guard that under-reads is a hole
+    # nobody notices.
+    for (i = 1; i <= len; i++) { m[i] = substr(s, i, 1) }
+
+    sp = 1
+    kind[1] = "CMD"; fend[1] = ""; fdep[1] = 0
+    hn = 0
+    i = 1
+
+    while (i <= len) {
+      c = substr(s, i, 1)
+      c2 = substr(s, i, 2)
+      c3 = substr(s, i, 3)
+      k = kind[sp]
+
+      # ---- single quotes: no expansion of any kind happens inside ----
+      if (k == "SQ") {
+        if (c == "\047") { m[i] = "\047"; sp--; i++; continue }
+        m[i] = "\001"; i++; continue
+      }
+
+      # ---- $\047…\047 : ANSI-C quoting. Escapes are consumed, nothing expands. ----
+      if (k == "ANSI") {
+        if (c == "\\") { m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; i += 2; continue }
+        if (c == "\047") { m[i] = "\047"; sp--; i++; continue }
+        m[i] = "\001"; i++; continue
+      }
+
+      # ---- a quoted region an interpreter runs, and a quoted single word, are read verbatim ----
+      # A single word in quotes is a TOKEN of the command line, not a payload: `git "push"` runs the
+      # same push as `git push`, and quoting every token is ordinary defensive style.
+      if (k == "TOK") {
+        if (c == "\\" && fend[sp] != "\047") {
+          m[i] = c; if (i + 1 <= len) { m[i + 1] = substr(s, i + 1, 1) }; i += 2; continue
+        }
+        if (c == fend[sp]) { m[i] = " "; sp--; i++; continue }
+        m[i] = c; i++; continue
+      }
+
+      # ---- heredoc body ----
+      if (k == "HD") {
+        # The terminator is recognised at the start of a physical line. The check is stateless — it
+        # asks where we ARE rather than carrying a flag — so a substitution that spans a newline
+        # inside the body cannot leave the frame believing it is mid-line forever.
+        if (i == 1 || substr(s, i - 1, 1) == "\n") {
+          e = index(substr(s, i), "\n")
+          eol = (e > 0) ? i + e - 1 : len + 1
+          line = substr(s, i, eol - i)
+          cand = line
+          # Only `<<-` allows an indented terminator, and only TABS are stripped. Stripping spaces
+          # too would end a body early at an indented line that happens to read like the delimiter,
+          # and the rest of that body would then be scanned as commands.
+          if (fdash[sp]) { sub(/^\t+/, "", cand) }
+          if (cand == fterm[sp]) {
+            for (j = i; j < eol; j++) { m[j] = "\001" }
+            if (eol <= len) { m[eol] = "\n" }
+            i = eol + 1
+            sp--
+            continue
+          }
+        }
+        if (c == "\n") { m[i] = "\n"; i++; continue }
+        # An UNQUOTED delimiter leaves the body expanded, so a substitution written in it genuinely
+        # runs. `<<\047EOF\047` and `<<"EOF"` are literal and stay data.
+        if (!fquo[sp]) {
+          if (c3 == "$((") { m[i] = "$"; m[i+1] = "("; m[i+2] = "("
+            sp++; kind[sp] = "ARITH"; fend[sp] = ""; fdep[sp] = 0; i += 3; continue }
+          if (c2 == "$(") { m[i] = "$"; m[i+1] = "("
+            sp++; kind[sp] = "CMD"; fend[sp] = ")"; fdep[sp] = 0; i += 2; continue }
+          if (c2 == "${") { m[i] = "$"; m[i+1] = "{"
+            sp++; kind[sp] = "PARAM"; fend[sp] = ""; fdep[sp] = 0; i += 2; continue }
+          if (c == "\140") { m[i] = "\140"
+            sp++; kind[sp] = "CMD"; fend[sp] = "\140"; fdep[sp] = 0; i++; continue }
+          if (c == "\\") { m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; i += 2; continue }
+        }
+        m[i] = "\001"; i++; continue
+      }
+
+      # ---- ${…} : data, but a default value may itself be a substitution ----
+      if (k == "PARAM") {
+        if (c == "\\") { m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; i += 2; continue }
+        if (c3 == "$((") { m[i] = "$"; m[i+1] = "("; m[i+2] = "("
+          sp++; kind[sp] = "ARITH"; fend[sp] = ""; fdep[sp] = 0; i += 3; continue }
+        if (c2 == "$(") { m[i] = "$"; m[i+1] = "("
+          sp++; kind[sp] = "CMD"; fend[sp] = ")"; fdep[sp] = 0; i += 2; continue }
+        if (c == "\140") { m[i] = "\140"
+          sp++; kind[sp] = "CMD"; fend[sp] = "\140"; fdep[sp] = 0; i++; continue }
+        if (c == "{") { fdep[sp]++; m[i] = "\001"; i++; continue }
+        if (c == "}") {
+          if (fdep[sp] > 0) { fdep[sp]--; m[i] = "\001"; i++; continue }
+          m[i] = "\001"; sp--; i++; continue
+        }
+        m[i] = "\001"; i++; continue
+      }
+
+      # ---- $((…)) : arithmetic, not a command, but substitutions inside it are ----
+      if (k == "ARITH") {
+        if (c == "\\") { m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; i += 2; continue }
+        if (c2 == "$(") { m[i] = "$"; m[i+1] = "("
+          sp++; kind[sp] = "CMD"; fend[sp] = ")"; fdep[sp] = 0; i += 2; continue }
+        if (c == "\140") { m[i] = "\140"
+          sp++; kind[sp] = "CMD"; fend[sp] = "\140"; fdep[sp] = 0; i++; continue }
+        if (c == "(") { fdep[sp]++; m[i] = "\001"; i++; continue }
+        if (c == ")") {
+          if (fdep[sp] > 0) { fdep[sp]--; m[i] = "\001"; i++; continue }
+          m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; sp--; i += 2; continue
+        }
+        m[i] = "\001"; i++; continue
+      }
+
+      # ---- double quotes: data, EXCEPT the expansions the shell performs inside them ----
+      if (k == "DQ") {
+        if (c == "\\") { m[i] = "\001"; if (i + 1 <= len) { m[i + 1] = "\001" }; i += 2; continue }
+        if (c3 == "$((") { m[i] = "$"; m[i+1] = "("; m[i+2] = "("
+          sp++; kind[sp] = "ARITH"; fend[sp] = ""; fdep[sp] = 0; i += 3; continue }
+        # The substitution runs whatever the quoting around it, so its content is read as the
+        # command it is — and read by these same rules, which is what makes the nesting unbounded.
+        if (c2 == "$(") { m[i] = "$"; m[i+1] = "("
+          sp++; kind[sp] = "CMD"; fend[sp] = ")"; fdep[sp] = 0; i += 2; continue }
+        if (c2 == "${") { m[i] = "$"; m[i+1] = "{"
+          sp++; kind[sp] = "PARAM"; fend[sp] = ""; fdep[sp] = 0; i += 2; continue }
+        if (c == "\140") { m[i] = "\140"
+          sp++; kind[sp] = "CMD"; fend[sp] = "\140"; fdep[sp] = 0; i++; continue }
+        if (c == "\"") { m[i] = "\""; sp--; i++; continue }
+        m[i] = "\001"; i++; continue
+      }
+
+      # ---- command context ----
+      if (c == "\\") {
+        nx = substr(s, i + 1, 1)
+        # A backslash before a newline is a LINE CONTINUATION: the shell joins the two lines and
+        # both characters vanish. Leaving them in place split `git \<newline>  commit` into two
+        # words no verb pattern could match, and the invocation went unseen.
+        if (nx == "\n") { m[i] = " "; m[i + 1] = " "; i += 2; continue }
+        m[i] = c; if (i + 1 <= len) { m[i + 1] = nx }; i += 2; continue
+      }
+
+      if (c == "#" && tk_wordstart(s, i)) {
+        while (i <= len && substr(s, i, 1) != "\n") { m[i] = "\001"; i++ }
+        continue
+      }
+
+      if (c == "\n") {
+        m[i] = "\n"; i++
+        # The bodies of every heredoc opened on the line that just ended follow, in the order the
+        # openers appeared, so the LAST one goes on the stack first.
+        if (hn > 0) {
+          for (w = hn; w >= 1; w--) {
+            sp++; kind[sp] = "HD"; fend[sp] = ""; fdep[sp] = 0
+            fterm[sp] = hterm[w]; fdash[sp] = hdash[w]; fquo[sp] = hquo[w]
+          }
+          hn = 0
+        }
+        continue
+      }
+
+      # A herestring has no body and no terminator, and its operand is an ordinary word. Consuming
+      # all three characters at once is the point: skipping only the first left the SECOND and third
+      # looking like a heredoc opener, whose delimiter word is command text and is kept — so
+      # `cat <<< \047git commit\047` read its quoted operand as a command. The same defect the
+      # original `%%<<*` truncation had, re-entered through the fix for it.
+      if (c3 == "<<<") { m[i] = "<"; m[i+1] = "<"; m[i+2] = "<"; i += 3; continue }
+
+      if (c2 == "<<") {
+        j = i + 2
+        dash = 0
+        if (substr(s, j, 1) == "-") { dash = 1; j++ }
+        while (j <= len && (substr(s, j, 1) == " " || substr(s, j, 1) == "\t")) { j++ }
+        quoted = 0; term = ""
+        dc = substr(s, j, 1)
+        if (dc == "\047" || dc == "\"") {
+          quoted = 1; j++
+          while (j <= len && substr(s, j, 1) != dc) { term = term substr(s, j, 1); j++ }
+          j++
+        } else if (dc == "\\") {
+          quoted = 1; j++
+          while (j <= len && tk_delimchar(substr(s, j, 1))) { term = term substr(s, j, 1); j++ }
+        } else {
+          while (j <= len && tk_delimchar(substr(s, j, 1))) { term = term substr(s, j, 1); j++ }
+        }
+        if (term != "") {
+          hn++; hterm[hn] = term; hdash[hn] = dash; hquo[hn] = quoted
+          for (w = i; w < j && w <= len; w++) { m[w] = substr(s, w, 1) }
+          i = j
+          continue
+        }
+      }
+
+      if (c3 == "$((") { m[i] = "$"; m[i+1] = "("; m[i+2] = "("
+        sp++; kind[sp] = "ARITH"; fend[sp] = ""; fdep[sp] = 0; i += 3; continue }
+      if (c2 == "$(") { m[i] = "$"; m[i+1] = "("
+        sp++; kind[sp] = "CMD"; fend[sp] = ")"; fdep[sp] = 0; i += 2; continue }
+      if (c2 == "${") { m[i] = "$"; m[i+1] = "{"
+        sp++; kind[sp] = "PARAM"; fend[sp] = ""; fdep[sp] = 0; i += 2; continue }
+      if (c2 == "$\047") { m[i] = "$"; m[i+1] = "\047"
+        sp++; kind[sp] = "ANSI"; fend[sp] = ""; fdep[sp] = 0; i += 2; continue }
+      if (c2 == "$\"") { m[i] = "$"; m[i+1] = "\""
+        sp++; kind[sp] = "DQ"; fend[sp] = ""; fdep[sp] = 0; i += 2; continue }
+
+      if (c == "\140") {
+        if (fend[sp] == "\140") { m[i] = "\140"; sp--; i++; continue }
+        m[i] = "\140"; sp++; kind[sp] = "CMD"; fend[sp] = "\140"; fdep[sp] = 0; i++; continue
+      }
+
+      if (c == "(") { m[i] = c; fdep[sp]++; i++; continue }
+      if (c == ")") {
+        if (fdep[sp] > 0) { fdep[sp]--; m[i] = c; i++; continue }
+        if (fend[sp] == ")") { m[i] = c; sp--; i++; continue }
+        m[i] = c; i++; continue
+      }
+
+      if (c == "\"" || c == "\047") {
+        # Closing the string an interpreter was told to run.
+        if (fend[sp] == c) { m[i] = " "; sp--; i++; continue }
+        q = c
+        # The decision is made at the OPENING quote, by what immediately precedes it, so each string
+        # answers for itself: applying an interpreter exemption to a whole command line masked away
+        # a real `-C` and left an unrelated commit message readable as a push, both at once.
+        if (substr(s, 1, i - 1) ~ SRE) {
+          m[i] = " "; sp++; kind[sp] = "CMD"; fend[sp] = q; fdep[sp] = 0; i++; continue
+        }
+        if (substr(s, 1, i - 1) ~ IRE) {
+          m[i] = " "; sp++; kind[sp] = "TOK"; fend[sp] = q; fdep[sp] = 0; i++; continue
+        }
+        spaced = 0
+        j = i + 1
+        while (j <= len) {
+          ch = substr(s, j, 1)
+          if (ch == "\\" && q != "\047") { j += 2; continue }
+          if (ch == q) { break }
+          if (ch == " " || ch == "\t" || ch == "\n") { spaced = 1; break }
+          j++
+        }
+        if (!spaced) {
+          m[i] = " "; sp++; kind[sp] = "TOK"; fend[sp] = q; fdep[sp] = 0; i++; continue
+        }
+        m[i] = q; sp++; kind[sp] = (q == "\047") ? "SQ" : "DQ"; fend[sp] = ""; fdep[sp] = 0
+        i++; continue
+      }
+
+      m[i] = c; i++
+    }
+  }
+'
+
 HOOK_SCAN_AWK='
   { lines[NR] = $0 }
   END {
@@ -308,104 +648,10 @@ HOOK_SCAN_AWK='
     for (n = 1; n <= NR; n++) { s = s (n > 1 ? "\n" : "") lines[n] }
     len = length(s)
 
-    q = ""
-    keep = 0
-    esc = 0
-    for (i = 1; i <= len; i++) {
-      c = substr(s, i, 1)
-
-      # A backslash-escaped quote neither opens nor closes a string. Without this the tracker went
-      # out of phase at the first escaped quote and every offset after it was wrong. Inside single
-      # quotes a backslash is an ordinary character, which is why q is checked.
-      if (esc) { esc = 0; m[i] = (q == "" || keep) ? c : "\001"; continue }
-      if (c == "\\" && q != "\047") { esc = 1; m[i] = (q == "" || keep) ? c : "\001"; continue }
-
-      if (q == "") {
-        m[i] = c
-        if (c == "\"" || c == "\047") {
-          q = c
-          openq = i
-          keep = (substr(s, 1, i - 1) ~ IRE)
-
-          # A quoted SINGLE WORD is a token of the command line, not a data payload. Quoting one
-          # changes nothing about what runs, so `git "push" origin main`, `git reset "--hard"` and
-          # `gh pr merge 1 --merge "--delete-branch"` must read exactly as their bare forms — and
-          # quoting every token is ordinary defensive shell style, not an exotic evasion. Only a
-          # quoted string containing whitespace is treated as a payload.
-          if (!keep) {
-            j = i + 1
-            spaced = 0
-            while (j <= len) {
-              ch = substr(s, j, 1)
-              if (ch == "\\" && q != "\047") { j += 2; continue }
-              if (ch == q) { break }
-              if (ch == " " || ch == "\t" || ch == "\n") { spaced = 1; break }
-              j++
-            }
-            if (!spaced) { keep = 1 }
-          }
-
-          # The quote characters themselves become spaces around a KEPT region, so a matcher reads
-          # `git "push"` exactly as `git  push `. Without this the region survived masking and still
-          # matched nothing, because every verb pattern expects whitespace before the verb. Length is
-          # preserved one for one, so the offsets the extractors depend on stay valid.
-          if (keep) { m[openq] = " " }
-        }
-      } else if (c == q) {
-        m[i] = keep ? " " : c
-        q = ""
-        keep = 0
-      } else {
-        m[i] = keep ? c : "\001"
-        if (q == "\047") { sq[i] = 1 }
-        # Where the enclosing quote OPENED. A substitution restores its span, and a quote that
-        # opened INSIDE that span must survive the restore while one opened outside it must not.
-        # Without this index the restore could only take everything back, which un-masked the
-        # quotes the pass above had just masked. See INFRA-075.
-        qopen[i] = openq
-      }
-    }
-
-    # Command substitution runs whatever the quoting around it, so its span is restored from the
-    # original — the SPAN, not the whole enclosing string. Keeping the entire string meant a message
-    # holding both a substitution and an unrelated mention of a guarded verb was read as that verb.
-    for (i = 1; i <= len; i++) {
-      # An escaped substitution does not substitute — it is the literal character. Skipping the
-      # escape here is what stops a commit message written with markdown code spans from being read
-      # as a subshell; the gate blocked its own commit before this line existed.
-      # Single quotes suppress every expansion, so nothing inside them is restored. Without
-      # this the pass reached into a single-quoted argument and read its text as a subshell
-      # — the gate blocked its own commit that way, which is the self-blocking this whole
-      # change exists to remove.
-      if (sq[i]) { continue }
-      if (substr(s, i, 1) == "\\") { i++; continue }
-      if (substr(s, i, 2) == "$(") {
-        depth = 0
-        for (j = i + 1; j <= len; j++) {
-          cj = substr(s, j, 1)
-          if (cj == "(") { depth++ } else if (cj == ")") { depth--; if (depth == 0) { break } }
-        }
-        stop = (j <= len) ? j : len
-        for (k = i; k <= stop; k++) {
-          # Restore the span, but NOT a region quoted inside it. A double-quoted substitution runs,
-          # so it must come back; a substitution whose own argument is quoted runs an echo over a
-          # payload, and restoring that raw read the payload as a command. The test is where the
-          # enclosing quote OPENED: before the span, the mask came from context the substitution
-          # overrides; inside it, the quote belongs to the substitution and stands.
-          if (qopen[k] != "" && qopen[k] >= i && qopen[k] <= stop) { continue }
-          m[k] = substr(s, k, 1)
-        }
-        i = stop
-      } else if (substr(s, i, 1) == "`") {
-        for (j = i + 1; j <= len; j++) { if (substr(s, j, 1) == "`") { break } }
-        stop = (j <= len) ? j : len
-        for (k = i; k <= stop; k++) {
-          if (qopen[k] != "" && qopen[k] >= i && qopen[k] <= stop) { continue }
-          m[k] = substr(s, k, 1)
-        }
-        i = stop
-      }
-    }
+    # The whole reading, delegated to the grammar. What used to sit here was a quote-state pass
+    # followed by a substitution-restore pass, and no arrangement of two linear passes can say
+    # what a quote inside a substitution inside a quote means. See the tokenizer above.
+    tk_mask(s, m, IRE, SRE)
 
     mask = ""
     for (i = 1; i <= len; i++) { mask = mask m[i] }
@@ -447,18 +693,24 @@ HOOK_SCAN_AWK='
 # Print the token that follows a match, located where quotes cannot lie. $2 is an ERE ending where
 # the value begins.
 hook_match_extract() {
-  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v ERE="$2" -v VRE="" "$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
 # Like hook_match_extract, but the value is found by $3 searched in the ORIGINAL starting at the
 # anchor $2's position in the mask. For values that legitimately live inside a quoted argument.
 hook_match_extract_after() {
-  printf '%s\n' "$1" | awk -v MODE=after -v IRE="$HOOK_INTERPRETER_RE" -v ERE="$2" -v VRE="$3" "$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=after -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="$3" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
 # What a verb-detection matcher should read.
+#
+# The raw command goes in, not `hook_executable_part`'s output. Heredoc bodies and comments used to
+# be cut out by two line-oriented passes BEFORE masking, which meant the masker was handed a string
+# whose structure had already been altered by a reader that did not know the grammar. The tokenizer
+# knows both, and reading them together is what lets a comment inside a substitution end at its own
+# newline rather than at the substitution's closing paren.
 hook_verb_scan() {
-  hook_executable_part "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v ERE="" -v VRE="" "$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="" -v VRE="" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
 # Token classes here exclude the newline as well as space and tab. That matters in `branch-guard.sh`,

--- a/scripts/harness/__tests__/branch-guard-reads-nested-commands.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-reads-nested-commands.test.mjs
@@ -1,0 +1,162 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_SRC = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * The guard's VERDICT, not the reading behind it.
+ *
+ * `hook-reading-matches-bash.test.mjs` proves `hook_verb_scan` agrees with bash. That is not the
+ * same claim as "the guard decides correctly", and the difference is not academic: `branch-guard.sh`
+ * takes `COMMAND_VERBS` from `hook_verb_scan` but `COMMAND_EXEC` from `hook_executable_part`, and
+ * greps different checks against different strings. A reading can be fixed while every decision that
+ * consults the OTHER string stays exactly as wrong — the "registered, never reached" shape this
+ * repository keeps meeting, where a mechanism is green about something nothing calls.
+ *
+ * So this file asks the hook itself. Every case runs `branch-guard.sh` end to end on a scratch
+ * repository, with every `BRANCH_GUARD_ALLOW_*` override scrubbed out of the environment, and
+ * asserts the exit code and the branch the guard names.
+ *
+ * Hermetic in the sense #1567 established: the hooks tree is copied to a temp directory OUTSIDE
+ * `.claude/worktrees/`, so the guard's reading of its own path does not depend on where the suite
+ * happens to be checked out. `gh` is stubbed to fail loudly, so a case that is supposed to be
+ * decided locally can never quietly reach the network and pass for the wrong reason.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeTemp(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+}
+
+function scratchRepo() {
+  const dir = makeTemp('bg-repo-');
+  const run = (...args) =>
+    execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+  run('init', '--quiet', '--initial-branch=main');
+  writeFileSync(path.join(dir, 'f.txt'), 'x\n');
+  run('add', '-A');
+  run('commit', '--quiet', '-m', 'chore: root');
+  run('remote', 'add', 'origin', 'https://example.invalid/scratch.git');
+  return dir;
+}
+
+/** The hooks tree, copied out of any worktree path, plus a `gh` that records and fails. */
+function hooksSandbox() {
+  const dir = makeTemp('bg-hooks-');
+  const hooks = path.join(dir, '.claude', 'hooks');
+  mkdirSync(path.dirname(hooks), { recursive: true });
+  cpSync(HOOKS_SRC, hooks, { recursive: true });
+
+  const bin = path.join(dir, 'bin');
+  mkdirSync(bin, { recursive: true });
+  const ghCalls = path.join(dir, 'gh-calls.log');
+  writeFileSync(
+    path.join(bin, 'gh'),
+    ['#!/bin/sh', `printf '%s\\n' "$*" >> ${JSON.stringify(ghCalls)}`, 'exit 1', ''].join('\n'),
+  );
+  chmodSync(path.join(bin, 'gh'), 0o755);
+
+  return { hook: path.join(hooks, 'branch-guard.sh'), bin, ghCalls };
+}
+
+function runGuard(command) {
+  const repo = scratchRepo();
+  const { hook, bin, ghCalls } = hooksSandbox();
+  const result = spawnSync('bash', [hook], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command }, cwd: repo }),
+    encoding: 'utf8',
+    cwd: repo,
+    // Only PATH, HOME and the project dir. Every BRANCH_GUARD_ALLOW_* override is absent by
+    // construction, so nothing below can pass because it was permitted to.
+    env: { PATH: `${bin}:${process.env.PATH}`, HOME: process.env.HOME, CLAUDE_PROJECT_DIR: repo },
+    timeout: 60_000,
+  });
+  return {
+    status: result.status ?? -1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    reachedGh: existsSync(ghCalls),
+  };
+}
+
+const NL = '\n';
+
+describe('branch-guard decides correctly on commands the old reading could not parse', () => {
+  it('blocks a plain push on a protected branch', () => {
+    // The control. Without it, a file where everything blocks would look like a working guard.
+    const verdict = runGuard('git push origin main');
+    expect(verdict.status, verdict.output).toBe(2);
+    expect(verdict.output).toMatch(/protected branch 'main'/);
+  });
+
+  // Each of these ran a real push on `develop` while exiting 0 — reproduced against the guard on
+  // develop before this landed. A guard that exits 0 on a real push is not a weaker guard, it is an
+  // absent one.
+  const BYPASSES = [
+    ['a line continuation splits the invocation across lines', `git \\${NL}  push origin main`],
+    ['a substitution nested inside a substitution', 'a=$(echo "$(git push origin main)")'],
+    [
+      'a substitution inside an unquoted heredoc body',
+      `cat <<EOF${NL}$(echo "$(git push origin main)")${NL}EOF`,
+    ],
+  ];
+
+  for (const [label, command] of BYPASSES) {
+    it(`blocks a push hidden by ${label}`, () => {
+      const verdict = runGuard(command);
+      expect(verdict.status, `the guard allowed a real push:\n${verdict.output}`).toBe(2);
+      expect(verdict.output).toMatch(/protected branch 'main'/);
+    });
+  }
+
+  it('names the branch a nested delete actually targets, and refuses it as protected', () => {
+    // The reading and the VERDICT are different claims. Once the substitution became visible, the
+    // delete was seen — but the branch name came back as `develop)`, because the value terminator
+    // stopped at whitespace and quotes and did not know that `)` ends a substitution. The guard
+    // still refused, so nothing was permitted that should not have been; it refused on the
+    // merged-PR check instead of the protected-branch check, naming a branch that does not exist.
+    // A guard that blocks for the wrong reason is one branch-name away from blocking nothing.
+    const verdict = runGuard('a=$(echo "$(git push origin --delete develop)")');
+    expect(verdict.status, verdict.output).toBe(2);
+    expect(verdict.output).toMatch(/protected branch 'develop'/);
+    expect(verdict.output).not.toMatch(/develop\)/);
+    expect(
+      verdict.reachedGh,
+      'the protected-branch check should have decided this locally, before any PR lookup',
+    ).toBe(false);
+  });
+
+  // The other half of the trade. A guard that refuses correct work gets switched off, so the
+  // mentions matter as much as the invocations.
+  it('says nothing about a push named inside a quoted argument', () => {
+    const verdict = runGuard("echo 'git push origin main'");
+    expect(verdict.status, `the guard refused an echo:\n${verdict.output}`).toBe(0);
+  });
+
+  it('says nothing about a push named inside a heredoc body with a quoted delimiter', () => {
+    const verdict = runGuard(`cat <<'EOF'${NL}git push origin main${NL}EOF`);
+    expect(verdict.status, `the guard refused a heredoc body:\n${verdict.output}`).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
+++ b/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
@@ -234,6 +234,13 @@ const HANDWRITTEN = [
   `echo $(( 1 + 1 )) ; echo ${SQ}git push${SQ}`,
   'echo $(( 1 + 1 )) ; git push',
   'echo $(( 2 << 1 )) ; git push',
+  // -- arithmetic NESTED IN arithmetic, which the corpus had no shape for. Reached three ways,
+  // because a context that reads its own nesting wrong reads it wrong however it was entered.
+  'echo $(( $((1+2)) + 1 ))',
+  'echo $(( $(( git push )) ))',
+  'echo "$(( $(( git push )) ))"',
+  `cat <<EOF${NL}$(( $(( git push )) ))${NL}EOF`,
+  'echo $(( $(( 1 + 2 )) )) ; git push',
   // -- a quoted argument spanning lines --
   `git commit -m "line one${NL}git push${NL}line three" 2>/dev/null || true`,
   // -- quoted single-word tokens are tokens, not payloads --
@@ -318,7 +325,7 @@ const KNOWN_OPEN = new Map([
   ],
 ]);
 
-describe("the reading of a command matches what bash does with it", () => {
+describe('the reading of a command matches what bash does with it', () => {
   it('has a corpus and an oracle', () => {
     // Fail closed: an emptied corpus or a stub that never records would make every case below pass
     // over nothing.
@@ -348,7 +355,9 @@ describe("the reading of a command matches what bash does with it", () => {
       if (known) {
         // Pinned as a disagreement, so closing it turns this case red and the exemption gets removed
         // rather than outliving its reason.
-        expect(wasSeen, `${known} — if this now agrees, delete the exemption`).not.toBe(actuallyRan);
+        expect(wasSeen, `${known} — if this now agrees, delete the exemption`).not.toBe(
+          actuallyRan,
+        );
         return;
       }
 

--- a/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
+++ b/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
@@ -9,9 +9,9 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const LIB = path.join(WORKSPACE_ROOT, '.claude/hooks/lib/command-scan.sh');
 
 /**
- * The guards read a shell command with regular expressions. Shell quoting is not a regular
- * language — nesting (`$(…)` inside quotes inside `$(…)`) needs a stack, and a regex has none — so
- * every masker is an approximation that holds until someone writes a spelling nobody tried.
+ * The guards read a shell command to decide what it will run. Shell quoting is not a regular
+ * language — nesting (`$(…)` inside quotes inside `$(…)`) needs a stack — so every masker built out
+ * of linear passes is an approximation that holds until someone writes a spelling nobody tried.
  *
  * Measured over four days: `branch-guard.sh` rewritten 26 times, seven distinct instances of this
  * one class, **every one found by a person hitting a new spelling**. Twice the new spelling refused
@@ -20,15 +20,19 @@ const LIB = path.join(WORKSPACE_ROOT, '.claude/hooks/lib/command-scan.sh');
  * A hand-written case list cannot end that, because the next spelling is by definition not on it.
  * What can is an ORACLE, and there is one sitting right there: bash. Generate the shapes, run each
  * one for real with a recording stub on `PATH`, and ask the shell whether the verb actually ran.
- * Then require the masker's reading to agree.
+ * Then require the reading to agree.
  *
  * Nothing destructive executes: `git` is a stub that records its argv and exits 0. The commands are
  * about what the SHELL does with the text, not about what git would have done.
  *
- * This is the mechanism INFRA-075 asks for, standing on its own: it needs no new tokenizer, and it
- * fails on a disagreement whatever the cause. A tokenizer, when it lands, is judged by this same
- * corpus.
+ * THE THRESHOLD IS STATED BEFORE THE READING IS BUILT, and it is not a percentage to be negotiated
+ * afterwards: every disagreement must be listed in `KNOWN_OPEN` with the item that owns it, and the
+ * rate must clear `MIN_AGREEMENT`. A case the reading gets wrong is a bug in the reading, not an
+ * exception to add — an entry may only be added here when the shape cannot be read at all by the
+ * grammar the tokenizer models, and the entry has to say why.
  */
+const MIN_AGREEMENT = 0.98;
+
 const scratch = [];
 
 afterAll(() => {
@@ -63,8 +67,16 @@ function sandbox() {
   return { dir, bin, log };
 }
 
+// Both readings are memoised so the summary case at the end can restate the whole corpus without
+// running it a second time. Two process spawns per shape is the cost of using a real shell as the
+// oracle; paying it twice would be the cost of not caching.
+const ranCache = new Map();
+const seenCache = new Map();
+
 /** Did bash actually invoke `git <verb>`? The oracle — real shell semantics, no parser involved. */
 function bashRuns(command, verb) {
+  const key = JSON.stringify([verb, command]);
+  if (ranCache.has(key)) return ranCache.get(key);
   const { dir, bin, log } = sandbox();
   spawnSync('bash', ['-c', command], {
     cwd: dir,
@@ -72,14 +84,17 @@ function bashRuns(command, verb) {
     encoding: 'utf8',
     timeout: 30_000,
   });
-  if (!existsSync(log)) return false;
-  return readFileSync(log, 'utf8')
-    .split('\n')
-    .some((line) => line.trim() === verb);
+  const answer = existsSync(log)
+    ? readFileSync(log, 'utf8')
+        .split('\n')
+        .some((line) => line.trim() === verb)
+    : false;
+  ranCache.set(key, answer);
+  return answer;
 }
 
 /**
- * What the shared masker lets a guard see: does the verb survive into the scanned text?
+ * What the shared reading lets a guard see: does the verb survive into the scanned text?
  *
  * The command and the verb arrive as ARGUMENTS, never interpolated into the probe script. An
  * earlier version built the script by substitution, so a corpus entry containing `$(…)` was
@@ -87,6 +102,8 @@ function bashRuns(command, verb) {
  * One escape level is the most this can afford, and this is that level.
  */
 function maskerSees(command, verb) {
+  const key = JSON.stringify([verb, command]);
+  if (seenCache.has(key)) return seenCache.get(key);
   const probe = [
     'source "$1"',
     'scanned=$(hook_verb_scan "$2")',
@@ -96,15 +113,22 @@ function maskerSees(command, verb) {
     encoding: 'utf8',
     timeout: 30_000,
   });
-  return result.status === 0;
+  const answer = result.status === 0;
+  seenCache.set(key, answer);
+  return answer;
 }
 
+const SQ = String.fromCharCode(39);
+const BT = String.fromCharCode(96);
+const NL = '\n';
+
 /**
- * The corpus. Every entry is a way of writing a command that a person might plausibly write, and
- * the point of each is a construct the masker has to get right — not a variation on one shape.
+ * Hand-written shapes. Every entry is a way of writing a command that a person might plausibly
+ * write, and the point of each is a CONSTRUCT the reading has to get right — not a variation on one
+ * shape.
  */
-const CORPUS = [
-  // Plain, and the boundary immediately after the verb — the shape no fixture had.
+const HANDWRITTEN = [
+  // -- plain invocations, and the boundary immediately after the verb --
   'git push',
   'git push;',
   'git push; echo done',
@@ -112,56 +136,207 @@ const CORPUS = [
   'git push|cat',
   '(git push)',
   '{ git push; }',
-  // Separators and continuations before it.
+  'if true; then git push; fi',
+  'for i in 1; do git push; done',
+  'case x in x) git push;; esac',
+  // -- separators, assignments, global flags --
   'cd /tmp && git push',
   'cd /tmp \\\n  && git push',
   'true; git push',
-  // Assignments and global flags between `git` and the verb.
   'FOO=1 git push',
   'FOO=1 BAR=2 git push',
   'git -C /tmp push',
   'git -c user.name=x push',
-  // Quoted MENTIONS — the verb is text, not a command. The masker must hide these.
-  "echo 'git push'",
+  // -- a backslash-newline joins two physical lines into one command --
+  'git \\\n  push',
+  'git push \\\n  origin main',
+  // -- quoted mentions: text, not commands --
+  `echo ${SQ}git push${SQ}`,
   'echo "git push"',
-  "git commit -m 'about to git push later'",
+  `git commit -m ${SQ}about to git push later${SQ}`,
   'git commit -m "about to git push later"',
+  `printf ${SQ}%s${SQ} ${SQ}git push${SQ}`,
+  'grep -r "git push" /dev/null',
+  // -- comments --
   '# git push',
   'echo hi # git push',
-  // A mention nested inside a substitution. Open until 2026-08-01, when the restore pass learned to
-  // keep a quote that opens INSIDE the span; the exemption was removed because this case went green,
-  // which is what pinning a disagreement AS a disagreement buys.
-  "out=$(echo 'git push'); echo $out",
-  // Interpreter strings — the verb really does run, inside another shell.
+  'echo hi #git push',
+  'echo "a" # git push',
+  'echo "# git push"',
+  `echo ${SQ}a # b${SQ} ; git push`,
+  `echo $(echo hi # comment${NL}) ; echo done`,
+  `x=$(echo hi # git push${NL}); echo done`,
+  `echo ok # a half-open remark ${SQ}${NL}git push`,
+  // -- the INFRA-075 reproduction, verbatim, and its family --
+  `out=$(printf ${SQ}x git push -m y${SQ} | bash h.sh); echo done`,
+  `out=$(echo ${SQ}git push${SQ}); echo $out`,
+  'out=$(printf "x git push -m y"); echo done',
+  // -- substitutions that really do run, at depth --
+  'a=$(git push)',
+  'a=$(echo "$(git push)")',
+  'a=$(echo "$(echo "$(git push)")")',
+  `a=$(echo "$(printf ${SQ}git push${SQ})")`,
+  `echo "$(echo ${SQ}git push${SQ}) done"`,
+  `echo "$(echo ${SQ}safe${SQ}) git push"`,
+  // -- backticks --
+  `x=${BT}git push${BT}`,
+  `x=${BT}echo ${SQ}git push${SQ}${BT}`,
+  `echo "${BT}echo ${SQ}git push${SQ}${BT}"`,
+  `x=${BT}echo "$(printf ${SQ}git push${SQ})"${BT}`,
+  // -- interpreter strings: shell-family ones are read as shell, the rest are read whole --
   'bash -c "git push"',
-  "sh -c 'git push'",
-  // Escapes.
+  `sh -c ${SQ}git push${SQ}`,
+  'bash -x -c "git push"',
+  '/bin/bash -c "git push"',
+  `bash -c "echo ${SQ}git push${SQ}"`,
+  `bash -c ${SQ}echo "git push"${SQ}`,
+  `bash -c "printf ${SQ}%s\\n${SQ} ${SQ}git push${SQ}"`,
+  'eval "git push"',
+  `python3 -c ${SQ}print(1)${SQ} "git push is a mention"`,
+  // -- ANSI-C and locale quoting --
+  `echo $${SQ}git push${SQ}`,
+  `echo $${SQ}a\\tgit push${SQ}`,
+  `printf $${SQ}x\\${SQ}y git push${SQ}`,
+  'echo $"git push"',
+  // -- escapes --
   'echo \\"git push\\"',
-  // A different verb entirely: must not read as a push.
+  'echo "he said \\"git push\\" ok"',
+  'echo "\\$(git push)"',
+  `echo ${SQ}\\${SQ} ; echo ${SQ}git push${SQ}`,
+  `git commit -m "use \\${BT}git push\\${BT} here" 2>/dev/null || true`,
+  // -- heredocs --
+  `cat <<EOF${NL}git push${NL}EOF`,
+  `cat <<${SQ}EOF${SQ}${NL}git push${NL}EOF`,
+  `cat <<EOF${NL}$(git push)${NL}EOF`,
+  `cat <<${SQ}EOF${SQ}${NL}$(git push)${NL}EOF`,
+  `cat <<EOF${NL}text${NL}EOF${NL}git push`,
+  `cat <<-EOF${NL}\tgit push${NL}\tEOF`,
+  `cat <<EOF${NL}a ${SQ}git push${SQ} b${NL}EOF`,
+  `cat <<EOF${NL}$(echo "$(git push)")${NL}EOF`,
+  `cat <<A${NL}git push${NL}A${NL}cat <<B${NL}text${NL}B${NL}git push`,
+  `cat <<EOF${NL}text${NL}  EOF${NL}git push${NL}EOF`,
+  // -- herestrings: no body, no terminator, and an operand that is an ordinary word --
+  `cat <<< ${SQ}git push${SQ}`,
+  'cat <<< "$(git push)"',
+  'cat <<< "git push"',
+  // -- redirections and process substitution --
+  'echo x > /dev/null; git push',
+  'echo x 2>&1 | cat; git push',
+  `cat <(echo ${SQ}git push${SQ})`,
+  'cat <(git push)',
+  `echo ${SQ}a>b${SQ} ; echo ${SQ}git push${SQ}`,
+  // -- parameter expansion --
+  'echo ${HOME:-git push}',
+  'echo ${UNSET_VAR_X:-$(git push)}',
+  'echo "${UNSET_VAR_X:-$(git push)}"',
+  `echo \${#HOME} ; echo ${SQ}git push${SQ}`,
+  // -- arithmetic, including the left shift that looks like a heredoc opener --
+  `echo $(( 1 + 1 )) ; echo ${SQ}git push${SQ}`,
+  'echo $(( 1 + 1 )) ; git push',
+  'echo $(( 2 << 1 )) ; git push',
+  // -- a quoted argument spanning lines --
+  `git commit -m "line one${NL}git push${NL}line three" 2>/dev/null || true`,
+  // -- quoted single-word tokens are tokens, not payloads --
+  'git "push"',
+  `git ${SQ}push${SQ}`,
+  'git push "--force"',
+  `echo ${SQ}push${SQ}`,
+  // -- git is not the first word of the command, and still runs --
+  'env git push',
+  `echo ${SQ}git push${SQ} && git push`,
+  // -- argument position: a word the shell never runs as a command --
+  'echo git push',
+  `eval ${SQ}echo git push${SQ}`,
+  // -- a different verb entirely: must not read as a push --
   'git pushd-something',
   'git push-tags-please',
 ];
 
 /**
+ * Generated shapes: a base command wrapped in layers of substitution and quoting, so the corpus
+ * reaches nesting depths a hand list never does. This is the half that answers "the next spelling
+ * is not on the list" — it enumerates spellings nobody wrote down.
+ */
+function generated() {
+  const bases = [
+    'git push',
+    `printf ${SQ}x git push y${SQ}`,
+    'echo no-verb-here',
+    'echo "git push"',
+  ];
+  const wordOf = [(c) => `$(${c})`, (c) => `${BT}${c}${BT}`];
+  const cmdOf = [
+    (w) => `v=${w}`,
+    (w) => `echo ${w}`,
+    (w) => `echo "${w}"`,
+    (w) => `printf ${SQ}%s${SQ} ${w}`,
+  ];
+  const out = [];
+  for (const base of bases) {
+    for (let depth = 1; depth <= 3; depth++) {
+      for (const wrapWord of wordOf) {
+        for (const wrapCmd of cmdOf) {
+          let cmd = base;
+          let usable = true;
+          for (let d = 0; d < depth; d++) {
+            // Nested backticks need an escaping the shell does not forgive, so only the outermost
+            // layer may be one.
+            const word = d === depth - 1 ? wrapWord(cmd) : `$(${cmd})`;
+            if (word.includes(BT) && cmd.includes(BT)) usable = false;
+            cmd = wrapCmd(word);
+          }
+          if (usable) out.push(cmd);
+        }
+      }
+    }
+  }
+  return [...new Set(out)];
+}
+
+const GENERATED = generated();
+const CORPUS = [...new Set([...HANDWRITTEN, ...GENERATED])];
+
+/**
  * Known-open disagreements, each naming the item that owns it. An exemption carries a reason and an
  * ID — an unexplained one is how a corpus becomes decorative.
  */
+const ARGUMENT_POSITION =
+  'INFRA-075, deliberately unmodelled — the verb is an ARGUMENT the shell never runs as a ' +
+  'command. Hiding it means masking every word that is not the first of a simple command, and ' +
+  'then `sudo git push`, `xargs git push`, `env git push`, `timeout 5 git push` and every other ' +
+  'exec-style wrapper not on some list goes unseen. An unmodelled wrapper is a silent BYPASS; a ' +
+  'mention read as a command is a refusal that announces itself. The trade is taken in the ' +
+  'direction that fails loudly.';
+
 const KNOWN_OPEN = new Map([
+  ['echo git push', ARGUMENT_POSITION],
+  [`eval ${SQ}echo git push${SQ}`, ARGUMENT_POSITION],
   [
     'echo \\"git push\\"',
-    'INFRA-075 (same root) — an escaped quote is a literal character, so the verb survives as bare ' +
-      'words in an ARGUMENT list. Telling an argument from a command needs command-position ' +
-      'tracking, which is the tokenizer that item asks for and not something a mask can do',
+    `${ARGUMENT_POSITION} Here the escaped quotes leave the verb as two bare words in an argument ` +
+      'list, which is the same problem wearing a different spelling.',
   ],
 ]);
 
-describe("the masker's reading of a command matches what bash does with it", () => {
+describe("the reading of a command matches what bash does with it", () => {
   it('has a corpus and an oracle', () => {
     // Fail closed: an emptied corpus or a stub that never records would make every case below pass
     // over nothing.
-    expect(CORPUS.length).toBeGreaterThan(20);
+    expect(CORPUS.length).toBeGreaterThan(150);
+    expect(GENERATED.length).toBeGreaterThan(50);
     expect(bashRuns('git push', 'push'), 'the oracle did not observe an obvious push').toBe(true);
-    expect(bashRuns("echo 'git push'", 'push'), 'the oracle saw a push in an echo').toBe(false);
+    expect(bashRuns(`echo ${SQ}git push${SQ}`, 'push'), 'the oracle saw a push in an echo').toBe(
+      false,
+    );
+  });
+
+  it('pins every exemption to a shape the corpus actually contains', () => {
+    // An exemption for a shape nobody tests is an exemption that can never be retired.
+    for (const command of KNOWN_OPEN.keys()) {
+      expect(CORPUS, `exempted shape is not in the corpus: ${JSON.stringify(command)}`).toContain(
+        command,
+      );
+    }
   });
 
   for (const command of CORPUS) {
@@ -173,20 +348,37 @@ describe("the masker's reading of a command matches what bash does with it", () 
       if (known) {
         // Pinned as a disagreement, so closing it turns this case red and the exemption gets removed
         // rather than outliving its reason.
-        expect(wasSeen, `${known} — if this now agrees, delete the exemption`).not.toBe(
-          actuallyRan,
-        );
+        expect(wasSeen, `${known} — if this now agrees, delete the exemption`).not.toBe(actuallyRan);
         return;
       }
 
       expect(
         wasSeen,
         actuallyRan
-          ? 'bash RAN git push and the masker did not see it — a guard reading this text is blind ' +
+          ? 'bash RAN git push and the reading did not see it — a guard reading this text is blind ' +
               'to a real invocation, which is a bypass'
-          : 'bash did NOT run git push and the masker saw one — a guard reading this text refuses ' +
+          : 'bash did NOT run git push and the reading saw one — a guard reading this text refuses ' +
               'correct work, which is how a guard gets disabled',
       ).toBe(actuallyRan);
     });
   }
+
+  it(`agrees with bash on at least ${Math.round(MIN_AGREEMENT * 100)}% of the corpus`, () => {
+    // The rate is a floor under the whole corpus, not a per-case verdict, so a future change cannot
+    // trade a batch of new disagreements for one new exemption and still look green. Both readings
+    // are memoised above, so this restates the measurement rather than repeating it.
+    const disagreements = CORPUS.filter(
+      (command) => bashRuns(command, 'push') !== maskerSees(command, 'push'),
+    );
+    const rate = (CORPUS.length - disagreements.length) / CORPUS.length;
+    expect(
+      rate,
+      `${disagreements.length} of ${CORPUS.length} shapes disagree with bash:\n` +
+        disagreements.map((c) => `  ${JSON.stringify(c)}`).join('\n'),
+    ).toBeGreaterThanOrEqual(MIN_AGREEMENT);
+    expect(
+      disagreements.sort(),
+      'every disagreement must be a listed known-open shape',
+    ).toStrictEqual([...KNOWN_OPEN.keys()].sort());
+  });
 });


### PR DESCRIPTION
Closes #1542

## What was wrong

`command-scan.sh` decided what a command runs with two linear passes: mask quoted regions, then restore command-substitution spans. Shell quoting is not a regular language, so no arrangement of linear passes can say what a quote inside a substitution inside a quote means. Both spellings of that were live at once when this started:

| command | bash | the guards |
| --- | --- | --- |
| `out=$(printf 'x git commit -m y' \| bash h.sh)` | commits nothing | **refused** (the issue's reproduction, closed by #1556) |
| `a=$(echo "$(git commit)")` | **commits** | **saw nothing** |

The second is the worse one and it arrived as the fix for the first: #1556 taught the restore pass to keep a quote that opened inside the span, which held the inner quotes masked — and with them the nested substitution that genuinely runs. A bypass, not a nuisance.

## What this does

Replaces both passes with a tokenizer over an explicit context stack, so a substitution's content is read by the same rules as the command around it, at any depth. It models:

single quotes · double quotes · ANSI-C `$'…'` · locale `$"…"` · backslash escapes · the backslash-newline continuation · `#` comments · heredocs (`<<`, `<<-`, quoted and unquoted delimiters) · herestrings · redirections · subshells · `${…}` · `$((…))` · `$(…)` and backtick substitutions **nested to any depth** · the string an interpreter is told to run.

**Two interpreter lists, not one.** Only shell-family interpreters and `eval` have their string descended into as shell. A `python3 -c` argument is a command but not a *shell* command, so applying shell quoting to it would be a second approximation dressed as a parse; those stay read whole.

Every caller is unchanged — the change sits behind the existing `command-scan.sh` interface.

## The acceptance criterion, set before the tokenizer was written

A differential corpus of **202 shapes** in `scripts/harness/__tests__/hook-reading-matches-bash.test.mjs` — 101 written by hand, 96 generated by wrapping base commands in up to three layers of substitution and quoting. Each is run for real through bash with a recording `git` stub on `PATH`, and the reading must agree with what the shell actually invoked. The threshold is stated in the file: every disagreement must be a listed known-open shape, and the rate must clear 98%.

| | agreement | of which bypasses |
| --- | --- | --- |
| before (pre-tokenizer) | **177 / 197** (89.8%) | 5 |
| after | **199 / 202** (98.5%) | 0 |

The committed test is red against the pre-fix library: 18 of its 200 cases fail.

## What the tokenizer still cannot read

**Command position** — deliberately, and this is the whole of the remaining 3:

```
echo git push
eval 'echo git push'
echo \"git push\"
```

The verb is an ARGUMENT the shell never runs as a command, and the reading still shows it. Hiding it means masking every word that is not the first of a simple command, and then `sudo git push`, `xargs git push`, `env git push`, `timeout 5 git push`, `command git push` and every other exec-style wrapper not on some list goes unseen. **An unmodelled wrapper is a silent bypass; an argument read as a command is a refusal that announces itself.** The trade is taken in the direction that fails loudly. All three are pinned in `KNOWN_OPEN` with that reason, so closing the class turns those cases red and retires the exemption.

Smaller limits, stated rather than found later:

- multiple heredoc openers on one line are queued in order, but a heredoc opened *inside* a substitution attaches its body to whatever line ends next;
- `${…}` and `$((…))` are read as data that may contain substitutions, not as their own grammars;
- `tcsh`/`csh` are on the shell list although their quoting differs from POSIX shells.

## False positives on the real tree

A guard that refuses correct work gets switched off, so this was measured rather than asserted. **2453 command lines** harvested from every `*.md`, `*.sh`, `*.mjs` and workflow file in the repository were read under both versions. **3 verdicts changed, all newly-SEEN, none newly blind** — and all three are a genuine `$(git …)` the shell would run:

```
`cat <<EOF${NL}$(git push)${NL}EOF`,
`cat <<EOF${NL}$(echo "$(git push)")${NL}EOF`,
the unquoted characters) is wrong in the other direction: `"$(git commit)"` inside double quotes
```

## Does this fix the guards' VERDICTS, or only the reading?

Asked on review, and answered by running `branch-guard.sh` itself on a scratch repo with every `BRANCH_GUARD_ALLOW_*` override absent and `gh` stubbed to fail loudly. It matters because `branch-guard` takes `COMMAND_VERBS` from `hook_verb_scan` but `COMMAND_EXEC` from `hook_executable_part`, so a fixed reading does not imply a fixed decision.

| command | develop | this branch |
| --- | --- | --- |
| `git push origin main` *(control)* | **BLOCKED** | **BLOCKED** |
| `git \`⏎`  push origin main` | allowed | **BLOCKED** |
| `a=$(echo "$(git push origin main)")` | allowed | **BLOCKED** |
| `cat <<EOF`⏎`$(echo "$(git push origin main)")`⏎`EOF` | allowed | **BLOCKED** |
| `a=$(echo "$(git push origin --delete develop)")` | allowed | **BLOCKED** |
| `echo 'git push origin main'` *(mention)* | allowed | allowed |
| `cat <<'EOF'`⏎`git push origin main`⏎`EOF` | allowed | allowed |

**Closed for `branch-guard`'s push and delete decisions.** The measurement also surfaced a fourth defect the reading alone hid: the nested delete named the branch **`develop)`**, paren included, so it missed the protected-branch check and was refused by the weaker merged-PR check instead. Fixed in 8aef2bfc0 (an unquoted value now ends at `)` and a backtick), red-proved first.

**Still open, stated plainly:** `pre-push-check.sh` and `worktree-cwd-guard.sh` also grep `COMMAND_EXEC`, the pre-tokenizer reading, and this PR does **not** measure their verdicts. #1572 tracks that, with the measurement behind it. A tokenizer that fixes the function but not the decision is the "registered, never reached" shape, so it is named here rather than left to be found later.

`scripts/harness/__tests__/branch-guard-reads-nested-commands.test.mjs` is the mechanism that keeps the table above honest — it asserts the exit code and the branch the guard NAMES, not the reading behind it.

## Verification

- Rebased onto `develop` @2e325094f (#1559, #1564, #1567). `pnpm harness:pre-push` runs **green** — 2032/2032, 122 files. The three `worktree-cwd-guard` failures an earlier revision worked around are gone, which is #1567's claim, tested rather than assumed. Nothing here was pushed with `--no-verify`.
- `pnpm harness:scan` — **84 of 84** after `pnpm build`.
- A 400-case fuzz over shell metacharacters: every input terminated and the output stayed length-preserving, which the `hook_match_*` offset arithmetic depends on.

## Note for the reviewer

`hook_executable_part` still uses the old line-oriented heredoc/comment passes, because three hooks call it directly and those files are owned by another change in flight. It is now documented as the weaker of the two readings, with `hook_verb_scan` named as the authority for verb detection. Collapsing them is a caller-side change and belongs to the item that owns those hooks.

The tokenizer lives inside `command-scan.sh` rather than in its own `lib/` file: `worktree-guard-alive.test.mjs` stages a worktree by copying exactly `worktree-cwd-guard.sh` and `lib/command-scan.sh`, so a second library file makes that fixture fail, and that test is owned elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso

