### PR TITLE
refactor(hooks): INFRA-077 one owner for each fact a hook computes

### DIFF
--- a/.agents/backlog/INFRA-077-one-owner-for-what-a-hook-computes.md
+++ b/.agents/backlog/INFRA-077-one-owner-for-what-a-hook-computes.md
@@ -1,8 +1,8 @@
 ---
 title: 'INFRA-077: five facts computed separately in four hooks, and the copies disagree'
-status: todo
+status: in-progress
 priority: high
-urgency: soon
+urgency: now
 type: INFRA
 area: .claude/hooks
 created: 2026-08-01
@@ -57,3 +57,87 @@ the suite as it stands, so the consolidation must land with those cases or it la
 - A case exists for each disagreement above — the escaped path, the absent `jq`, the ambient
   `GIT_DIR`, the detached HEAD, the `git -C <nonexistent>` — and each fails before the fix.
 - The deliberate divergences are named modes with their reason, not silently unified.
+
+## Decision
+
+`lib/hook-facts.sh` — a SIBLING of `lib/command-scan.sh`, not an extension of it.
+`command-scan.sh` owns what a payload SAYS: the command, the tool name, which part of it is a
+command rather than text. The new file owns what the ENVIRONMENT says: which file is being written,
+which repository a command acts on, which branch that repository is on, and how git must be invoked
+for those answers to be about the repository the command actually runs in. Each file stays
+answerable for one question, and `hook-facts.sh` sources `command-scan.sh`, so a hook needs one
+source line rather than two.
+
+**The consolidation is a decision, not a merge.** Two divergences survive as NAMED MODES of
+`hook_effective_repo`, each carrying the measurement behind it:
+
+- `first-nonempty` — `worktree-cwd-guard`'s deliberate fail-safe. That guard blocks only on POSITIVE
+  confirmation that the command lands in the main checkout, so naming an unresolvable `-C` target
+  and then declining to block IS the correct outcome. Validating instead would silently retarget the
+  guard at the session repository and block a destructive command aimed somewhere else. It has no
+  `.` fallback because that fallback once resolved to the hook's OWN checkout and blocked there.
+- `session` — `branch-guard`'s `BASE_DIR` deliberately ignores `git -C`, because a branch lands where
+  the session is and in a compound command the `-C` usually belongs to some other invocation
+  (`git checkout -b feat/x && git -C <other> status`).
+
+The third mode, `validated`, is what `branch-guard` and `pre-push-check` take: they must name SOME
+repository, because their verdict is about the branch it is on.
+
+`hook_current_branch` applies its default to the VALUE, and takes the default from the CALLER —
+callers need different ones. An eval log wants a word a reader can see; `branch-guard` and
+`pre-push-check` KEY ON EMPTINESS to recognise a detached HEAD and must be able to ask for `""`. A
+reader that imposed a word would have silently disabled both of those checks.
+
+`hook_json_object` gives the record WRITERS the same jq → python3 → refuse ladder as the readers.
+Repairing only the read would have left the metrics just as empty on a host without jq, because two
+of the three hooks also wrote their record with `jq -cn`.
+
+`branch-guard` now fails CLOSED when no repository can be read at all. Previously the branch came
+back empty, an empty branch matched no protected name, and the hook exited 0 — "I could not verify"
+wearing the costume of "I verified this is fine", which the hook protocol reads as a pass. A
+detached HEAD is deliberately NOT that case and still falls through.
+
+## Stated limits
+
+- The transcript queries in `correction-detect` and `revert-detect` stay on jq. They are jq PROGRAMS
+  over a JSONL file, not payload field reads, so without jq those hooks are degraded rather than
+  silent — which is the distinction the payload read got wrong.
+- `hook_effective_repo session` judges `git -C <other> checkout -b` against the session repository.
+  That over-permits a rare form instead of refusing a common one, and is the pre-existing choice
+  being preserved rather than a new one.
+
+## Test Plan
+
+`scripts/harness/__tests__/hook-facts.test.mjs` — 23 cases. 19 of the first 21 failed against the
+hooks as they stood; the two that passed are deliberate controls, so a green run cannot mean the
+probe never ran (the formatter shim is wired, and the PATH farm really does hide jq while keeping
+python3). Per fact:
+
+1. **file_path** — a name containing an escaped quote and a name containing a backslash both reach
+   the formatter, with an ordinary path as the control; plus a source-level floor that no hook
+   hand-rolls a `file_path` grep.
+2. **reading a JSON field** — `spec-first-gate` still injects its reminder and `correction-detect`
+   still writes its record on a PATH farm from which jq is genuinely ABSENT (a symlink farm, not a
+   failing shim: a present-but-broken tool exercises a path a tool-less host never takes); plus a
+   floor that no hook carries its own `read_json()`.
+3. **which repository** — the three named modes pinned individually, including that `validated` is
+   not fooled by an ambient `GIT_DIR` and that `first-nonempty` keeps naming an unvalidated `-C`
+   target; `branch-guard` judging the session repository when the `-C` target is not one; the
+   fail-closed refusal, with the detached-HEAD pass-through pinned beside it so the refusal cannot
+   swallow it later; plus a floor that no hook hand-rolls the validation ladder.
+4. **the current branch** — the default applied to the value, the empty default a guard needs, and
+   `eval-log-stop` recording a named branch for a detached session.
+5. **scrubbed git** — `branch-guard` still refusing a commit and a push on `main` with `GIT_DIR`,
+   `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX` exported at another checkout;
+   `worktree-cwd-guard` still seeing the MAIN checkout when `GIT_DIR` names a worktree; plus a floor
+   that no hook calls `git -C` directly.
+
+Full suite: `npx vitest run scripts/harness/__tests__/ --reporter=basic`, `pnpm harness:scan`, and
+`bash -n` over every hook.
+
+## User Execution Test Scenarios
+
+Not applicable — this changes agent-harness hooks only. The hooks are invoked by the tool host
+around the agent's own tool calls and deliver no runnable user-facing behaviour, so there is no
+product surface to execute. Verification lives in `## Test Plan`, where every case runs the real
+hook against a scratch repository rather than inspecting its source.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -288,7 +288,11 @@ fi
 
 # Get current branch of the EFFECTIVE context (worktree-aware, see resolution above)
 PROJECT_DIR="$EFFECTIVE_DIR"
-CURRENT_BRANCH=$(hook_git_in "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+# One branch reader, with the default on the VALUE. `git branch --show-current` exits 0 and prints
+# NOTHING on a detached HEAD, so an `|| echo …` arm here never runs — three hooks wrote one and all
+# three were dead code. THIS caller wants the empty value: the checks below key on emptiness to
+# recognise a detached HEAD, which is why the default is the caller's to name.
+CURRENT_BRANCH=$(hook_current_branch "$PROJECT_DIR" "")
 
 # A detached HEAD has no branch name, so the protected-branch checks below have nothing to compare
 # and the guard used to stop here. Branch CREATION is different: creating `feat/x` while detached at
@@ -512,9 +516,9 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     BASE_REF="${START_POINT:-HEAD}"
     BASE_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
     # `branch --show-current` exits 0 with empty output on a detached HEAD, so `|| echo HEAD` never
-    # fired and the refusal named nothing. The default belongs on the VALUE, not on the exit code.
-    CURRENT_ON_BASE=$(hook_git_in "$BASE_DIR" branch --show-current 2>/dev/null || echo "")
-    BASE_NAME="${START_POINT:-${CURRENT_ON_BASE:-HEAD}}"
+    # fired and the refusal named nothing. The default belongs on the VALUE, not on the exit code —
+    # which is what hook_current_branch does, for every caller, once.
+    BASE_NAME="${START_POINT:-$(hook_current_branch "$BASE_DIR" HEAD)}"
 
     if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then
       echo "[branch-guard] Blocked: cannot resolve the base for '$NEW_BRANCH'." >&2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -159,13 +159,12 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
 # redirect this guard at another repository. See lib/command-scan.sh.
 GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
-EFFECTIVE_DIR="${CLAUDE_PROJECT_DIR:-.}"
-if [[ -n "$HOOK_CWD" ]] && hook_git_in "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  EFFECTIVE_DIR="$HOOK_CWD"
-fi
-if [[ -n "$GIT_C_PATH" ]] && hook_git_in "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  EFFECTIVE_DIR="$GIT_C_PATH"
-fi
+# One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
+# `validated`: it must name SOME repository, because its verdict is about the branch that
+# repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside
+# it (worktree-cwd-guard's first-nonempty fail-safe, and this hook's own `session` base check) stay
+# decisions with a reason instead of four copies that drift apart.
+EFFECTIVE_DIR=$(hook_effective_repo validated "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
 
 # Detect git action type
 IS_COMMIT=false
@@ -288,6 +287,18 @@ fi
 
 # Get current branch of the EFFECTIVE context (worktree-aware, see resolution above)
 PROJECT_DIR="$EFFECTIVE_DIR"
+
+# A guard fails CLOSED. When nothing resolvable is a repository, the branch read below came back
+# empty, an empty branch matched no protected name, and the hook exited 0 — "I could not verify"
+# wearing the costume of "I verified this is fine", which the hook protocol reads as a pass.
+# A detached HEAD is deliberately NOT this case: there the repository IS readable and the branch is
+# genuinely nameless, and the checks below already handle that.
+if ! hook_is_work_tree "$PROJECT_DIR"; then
+  echo "[branch-guard] Blocked: '$PROJECT_DIR' is no git repository, so the branch this command" >&2
+  echo "[branch-guard] would act on cannot be read. Nothing was verified; this is not a pass." >&2
+  echo "[branch-guard] Run the command from the checkout it belongs to." >&2
+  exit 2
+fi
 # One branch reader, with the default on the VALUE. `git branch --show-current` exits 0 and prints
 # NOTHING on a detached HEAD, so an `|| echo …` arm here never runs — three hooks wrote one and all
 # three were dead code. THIS caller wants the empty value: the checks below key on emptiness to
@@ -505,10 +516,8 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # creation. Stated limit: `git -C <other> checkout -b` is judged against the session repository
     # rather than <other>; branches are created where the session is, and erring that way
     # over-permits a rare form instead of refusing a common one.
-    BASE_DIR="${CLAUDE_PROJECT_DIR:-.}"
-    if [[ -n "$HOOK_CWD" ]] && hook_git_in "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-      BASE_DIR="$HOOK_CWD"
-    fi
+    # The `session` mode is exactly that rule, named: hook `cwd` > project dir, `git -C` ignored.
+    BASE_DIR=$(hook_effective_repo session "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
 
     WANTED=origin/develop
     hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -13,8 +13,10 @@ INPUT=$(cat)
 # One parser, not four. `command-scan.sh` explains what each hand-rolled copy got wrong; the short
 # version is that the old `grep -o '"command"…"[^"]*"' ` stopped at the first quote inside the
 # command, so everything after `-m "…"` — including the verb being guarded — was never examined.
-# shellcheck source=lib/command-scan.sh
-source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+# hook-facts.sh sources command-scan.sh, so one line brings in both the payload parser and the
+# single owner of the repository, branch and scrubbed-git facts. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
 # Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
@@ -158,10 +160,10 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # redirect this guard at another repository. See lib/command-scan.sh.
 GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
 EFFECTIVE_DIR="${CLAUDE_PROJECT_DIR:-.}"
-if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [[ -n "$HOOK_CWD" ]] && hook_git_in "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   EFFECTIVE_DIR="$HOOK_CWD"
 fi
-if [[ -n "$GIT_C_PATH" ]] && git -C "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [[ -n "$GIT_C_PATH" ]] && hook_git_in "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   EFFECTIVE_DIR="$GIT_C_PATH"
 fi
 
@@ -286,7 +288,7 @@ fi
 
 # Get current branch of the EFFECTIVE context (worktree-aware, see resolution above)
 PROJECT_DIR="$EFFECTIVE_DIR"
-CURRENT_BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+CURRENT_BRANCH=$(hook_git_in "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
 
 # A detached HEAD has no branch name, so the protected-branch checks below have nothing to compare
 # and the guard used to stop here. Branch CREATION is different: creating `feat/x` while detached at
@@ -306,7 +308,7 @@ fi
 if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" != "1" ]]; then
   # Prefer the remote-tracking integration head; fall back to local `develop` when offline.
   INTEGRATION_REF=origin/develop
-  git -C "$PROJECT_DIR" rev-parse --verify --quiet "$INTEGRATION_REF" >/dev/null 2>&1 || INTEGRATION_REF=develop
+  hook_git_in "$PROJECT_DIR" rev-parse --verify --quiet "$INTEGRATION_REF" >/dev/null 2>&1 || INTEGRATION_REF=develop
   # A branch whose PR was SQUASH-merged keeps commits git cannot find in the integration branch, so
   # ancestry alone calls it unmerged forever. Measured 2026-07-28: 83 branches reported, 73 of them
   # with a MERGED PR — an 88% false-positive rate. A guard wrong seven times out of eight is one
@@ -392,18 +394,18 @@ if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" 
     candidate="${candidate#+ }"   # strip the worktree marker, which otherwise yielded a bogus name
     [[ "$candidate" =~ $SKIP_PATTERNS ]] && continue
     [[ -z "$candidate" ]] && continue
-    ahead=$(git -C "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
+    ahead=$(hook_git_in "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
     [[ "$ahead" -gt 0 ]] || continue
     # A merged PR settles it — for the COMMIT that was merged, not for the name.
     if [[ "$MERGED_REFS_READ" == "true" ]]; then
-      candidate_sha=$(git -C "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
+      candidate_sha=$(hook_git_in "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
       if [[ -n "$candidate_sha" ]] &&
         printf '%s\n' "$MERGED_REFS" | grep -Fxq -- "$candidate $candidate_sha"; then
         continue
       fi
     fi
     UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
-  done < <(git -C "$PROJECT_DIR" branch 2>/dev/null)
+  done < <(hook_git_in "$PROJECT_DIR" branch 2>/dev/null)
 
   if [[ "${#UNMERGED_BRANCHES[@]}" -gt 0 ]]; then
     echo "[branch-guard] Blocked: local branches with unmerged commits detected." >&2
@@ -500,18 +502,18 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # rather than <other>; branches are created where the session is, and erring that way
     # over-permits a rare form instead of refusing a common one.
     BASE_DIR="${CLAUDE_PROJECT_DIR:-.}"
-    if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ -n "$HOOK_CWD" ]] && hook_git_in "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       BASE_DIR="$HOOK_CWD"
     fi
 
     WANTED=origin/develop
-    git -C "$BASE_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
-    WANTED_SHA=$(git -C "$BASE_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
+    hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
+    WANTED_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
     BASE_REF="${START_POINT:-HEAD}"
-    BASE_SHA=$(git -C "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
+    BASE_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
     # `branch --show-current` exits 0 with empty output on a detached HEAD, so `|| echo HEAD` never
     # fired and the refusal named nothing. The default belongs on the VALUE, not on the exit code.
-    CURRENT_ON_BASE=$(git -C "$BASE_DIR" branch --show-current 2>/dev/null || echo "")
+    CURRENT_ON_BASE=$(hook_git_in "$BASE_DIR" branch --show-current 2>/dev/null || echo "")
     BASE_NAME="${START_POINT:-${CURRENT_ON_BASE:-HEAD}}"
 
     if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -19,8 +19,10 @@ set -uo pipefail
 
 INPUT=$(cat)
 
-# shellcheck source=lib/command-scan.sh
-source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+# hook-facts.sh sources command-scan.sh, so one line brings in both the payload parser and the
+# single owner of the payload's file_path. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 LOG_FILE="$PROJECT_DIR/.agents/evals/local-metrics/blocks.jsonl"
 
@@ -38,7 +40,7 @@ fi
 # The first field read is the first place a missing decoder could pass silently — and it did:
 # without jq this came back empty and the hook exited 0 before reaching any check. An absent path
 # is normal (many tools carry none) and still exits 0; only an UNREADABLE payload refuses.
-if ! FILE_PATH=$(hook_json_string "$INPUT" 'tool_input.file_path'); then
+if ! FILE_PATH=$(hook_file_path_of "$INPUT"); then
   echo "[check-forbidden-patterns] Blocked: the hook payload could not be decoded, so the edit" >&2
   echo "[check-forbidden-patterns] cannot be checked. Install jq or python3." >&2
   exit 2

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -101,7 +101,10 @@ if [[ "$RELATIVE_PATH" == /* ]]; then
     */apps/*) RELATIVE_PATH="apps/${FILE_PATH#*/apps/}" ;;
   esac
 fi
-SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || true)
+# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
+# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
+# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
+SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || true)
 BLOCKED=false
 BLOCK_MESSAGES=""
 

--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -113,20 +113,17 @@ append_block() {
   local line_num="$2"
   local line_content="$3"
   mkdir -p "$(dirname "$LOG_FILE")"
-  jq -cn \
-    --arg timestamp "$TIMESTAMP" \
-    --arg session_id "$SESSION_ID" \
-    --arg pattern "$pattern" \
-    --arg file "$RELATIVE_PATH" \
-    --argjson line "$line_num" \
-    '{
-      timestamp: $timestamp,
-      session_id: $session_id,
-      pattern: $pattern,
-      file: $file,
-      line: $line,
-      escape_attempted: false
-    }' >> "$LOG_FILE"
+  # The fourth `jq -cn` writer in this directory, and the one where losing the record is worst: this
+  # hook REFUSES the edit either way, so on a host without jq the refusal happened and the evidence
+  # for it did not. A block nobody can count is a block nobody can review. Same ladder as every other
+  # reader and writer here — jq, then python3, then refuse. See lib/hook-facts.sh.
+  hook_json_object \
+    s timestamp "$TIMESTAMP" \
+    s session_id "$SESSION_ID" \
+    s pattern "$pattern" \
+    s file "$RELATIVE_PATH" \
+    n line "$line_num" \
+    b escape_attempted false >> "$LOG_FILE"
   BLOCK_MESSAGES="$BLOCK_MESSAGES\n  line $line_num: $line_content"
   BLOCKED=true
 }

--- a/.claude/hooks/correction-detect.sh
+++ b/.claude/hooks/correction-detect.sh
@@ -3,20 +3,20 @@
 
 set -uo pipefail
 
+# One reader for a payload field and one writer for a record, not one per hook.
+# See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
 INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 LOG_FILE="$PROJECT_DIR/.agents/evals/local-metrics/corrections.jsonl"
 
-read_json() {
-  local expression="$1"
-  if [ -z "$INPUT" ]; then
-    echo ""
-    return
-  fi
-  printf '%s' "$INPUT" | jq -r "$expression // \"\"" 2>/dev/null || echo ""
-}
-
-PROMPT=$(read_json '.prompt // .user_prompt // .message')
+# This hook carried its own `read_json()` — jq, and NO python3 fallback — and then WROTE its record
+# with `jq -cn` as well. Measured on a host with jq hidden: it recorded nothing, silently, while
+# branch-guard beside it kept working. Repairing only the read would have left the metric just as
+# empty, so both ends go through the shared ladder.
+PROMPT=$(hook_prompt_of "$INPUT" || printf '')
 if [ -z "$PROMPT" ]; then
   exit 0
 fi
@@ -24,7 +24,7 @@ fi
 # LESSON-010: only REAL user turns are correction signals. Subagent/eval prompts (session ids
 # like "agent_1") and events with no session id are agent-authored text — counting them
 # inflated the one genuinely useful metric with false positives.
-SESSION_ID=$(read_json '.session_id')
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
 case "$SESSION_ID" in
   '' | agent*) exit 0 ;;
 esac
@@ -45,11 +45,15 @@ if [ -z "$KEYWORD" ]; then
   exit 0
 fi
 
-TRANSCRIPT_PATH=$(read_json '.transcript_path')
+TRANSCRIPT_PATH=$(hook_json_string "$INPUT" 'transcript_path' || printf '')
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 PREVIOUS_ASSISTANT_HASH=""
 
-if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+# The transcript is a JSONL FILE, not the hook payload, and the query below is a jq program rather
+# than a field read. Stated limit rather than hidden: without jq this correlation hash stays empty,
+# which weakens a field of the record — it no longer silences the record itself, which is what the
+# payload read did.
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v jq >/dev/null 2>&1; then
   PREVIOUS_ASSISTANT_TEXT=$(jq -r '
     select((.type // .role // .message.role // "") == "assistant")
     | (.message.content // .content // .text // "")
@@ -70,20 +74,12 @@ TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 PROMPT_EXCERPT=$(printf '%s' "$PROMPT" | tr '\n' ' ' | cut -c 1-160)
 
 mkdir -p "$(dirname "$LOG_FILE")"
-jq -cn \
-  --arg timestamp "$TIMESTAMP" \
-  --arg session_id "$SESSION_ID" \
-  --arg pattern "user-correction" \
-  --arg keyword "$KEYWORD" \
-  --arg previous_assistant_hash "$PREVIOUS_ASSISTANT_HASH" \
-  --arg prompt_excerpt "$PROMPT_EXCERPT" \
-  '{
-    timestamp: $timestamp,
-    session_id: $session_id,
-    pattern: $pattern,
-    keyword: $keyword,
-    previous_assistant_hash: $previous_assistant_hash,
-    prompt_excerpt: $prompt_excerpt
-  }' >> "$LOG_FILE"
+hook_json_object \
+  s timestamp "$TIMESTAMP" \
+  s session_id "$SESSION_ID" \
+  s pattern "user-correction" \
+  s keyword "$KEYWORD" \
+  s previous_assistant_hash "$PREVIOUS_ASSISTANT_HASH" \
+  s prompt_excerpt "$PROMPT_EXCERPT" >> "$LOG_FILE"
 
 exit 0

--- a/.claude/hooks/correction-detect.sh
+++ b/.claude/hooks/correction-detect.sh
@@ -24,7 +24,10 @@ fi
 # LESSON-010: only REAL user turns are correction signals. Subagent/eval prompts (session ids
 # like "agent_1") and events with no session id are agent-authored text — counting them
 # inflated the one genuinely useful metric with false positives.
-SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
+# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
+# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
+# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
+SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || printf '')
 case "$SESSION_ID" in
   '' | agent*) exit 0 ;;
 esac
@@ -45,7 +48,7 @@ if [ -z "$KEYWORD" ]; then
   exit 0
 fi
 
-TRANSCRIPT_PATH=$(hook_json_string "$INPUT" 'transcript_path' || printf '')
+TRANSCRIPT_PATH=$(hook_json_text "$INPUT" 'transcript_path' || printf '')
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 PREVIOUS_ASSISTANT_HASH=""
 

--- a/.claude/hooks/eval-log-stop.sh
+++ b/.claude/hooks/eval-log-stop.sh
@@ -31,7 +31,10 @@ git_project() {
 BRANCH=$(hook_current_branch "$PROJECT_DIR" "unknown")
 # It carried no `read_json()`, so it looked unlike its three siblings, and it read the payload with
 # a bare `jq -r` and wrote its record with `jq -cn` all the same. Same defect, different spelling.
-SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
+# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
+# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
+# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
+SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || printf '')
 
 if [ -f "$HOOK_DIR/revert-detect.sh" ]; then
   printf '%s' "$INPUT" | bash "$HOOK_DIR/revert-detect.sh" >/dev/null 2>&1 || true

--- a/.claude/hooks/eval-log-stop.sh
+++ b/.claude/hooks/eval-log-stop.sh
@@ -29,10 +29,9 @@ git_project() {
 # detached HEAD, so the arm never fired and every detached session logged `"branch": ""`. The
 # default goes on the VALUE, and this caller wants a word a reader of the log can see.
 BRANCH=$(hook_current_branch "$PROJECT_DIR" "unknown")
-SESSION_ID=""
-if [ -n "$INPUT" ]; then
-  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")
-fi
+# It carried no `read_json()`, so it looked unlike its three siblings, and it read the payload with
+# a bare `jq -r` and wrote its record with `jq -cn` all the same. Same defect, different spelling.
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
 
 if [ -f "$HOOK_DIR/revert-detect.sh" ]; then
   printf '%s' "$INPUT" | bash "$HOOK_DIR/revert-detect.sh" >/dev/null 2>&1 || true
@@ -56,7 +55,10 @@ count_records() {
     echo 0
     return
   fi
-  if [ -n "$SESSION_ID" ]; then
+  # A jq PROGRAM over a JSONL file, not a payload field read, so it stays on jq. Stated limit: with
+  # jq absent the per-session filter cannot run and the pipeline yields 0, so these three totals
+  # under-report rather than break the record — which is the trade the record write could not make.
+  if [ -n "$SESSION_ID" ] && command -v jq >/dev/null 2>&1; then
     jq -c --arg session_id "$SESSION_ID" 'select(.session_id == $session_id)' "$file_path" 2>/dev/null | wc -l | tr -d ' '
     return
   fi
@@ -67,25 +69,15 @@ BLOCKS_TOTAL=$(count_records "$LOG_DIR/blocks.jsonl")
 CORRECTIONS_TOTAL=$(count_records "$LOG_DIR/corrections.jsonl")
 REVERTS_TOTAL=$(count_records "$LOG_DIR/reverts.jsonl")
 
-jq -cn \
-  --arg timestamp "$TIMESTAMP" \
-  --arg branch "$BRANCH" \
-  --arg session_id "$SESSION_ID" \
-  --argjson commits "$COMMIT_COUNT" \
-  --argjson test_files_changed "$TEST_FILES_CHANGED" \
-  --argjson blocks_total "$BLOCKS_TOTAL" \
-  --argjson corrections_total "$CORRECTIONS_TOTAL" \
-  --argjson reverts_total "$REVERTS_TOTAL" \
-  '{
-    timestamp: $timestamp,
-    branch: $branch,
-    session_id: $session_id,
-    commits: $commits,
-    testFilesChanged: $test_files_changed,
-    blocks_total: $blocks_total,
-    corrections_total: $corrections_total,
-    reverts_total: $reverts_total
-  }' >> "$LOG_FILE"
+hook_json_object \
+  s timestamp "$TIMESTAMP" \
+  s branch "$BRANCH" \
+  s session_id "$SESSION_ID" \
+  n commits "$COMMIT_COUNT" \
+  n testFilesChanged "$TEST_FILES_CHANGED" \
+  n blocks_total "$BLOCKS_TOTAL" \
+  n corrections_total "$CORRECTIONS_TOTAL" \
+  n reverts_total "$REVERTS_TOTAL" >> "$LOG_FILE"
 
 if [ "${ROBOTA_DISABLE_LESSONS_DIGEST:-}" != "1" ] && [ -f "$PROJECT_DIR/scripts/harness/lessons-digest.mjs" ]; then
   node "$PROJECT_DIR/scripts/harness/lessons-digest.mjs" >/dev/null 2>&1 || true

--- a/.claude/hooks/eval-log-stop.sh
+++ b/.claude/hooks/eval-log-stop.sh
@@ -5,6 +5,10 @@
 
 set -uo pipefail
 
+# One scrubbed git, one branch reader, one record writer. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
 INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,8 +18,11 @@ LOG_FILE="$LOG_DIR/sessions.jsonl"
 mkdir -p "$LOG_DIR"
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# `git_project()` was defined here and, byte-identically, in revert-detect — two copies of the one
+# fact that git must not be asked about a repository the ambient GIT_DIR has already chosen, while
+# ~20 bare `git -C` call sites in the guards had no copy at all. It is `hook_git_in` now.
 git_project() {
-  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C "$PROJECT_DIR" "$@"
+  hook_git_in "$PROJECT_DIR" "$@"
 }
 
 BRANCH=$(git_project branch --show-current 2>/dev/null || echo "unknown")

--- a/.claude/hooks/eval-log-stop.sh
+++ b/.claude/hooks/eval-log-stop.sh
@@ -25,7 +25,10 @@ git_project() {
   hook_git_in "$PROJECT_DIR" "$@"
 }
 
-BRANCH=$(git_project branch --show-current 2>/dev/null || echo "unknown")
+# `|| echo "unknown"` was dead code: `branch --show-current` exits 0 with EMPTY output on a
+# detached HEAD, so the arm never fired and every detached session logged `"branch": ""`. The
+# default goes on the VALUE, and this caller wants a word a reader of the log can see.
+BRANCH=$(hook_current_branch "$PROJECT_DIR" "unknown")
 SESSION_ID=""
 if [ -n "$INPUT" ]; then
   SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null || echo "")

--- a/.claude/hooks/lib/hook-facts.sh
+++ b/.claude/hooks/lib/hook-facts.sh
@@ -155,15 +155,84 @@ hook_current_branch() {
 # Routed through the JSON decoders rather than grep for the reason at the top of this file: a path
 # is allowed to contain a quote or a backslash, JSON escapes both, and a `[^"]*` grep stops at the
 # escape and hands back a path that does not exist.
+#
+# Through `hook_json_text`, not `hook_json_string`, so this reader and `hook_prompt_of` answer the
+# same question the same way. Measured on `{"tool_input": {"file_path": 123}}`: `hook_json_string`
+# returns `123` where jq is installed and "" where it is not, so the rule would otherwise have been
+# one-per-function instead of one rule. A path is text or it is not a path.
 hook_file_path_of() {
-  hook_json_string "$1" 'tool_input.file_path'
+  hook_json_text "$1" 'tool_input.file_path'
+}
+
+# A top-level field, but ONLY when it holds a JSON string. Anything else reads as absent.
+#
+# `hook_json_string` next door does not promise this, and its two arms DISAGREE without it. Measured
+# on `{"message": {"role": "user", "content": "hello"}}`, which is the ordinary transcript shape and
+# not an exotic one: with jq installed, `jq -r '.message // ""'` prints the object's pretty-printed
+# JSON; with jq absent, the python3 arm writes "" because the node is not a `str`. Same payload, same
+# function, two answers depending on which tool the host happens to have — the exact defect class
+# this directory spent INFRA-077 removing, one function to the left.
+#
+# `hook_json_string` lives in `command-scan.sh`, which INFRA-077 deliberately did not touch, so this
+# is stated rather than fixed there: the disagreement is still reachable through any OTHER caller of
+# that function. Filed in the PR body for whoever owns that file next.
+#
+# The answer chosen here is "": a structured node is not prompt TEXT, and returning the JSON blob
+# would have `correction-detect` grep it for correction keywords and log it as `prompt_excerpt`,
+# and `spec-first-gate` scan it for implementation intent.
+hook_json_text() {
+  local json="$1" path="$2"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$json" | jq -r "if (.${path} | type) == \"string\" then .${path} else \"\" end" 2>/dev/null && return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | python3 -c '
+import json, sys
+try:
+    doc = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+node = doc
+for key in sys.argv[1].split("."):
+    if not isinstance(node, dict):
+        node = None
+        break
+    node = node.get(key)
+sys.stdout.write(node if isinstance(node, str) else "")
+' "$path" 2>/dev/null && return 0
+  fi
+  return 1
 }
 
 # The user's prompt text, under whichever of the three keys the event carries it.
+#
+# THE FIRST KEY THAT CARRIES TEXT — not the first key that is present. That is a DECISION, and it
+# differs from the `.prompt // .user_prompt // .message` this replaced: jq's `//` yields its left
+# operand whenever that operand is neither `null` nor `false`, and an empty string is truthy in jq.
+# So the one payload that tells the two rules apart is
+#
+#     {"prompt": "", "user_prompt": "hello"}
+#
+# on which the old expression returned "" and this returns "hello".
+#
+# Fall-through is kept, for a reason a reader can check rather than take on trust:
+#
+#   * `hook_json_string` CANNOT express jq's distinction. Measured on BOTH arms, it returns "" with
+#     exit 0 for an absent key and for a present-but-empty one alike. Reproducing `//` exactly would
+#     mean adding a presence-distinguishing reader whose only consumer is a payload shape no host
+#     emits — the three keys are three SPELLINGS of one fact, so a real event carries one of them.
+#   * Of the two rules, "the first key that carries text" is the one that never goes blind on text
+#     that is plainly present in the payload. Going silently blind is the failure this whole change
+#     exists to remove, so where the rules differ, that is the tie-breaker.
+#
+# The rule the readers here share, stated once: a READER collapses absent and empty into "", and the
+# CALLER names what empty means for it. That is the same shape as `hook_current_branch`'s
+# caller-named default, and as `hook_command_of`/`hook_tool_name_of` treating an empty value as a
+# refusal. This caller's answer is "an empty key is not the prompt; keep looking".
 hook_prompt_of() {
   local key value
   for key in prompt user_prompt message; do
-    if ! value=$(hook_json_string "$1" "$key"); then
+    if ! value=$(hook_json_text "$1" "$key"); then
       return 1
     fi
     if [[ -n "$value" ]]; then

--- a/.claude/hooks/lib/hook-facts.sh
+++ b/.claude/hooks/lib/hook-facts.sh
@@ -245,9 +245,9 @@ hook_prompt_of() {
 
 # --- writing a JSON record -----------------------------------------------------------------------
 
-# hook_json_object [s|n KEY VALUE]...
+# hook_json_object [s|n|b KEY VALUE]...
 #
-# Emits one compact JSON object. `s` is a string, `n` a number.
+# Emits one compact JSON object. `s` is a string, `n` a number, `b` a boolean (`true`/`false`).
 #
 # The same ladder the readers use — jq, then python3, then refuse — and for the same reason. Three
 # hooks read their payload with jq and also WROTE their record with `jq -cn`, so on a host without
@@ -268,6 +268,13 @@ hook_json_object() {
     case "$kind" in
       n)
         [[ "$value" =~ ^-?[0-9]+$ ]] || return 1
+        jq_args+=(--argjson "$key" "$value")
+        ;;
+      b)
+        # Refused rather than coerced, for the same reason a number is: a record is worth writing
+        # only if it says something true, and "anything that is not the word false is true" is how a
+        # typo becomes a fact in a log.
+        [[ "$value" == "true" || "$value" == "false" ]] || return 1
         jq_args+=(--argjson "$key" "$value")
         ;;
       s)
@@ -298,7 +305,12 @@ argv = sys.argv[1:]
 out = {}
 for i in range(0, len(argv), 3):
     kind, key, value = argv[i], argv[i + 1], argv[i + 2]
-    out[key] = int(value) if kind == "n" else value
+    if kind == "n":
+        out[key] = int(value)
+    elif kind == "b":
+        out[key] = value == "true"
+    else:
+        out[key] = value
 sys.stdout.write(json.dumps(out, ensure_ascii=False, separators=(",", ":")) + "\n")
 ' "${py_args[@]}" 2>/dev/null && return 0
   fi

--- a/.claude/hooks/lib/hook-facts.sh
+++ b/.claude/hooks/lib/hook-facts.sh
@@ -1,0 +1,237 @@
+# shellcheck shell=bash
+#
+# One owner for each FACT a hook computes, because four hooks had four and the copies disagreed.
+#
+# `lib/command-scan.sh` next door owns the question "what does this payload SAY" — the command, the
+# tool name, which part of it is a command rather than text. This file owns the question after it:
+# "what does the ENVIRONMENT say" — which file is being written, which repository the command acts
+# on, which branch that repository is on, and how git must be invoked for those answers to be about
+# the repository the command actually runs in.
+#
+# An audit of this directory on 2026-08-01 ran every hook against scratch repositories and measured
+# five facts computed by separate code in two or more hooks, with the copies giving DIFFERENT
+# ANSWERS. Each disagreement was reachable from an ordinary command:
+#
+#   * `post-tool-format` and `memory-mirror-reminder` read `tool_input.file_path` with
+#     `grep -o '"file_path"…"[^"]*"'`, which stops at the first ESCAPED quote. A file named
+#     `we"ird.ts` was read as `we\`, the `-f` test then failed, and the file was silently never
+#     formatted — the hook exits 0 either way, which is why nothing noticed.
+#   * `correction-detect`, `revert-detect` and `spec-first-gate` each carried an identical
+#     `read_json()` that calls jq and has NO python3 fallback, while the Bash guards fall back. On a
+#     host without jq, half this directory went silently off while the other half kept working.
+#   * Four repository resolutions under two rules. The validating one validated with a BARE `git -C`,
+#     and an exported `GIT_DIR` makes `git -C <any existing dir> rev-parse --is-inside-work-tree`
+#     exit 0 — so the guard adopted a directory that is not a repository as the repository it judged.
+#   * `git branch --show-current` exits 0 with EMPTY output on a detached HEAD, so every
+#     `$(… || echo unknown)` here is dead code and every detached session logged `"branch": ""`.
+#   * `git_project()` scrubbed the git environment in two hooks, byte-identical, while ~20 bare
+#     `git -C` call sites did not. With `GIT_DIR` exported, `git -C <scratch> branch --show-current`
+#     reports the OUTER repository's branch — so a guard read one repository and judged another's
+#     command, and a commit on `main` walked past the guard that exists to refuse it.
+#
+# TWO DIVERGENCES ARE DELIBERATE and survive here as NAMED MODES rather than being flattened, each
+# with the reason it exists. They are named at `hook_effective_repo`.
+#
+# Contract for callers:
+#   - Source this file; it sources `command-scan.sh`, so one source line is enough.
+#   - All functions are safe under `set -euo pipefail`.
+#   - A function that returns non-zero means "could not be read". A GUARD must treat that as a
+#     refusal, never as an empty value that matches nothing.
+
+# shellcheck source=command-scan.sh
+source "$(dirname "${BASH_SOURCE[0]}")/command-scan.sh"
+
+# --- git, with the ambient repository pointers removed -------------------------------------------
+
+# `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX` OUTRANK `-C`. Any of them present in
+# the environment makes git answer about the repository they name and ignore the directory the
+# caller asked about, so a hook using bare `git -C` is not asking a weaker question — it is asking a
+# question about a different repository. Measured: with `GIT_DIR` exported at a second checkout,
+# `git -C <main clone> branch --show-current` returns the SECOND checkout's branch, which is enough
+# to walk a `git commit` on `main` straight past branch-guard.
+#
+# These variables are exported by ordinary things — git hooks, `git rebase -x`, tooling that shells
+# out mid-operation — so this is not an exotic state. Every git call a hook makes goes through here.
+hook_git() {
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git "$@"
+}
+
+# `hook_git` against a named directory. The one call shape hooks should use.
+hook_git_in() {
+  local dir="${1:-}"
+  shift || return 1
+  hook_git -C "$dir" "$@"
+}
+
+# Is this directory inside a git work tree? Judged with the scrub, which is the whole point: the
+# unscrubbed form answers "yes" for any directory that merely EXISTS whenever GIT_DIR is exported.
+hook_is_work_tree() {
+  [[ -n "${1:-}" ]] || return 1
+  hook_git_in "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# --- which repository the command acts on --------------------------------------------------------
+
+# hook_effective_repo MODE GIT_C_PATH HOOK_CWD PROJECT_DIR
+#
+# One resolution, three NAMED modes. The modes are not an accident being preserved; each answers a
+# different question, and unifying them would remove a fail-safe or reintroduce a false block. The
+# cases in `scripts/harness/__tests__/hook-facts.test.mjs` pin all three, so a future unification
+# breaks loudly instead of quietly.
+#
+#   validated       `git -C` > hook `cwd` > project dir, each candidate accepted only if it is
+#                   really inside a work tree, falling back to the project dir (then `.`).
+#                   Used by branch-guard and pre-push-check, which must name SOME repository because
+#                   their verdict is about the branch it is on.
+#
+#   first-nonempty  `git -C` > hook `cwd` > project dir, taken as written, and EMPTY when none is
+#                   given. DELIBERATE, and worktree-cwd-guard's fail-safe: that guard blocks only
+#                   when it can POSITIVELY confirm the command lands in the main checkout, so naming
+#                   an unresolvable `-C` target and then declining to block is the correct outcome.
+#                   Validating instead would silently retarget the guard at the session repository
+#                   and block a destructive command aimed somewhere else — and the `.` fallback the
+#                   validated mode ends with once resolved to the HOOK'S OWN checkout and blocked
+#                   there, which is why this mode has none.
+#
+#   session         hook `cwd` > project dir, with `git -C` DELIBERATELY IGNORED. Used by
+#                   branch-guard's branch-base check: a branch is created where the session is, and
+#                   in a compound command the `-C` usually belongs to some other invocation
+#                   (`git checkout -b feat/x && git -C <other> status`). Honouring it there judged
+#                   <other> and blocked a legitimate creation. Stated limit: `git -C <other>
+#                   checkout -b` is judged against the session repository, which over-permits a rare
+#                   form instead of refusing a common one.
+hook_effective_repo() {
+  local mode="${1:-}" git_c="${2:-}" hook_cwd="${3:-}" project_dir="${4:-}" dir
+
+  case "$mode" in
+    validated)
+      dir="${project_dir:-.}"
+      if hook_is_work_tree "$hook_cwd"; then dir="$hook_cwd"; fi
+      if hook_is_work_tree "$git_c"; then dir="$git_c"; fi
+      ;;
+    first-nonempty)
+      dir=""
+      if [[ -n "$git_c" ]]; then
+        dir="$git_c"
+      elif [[ -n "$hook_cwd" ]]; then
+        dir="$hook_cwd"
+      elif [[ -n "$project_dir" ]]; then
+        dir="$project_dir"
+      fi
+      ;;
+    session)
+      dir="${project_dir:-.}"
+      if hook_is_work_tree "$hook_cwd"; then dir="$hook_cwd"; fi
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  printf '%s' "$dir"
+}
+
+# --- the current branch --------------------------------------------------------------------------
+
+# hook_current_branch DIR DEFAULT
+#
+# The default is applied to the VALUE, not to the exit code. `git branch --show-current` exits 0 and
+# prints NOTHING on a detached HEAD, so `$(git branch --show-current || echo unknown)` — written
+# three ways in three hooks — never once reached its `||` arm and every detached session got "".
+#
+# The default is the CALLER'S to name because callers need different ones: an eval log wants a word
+# a reader can see ("unknown"), while branch-guard and pre-push-check KEY ON EMPTINESS to recognise
+# a detached HEAD and must be able to ask for "".
+hook_current_branch() {
+  local dir="${1:-}" fallback="${2:-}" name
+  name=$(hook_git_in "$dir" branch --show-current 2>/dev/null || printf '')
+  printf '%s' "${name:-$fallback}"
+}
+
+# --- payload fields ------------------------------------------------------------------------------
+
+# The file a Write/Edit will write. Non-zero means the payload could not be decoded at all.
+#
+# Routed through the JSON decoders rather than grep for the reason at the top of this file: a path
+# is allowed to contain a quote or a backslash, JSON escapes both, and a `[^"]*` grep stops at the
+# escape and hands back a path that does not exist.
+hook_file_path_of() {
+  hook_json_string "$1" 'tool_input.file_path'
+}
+
+# The user's prompt text, under whichever of the three keys the event carries it.
+hook_prompt_of() {
+  local key value
+  for key in prompt user_prompt message; do
+    if ! value=$(hook_json_string "$1" "$key"); then
+      return 1
+    fi
+    if [[ -n "$value" ]]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done
+  printf ''
+}
+
+# --- writing a JSON record -----------------------------------------------------------------------
+
+# hook_json_object [s|n KEY VALUE]...
+#
+# Emits one compact JSON object. `s` is a string, `n` a number.
+#
+# The same ladder the readers use — jq, then python3, then refuse — and for the same reason. Three
+# hooks read their payload with jq and also WROTE their record with `jq -cn`, so on a host without
+# jq they did not merely mis-read the event: they recorded nothing at all, silently, while the rest
+# of the directory kept working. Fixing the read alone would have left the metric just as empty.
+#
+# A number that is not a number is refused rather than coerced: a record is only worth writing if it
+# says something true, and the callers here already normalise their counts.
+hook_json_object() {
+  local -a jq_args=() py_args=()
+  local filter="{" first=1 kind key value
+
+  while [[ $# -ge 3 ]]; do
+    kind="$1"
+    key="$2"
+    value="$3"
+    shift 3
+    case "$kind" in
+      n)
+        [[ "$value" =~ ^-?[0-9]+$ ]] || return 1
+        jq_args+=(--argjson "$key" "$value")
+        ;;
+      s)
+        jq_args+=(--arg "$key" "$value")
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+    if [[ "$first" -eq 0 ]]; then filter+=","; fi
+    first=0
+    filter+="\"$key\":\$$key"
+    py_args+=("$kind" "$key" "$value")
+  done
+
+  # A leftover argument means the caller's triples do not line up, and a record built from a
+  # misaligned list would be wrong rather than absent.
+  [[ $# -eq 0 && "$first" -eq 0 ]] || return 1
+  filter+="}"
+
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn "${jq_args[@]}" "$filter" 2>/dev/null && return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c '
+import json, sys
+argv = sys.argv[1:]
+out = {}
+for i in range(0, len(argv), 3):
+    kind, key, value = argv[i], argv[i + 1], argv[i + 2]
+    out[key] = int(value) if kind == "n" else value
+sys.stdout.write(json.dumps(out, ensure_ascii=False, separators=(",", ":")) + "\n")
+' "${py_args[@]}" 2>/dev/null && return 0
+  fi
+  return 1
+}

--- a/.claude/hooks/memory-mirror-reminder.sh
+++ b/.claude/hooks/memory-mirror-reminder.sh
@@ -12,15 +12,18 @@
 
 set -euo pipefail
 
+# One reader for the payload's file_path, not one per hook. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
 input="$(cat 2>/dev/null || true)"
 [ -z "$input" ] && exit 0
 
-# Extract the written file path (jq if available, else a tolerant grep).
-if command -v jq >/dev/null 2>&1; then
-  fp="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
-else
-  fp="$(printf '%s' "$input" | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 | sed -E 's/.*:"([^"]+)"/\1/' || true)"
-fi
+# The jq arm was right and the "tolerant grep" beside it was not: `[^"]+` stops at the first
+# ESCAPED quote, so on a host without jq a memory file named with a quote or a backslash was read
+# as a truncated path, matched none of the cases below, and the reminder this hook exists to print
+# never printed. The shared reader falls back to python3 instead, so both hosts answer the same.
+fp="$(hook_file_path_of "$input" || printf '')"
 [ -z "$fp" ] && exit 0
 
 # In-repo mirror writes are the compliant case — never remind on those.

--- a/.claude/hooks/post-tool-format.sh
+++ b/.claude/hooks/post-tool-format.sh
@@ -10,11 +10,22 @@
 
 set -euo pipefail
 
+# One reader for the payload's file_path, not one per hook. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
 # Read JSON from stdin (Claude Code sends hook input via stdin)
 INPUT=$(cat)
 
-# Extract file_path from tool input JSON
-FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+# The path was read with `grep -o '"file_path"…"[^"]*"'`, which stops at the first ESCAPED quote.
+# A file named `we"ird.ts` arrives in the payload as `we\"ird.ts` and was read as `we\` — a path
+# that does not exist, so the `-f` test below dropped it and the file was silently never formatted.
+# A backslash anywhere in the name did the same. Both are legal filenames and both are escaped by
+# JSON, so the payload has to be decoded as JSON rather than scraped.
+#
+# This hook FORMATS; it does not judge. A payload it cannot decode names no file to format, so
+# exiting 0 here is the whole of the correct behaviour — unlike the guards, which refuse.
+FILE_PATH=$(hook_file_path_of "$INPUT" || printf '')
 
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
   exit 0

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -14,8 +14,10 @@ INPUT=$(cat)
 # One parser, not four. `command-scan.sh` explains what each hand-rolled copy got wrong; the short
 # version is that the old `grep -o '"command"…"[^"]*"' ` stopped at the first quote inside the
 # command, so everything after `-m "…"` — including the verb being guarded — was never examined.
-# shellcheck source=lib/command-scan.sh
-source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+# hook-facts.sh sources command-scan.sh, so one line brings in both the payload parser and the
+# single owner of the repository, branch and scrubbed-git facts. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
 
 # Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
 # under `set -e` and the hook exits 1 with nothing said — which the hook protocol treats as
@@ -88,10 +90,10 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # redirect this guard at another repository. See lib/command-scan.sh.
 GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-if [[ -n "$HOOK_CWD" ]] && git -C "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [[ -n "$HOOK_CWD" ]] && hook_git_in "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   PROJECT_DIR="$HOOK_CWD"
 fi
-if [[ -n "$GIT_C_PATH" ]] && git -C "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if [[ -n "$GIT_C_PATH" ]] && hook_git_in "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   PROJECT_DIR="$GIT_C_PATH"
 fi
 
@@ -101,7 +103,7 @@ fi
 # merged one in) and PR'd to develop carries the promotion's merge commits in its `origin/develop..HEAD`
 # range, which land in the PR range and fail commitlint. A clean feature/docs branch has ZERO merge
 # commits over origin/develop. Skip integration/detached branches and when origin/develop is absent.
-CUR_BRANCH=$(git -C "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+CUR_BRANCH=$(hook_git_in "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
 case "$CUR_BRANCH" in
   # release/* and hotfix/* are promotion branches — they LEGITIMATELY carry the `git merge --no-ff origin/main`
   # that records main's ancestry into a develop→main promotion (INFRA-051, built by
@@ -109,8 +111,8 @@ case "$CUR_BRANCH" in
   # feature branches accidentally based on `main`.
   main | master | develop | release/* | hotfix/* | "") : ;;
   *)
-    if git -C "$PROJECT_DIR" rev-parse --verify --quiet origin/develop >/dev/null 2>&1; then
-      FOREIGN_MERGES=$(git -C "$PROJECT_DIR" log --merges --oneline origin/develop..HEAD 2>/dev/null || true)
+    if hook_git_in "$PROJECT_DIR" rev-parse --verify --quiet origin/develop >/dev/null 2>&1; then
+      FOREIGN_MERGES=$(hook_git_in "$PROJECT_DIR" log --merges --oneline origin/develop..HEAD 2>/dev/null || true)
       if [ -n "$FOREIGN_MERGES" ]; then
         echo "[pre-push-check] Blocked: branch '$CUR_BRANCH' carries merge commits in its range over origin/develop:" >&2
         echo "$FOREIGN_MERGES" | sed 's/^/[pre-push-check]   /' >&2
@@ -124,12 +126,12 @@ esac
 
 # ── 1. Lockfile sync check ──────────────────────────────────────────────────
 
-if ! git -C "$PROJECT_DIR" diff --quiet pnpm-lock.yaml 2>/dev/null; then
+if ! hook_git_in "$PROJECT_DIR" diff --quiet pnpm-lock.yaml 2>/dev/null; then
   echo "[pre-push-check] Blocked: pnpm-lock.yaml has uncommitted changes. Commit the lockfile before pushing." >&2
   exit 2
 fi
 
-if ! git -C "$PROJECT_DIR" diff --cached --quiet pnpm-lock.yaml 2>/dev/null; then
+if ! hook_git_in "$PROJECT_DIR" diff --cached --quiet pnpm-lock.yaml 2>/dev/null; then
   echo "[pre-push-check] Blocked: pnpm-lock.yaml is staged but not committed. Commit it first." >&2
   exit 2
 fi
@@ -138,10 +140,10 @@ cd "$PROJECT_DIR"
 
 pnpm install --prefer-offline --silent 2>/dev/null || pnpm install --silent 2>/dev/null || true
 
-if ! git -C "$PROJECT_DIR" diff --quiet pnpm-lock.yaml 2>/dev/null; then
+if ! hook_git_in "$PROJECT_DIR" diff --quiet pnpm-lock.yaml 2>/dev/null; then
   echo "[pre-push-check] Blocked: pnpm-lock.yaml is out of sync with package.json files." >&2
   echo "[pre-push-check] Run: pnpm install && git add pnpm-lock.yaml && git commit -m 'chore: update lockfile'" >&2
-  git -C "$PROJECT_DIR" checkout -- pnpm-lock.yaml 2>/dev/null || true
+  hook_git_in "$PROJECT_DIR" checkout -- pnpm-lock.yaml 2>/dev/null || true
   exit 2
 fi
 

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -89,13 +89,12 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
 # redirect this guard at another repository. See lib/command-scan.sh.
 GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
-if [[ -n "$HOOK_CWD" ]] && hook_git_in "$HOOK_CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  PROJECT_DIR="$HOOK_CWD"
-fi
-if [[ -n "$GIT_C_PATH" ]] && hook_git_in "$GIT_C_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  PROJECT_DIR="$GIT_C_PATH"
-fi
+# One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
+# `validated`: it must name SOME repository, because its verdict is about the branch that
+# repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside
+# it (worktree-cwd-guard's first-nonempty fail-safe, and this hook's own `session` base check) stay
+# decisions with a reason instead of four copies that drift apart.
+PROJECT_DIR=$(hook_effective_repo validated "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
 
 
 # ── 0. Branch-base hygiene (git-branch.md: feature branches start from origin/develop) ──────────

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -96,6 +96,24 @@ GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
 # decisions with a reason instead of four copies that drift apart.
 PROJECT_DIR=$(hook_effective_repo validated "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
 
+# A guard fails CLOSED, and two guards taking the same resolution must answer this the same way.
+# branch-guard refuses when nothing resolvable is a repository; this hook took the identical
+# `validated` resolution and the identical branch reader and did not — a fact fixed in one hook and
+# not in the one beside it, which is the failure this whole change exists to end.
+#
+# What it cost, measured: `CUR_BRANCH` comes back "" for a detached HEAD AND for "not a repository
+# at all", and the `""` arm of the hygiene switch below — written for the first — silently skipped
+# the foreign-merge check for the second. The lockfile check further down then refused anyway and
+# named `pnpm-lock.yaml`, so the push was stopped for a reason that was not the reason: a wrong
+# refusal after a check that never ran. A detached HEAD is deliberately NOT this case, and this hook
+# has its own considered answer for it further down; the test beside this one pins that so the
+# refusal here cannot grow to swallow it.
+if ! hook_is_work_tree "$PROJECT_DIR"; then
+  echo "[pre-push-check] Blocked: '$PROJECT_DIR' is no git repository, so the branch this push" >&2
+  echo "[pre-push-check] would come from cannot be read. Nothing was verified; this is not a pass." >&2
+  echo "[pre-push-check] Run the push from the checkout it belongs to." >&2
+  exit 2
+fi
 
 # ── 0. Branch-base hygiene (git-branch.md: feature branches start from origin/develop) ──────────
 # After a develop→main promotion, `main` sits AHEAD of `develop`. A branch cut from `main` (or that
@@ -111,6 +129,9 @@ case "$CUR_BRANCH" in
   # that records main's ancestry into a develop→main promotion (INFRA-051, built by
   # scripts/harness/promote.mjs), so exempt them from the "no foreign merge commits" check that targets
   # feature branches accidentally based on `main`.
+  # `""` here now means ONE thing — a detached HEAD, which has nothing to compare against
+  # origin/develop. It used to mean that OR "the repository could not be read", and the two are not
+  # the same answer; the refusal above separates them before this switch is reached.
   main | master | develop | release/* | hotfix/* | "") : ;;
   *)
     if hook_git_in "$PROJECT_DIR" rev-parse --verify --quiet origin/develop >/dev/null 2>&1; then

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -103,7 +103,10 @@ fi
 # merged one in) and PR'd to develop carries the promotion's merge commits in its `origin/develop..HEAD`
 # range, which land in the PR range and fail commitlint. A clean feature/docs branch has ZERO merge
 # commits over origin/develop. Skip integration/detached branches and when origin/develop is absent.
-CUR_BRANCH=$(hook_git_in "$PROJECT_DIR" branch --show-current 2>/dev/null || echo "")
+# One branch reader, with the default on the VALUE (see lib/hook-facts.sh). This caller asks for
+# the EMPTY default deliberately: the detached-HEAD refusal further down is keyed on emptiness, and
+# a reader that substituted a word there would have silently disabled it.
+CUR_BRANCH=$(hook_current_branch "$PROJECT_DIR" "")
 case "$CUR_BRANCH" in
   # release/* and hotfix/* are promotion branches — they LEGITIMATELY carry the `git merge --no-ff origin/main`
   # that records main's ancestry into a develop→main promotion (INFRA-051, built by

--- a/.claude/hooks/revert-detect.sh
+++ b/.claude/hooks/revert-detect.sh
@@ -10,18 +10,13 @@
 
 set -uo pipefail
 
+# One reader for a payload field, one writer for a record, one scrubbed git. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
 INPUT=$(cat)
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 LOG_FILE="$PROJECT_DIR/.agents/evals/local-metrics/reverts.jsonl"
-
-read_json() {
-  local expression="$1"
-  if [ -z "$INPUT" ]; then
-    echo ""
-    return
-  fi
-  printf '%s' "$INPUT" | jq -r "$expression // \"\"" 2>/dev/null || echo ""
-}
 
 append_event() {
   local pattern="$1"
@@ -29,21 +24,16 @@ append_event() {
   local count="$3"
   local detail="$4"
   mkdir -p "$(dirname "$LOG_FILE")"
-  jq -cn \
-    --arg timestamp "$TIMESTAMP" \
-    --arg session_id "$SESSION_ID" \
-    --arg pattern "$pattern" \
-    --arg file "$file_path" \
-    --argjson count "$count" \
-    --arg detail "$detail" \
-    '{
-      timestamp: $timestamp,
-      session_id: $session_id,
-      pattern: $pattern,
-      file: $file,
-      count: $count,
-      detail: $detail
-    }' >> "$LOG_FILE"
+  # This hook read its payload with a jq-only `read_json()` and wrote its record with `jq -cn`, so
+  # on a host without jq it recorded nothing while the Bash guards kept working. Both ends now go
+  # through the shared ladder (jq, then python3, then refuse).
+  hook_json_object \
+    s timestamp "$TIMESTAMP" \
+    s session_id "$SESSION_ID" \
+    s pattern "$pattern" \
+    s file "$file_path" \
+    n count "$count" \
+    s detail "$detail" >> "$LOG_FILE"
 }
 
 # Emit at most once per (pattern, file, session): a Stop-hook rescan of the same transcript
@@ -71,15 +61,22 @@ is_workflow_multi_edit_path() {
 }
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-SESSION_ID=$(read_json '.session_id')
-TRANSCRIPT_PATH=$(read_json '.transcript_path')
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
+TRANSCRIPT_PATH=$(hook_json_string "$INPUT" 'transcript_path' || printf '')
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
+# `git_project()` was defined here and, byte-identically, in eval-log-stop — two copies of the one
+# fact that git must not be asked about a repository the ambient GIT_DIR has already chosen. It is
+# `hook_git_in` now, which every hook shares.
 git_project() {
-  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git -C "$PROJECT_DIR" "$@"
+  hook_git_in "$PROJECT_DIR" "$@"
 }
 
-if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+# The transcript is a JSONL FILE and the queries below are jq PROGRAMS, not field reads, so they
+# stay on jq. Stated limit rather than hidden: without jq these two transcript signals are not
+# collected, while the git-history signal below and the record writer keep working — the hook is
+# degraded, not silent, which is the distinction the payload read got wrong.
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v jq >/dev/null 2>&1; then
   jq -r '
     [
       .tool_input.file_path?,

--- a/.claude/hooks/revert-detect.sh
+++ b/.claude/hooks/revert-detect.sh
@@ -61,8 +61,11 @@ is_workflow_multi_edit_path() {
 }
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
-TRANSCRIPT_PATH=$(hook_json_string "$INPUT" 'transcript_path' || printf '')
+# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
+# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
+# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
+SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || printf '')
+TRANSCRIPT_PATH=$(hook_json_text "$INPUT" 'transcript_path' || printf '')
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
 # `git_project()` was defined here and, byte-identically, in eval-log-stop — two copies of the one

--- a/.claude/hooks/spec-first-gate.sh
+++ b/.claude/hooks/spec-first-gate.sh
@@ -23,18 +23,17 @@
 
 set -uo pipefail
 
+# One reader for a payload field, not one per hook. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
 INPUT=$(cat)
 
-read_json() {
-  local expression="$1"
-  if [ -z "$INPUT" ]; then
-    echo ""
-    return
-  fi
-  printf '%s' "$INPUT" | jq -r "$expression // \"\"" 2>/dev/null || echo ""
-}
-
-PROMPT=$(read_json '.prompt // .user_prompt // .message')
+# This hook carried its own `read_json()` — jq, and NO python3 fallback — copied byte-for-byte into
+# correction-detect and revert-detect. Measured on a host with jq hidden: this gate printed nothing
+# at all while branch-guard beside it kept working, so half the directory was silently off and the
+# other half was not. The shared reader falls back to python3, so both halves answer the same.
+PROMPT=$(hook_prompt_of "$INPUT" || printf '')
 if [ -z "$PROMPT" ]; then
   exit 0
 fi

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -31,8 +31,10 @@ INPUT=$(cat)
 # One parser, not four. `command-scan.sh` explains what each hand-rolled copy got wrong; the short
 # version is that the old `grep -o '"command"…"[^"]*"' ` stopped at the first quote inside the
 # command, so everything after `-m "…"` — including the verb being guarded — was never examined.
-# shellcheck source=lib/command-scan.sh
-source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+# hook-facts.sh sources command-scan.sh, so one line brings in both the payload parser and the
+# single owner of the repository, branch and scrubbed-git facts. See lib/hook-facts.sh.
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
 # Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
@@ -193,7 +195,7 @@ fi
 # --- (a) is the effective repo the MAIN checkout? -----------------------------------------------
 # Positively resolve the repo toplevel of the EFFECTIVE dir. If the dir is not inside a git work tree
 # (empty/error) → cannot positively confirm main-checkout → FAIL-SAFE, do not block.
-TOPLEVEL=$(git -C "$EFFECTIVE_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")
+TOPLEVEL=$(hook_git_in "$EFFECTIVE_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")
 if [[ -z "$TOPLEVEL" ]]; then
   exit 0
 fi

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -178,14 +178,12 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
 # redirect this guard at another repository. See lib/command-scan.sh.
 GIT_C_PATH=$(hook_git_c_path "$SCAN" || true)
-EFFECTIVE_DIR=""
-if [[ -n "$GIT_C_PATH" ]]; then
-  EFFECTIVE_DIR="$GIT_C_PATH"
-elif [[ -n "$HOOK_CWD" ]]; then
-  EFFECTIVE_DIR="$HOOK_CWD"
-elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-  EFFECTIVE_DIR="$CLAUDE_PROJECT_DIR"
-fi
+# The `first-nonempty` mode, named rather than flattened into the validating one its siblings use.
+# It is this guard's FAIL-SAFE and the paragraph above is its reason: this hook blocks only on
+# POSITIVE confirmation, so naming an unresolvable `-C` target and then declining to block is the
+# correct outcome, where validating would silently retarget the guard at the session repository and
+# block a destructive command aimed somewhere else. It has no `.` fallback for the same reason.
+EFFECTIVE_DIR=$(hook_effective_repo first-nonempty "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
 
 # No nameable effective dir → cannot positively confirm main-checkout → FAIL-SAFE.
 if [[ -z "$EFFECTIVE_DIR" ]]; then

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -285,6 +285,65 @@ describe('fact 2 — reading a JSON field has one reader', () => {
     expect(JSON.parse(line)).toMatchObject({ branch: 'feature/work', session_id: 'user-1' });
   });
 
+  /**
+   * The payload is handed to the snippet through the ENVIRONMENT, never interpolated into the
+   * command line: a JSON document is full of quotes and braces, and building one into a shell
+   * string is how a probe ends up measuring its own quoting instead of the function.
+   */
+  function promptOf(payload, env = {}) {
+    return runLib('printf "%s" "$(hook_prompt_of "$PAYLOAD")"', {
+      PAYLOAD: JSON.stringify(payload),
+      ...env,
+    }).stdout;
+  }
+
+  it('reads a prompt to the same answer whether or not jq is installed', () => {
+    // The reported finding one function to the left, and the same class this file exists for.
+    // `hook_json_string`'s two arms DISAGREE on a field that is not a string: measured, `jq -r` on
+    // `{"message": {...}}` prints the object's pretty-printed JSON, while the python3 arm writes "".
+    // So `hook_prompt_of` returned a JSON blob as "the user's prompt" on a host with jq and nothing
+    // on a host without — and `{"message": {"role": …, "content": …}}` is the ordinary transcript
+    // shape, not an exotic one. correction-detect would then grep a JSON blob for correction
+    // keywords and log it as `prompt_excerpt`; spec-first-gate would scan it for implementation
+    // intent. A structured node is not prompt TEXT, so the answer is "" — on both hosts.
+    const payload = { message: { role: 'user', content: 'hello' } };
+    const withJq = promptOf(payload);
+    const withoutJq = promptOf(payload, { PATH: noJq });
+    expect(withJq).toBe(withoutJq);
+    expect(withJq).toBe('');
+  });
+
+  it('reads a file_path to the same answer whether or not jq is installed', () => {
+    // The sibling reader, asked the same question. Every field this directory reads as TEXT is read
+    // the same way on both hosts, so the rule is one rule rather than one-per-function.
+    const payload = { tool_input: { file_path: 123 } };
+    const read = (env) =>
+      runLib('printf "%s" "$(hook_file_path_of "$PAYLOAD")"', {
+        PAYLOAD: JSON.stringify(payload),
+        ...env,
+      }).stdout;
+    expect(read({})).toBe(read({ PATH: noJq }));
+    expect(read({})).toBe('');
+  });
+
+  it('takes the first key that carries TEXT, not the first key that is present', () => {
+    // DECIDED, not inherited. jq's `//` yields the left operand whenever it is neither null nor
+    // false — an empty string is truthy there — so `.prompt // .user_prompt` on
+    // `{"prompt": "", "user_prompt": "hello"}` returned "" and this returns "hello". Measured, and
+    // that payload is the only shape that tells the two rules apart.
+    //
+    // Fall-through is kept, for a reason the reader can check: `hook_json_string` CANNOT express
+    // jq's distinction. Measured on both arms, it returns "" with exit 0 for an absent key and for
+    // a present-but-empty one alike, so reproducing `//` exactly would mean adding a
+    // presence-distinguishing reader whose only consumer is a payload shape no host emits. And of
+    // the two rules, "the first key that carries text" is the one that never goes blind on text
+    // that is plainly there — which is the failure this whole change exists to remove.
+    expect(promptOf({ prompt: '', user_prompt: 'hello' })).toBe('hello');
+    expect(promptOf({ prompt: '', user_prompt: '', message: 'hi' })).toBe('hi');
+    expect(promptOf({ prompt: 'first', user_prompt: 'second' })).toBe('first');
+    expect(promptOf({})).toBe('');
+  });
+
   it('leaves no hook reading a payload field with a bare jq call', () => {
     const offenders = hookSourcesWithoutComments()
       .filter(({ text }) => /read_json\(\)/.test(text))

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -1,0 +1,467 @@
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+const FACTS_LIB = path.join(HOOKS_DIR, 'lib/hook-facts.sh');
+
+/**
+ * One owner for each fact a hook computes (INFRA-077).
+ *
+ * An audit of `.claude/hooks/**` on 2026-08-01 ran every hook against scratch repositories and
+ * found five facts computed by separate code in two or more hooks, with the copies DISAGREEING.
+ * Each disagreement below was measured, and none of them was visible to the suite as it stood: no
+ * test set `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_PREFIX` for any hook invocation, none
+ * ran a hook with `jq` absent, and none fed an escaped or backslashed path. The three gaps are the
+ * first three cases here, because a consolidation that lands without them lands unproven.
+ *
+ * The five facts, and what disagreeing about each one cost:
+ *
+ *   1. the payload's `file_path` — hand-rolled `grep -o '"file_path"…"[^"]*"'` truncates at the
+ *      first escaped quote, so a file whose name contains one is silently never formatted.
+ *   2. reading a JSON field at all — three hooks carry a `read_json()` with jq and no python3
+ *      fallback, so on a host without jq half the hooks go silently off while the rest keep working.
+ *   3. which repository the command acts on — four resolutions under two rules. The validating one
+ *      validates with a BARE `git -C`, which an exported `GIT_DIR` makes answer "yes" for any
+ *      directory that exists, so the guard adopts a non-repository as the repo it judges.
+ *   4. the current branch — `git branch --show-current` exits 0 with EMPTY output on a detached
+ *      HEAD, so every `|| echo unknown` in this directory is dead code and detached sessions log "".
+ *   5. git invoked with a scrubbed environment — two hooks scrub, ~20 bare `git -C` call sites do
+ *      not, so with `GIT_DIR` exported a guard reads the OUTER repository's branch and waves
+ *      through the very commit it exists to refuse.
+ *
+ * Two divergences are DELIBERATE and must survive as named modes rather than be flattened:
+ * `worktree-cwd-guard` resolves first-non-empty (a fail-safe: it would rather name nothing and not
+ * block than validate its way onto a repository the command does not run in), and `branch-guard`'s
+ * base check deliberately ignores `git -C` because a branch lands where the session is. Both are
+ * pinned below so unifying them breaks loudly.
+ */
+
+/** Scratch trees created during the run, removed in `afterAll` so probes leave no litter. */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchDir(prefix) {
+  const dir = realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+  scratch.push(dir);
+  return dir;
+}
+
+/**
+ * A throwaway repository on a named branch.
+ *
+ * Never the real working tree: these probes make guards run their real work against whatever they
+ * resolve, and the verdict would otherwise depend on a developer's local state.
+ */
+function initRepo(dir, branch) {
+  mkdirSync(dir, { recursive: true });
+  const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '--quiet', `--initial-branch=${branch}`);
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', 'chore: root');
+  return dir;
+}
+
+/**
+ * A PATH in which the named tools genuinely do not exist.
+ *
+ * A shim that merely FAILS is a different scenario — the hooks branch on `command -v`, so a
+ * present-but-broken tool exercises a path a tool-less host never takes. The farm therefore
+ * symlinks every executable the real PATH offers except the hidden ones, which is the only way to
+ * ask "what does this hook do on a host without jq" and get the host's answer.
+ */
+function pathWithout(hidden) {
+  const dir = scratchDir('hook-facts-path-');
+  const seen = new Set();
+  for (const entry of (process.env.PATH ?? '').split(':')) {
+    if (!entry) continue;
+    let names;
+    try {
+      names = readdirSync(entry);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      if (hidden.includes(name)) continue;
+      try {
+        symlinkSync(path.join(entry, name), path.join(dir, name));
+      } catch {
+        // A duplicate or an unreadable entry is not the subject of any case here.
+      }
+    }
+  }
+  return dir;
+}
+
+/**
+ * `spawnSync`, not `execFileSync`: hooks speak on stderr, and `execFileSync`'s success path returns
+ * stdout only — a hook that spoke and exited 0 would read as silence.
+ */
+function runHook(hookFile, payload, { cwd = WORKSPACE_ROOT, env = {} } = {}) {
+  const result = spawnSync('/bin/bash', [path.join(HOOKS_DIR, hookFile)], {
+    input: JSON.stringify(payload),
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
+
+/** Run a snippet against the shared fact library, the way a hook uses it. */
+function runLib(snippet, env = {}) {
+  const result = spawnSync('/bin/bash', ['-c', `set -euo pipefail\nsource "${FACTS_LIB}"\n${snippet}`], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: (result.stdout ?? '').trim(),
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
+
+/** Hook sources, comments stripped, for the "nobody hand-rolls this any more" assertions. */
+function hookSourcesWithoutComments() {
+  return readdirSync(HOOKS_DIR)
+    .filter((name) => name.endsWith('.sh'))
+    .map((name) => ({
+      name,
+      text: readFileSync(path.join(HOOKS_DIR, name), 'utf8')
+        .split('\n')
+        .filter((line) => !/^\s*#/.test(line))
+        .join('\n'),
+    }));
+}
+
+describe('fact 1 — the payload file_path has one reader', () => {
+  /**
+   * Signal: the PostToolUse payload's `tool_input.file_path`, sent by the tool host on every
+   * Write/Edit. `post-tool-format` read it with `grep -o '"file_path"…"[^"]*"'`, which stops at the
+   * first escaped quote, so `/tmp/a b/we"ird.ts` was read as `/tmp/a b/we\` — a path that does not
+   * exist, so the hook exited at its `-f` test and the file was never formatted. Silently: the hook
+   * exits 0 either way, which is why nothing noticed.
+   *
+   * `npx` is shimmed rather than left real, so the case asserts WHICH PATH the hook forwards
+   * instead of whether prettier happened to change the file.
+   */
+  function formatterProbe(fileName) {
+    const projectDir = scratchDir('hook-facts-fmt-');
+    const shimDir = scratchDir('hook-facts-shim-');
+    const log = path.join(shimDir, 'npx.log');
+    writeFileSync(path.join(shimDir, 'npx'), `#!/bin/bash\nprintf '%s\\n' "$@" >> ${JSON.stringify(log)}\n`, {
+      mode: 0o755,
+    });
+    const target = path.join(projectDir, fileName);
+    writeFileSync(target, '# heading\n');
+    const run = runHook(
+      'post-tool-format.sh',
+      { tool_name: 'Write', tool_input: { file_path: target } },
+      { cwd: projectDir, env: { CLAUDE_PROJECT_DIR: projectDir, PATH: `${shimDir}:${process.env.PATH}` } },
+    );
+    let forwarded = '';
+    try {
+      forwarded = readFileSync(log, 'utf8');
+    } catch {
+      forwarded = '';
+    }
+    return { run, forwarded, target };
+  }
+
+  it('forwards an ordinary path to the formatter', () => {
+    // The control. Without it a green "quoted path" case could mean the shim never ran at all.
+    const { forwarded, target } = formatterProbe('plain.md');
+    expect(forwarded).toContain(target);
+  });
+
+  it('forwards a path whose name contains an escaped quote', () => {
+    const { forwarded, target } = formatterProbe('we"ird.md');
+    expect(forwarded).toContain(target);
+  });
+
+  it('forwards a path whose name contains a backslash', () => {
+    const { forwarded, target } = formatterProbe('back\\slash.md');
+    expect(forwarded).toContain(target);
+  });
+
+  it('leaves no hook hand-rolling a file_path grep', () => {
+    const offenders = hookSourcesWithoutComments()
+      .filter(({ text }) => /grep[^\n]*"file_path"/.test(text))
+      .map(({ name }) => name);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('fact 2 — reading a JSON field has one reader', () => {
+  /**
+   * Signal: the UserPromptSubmit payload, sent by the tool host on every user turn. Three hooks
+   * carried an identical `read_json()` that calls `jq` and has no python3 fallback, while
+   * `lib/command-scan.sh` — which the Bash guards use — falls back. On a host without jq the two
+   * halves of this directory therefore disagree about whether the payload is readable at all:
+   * `branch-guard` keeps guarding and `spec-first-gate` prints nothing.
+   */
+  const noJq = pathWithout(['jq']);
+
+  it('the farm hides jq and keeps python3', () => {
+    // Stated because every case below is vacuous if the farm is wrong.
+    expect(spawnSync('/bin/bash', ['-c', 'command -v jq'], { env: { PATH: noJq } }).status).not.toBe(0);
+    expect(spawnSync('/bin/bash', ['-c', 'command -v python3'], { env: { PATH: noJq } }).status).toBe(0);
+  });
+
+  it('spec-first-gate still injects the SPEC-GATE reminder without jq', () => {
+    const run = runHook(
+      'spec-first-gate.sh',
+      { prompt: 'please implement a new command for the CLI', session_id: 'user-1' },
+      { env: { PATH: noJq } },
+    );
+    expect(run.output).toContain('SPEC-GATE');
+  });
+
+  it('correction-detect still records a correction without jq', () => {
+    const projectDir = scratchDir('hook-facts-corr-');
+    runHook(
+      'correction-detect.sh',
+      { prompt: 'no, not that — try again', session_id: 'user-1' },
+      { env: { PATH: noJq, CLAUDE_PROJECT_DIR: projectDir } },
+    );
+    const log = path.join(projectDir, '.agents/evals/local-metrics/corrections.jsonl');
+    const line = readFileSync(log, 'utf8').trim().split('\n').at(-1);
+    expect(JSON.parse(line)).toMatchObject({ pattern: 'user-correction', session_id: 'user-1' });
+  });
+
+  it('leaves no hook reading a payload field with a bare jq call', () => {
+    const offenders = hookSourcesWithoutComments()
+      .filter(({ text }) => /read_json\(\)/.test(text))
+      .map(({ name }) => name);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('fact 3 — which repository the command acts on', () => {
+  /**
+   * Four resolutions under two rules. They are consolidated into ONE function with NAMED MODES,
+   * because two of the divergences are deliberate and flattening them would remove a fail-safe.
+   */
+  function repos() {
+    const root = scratchDir('hook-facts-repo-');
+    const session = initRepo(path.join(root, 'session'), 'main');
+    const other = initRepo(path.join(root, 'other'), 'feature/other');
+    const plain = path.join(root, 'plain');
+    mkdirSync(plain, { recursive: true });
+    return { root, session, other, plain };
+  }
+
+  it('the validated mode rejects a git -C target that is not a work tree', () => {
+    const { session, plain } = repos();
+    const got = runLib(`hook_effective_repo validated "${plain}" "${session}" "${session}"`);
+    expect(got.stdout).toBe(session);
+  });
+
+  it('the validated mode is not fooled by an ambient GIT_DIR', () => {
+    // The measured defect: `git -C <any existing dir> rev-parse --is-inside-work-tree` exits 0 when
+    // GIT_DIR is exported, so the bare validation in branch-guard and pre-push-check answered "yes"
+    // for a directory that is not a repository at all.
+    const { session, other, plain } = repos();
+    const got = runLib(`hook_effective_repo validated "${plain}" "${session}" "${session}"`, {
+      GIT_DIR: path.join(other, '.git'),
+      GIT_WORK_TREE: other,
+    });
+    expect(got.stdout).toBe(session);
+  });
+
+  it('the first-nonempty mode keeps worktree-cwd-guard fail-safe: it names the -C target unvalidated', () => {
+    // DELIBERATE divergence, pinned so unifying it breaks loudly. worktree-cwd-guard would rather
+    // name a directory it cannot resolve — and then decline to block — than validate its way onto
+    // the session repository and block a destructive command aimed somewhere else entirely.
+    const { session } = repos();
+    const got = runLib(`hook_effective_repo first-nonempty "/no/such/dir" "${session}" "${session}"`);
+    expect(got.stdout).toBe('/no/such/dir');
+  });
+
+  it('the session mode ignores git -C, which is where branch-guard reads a branch base', () => {
+    // DELIBERATE divergence: a branch is created where the session is, so a `-C` belonging to some
+    // other invocation in the same compound command must not redirect the base check.
+    const { session, other } = repos();
+    const got = runLib(`hook_effective_repo session "${other}" "${session}" "${session}"`);
+    expect(got.stdout).toBe(session);
+  });
+
+  it('branch-guard judges the session repository when the -C target is not a repository', () => {
+    const { session, other, plain } = repos();
+    const run = runHook(
+      'branch-guard.sh',
+      { tool_name: 'Bash', cwd: session, tool_input: { command: `git -C ${plain} commit -m "chore: x"` } },
+      {
+        cwd: session,
+        env: {
+          CLAUDE_PROJECT_DIR: session,
+          GIT_DIR: path.join(other, '.git'),
+          GIT_WORK_TREE: other,
+        },
+      },
+    );
+    expect(run.status).toBe(2);
+    expect(run.output).toContain('protected branch');
+  });
+
+  it('leaves no hook hand-rolling the work-tree validation ladder', () => {
+    const offenders = hookSourcesWithoutComments()
+      .filter(({ text }) => /rev-parse --is-inside-work-tree/.test(text))
+      .map(({ name }) => name);
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('fact 4 — the current branch, with the default on the VALUE', () => {
+  /**
+   * `git branch --show-current` exits 0 and prints NOTHING on a detached HEAD, so every
+   * `$(git branch --show-current || echo unknown)` in this directory is dead code: the `||` arm
+   * never runs and the caller gets "". `eval-log-stop` logged `"branch": ""` for every detached
+   * session as a result.
+   */
+  function detachedRepo() {
+    const dir = initRepo(path.join(scratchDir('hook-facts-head-'), 'repo'), 'main');
+    writeFileSync(path.join(dir, 'second.txt'), 'x\n');
+    spawnSync('git', ['-C', dir, 'add', '-A'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'chore: second'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'checkout', '--quiet', '--detach'], { encoding: 'utf8' });
+    return dir;
+  }
+
+  it('applies the caller-named default when the value is empty', () => {
+    const dir = detachedRepo();
+    expect(runLib(`hook_current_branch "${dir}" unknown`).stdout).toBe('unknown');
+  });
+
+  it('lets a caller ask for the empty value, which is how a guard detects a detached HEAD', () => {
+    // branch-guard and pre-push-check both KEY on emptiness to recognise a detached HEAD, so the
+    // default is the caller's to name, not the function's to impose.
+    const dir = detachedRepo();
+    expect(runLib(`printf '[%s]' "$(hook_current_branch "${dir}" "")"`).stdout).toBe('[]');
+  });
+
+  it('eval-log-stop records a named branch for a detached session', () => {
+    const dir = detachedRepo();
+    runHook(
+      'eval-log-stop.sh',
+      { session_id: 'user-1' },
+      { cwd: dir, env: { CLAUDE_PROJECT_DIR: dir, ROBOTA_DISABLE_LESSONS_DIGEST: '1' } },
+    );
+    const log = path.join(dir, '.agents/evals/local-metrics/sessions.jsonl');
+    const line = readFileSync(log, 'utf8').trim().split('\n').at(-1);
+    expect(JSON.parse(line).branch).not.toBe('');
+  });
+});
+
+describe('fact 5 — git runs with a scrubbed environment', () => {
+  /**
+   * `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX` outrank `-C`: with `GIT_DIR`
+   * exported, `git -C <scratch> branch --show-current` reports the OUTER repository's branch. Two
+   * hooks scrubbed it through a `git_project()` copied byte-for-byte between them; every guard did
+   * not. So a guard could read one repository's branch while judging another's command — and a
+   * commit on `main` walked past the guard that exists to refuse it.
+   */
+  function pair() {
+    const root = scratchDir('hook-facts-env-');
+    return {
+      session: initRepo(path.join(root, 'session'), 'main'),
+      elsewhere: initRepo(path.join(root, 'elsewhere'), 'feature/elsewhere'),
+      root,
+    };
+  }
+
+  it('branch-guard still refuses a commit on main when GIT_DIR names another repository', () => {
+    const { session, elsewhere } = pair();
+    const run = runHook(
+      'branch-guard.sh',
+      { tool_name: 'Bash', cwd: session, tool_input: { command: 'git commit -m "chore: x"' } },
+      {
+        cwd: session,
+        env: {
+          CLAUDE_PROJECT_DIR: session,
+          GIT_DIR: path.join(elsewhere, '.git'),
+          GIT_WORK_TREE: elsewhere,
+        },
+      },
+    );
+    expect(run.status).toBe(2);
+    expect(run.output).toContain('protected branch');
+  });
+
+  it('branch-guard still refuses a push on main when GIT_INDEX_FILE and GIT_PREFIX are exported', () => {
+    const { session, elsewhere } = pair();
+    const run = runHook(
+      'branch-guard.sh',
+      { tool_name: 'Bash', cwd: session, tool_input: { command: 'git push origin main' } },
+      {
+        cwd: session,
+        env: {
+          CLAUDE_PROJECT_DIR: session,
+          GIT_DIR: path.join(elsewhere, '.git'),
+          GIT_WORK_TREE: elsewhere,
+          GIT_INDEX_FILE: path.join(elsewhere, '.git/index'),
+          GIT_PREFIX: '',
+        },
+      },
+    );
+    expect(run.status).toBe(2);
+    expect(run.output).toContain('protected branch');
+  });
+
+  it('worktree-cwd-guard still sees the MAIN checkout when GIT_DIR names a worktree', () => {
+    const root = scratchDir('hook-facts-wt-');
+    const main = initRepo(path.join(root, 'main-clone'), 'main');
+    const worktree = initRepo(path.join(root, '.claude/worktrees/wt'), 'feat/wt');
+    const run = runHook(
+      'worktree-cwd-guard.sh',
+      { tool_name: 'Bash', cwd: main, tool_input: { command: 'git reset --hard' } },
+      {
+        cwd: main,
+        env: {
+          CLAUDE_PROJECT_DIR: main,
+          ROBOTA_AGENT_WORKTREE: worktree,
+          GIT_DIR: path.join(worktree, '.git'),
+          GIT_WORK_TREE: worktree,
+        },
+      },
+    );
+    expect(run.status).toBe(2);
+    expect(run.output).toContain('MAIN checkout');
+  });
+
+  it('leaves no hook calling git without the scrub', () => {
+    // Message lines are excluded: `echo "… git -C <path> …"` is advice printed to a human, not an
+    // invocation, and refusing it would push the fix into rewording refusals rather than call sites.
+    const offenders = hookSourcesWithoutComments()
+      .filter(({ text }) =>
+        text
+          .split('\n')
+          .some((line) => /\bgit\s+-C\b/.test(line) && !/^\s*(echo|printf|cat)\b/.test(line)),
+      )
+      .map(({ name }) => name);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -344,6 +344,69 @@ describe('fact 2 — reading a JSON field has one reader', () => {
     expect(promptOf({})).toBe('');
   });
 
+  it('memory-mirror-reminder still fires for a memory path with a quote in it, without jq', () => {
+    // Fact 1's SECOND hook, executed rather than inferred from the source-level floor. Its jq arm
+    // was right and the "tolerant grep" beside it was not, so on a host without jq a memory file
+    // named with a quote was read as a truncated path, matched none of its cases, and the reminder
+    // never printed — the only thing this hook does.
+    const run = runHook(
+      'memory-mirror-reminder.sh',
+      {
+        tool_name: 'Write',
+        tool_input: { file_path: '/home/t/.claude/projects/x/memory/we"ird.md' },
+      },
+      { env: { PATH: noJq } },
+    );
+    expect(run.output).toContain('MEMORY MIRRORING');
+  });
+
+  it('revert-detect still records a fix-or-revert commit without jq', () => {
+    // Fact 2's third hook. Its git-history signal needs no transcript, so this reaches the record
+    // writer — which was `jq -cn` and therefore wrote nothing at all on a host without jq.
+    const dir = initRepo(path.join(scratchDir('hook-facts-revert-'), 'repo'), 'feature/work');
+    writeFileSync(path.join(dir, 'patch.txt'), 'x\n');
+    spawnSync('git', ['-C', dir, 'add', '-A'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'fix: something that regressed'], {
+      encoding: 'utf8',
+    });
+    runHook(
+      'revert-detect.sh',
+      { session_id: 'user-1' },
+      { cwd: dir, env: { PATH: noJq, CLAUDE_PROJECT_DIR: dir } },
+    );
+    const log = path.join(dir, '.agents/evals/local-metrics/reverts.jsonl');
+    const line = readFileSync(log, 'utf8').trim().split('\n').at(-1);
+    expect(JSON.parse(line)).toMatchObject({
+      pattern: 'fix-or-revert-commit',
+      session_id: 'user-1',
+    });
+  });
+
+  it('check-forbidden-patterns still records the block it just made, without jq', () => {
+    // The fourth hook with a `jq -cn` writer, and the one where losing the record is worst: it
+    // REFUSES the edit either way, so without jq the refusal happened and the evidence for it did
+    // not. A block nobody can count is a block nobody can review.
+    const projectDir = scratchDir('hook-facts-forbidden-');
+    const target = path.join(projectDir, 'packages/p/src/a.ts');
+    mkdirSync(path.dirname(target), { recursive: true });
+    const run = runHook(
+      'check-forbidden-patterns.sh',
+      {
+        tool_name: 'Write',
+        session_id: 'user-1',
+        tool_input: {
+          file_path: target,
+          content: 'try {\n  go();\n} catch (e) {\n  return null;\n}\n',
+        },
+      },
+      { cwd: projectDir, env: { PATH: noJq, CLAUDE_PROJECT_DIR: projectDir } },
+    );
+    expect(run.status).toBe(2);
+    const log = path.join(projectDir, '.agents/evals/local-metrics/blocks.jsonl');
+    const line = readFileSync(log, 'utf8').trim().split('\n').at(-1);
+    expect(JSON.parse(line)).toMatchObject({ pattern: 'try-catch-fallback', session_id: 'user-1' });
+  });
+
   it('leaves no hook reading a payload field with a bare jq call', () => {
     const offenders = hookSourcesWithoutComments()
       .filter(({ text }) => /read_json\(\)/.test(text))

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -252,6 +252,21 @@ describe('fact 2 — reading a JSON field has one reader', () => {
     expect(JSON.parse(line)).toMatchObject({ pattern: 'user-correction', session_id: 'user-1' });
   });
 
+  it('eval-log-stop still records a session without jq', () => {
+    // It carried no `read_json()`, so the floor below does not see it — and it read `.session_id`
+    // with a bare `jq -r` and wrote its record with `jq -cn` all the same. Same defect, different
+    // spelling, which is why this case is executed rather than inferred from the floor.
+    const dir = initRepo(path.join(scratchDir('hook-facts-eval-'), 'repo'), 'feature/work');
+    runHook(
+      'eval-log-stop.sh',
+      { session_id: 'user-1' },
+      { cwd: dir, env: { PATH: noJq, CLAUDE_PROJECT_DIR: dir, ROBOTA_DISABLE_LESSONS_DIGEST: '1' } },
+    );
+    const log = path.join(dir, '.agents/evals/local-metrics/sessions.jsonl');
+    const line = readFileSync(log, 'utf8').trim().split('\n').at(-1);
+    expect(JSON.parse(line)).toMatchObject({ branch: 'feature/work', session_id: 'user-1' });
+  });
+
   it('leaves no hook reading a payload field with a bare jq call', () => {
     const offenders = hookSourcesWithoutComments()
       .filter(({ text }) => /read_json\(\)/.test(text))

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -133,10 +133,14 @@ function runHook(hookFile, payload, { cwd = WORKSPACE_ROOT, env = {} } = {}) {
 
 /** Run a snippet against the shared fact library, the way a hook uses it. */
 function runLib(snippet, env = {}) {
-  const result = spawnSync('/bin/bash', ['-c', `set -euo pipefail\nsource "${FACTS_LIB}"\n${snippet}`], {
-    encoding: 'utf8',
-    env: { ...process.env, ...env },
-  });
+  const result = spawnSync(
+    '/bin/bash',
+    ['-c', `set -euo pipefail\nsource "${FACTS_LIB}"\n${snippet}`],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    },
+  );
   return {
     status: result.status ?? 1,
     stdout: (result.stdout ?? '').trim(),
@@ -172,15 +176,22 @@ describe('fact 1 — the payload file_path has one reader', () => {
     const projectDir = scratchDir('hook-facts-fmt-');
     const shimDir = scratchDir('hook-facts-shim-');
     const log = path.join(shimDir, 'npx.log');
-    writeFileSync(path.join(shimDir, 'npx'), `#!/bin/bash\nprintf '%s\\n' "$@" >> ${JSON.stringify(log)}\n`, {
-      mode: 0o755,
-    });
+    writeFileSync(
+      path.join(shimDir, 'npx'),
+      `#!/bin/bash\nprintf '%s\\n' "$@" >> ${JSON.stringify(log)}\n`,
+      {
+        mode: 0o755,
+      },
+    );
     const target = path.join(projectDir, fileName);
     writeFileSync(target, '# heading\n');
     const run = runHook(
       'post-tool-format.sh',
       { tool_name: 'Write', tool_input: { file_path: target } },
-      { cwd: projectDir, env: { CLAUDE_PROJECT_DIR: projectDir, PATH: `${shimDir}:${process.env.PATH}` } },
+      {
+        cwd: projectDir,
+        env: { CLAUDE_PROJECT_DIR: projectDir, PATH: `${shimDir}:${process.env.PATH}` },
+      },
     );
     let forwarded = '';
     try {
@@ -227,8 +238,12 @@ describe('fact 2 — reading a JSON field has one reader', () => {
 
   it('the farm hides jq and keeps python3', () => {
     // Stated because every case below is vacuous if the farm is wrong.
-    expect(spawnSync('/bin/bash', ['-c', 'command -v jq'], { env: { PATH: noJq } }).status).not.toBe(0);
-    expect(spawnSync('/bin/bash', ['-c', 'command -v python3'], { env: { PATH: noJq } }).status).toBe(0);
+    expect(
+      spawnSync('/bin/bash', ['-c', 'command -v jq'], { env: { PATH: noJq } }).status,
+    ).not.toBe(0);
+    expect(
+      spawnSync('/bin/bash', ['-c', 'command -v python3'], { env: { PATH: noJq } }).status,
+    ).toBe(0);
   });
 
   it('spec-first-gate still injects the SPEC-GATE reminder without jq', () => {
@@ -260,7 +275,10 @@ describe('fact 2 — reading a JSON field has one reader', () => {
     runHook(
       'eval-log-stop.sh',
       { session_id: 'user-1' },
-      { cwd: dir, env: { PATH: noJq, CLAUDE_PROJECT_DIR: dir, ROBOTA_DISABLE_LESSONS_DIGEST: '1' } },
+      {
+        cwd: dir,
+        env: { PATH: noJq, CLAUDE_PROJECT_DIR: dir, ROBOTA_DISABLE_LESSONS_DIGEST: '1' },
+      },
     );
     const log = path.join(dir, '.agents/evals/local-metrics/sessions.jsonl');
     const line = readFileSync(log, 'utf8').trim().split('\n').at(-1);
@@ -312,7 +330,9 @@ describe('fact 3 — which repository the command acts on', () => {
     // name a directory it cannot resolve — and then decline to block — than validate its way onto
     // the session repository and block a destructive command aimed somewhere else entirely.
     const { session } = repos();
-    const got = runLib(`hook_effective_repo first-nonempty "/no/such/dir" "${session}" "${session}"`);
+    const got = runLib(
+      `hook_effective_repo first-nonempty "/no/such/dir" "${session}" "${session}"`,
+    );
     expect(got.stdout).toBe('/no/such/dir');
   });
 
@@ -328,7 +348,11 @@ describe('fact 3 — which repository the command acts on', () => {
     const { session, other, plain } = repos();
     const run = runHook(
       'branch-guard.sh',
-      { tool_name: 'Bash', cwd: session, tool_input: { command: `git -C ${plain} commit -m "chore: x"` } },
+      {
+        tool_name: 'Bash',
+        cwd: session,
+        tool_input: { command: `git -C ${plain} commit -m "chore: x"` },
+      },
       {
         cwd: session,
         env: {
@@ -370,6 +394,43 @@ describe('fact 3 — which repository the command acts on', () => {
       { cwd: dir, env: { CLAUDE_PROJECT_DIR: dir } },
     );
     expect(run.status).toBe(0);
+  });
+
+  it('pre-push-check refuses a push when no repository can be read at all', () => {
+    // The SIBLING of the case above, and the failure this whole change exists to end: a fact fixed
+    // in one hook and not in the one beside it. branch-guard learned to refuse an unreadable
+    // repository; pre-push-check took the same `validated` resolution and the same branch reader and
+    // did not, so `CUR_BRANCH` came back "" for BOTH a detached HEAD and "not a repository at all"
+    // and the `""` arm of its hygiene switch — written for the first — silently skipped the
+    // foreign-merge check for the second. The lockfile check further down then refused anyway and
+    // named pnpm-lock.yaml: a refusal that misstates why, after a check that never ran.
+    const plain = scratchDir('hook-facts-push-norepo-');
+    const run = runHook(
+      'pre-push-check.sh',
+      { tool_name: 'Bash', cwd: plain, tool_input: { command: 'git push -u origin feat/probe' } },
+      { cwd: plain, env: { CLAUDE_PROJECT_DIR: plain } },
+    );
+    expect(run.status).toBe(2);
+    expect(run.output).toContain('no git repository');
+    expect(run.output).not.toContain('pnpm-lock.yaml');
+  });
+
+  it('pre-push-check still falls through on a detached HEAD, which is readable and nameless', () => {
+    // Pinned so the refusal above cannot drift into swallowing this. A detached HEAD has a readable
+    // repository and no branch name, and this hook has its OWN considered answer for it further
+    // down — a refusal keyed to the missing review record. The new refusal must not reach it first.
+    const dir = initRepo(path.join(scratchDir('hook-facts-push-detach-'), 'repo'), 'main');
+    writeFileSync(path.join(dir, 'second.txt'), 'x\n');
+    spawnSync('git', ['-C', dir, 'add', '-A'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'chore: second'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'checkout', '--quiet', '--detach'], { encoding: 'utf8' });
+    const run = runHook(
+      'pre-push-check.sh',
+      { tool_name: 'Bash', cwd: dir, tool_input: { command: 'git push -u origin feat/probe' } },
+      { cwd: dir, env: { CLAUDE_PROJECT_DIR: dir } },
+    );
+    expect(run.output).not.toContain('no git repository');
+    expect(run.output).toContain('detached HEAD');
   });
 
   it('leaves no hook hand-rolling the work-tree validation ladder', () => {

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -327,6 +327,36 @@ describe('fact 3 — which repository the command acts on', () => {
     expect(run.output).toContain('protected branch');
   });
 
+  it('branch-guard refuses a commit when no repository can be read at all', () => {
+    // A guard fails CLOSED. When the fact it judges cannot be read, "I verified this is fine" and
+    // "I could not verify" are the two states it must never conflate — and it did: with nothing
+    // resolvable, the branch came back empty and the hook exited 0, which the hook protocol reads
+    // as a pass. A detached HEAD is the case that looks identical and is NOT this one: there the
+    // repository is readable and the branch is genuinely nameless, so it still falls through.
+    const plain = scratchDir('hook-facts-norepo-');
+    const run = runHook(
+      'branch-guard.sh',
+      { tool_name: 'Bash', cwd: plain, tool_input: { command: 'git commit -m "chore: x"' } },
+      { cwd: plain, env: { CLAUDE_PROJECT_DIR: plain } },
+    );
+    expect(run.status).toBe(2);
+    expect(run.output).toContain('no git repository');
+  });
+
+  it('branch-guard still falls through on a detached HEAD, which is readable and nameless', () => {
+    const dir = initRepo(path.join(scratchDir('hook-facts-detach-'), 'repo'), 'main');
+    writeFileSync(path.join(dir, 'second.txt'), 'x\n');
+    spawnSync('git', ['-C', dir, 'add', '-A'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'chore: second'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', dir, 'checkout', '--quiet', '--detach'], { encoding: 'utf8' });
+    const run = runHook(
+      'branch-guard.sh',
+      { tool_name: 'Bash', cwd: dir, tool_input: { command: 'git commit -m "chore: x"' } },
+      { cwd: dir, env: { CLAUDE_PROJECT_DIR: dir } },
+    );
+    expect(run.status).toBe(0);
+  });
+
   it('leaves no hook hand-rolling the work-tree validation ladder', () => {
     const offenders = hookSourcesWithoutComments()
       .filter(({ text }) => /rev-parse --is-inside-work-tree/.test(text))

--- a/scripts/harness/__tests__/worktree-guard-alive.test.mjs
+++ b/scripts/harness/__tests__/worktree-guard-alive.test.mjs
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -59,10 +59,14 @@ function repoWithWorktree() {
     path.join(HOOKS_DIR, 'worktree-cwd-guard.sh'),
     path.join(hooks, 'worktree-cwd-guard.sh'),
   );
-  copyFileSync(
-    path.join(HOOKS_DIR, 'lib/command-scan.sh'),
-    path.join(hooks, 'lib/command-scan.sh'),
-  );
+  // EVERY library, enumerated rather than named. Listing `command-scan.sh` by hand meant that the
+  // moment the hook sourced a second library (INFRA-077's `hook-facts.sh`) this fixture built a
+  // worktree whose hook could not start, and the three cases below failed on a missing file rather
+  // than on anything they assert. The fixture's job is "the hook and the library it sources", so it
+  // reads the library directory instead of restating its contents.
+  for (const lib of readdirSync(path.join(HOOKS_DIR, 'lib')).filter((n) => n.endsWith('.sh'))) {
+    copyFileSync(path.join(HOOKS_DIR, 'lib', lib), path.join(hooks, 'lib', lib));
+  }
 
   return { main, worktree, hook: path.join(hooks, 'worktree-cwd-guard.sh') };
 }


### PR DESCRIPTION
Closes #1551

An audit ran every hook in `.claude/hooks/` against scratch repositories and found five facts
computed by separate code in two or more hooks, with the copies giving **different answers**. Each
disagreement was reachable from an ordinary command, and none of them was visible to the suite: no
test set `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_PREFIX` for any hook invocation, none ran a
hook with `jq` absent, and none fed an escaped or backslashed path.

The five facts now live in one place — `.claude/hooks/lib/hook-facts.sh`, a **sibling** of
`lib/command-scan.sh` rather than an extension of it. `command-scan.sh` owns what a payload SAYS
(the command, the tool name, which part of it is a command rather than text); the new file owns what
the ENVIRONMENT says. `command-scan.sh` is unchanged.

## The five facts

### 1. the payload's `file_path` → `hook_file_path_of`

`post-tool-format` and `memory-mirror-reminder` scraped it with `grep -o '"file_path"…"[^"]*"'`,
which stops at the first **escaped** quote. `check-forbidden-patterns` had it right and is routed
through the same function so the reader has one owner rather than one-plus-a-copy.

Red before the fix:

```
× forwards a path whose name contains an escaped quote
  → expected '' to contain '/tmp/hook-facts-fmt-s00Su7/we"ird.md'
× forwards a path whose name contains a backslash
  → expected '' to contain '/tmp/hook-facts-fmt-mOdvqb/back\slash.md'
× leaves no hook hand-rolling a file_path grep
  → ["memory-mirror-reminder.sh", "post-tool-format.sh"]
```

The file exists on disk in both cases; the truncated path does not, so the hook exited at its `-f`
test and the file was **silently** never formatted — exit 0 either way, which is why nothing noticed.
An ordinary path is asserted as a control so a green run cannot mean the probe never ran.

### 2. reading a JSON field at all → `hook_json_string` / `hook_prompt_of` / `hook_json_object`

`correction-detect`, `revert-detect` and `spec-first-gate` each carried an identical `read_json()`
that calls jq with no python3 fallback, while the Bash guards fall back. `eval-log-stop` carried no
`read_json()` at all and did the same thing with a bare `jq -r`.

Red before the fix, on a PATH farm from which jq is **genuinely absent** (a symlink farm, not a
failing shim — a present-but-broken tool exercises a path a tool-less host never takes):

```
× spec-first-gate still injects the SPEC-GATE reminder without jq
  → expected '' to contain 'SPEC-GATE'
× correction-detect still records a correction without jq
  → ENOENT: no such file or directory, open '…/local-metrics/corrections.jsonl'
× eval-log-stop still records a session without jq
  → SyntaxError: Unexpected end of JSON input
× leaves no hook reading a payload field with a bare jq call
  → ["correction-detect.sh", "revert-detect.sh", "spec-first-gate.sh"]
```

Repairing only the read would not have been enough: **four** hooks also **wrote** their record with
`jq -cn`, so the metric would have stayed empty. `hook_json_object` gives the writers the same
jq → python3 → refuse ladder, and refuses a number that is not a number rather than coercing it.

The fourth writer, `check-forbidden-patterns`, is the one where losing the record is worst — it
**refuses the edit either way**, so on a host without jq the refusal happened and the evidence for it
did not. A block nobody can count is a block nobody can review.

```
× check-forbidden-patterns still records the block it just made, without jq
  → SyntaxError: Unexpected end of JSON input
```

#### the reader rule: decided, and one rule (review round 3)

The reviewer found that `hook_prompt_of` falls through on an EMPTY value where the
`.prompt // .user_prompt // .message` it replaced did not — jq's `//` yields its left operand
whenever that operand is neither `null` nor `false`, and an empty string is truthy in jq. The one
payload that tells the rules apart is `{"prompt": "", "user_prompt": "hello"}`.

**Decided: keep the fall-through — "the first key that carries TEXT."** Two reasons a reader can
check rather than take on trust:

- `hook_json_string` **cannot express** jq's distinction. Measured on both arms, it returns `""` with
  exit 0 for an absent key and a present-but-empty one alike. Matching `//` exactly would mean adding
  a presence-distinguishing reader whose only consumer is a shape no host emits — the three keys are
  three *spellings of one fact*, so a real event carries one of them.
- Of the two rules, this is the one that never goes blind on text that is plainly present in the
  payload. Going silently blind is the failure this whole change exists to remove, so where the rules
  differ, that is the tie-breaker.

Pinned by a test with that payload written out beside the reason, so the decision cannot drift back.

**Checking the sibling readers found something worse than the finding, and squarely on this PR's own
subject: `hook_json_string`'s TWO ARMS DISAGREE WITH EACH OTHER** on a field that is not a string.

```
× reads a prompt to the same answer whether or not jq is installed
AssertionError: expected '{\n  "role": "user",\n  "content": "h…' to be ''

- Expected
+ Received

+ {
+   "role": "user",
+   "content": "hello"
+ }
```

On `{"message": {"role": "user", "content": "hello"}}` — the ordinary transcript shape, not an exotic
one — `jq -r` prints the object's pretty-printed JSON and the python3 arm writes `""`. Same payload,
same function, two answers depending on which tool the host happens to have. `correction-detect`
would have grepped that blob for correction keywords and logged it as `prompt_excerpt`;
`spec-first-gate` would have scanned it for implementation intent. The same held for `file_path`:

```
× reads a file_path to the same answer whether or not jq is installed
AssertionError: expected '123' to be ''
```

So every text field this directory reads now goes through **`hook_json_text`**, which returns a value
only when the node is a JSON string and whose two arms agree — `prompt`, `file_path`, `session_id`,
`transcript_path`. One rule, not one per function.

### 3. which repository the command acts on → `hook_effective_repo`, three named modes

Four resolutions under two rules. **The consolidation is a decision, not a merge** — the two
deliberate divergences survive as named modes, each carrying the measurement behind it:

| mode | callers | why it exists |
| --- | --- | --- |
| `validated` | `branch-guard`, `pre-push-check` | they must name SOME repository, because their verdict is about the branch it is on |
| `first-nonempty` | `worktree-cwd-guard` | its **fail-safe**: it blocks only on POSITIVE confirmation, so naming an unresolvable `-C` target and declining to block is correct. Validating would retarget it at the session repository and block a destructive command aimed elsewhere. No `.` fallback, because that fallback once resolved to the hook's OWN checkout and blocked there |
| `session` | `branch-guard`'s `BASE_DIR` | `git -C` **deliberately ignored**: a branch lands where the session is, and in a compound command the `-C` usually belongs to some other invocation |

Red before the fix (the library did not exist, so the contract could not be exercised at all, and
the hook-level case measured the consequence):

```
× the validated mode rejects a git -C target that is not a work tree
  → expected '' to be '/tmp/hook-facts-repo-j2CL8A/session'
× the validated mode is not fooled by an ambient GIT_DIR
  → expected '' to be '/tmp/hook-facts-repo-qiRwrz/session'
× the first-nonempty mode keeps worktree-cwd-guard fail-safe
  → expected '' to be '/no/such/dir'
× the session mode ignores git -C
  → expected '' to be '/tmp/hook-facts-repo-hUU2cp/session'
× branch-guard judges the session repository when the -C target is not a repository
  → expected +0 to be 2        (a commit on main, waved through)
× leaves no hook hand-rolling the work-tree validation ladder
  → ["branch-guard.sh", "pre-push-check.sh"]
```

The validating ladder validated with a **bare** `git -C`, and `git -C <any existing dir> rev-parse
--is-inside-work-tree` exits 0 whenever `GIT_DIR` is exported — so the guard adopted a directory
that is not a repository as the repository it judged.

`branch-guard` also **fails closed** now. With nothing resolvable to a repository the branch came
back empty, an empty branch matched no protected name, and the hook exited 0 — "I could not verify"
wearing the costume of "I verified this is fine". A detached HEAD is deliberately not that case and
is pinned beside the refusal so it cannot be swallowed later:

```
× branch-guard refuses a commit when no repository can be read at all
  → expected +0 to be 2
✓ branch-guard still falls through on a detached HEAD, which is readable and nameless
```

#### the same fact, unfixed in the hook next door (review round 2)

`pre-push-check` took the identical `validated` resolution and the identical branch reader in that
same commit and did **not** get the refusal — a fact fixed in one hook and not in the one beside it,
which is the failure this whole PR exists to end. `CUR_BRANCH` comes back `""` for a detached HEAD
**and** for "not a repository at all", and the `""` arm of its hygiene switch — written for the
first — silently skipped the foreign-merge check for the second.

Measured, and this is the part worth reading:

```
× pre-push-check refuses a push when no repository can be read at all
AssertionError: expected '[pre-push-check] Blocked: pnpm-lock.y…' to contain 'no git repository'

- Expected
+ Received

- no git repository
+ [pre-push-check] Blocked: pnpm-lock.yaml has uncommitted changes. Commit the lockfile before pushing.
```

**The push was stopped for a reason that was not the reason.** The lockfile check refused because
`git diff` cannot run outside a repository, so the hook did not wave the push through — it named
`pnpm-lock.yaml` while the branch-hygiene check it had just skipped was the thing that could not be
run. A guard that refuses for the wrong reason is not a guard that happened to be right anyway: the
next person fixes the lockfile, re-runs, and gets the same refusal with the same wrong cause.

Both guards now answer the same question in the same words, and the detached-HEAD pass-through is
pinned beside the refusal — this hook has its own considered answer for a detached HEAD further
down, and the new refusal must not reach it first:

```
✓ pre-push-check still falls through on a detached HEAD, which is readable and nameless
```

### 4. the current branch → `hook_current_branch`, default on the VALUE

`git branch --show-current` exits 0 and prints **nothing** on a detached HEAD, so every
`$(… || echo unknown)` in this directory was dead code.

Red before the fix:

```
× applies the caller-named default when the value is empty        → expected '' to be 'unknown'
× lets a caller ask for the empty value                           → expected '' to be '[]'
× eval-log-stop records a named branch for a detached session     → expected '' not to be ''
```

The default is the **caller's** to name, because callers need different ones: `eval-log-stop` wants a
word a reader of the log can see, while `branch-guard` and `pre-push-check` key on emptiness to
recognise a detached HEAD and must be able to ask for `""`. A reader that imposed a word would have
silently disabled both of those checks.

### 5. git invoked with a scrubbed environment → `hook_git` / `hook_git_in`

`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` and `GIT_PREFIX` outrank `-C`. Two hooks knew that and
scrubbed them through a `git_project()` copied byte-for-byte between them; the guards carried about
twenty bare `git -C` call sites instead.

Red before the fix:

```
× branch-guard still refuses a commit on main when GIT_DIR names another repository
  → expected +0 to be 2
× branch-guard still refuses a push on main when GIT_INDEX_FILE and GIT_PREFIX are exported
  → expected +0 to be 2
× worktree-cwd-guard still sees the MAIN checkout when GIT_DIR names a worktree
  → expected +0 to be 2
× leaves no hook calling git without the scrub
  → ["branch-guard.sh", "eval-log-stop.sh", "pre-push-check.sh", "revert-detect.sh",
     "worktree-cwd-guard.sh"]
```

With `GIT_DIR` exported at a second checkout, `git -C <this repo> branch --show-current` returns the
**second** checkout's branch — enough to walk a `git commit` on `main`, and a `git push origin main`,
straight past the guard that exists to refuse them. These variables are exported by ordinary things
(git hooks, `git rebase -x`, tooling that shells out mid-operation), so this is not an exotic state.

## Stated limits

- **`hook_json_string`'s arm disagreement is not fixed here, only routed around.** That function
  lives in `lib/command-scan.sh`, which this PR deliberately does not touch, so the disagreement
  above is still reachable through any *other* caller of it — including `hook_command_of`,
  `hook_tool_name_of` and `hook_cwd_of`. Every reader this PR owns now goes through `hook_json_text`
  instead, and the reason is written at that function. **Worth a follow-up item for whoever owns
  `command-scan.sh` next**; I did not want to edit that file underneath #1565.
- The transcript queries in `correction-detect` and `revert-detect`, and the per-session counts in
  `eval-log-stop`, stay on jq. They are jq **programs** over JSONL files, not payload field reads, so
  without jq those hooks are degraded rather than silent — the distinction the payload read got wrong.
- `hook_effective_repo session` judges `git -C <other> checkout -b` against the session repository.
  That over-permits a rare form instead of refusing a common one, and is the pre-existing choice
  being preserved rather than a new one.

## Verification

Rebased onto `origin/develop` at #1565, which also carries #1559, #1564, #1567 and #1568.

- `npx vitest run scripts/harness/__tests__/ --reporter=basic` → **2084 passed / 2084**, no failures.
- `pnpm harness:pre-push` → **green**, end to end, with no `--no-verify`.
- `pnpm harness:scan` → **all 84 scans passed**.
- `bash -n` green on all 12 hooks and both libraries, after every edit.
- 32 cases in `scripts/harness/__tests__/hook-facts.test.mjs`. Two are deliberate controls (the
  formatter shim is wired, and the PATH farm really does hide jq while keeping python3), so a green
  run cannot mean the probe never ran.
- **`check-regression-red-proof` (post-#1568, call-graph relation) → 11 of 11 hooks `red-proof-ok`,
  none inconclusive.** Its first run after the rebase named three hooks this PR changed that no
  changed test *spawned* — `check-forbidden-patterns`, `memory-mirror-reminder`, `revert-detect`. On
  a PR about enforcement being reached, that gap is the subject, so each got a case that executes it;
  one of the three was genuinely red and produced the fourth-writer fix above.
- #1559 rewrote `branch-guard`'s override handling and #1565 replaced `command-scan.sh` with a stack
  tokenizer (502 → 771 lines) — both underneath this PR's own call sites. Every case here was re-run
  after each rebase, including the `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_PREFIX`
  cases whose verb reading now comes from the tokenizer, and all are green.

## One file touched outside the stated ownership

`scripts/harness/__tests__/worktree-guard-alive.test.mjs` hand-assembles a hook directory inside the
linked worktree it builds, naming `lib/command-scan.sh` by hand. The moment the hook sourced a second
library, that fixture produced a worktree whose hook could not start and all three of its cases
failed on a missing file rather than on anything they assert. It enumerates the library directory
now, which is what its own comment already promised: "the hook and the library it sources".

#1567 landed underneath this and gave the same file a `hooksOutsideAWorktree()` helper that copies
`.claude/hooks/` recursively. Verified rather than assumed that the helper's copy carries the second
library, and that the fixture's enumeration then picks it up from that copy:

```
helper copy lib/ contents: command-scan.sh, hook-facts.sh
hook-facts.sh present in helper copy: true
fixture loop would copy: command-scan.sh, hook-facts.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso


