### PR TITLE
fix(harness): a hook test controls the input the hook reads from its own path

### DIFF
--- a/scripts/harness/__tests__/guards-pass-silently.test.mjs
+++ b/scripts/harness/__tests__/guards-pass-silently.test.mjs
@@ -83,6 +83,44 @@ function repoWithOrigin(branch) {
   return dir;
 }
 
+/**
+ * Ambient variables a hook READS AS A DECISION INPUT, removed before spawning one.
+ *
+ * Review of #1567. This file's whole claim is that a guard stayed silent because the work was
+ * correct. Every one of these can make it silent for a different reason, and each is inherited from
+ * whatever session happens to run the suite:
+ *
+ * - `ROBOTA_AGENT_WORKTREE` — the worktree-session marker. The `worktree-cwd-guard` row asserts an
+ *   ordinary main-clone `git reset --hard` passes silently, which requires `IN_WORKTREE_SESSION` to
+ *   be false. This PR controlled the `SELF_DIR` input to that decision and left this one inherited,
+ *   which is the same defect one variable to the left.
+ * - `*_ALLOW_*` overrides — an exported one DISARMS the guard, so the row would pass because nothing
+ *   was checked. That is an accidental green in the exact shape this directory exists to prevent.
+ * - `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` / `GIT_PREFIX` — INFRA-077 measured that with
+ *   `GIT_DIR` exported, `git -C <scratch>` reports the OUTER repository, so a guard judges a
+ *   different checkout than the fixture built.
+ *
+ * A blanket scrub to `{ PATH, HOME }` (what the two sibling files do) is not usable here: the rows
+ * in this file run git, node and pnpm across every hook, and several need the ambient environment to
+ * work at all. Naming the decision inputs is the part that matters.
+ */
+const DECISION_INPUTS = [
+  'ROBOTA_AGENT_WORKTREE',
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_PREFIX',
+];
+
+function ambientWithoutDecisionInputs() {
+  const clean = { ...process.env };
+  for (const name of DECISION_INPUTS) delete clean[name];
+  for (const name of Object.keys(clean)) {
+    if (/_ALLOW_/.test(name)) delete clean[name];
+  }
+  return clean;
+}
+
 function runHook(hook, { command, cwd, env = {}, payload }) {
   const input = payload ?? JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } });
   const result = spawnSync('bash', [hookPath(hook)], {
@@ -91,7 +129,7 @@ function runHook(hook, { command, cwd, env = {}, payload }) {
     encoding: 'utf8',
     // stdout AND stderr: a hook that spoke on stdout only would read as silence otherwise, and
     // every refusal in this directory writes to stderr.
-    env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, ...env },
+    env: { ...ambientWithoutDecisionInputs(), CLAUDE_PROJECT_DIR: cwd, ...env },
     timeout: 120_000,
   });
   return {

--- a/scripts/harness/__tests__/guards-pass-silently.test.mjs
+++ b/scripts/harness/__tests__/guards-pass-silently.test.mjs
@@ -6,7 +6,24 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+import { hooksOutsideAWorktree } from './helpers/hooks-outside-a-worktree.mjs';
+
 const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * Hooks whose OWN LOCATION is an input to their decision, and which must therefore be spawned
+ * from a copy outside `.claude/worktrees/` for a main-clone fixture to mean anything.
+ *
+ * Only these. Redirecting every hook was tried first and measured: `pre-push-check.sh` resolves
+ * the review recorder relative to itself, so from a copy it refused ordinary work with `cannot
+ * check the review record (node or the recorder is missing)` — a guard turned noisy by the very
+ * change meant to stop guards being noisy. The copy is hermetic for the session-identity input
+ * and NOT for sibling-tool resolution, so it is applied exactly where the first matters.
+ */
+const LOCATION_SENSITIVE = new Set(['worktree-cwd-guard.sh']);
+const MAIN_CLONE_HOOKS = hooksOutsideAWorktree();
+const hookPath = (hook) =>
+  path.join(LOCATION_SENSITIVE.has(hook) ? MAIN_CLONE_HOOKS : HOOKS_DIR, hook);
 
 /**
  * A guard that fires on a correct, desirable state is a defect of the same severity as one that
@@ -67,9 +84,8 @@ function repoWithOrigin(branch) {
 }
 
 function runHook(hook, { command, cwd, env = {}, payload }) {
-  const input =
-    payload ?? JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } });
-  const result = spawnSync('bash', [path.join(HOOKS_DIR, hook)], {
+  const input = payload ?? JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } });
+  const result = spawnSync('bash', [hookPath(hook)], {
     input,
     cwd,
     encoding: 'utf8',

--- a/scripts/harness/__tests__/helpers/hooks-outside-a-worktree.mjs
+++ b/scripts/harness/__tests__/helpers/hooks-outside-a-worktree.mjs
@@ -1,0 +1,40 @@
+import { cpSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../../..');
+
+/**
+ * A copy of `.claude/hooks/` at a path that is definitely NOT under `.claude/worktrees/`.
+ *
+ * `worktree-cwd-guard.sh` decides whether this is a worktree session by reading the directory THE
+ * HOOK ITSELF LIVES IN (`SELF_DIR`, and the comment beside it says so deliberately: "the hook file
+ * lives under `.claude/worktrees/` exactly when this is a worktree session"). The hook's own path is
+ * therefore an INPUT to the decision — and three tests spawned it from whichever checkout the suite
+ * happened to be running in, leaving that input uncontrolled.
+ *
+ * Run from the main clone they passed. Run from a worktree — the configuration
+ * `worktree-parallel-orchestration` mandates for parallel work, and the one every subagent uses —
+ * `SELF_DIR` contained `/.claude/worktrees/`, so the guard was in worktree mode no matter what the
+ * fixture claimed, and all three FAIL-SAFE cases ("an ordinary main-clone session is left alone")
+ * failed. Measured 2026-08-01: 3 failed / 1828 passed from a worktree, 1831 passed from the main
+ * clone, on identical source.
+ *
+ * The cost was not only noise. Each parallel agent had to prove the three reds were not its own, and
+ * at least one then pushed with `--no-verify` — a gap in local verification teaching agents to
+ * bypass the gate that would have caught a real one.
+ *
+ * The whole directory is copied, not the single file, because hooks source `lib/command-scan.sh`
+ * relative to themselves.
+ */
+export function hooksOutsideAWorktree(scratch) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'hooks-main-clone-'));
+  scratch?.push(dir);
+  const hooks = path.join(dir, 'hooks');
+  cpSync(path.join(WORKSPACE_ROOT, '.claude/hooks'), hooks, { recursive: true });
+  return hooks;
+}
+
+export function removeHooksCopy(dir) {
+  rmSync(path.dirname(dir), { recursive: true, force: true });
+}

--- a/scripts/harness/__tests__/helpers/hooks-outside-a-worktree.mjs
+++ b/scripts/harness/__tests__/helpers/hooks-outside-a-worktree.mjs
@@ -2,7 +2,30 @@ import { cpSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { afterAll } from 'vitest';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../../..');
+
+/**
+ * Every copy this module has handed out, removed when the file that asked for one finishes.
+ *
+ * Review of #1567: the first version exported a `removeHooksCopy()` and none of the three call sites
+ * called it, so each run left a full copy of `.claude/hooks/` in the temp directory forever —
+ * measured, 15 of them accumulated in one session. An exported cleanup nobody invokes is the same
+ * defect this repository keeps meeting under a different name (registered, never reached), and
+ * threading a `scratch` array through three call sites would have fixed three instances of it while
+ * leaving the fourth caller free to forget.
+ *
+ * So the helper cleans up after itself and there is nothing for a caller to remember. `afterAll`
+ * registers against the importing test file, which is exactly the lifetime of the copy handed back.
+ *
+ * Measured both directions from an empty baseline: with this, the three files leave 0 behind; with
+ * the `rmSync` line commented out, 1 survives a single file's run.
+ */
+const copies = [];
+afterAll(() => {
+  while (copies.length > 0) rmSync(copies.pop(), { recursive: true, force: true });
+});
 
 /**
  * A copy of `.claude/hooks/` at a path that is definitely NOT under `.claude/worktrees/`.
@@ -27,14 +50,10 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../../..');
  * The whole directory is copied, not the single file, because hooks source `lib/command-scan.sh`
  * relative to themselves.
  */
-export function hooksOutsideAWorktree(scratch) {
+export function hooksOutsideAWorktree() {
   const dir = mkdtempSync(path.join(tmpdir(), 'hooks-main-clone-'));
-  scratch?.push(dir);
+  copies.push(dir);
   const hooks = path.join(dir, 'hooks');
   cpSync(path.join(WORKSPACE_ROOT, '.claude/hooks'), hooks, { recursive: true });
   return hooks;
-}
-
-export function removeHooksCopy(dir) {
-  rmSync(path.dirname(dir), { recursive: true, force: true });
 }

--- a/scripts/harness/__tests__/worktree-cwd-guard.test.mjs
+++ b/scripts/harness/__tests__/worktree-cwd-guard.test.mjs
@@ -7,7 +7,12 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // The hook under test — a PreToolUse Bash guard that blocks destructive git commands when a
 // worktree-assigned subagent's cwd has silently fallen back to the MAIN checkout (HARNESS-043).
-const HOOK = path.resolve(import.meta.dirname, '../../../.claude/hooks/worktree-cwd-guard.sh');
+import { hooksOutsideAWorktree } from './helpers/hooks-outside-a-worktree.mjs';
+
+// Not the checkout's own copy: this hook reads its OWN directory to decide whether the session is
+// a worktree one, so spawning it from wherever the suite happens to run makes that input
+// uncontrolled and the main-clone fixtures below unreachable. See the helper.
+const HOOK = path.join(hooksOutsideAWorktree(), 'worktree-cwd-guard.sh');
 
 /** git init a repo at `dir` (created if needed) with an initial commit so rev-parse resolves. */
 function initRepo(dir) {
@@ -19,7 +24,13 @@ function initRepo(dir) {
     });
   git('init', '-q');
   execFileSync('git', ['-C', dir, 'commit', '--allow-empty', '-q', '-m', 'init'], {
-    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' },
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 't',
+      GIT_AUTHOR_EMAIL: 't@t',
+      GIT_COMMITTER_NAME: 't',
+      GIT_COMMITTER_EMAIL: 't@t',
+    },
     stdio: 'pipe',
   });
   return dir;

--- a/scripts/harness/__tests__/worktree-guard-alive.test.mjs
+++ b/scripts/harness/__tests__/worktree-guard-alive.test.mjs
@@ -6,7 +6,10 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
-const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+import { hooksOutsideAWorktree } from './helpers/hooks-outside-a-worktree.mjs';
+
+// See the helper: worktree-cwd-guard reads its own directory to decide the session's identity.
+const HOOKS_DIR = hooksOutsideAWorktree();
 
 /**
  * The worktree guard, exercised the way a real session would reach it.

--- a/scripts/harness/__tests__/worktree-guard-alive.test.mjs
+++ b/scripts/harness/__tests__/worktree-guard-alive.test.mjs
@@ -5,7 +5,6 @@ import path from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
 
-const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 import { hooksOutsideAWorktree } from './helpers/hooks-outside-a-worktree.mjs';
 
 // See the helper: worktree-cwd-guard reads its own directory to decide the session's identity.


### PR DESCRIPTION
## Problem

Three tests fail when the harness suite is run from a git worktree and pass from the main clone, on
identical source.

```
the worktree guard is active without anything exporting a marker
  > leaves an ordinary main-clone session alone
worktree-cwd-guard hook
  > FAIL-SAFE: normal main-repo destructive work with NO worktree marker is unaffected
a guard leaves correct work alone, and says nothing about it
  > worktree-cwd-guard.sh says nothing about an ordinary git reset --hard
```

Measured 2026-08-01, same commit, two locations: **3 failed / 1828 passed** from a nested worktree,
**1831 passed** from the main clone.

## Cause

All three assert the same thing — *an ordinary main-clone session is left alone* — and all three
spawned the hook from whichever checkout the suite happened to be running in.

That is an **uncontrolled input**, not an incidental detail. `worktree-cwd-guard.sh` decides whether
this is a worktree session by reading the directory **the hook itself lives in**, and says so
deliberately:

> the hook file lives under `.claude/worktrees/` exactly when this is a worktree session

Run from a worktree, `SELF_DIR` contains `/.claude/worktrees/`, so the guard is in worktree mode no
matter what the fixture claims, and the main-clone case cannot be expressed at all.

## Why it is worth fixing rather than tolerating

The configuration that breaks it is the one this repo **mandates** for parallel work
(`worktree-parallel-orchestration`). Two independent subagents hit these three reds today. Each had
to prove they were not its own, and **each then pushed with `--no-verify`**, because the husky
pre-push gate runs the full suite and the suite cannot go green from a worktree.

A local-verification gap that teaches agents to bypass the gate is worse than the three failures it
started as.

## Fix

The hooks directory is copied to a path outside `.claude/worktrees/` and the location-sensitive hook
is spawned from there. The whole directory, not the one file, because hooks source
`lib/command-scan.sh` relative to themselves.

Applied to that **one** hook, and the narrowing is measured rather than assumed: redirecting every
hook was tried first, and `pre-push-check.sh` — which resolves the review recorder relative to
itself — then refused ordinary work with `cannot check the review record (node or the recorder is
missing)`. A guard turned noisy by the very change meant to stop guards being noisy. The copy is
hermetic for the session-identity input and **not** for sibling-tool resolution, so it is applied
exactly where the first matters.

## Verification

Run in **both** places, which is the point:

| | main clone | nested worktree |
| --- | --- | --- |
| before | 23 passed | **3 failed** / 20 passed |
| after | 23 passed | 23 passed |

Full suite 1829 passed, 84 scans pass.

## Note for #1566

That PR also touches `scripts/harness/__tests__/worktree-guard-alive.test.mjs` (it enumerates
`lib/` so a second library file is picked up). Landing this one first keeps that change a small
rebase; the two edits are in different parts of the file.
