### PR TITLE
fix(harness): the spawn relation reads the call graph instead of two independent greps

### DIFF
--- a/.agents/backlog/INFRA-073-one-verdict-for-an-aggregate.md
+++ b/.agents/backlog/INFRA-073-one-verdict-for-an-aggregate.md
@@ -40,8 +40,9 @@ The gate judges an **aggregate** and reports a **scalar**. Any pass hides inside
 granularity complaint against this gate is the same statement at a different level:
 
 - **This item** — subject-level vs source-file-level, for the code under test.
-- **[INFRA-072](INFRA-072-a-test-that-does-not-reach-what-it-names.md)** — file-level vs case-level,
-  for the tests doing the proving.
+- **[INFRA-072](completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md)** — file-level vs
+  case-level, for the tests doing the proving. Decided 2026-08-01: per-case granularity, which
+  closes the masking half only.
 
 They should be decided together, because a fix that splits one and not the other leaves the same
 shape one level down.

--- a/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
+++ b/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
@@ -1,11 +1,12 @@
 ---
 title: 'INFRA-072: a test that passes without reaching the behavior it names'
-status: todo
+status: done
 priority: high
 urgency: next
 type: INFRA
 area: scripts/harness
 created: 2026-07-31
+completed: 2026-08-01
 depends_on: [INFRA-071]
 issue: https://github.com/woojubb/robota/issues/1537
 ---
@@ -61,3 +62,43 @@ behavior rather than in the abstract.
   check, demonstrated by replaying at least one of the four above.
 - The check distinguishes "this case reached the behavior" from "this file contains some case that
   failed", since the second is what already passes today.
+
+## Decision (2026-08-01) — direction 1, and what it does not reach
+
+INFRA-071 has produced verdicts and INFRA-073 has landed, so the choice is made against measured
+behaviour rather than in the abstract. **Direction 1 (per-case granularity) is implemented.**
+
+A changed test file's diff is read for the case titles the range ADDED, and at least one of those
+must fail on the reversed source. A case that fails while every case the range added passes is no
+longer a proof: the outcome is `added-cases-pass` and the verdict is `accidental-green-fail`. A range
+that adds no title this can read — a regression fixed by EDITING an existing case — keeps FILE
+granularity, because demanding a new title there would fail correct work.
+
+Directions 2 and 3 are NOT taken, and the reason is that both need a way to name a branch inside a
+`bash` hook. Neither is closed by this item; whoever picks one up should read the four rows below
+first, because they are what a stronger check would have to reach.
+
+### The four motivating cases, judged against what landed
+
+| Case | Caught? | Why |
+| --- | --- | --- |
+| `hooks-have-execution-coverage` | **no** | the logic under test is IN the test file, so there is no source to reverse and no pair to judge. Per-case granularity operates inside a verdict this case never reaches. |
+| `remaining-hooks-run` (two hooks) | **no** | the hooks it names were not changed in the range, so no pair exists. INFRA-074's relation now says so precisely instead of approximately, but "no pair" is still no verdict. |
+| `remaining-hooks-run` (extension) | **no** | it fails reversed for the wrong reason — it crashes before reaching the filter. The gate reads pass/fail and cannot read WHY. This is direction 2/3 territory. |
+| `remaining-hooks-run` (unset var) | **partly** | it asserts an exit code both paths share, so it passes reversed. It is caught when it is the range's own added case and the file's red comes from a pre-existing case — the masking measured on `2ac10f251..b1f46acf3`. It is NOT caught when a genuine added case fails beside it, because requiring EVERY added case to fail would fail correct work: a range that adds three cases for one fix does not make all three depend on it. |
+
+So direction 1 closes the masking half and nothing else, which is what the item said it would. The
+remaining half — a case that fails for the wrong reason, or passes beside a genuine sibling — needs
+the branch-level or coverage-delta work, and stays open as a separate decision.
+
+## GATE-COMPLETE (2026-08-01)
+
+- `addedCaseTitleMatchers` reads titles off ADDED diff lines only; a context line and a REMOVED line
+  are excluded, pinned by a case that would otherwise hand the verdict back to the pre-existing case
+  the granularity exists to exclude.
+- The table form `it.each(rows)(...)` with an interpolated title is read: the interpolations become
+  wildcards, so a wider match is a weaker check rather than a wrong verdict.
+- Through the orchestrator: a vacuous new case beside an old failing one now reports
+  `accidental-green-fail (added-cases-pass)` where it previously reported `red-proof-ok`.
+- C1 is preserved: a sibling file that failed to collect still outranks a passing added case, so the
+  verdict is INCONCLUSIVE and never a false accidental-green.

--- a/.agents/backlog/completed/INFRA-074-the-spawn-relation-is-not-tied-to-its-argument.md
+++ b/.agents/backlog/completed/INFRA-074-the-spawn-relation-is-not-tied-to-its-argument.md
@@ -1,11 +1,12 @@
 ---
 title: 'INFRA-074: the spawn relation names a hook and spawns a shell, without tying one to the other'
-status: todo
+status: done
 priority: high
 urgency: soon
 type: INFRA
 area: scripts/harness
 created: 2026-07-31
+completed: 2026-08-01
 depends_on: []
 issue: https://github.com/woojubb/robota/issues/1540
 ---
@@ -57,3 +58,48 @@ verdicts start deciding merges.
   could not and returns INCONCLUSIVE instead of guessing.
 - A test naming one hook while spawning another is not counted as executing the first, proven by a
   case that fails on today's implementation.
+
+## GATE-COMPLETE (2026-08-01)
+
+Resolved by reading the call graph, in `scripts/harness/lib/spawn-call-graph.mjs`.
+
+**Red first.** The misclassification case — a module that names `branch-guard.sh` in real code while
+spawning `worktree-cwd-guard.sh` — was written and run against the pre-fix relation:
+
+```
+FAIL  check-regression-red-proof.test.mjs > a test that NAMES one hook while spawning another
+AssertionError: a bystander that never ran this hook was counted as executing it:
+expected true to be false
+```
+
+**What the relation does now.** It parses the module, finds the spawn calls by their `child_process`
+IMPORT BINDING (so a `spawnSync('bash', …)` inside a string literal is not one), and resolves the
+expression in ARGV SCRIPT POSITION back through the module's own bindings — literals, template and
+`+` concatenation, `path.join`/`path.resolve` under either spelling, `const` initialisers, object and
+array literals, `for…of` element bindings, destructuring, local function return values, and a
+PARAMETER by unioning the arguments at every call site of its function. That last one is the case a
+narrower text pattern could not reach: `run('some-hook.sh', …)` where `run` joins it.
+
+**Three answers, never a guess.** A target that cannot be pinned — a path built from `readdirSync()`
+— answers UNDETERMINED. The red-proof gate refuses to let an UNDETERMINED test decide and says so in
+the verdict; the coverage floor counts only a resolved execution and names the unresolved files in
+its message, because counting a directory sweep as coverage would satisfy that floor for every hook
+at once.
+
+**Measured over the whole tree** (120 harness test files × 12 hooks = 1440 pairs):
+
+| | claimed `executes` | `undetermined` |
+| --- | --- | --- |
+| before | 28 | — (no such answer) |
+| after | 27 | 32 |
+
+The one dropped pair is the defect: `check-regression-red-proof.test.mjs` → `branch-guard.sh`, a file
+that imports no `child_process` at all and whose every `spawnSync('bash'` sits inside a fixture
+STRING. No true pair was lost — the other 27 are unchanged. The 32 new UNDETERMINED pairs are three
+files that genuinely build their spawn target at runtime (`guards-fail-closed` sweeps the hooks
+directory, `hook-command-parsing` runs `bash -n` over every shell file it finds,
+`hook-reading-matches-bash` runs `bash -c` on a script it assembles). Every hook still has at least
+one RESOLVED runner, so the coverage floor stays green while getting strictly stricter.
+
+The containment note naming this item is removed from `testExecutesHook`. The gate remains ADVISORY;
+promoting it is INFRA-046's decision, not this one's.

--- a/.agents/memory/finding-depth-and-guard-properties.md
+++ b/.agents/memory/finding-depth-and-guard-properties.md
@@ -62,7 +62,8 @@ change, so nothing in the diff signals anything and review sees a reuse.
   twelve CI runs, zero verdicts, no error anyone saw.
 - `testExecutesHook` was grep-level for an advisory floor; reused to pick which tests may set a
   verdict, the same imprecision can decide a hook it never ran
-  ([INFRA-074](../backlog/INFRA-074-the-spawn-relation-is-not-tied-to-its-argument.md)).
+  ([INFRA-074](../backlog/completed/INFRA-074-the-spawn-relation-is-not-tied-to-its-argument.md),
+  resolved 2026-08-01 by reading the call graph rather than narrowing the text pattern).
 
 Floor: `scan-helper-limits`. `@limits` on the docblock is opt-in; acknowledging it at each importing
 module is not.

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -2,8 +2,11 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { EXECUTION } from '../lib/spawn-call-graph.mjs';
+
 import {
   VERDICT,
+  addedCaseTitleMatchers,
   classifyChanges,
   classifyVitestOutcome,
   decidePairVerdict,
@@ -21,8 +24,8 @@ import {
   testExecutesHook,
 } from '../check-regression-red-proof.mjs';
 
-// LIMITS testExecutesHook: they hold here — this file TESTS the relation, so its imprecision is
-// the subject rather than a dependency. Nothing here rides on the answer being exact.
+// LIMITS testExecutesHook: they hold here — this file TESTS the relation, so what it can and
+// cannot resolve is the subject rather than a dependency. Nothing here rides on the answer.
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const abs = (rel) => path.resolve(WORKSPACE_ROOT, rel);
@@ -83,24 +86,148 @@ describe('HARNESS-041 file classification', () => {
     // The relation that stands in for the import graph when the source is a shell script. A hook
     // named in a COMMENT is described, not run — the distinction this gate exists to make, and one
     // an earlier version of this same rule got wrong in the coverage floor beside it.
-    const spawns = "run('branch-guard.sh');\nspawnSync('bash', [hook]);";
-    const mentions = "// branch-guard.sh is discussed here\nspawnSync('bash', [other]);";
+    const spawns = [
+      "import { spawnSync } from 'node:child_process';",
+      "const hook = '.claude/hooks/branch-guard.sh';",
+      "spawnSync('bash', [hook]);",
+    ].join('\n');
+    const mentions = [
+      "import { spawnSync } from 'node:child_process';",
+      '// branch-guard.sh is discussed here',
+      "spawnSync('bash', ['.claude/hooks/merge-gate.sh']);",
+    ].join('\n');
     const noSpawn = "const p = 'branch-guard.sh';";
 
-    expect(testExecutesHook(spawns, '.claude/hooks/branch-guard.sh')).toBe(true);
-    expect(testExecutesHook(mentions, '.claude/hooks/branch-guard.sh')).toBe(false);
-    expect(testExecutesHook(noSpawn, '.claude/hooks/branch-guard.sh')).toBe(false);
+    expect(testExecutesHook(spawns, '.claude/hooks/branch-guard.sh')).toBe(EXECUTION.EXECUTES);
+    expect(testExecutesHook(mentions, '.claude/hooks/branch-guard.sh')).toBe(
+      EXECUTION.NOT_EXECUTED,
+    );
+    expect(testExecutesHook(noSpawn, '.claude/hooks/branch-guard.sh')).toBe(EXECUTION.NOT_EXECUTED);
 
-    // Both halves must read the same text. Stripping comments for the NAME while matching the
-    // spawn against the raw source lets a documented example — the hook named in real code, the
-    // spawn shown in a comment — count as execution. Since this now picks which tests may set the
-    // verdict, that bystander could decide a hook it never runs.
+    // A documented example — the hook named in real code, the spawn shown in a comment — is not an
+    // execution. The text relation needed both halves read from the same comment-stripped source to
+    // get this right; reading the call graph gets it right because a comment is not a call.
     const documented = [
       "const hook = 'branch-guard.sh';",
       "// e.g. spawnSync('bash', [hook])",
       'expect(hook).toBeTruthy();',
     ].join('\n');
-    expect(testExecutesHook(documented, '.claude/hooks/branch-guard.sh')).toBe(false);
+    expect(testExecutesHook(documented, '.claude/hooks/branch-guard.sh')).toBe(
+      EXECUTION.NOT_EXECUTED,
+    );
+  });
+
+  it('a test that NAMES one hook while spawning another does not execute the first (INFRA-074)', () => {
+    // The misclassification the relation was held for. The two halves were independent — the name
+    // had to appear, and the file had to spawn a shell — with nothing tying the spawn to the name.
+    // This file spawns `worktree-cwd-guard.sh` and only MENTIONS `branch-guard.sh` in a value it
+    // asserts on, so it can say nothing about `branch-guard.sh` at all.
+    //
+    // Recorded against the pre-fix relation, so the case is known to be red rather than assumed:
+    //   AssertionError: a bystander that never ran this hook was counted as executing it:
+    //   expected true to be false
+    const namesOneSpawnsAnother = [
+      "import { spawnSync } from 'node:child_process';",
+      "import path from 'node:path';",
+      "const REGISTERED = ['branch-guard.sh', 'worktree-cwd-guard.sh'];",
+      "const result = spawnSync('bash', [path.join(HOOKS_DIR, 'worktree-cwd-guard.sh')]);",
+      "expect(REGISTERED).toContain('branch-guard.sh');",
+    ].join('\n');
+
+    expect(
+      testExecutesHook(namesOneSpawnsAnother, '.claude/hooks/branch-guard.sh'),
+      'a bystander that never ran this hook was counted as executing it',
+    ).toBe(EXECUTION.NOT_EXECUTED);
+    expect(testExecutesHook(namesOneSpawnsAnother, '.claude/hooks/worktree-cwd-guard.sh')).toBe(
+      EXECUTION.EXECUTES,
+    );
+  });
+
+  it('follows the hook name THROUGH a helper that joins it (INFRA-074)', () => {
+    // Why a narrower text pattern was rejected on evidence rather than on taste: requiring the name
+    // inside a `path.join(...)` missed every test written this way, and these run the hook just as
+    // truly. The binding is the argument flowing into `run`, which only the call graph can follow.
+    const throughAHelper = [
+      "import { spawnSync } from 'node:child_process';",
+      "import path from 'node:path';",
+      'function run(hook, input) {',
+      "  return spawnSync('bash', [path.join(HOOKS_DIR, hook)], { input });",
+      '}',
+      "run('merge-gate.sh', payload);",
+    ].join('\n');
+
+    expect(testExecutesHook(throughAHelper, '.claude/hooks/merge-gate.sh')).toBe(
+      EXECUTION.EXECUTES,
+    );
+    expect(testExecutesHook(throughAHelper, '.claude/hooks/branch-guard.sh')).toBe(
+      EXECUTION.NOT_EXECUTED,
+    );
+  });
+
+  it('a spawn written inside a string literal is not a spawn (INFRA-074)', () => {
+    // This very file is the measured instance: it names `branch-guard.sh` and contains the text
+    // `spawnSync('bash'` in fixture STRINGS, and the old relation therefore counted it as running
+    // the hook. Resolution goes through the import binding and the AST, so quoted code is data.
+    const quotedOnly = [
+      "const spawns = \"run('branch-guard.sh');\\nspawnSync('bash', [hook]);\";",
+      'expect(spawns.length).toBeGreaterThan(0);',
+    ].join('\n');
+
+    expect(testExecutesHook(quotedOnly, '.claude/hooks/branch-guard.sh')).toBe(
+      EXECUTION.NOT_EXECUTED,
+    );
+  });
+
+  it('says UNDETERMINED when the spawn target is built at runtime, and never guesses', () => {
+    // The third answer, and the reason there is one. A sweep over the hooks directory really does
+    // run every hook, so answering "no" would fire this relation's consumers on correct work; but
+    // the file names nothing, so answering "yes" would hand a verdict to a case that states nothing
+    // about the hook. Both consumers get the ambiguity instead of a coin flip.
+    const dynamic = [
+      "import { spawnSync } from 'node:child_process';",
+      "import { readdirSync } from 'node:fs';",
+      "import path from 'node:path';",
+      'for (const name of readdirSync(HOOKS_DIR)) {',
+      "  spawnSync('bash', [path.join(HOOKS_DIR, name)], { input: '' });",
+      '}',
+    ].join('\n');
+
+    expect(testExecutesHook(dynamic, '.claude/hooks/branch-guard.sh')).toBe(EXECUTION.UNDETERMINED);
+
+    // And an argument vector that cannot reach a script raises no ambiguity at all: `git` does not
+    // run its arguments. Without that distinction every temp-directory argument in the suite made
+    // its file undetermined for every hook, which is the grep it replaced wearing a costume.
+    const gitOnly = [
+      "import { spawnSync } from 'node:child_process';",
+      "spawnSync('git', ['-C', someTempDir, 'status']);",
+    ].join('\n');
+
+    expect(testExecutesHook(gitOnly, '.claude/hooks/branch-guard.sh')).toBe(EXECUTION.NOT_EXECUTED);
+  });
+
+  it('reads the script out of ARGV POSITION, not out of any argument', () => {
+    // `bash -n <file>` names the file after a flag; `node run.mjs <tmpdir>` names it first and the
+    // rest belong to the script. Treating every element as a possible script made an unresolvable
+    // temp directory read as "might run anything" — measured at 331 undetermined pairs over the
+    // harness suite against 27 resolved ones.
+    const afterAFlag = [
+      "import { spawnSync } from 'node:child_process';",
+      "import path from 'node:path';",
+      "spawnSync('bash', ['-n', path.join(HOOKS_DIR, 'spec-first-gate.sh')]);",
+    ].join('\n');
+    const asAnArgumentToSomethingElse = [
+      "import { spawnSync } from 'node:child_process';",
+      "import path from 'node:path';",
+      "spawnSync('node', [path.join(HARNESS_DIR, 'scan-hook-registration.mjs'), 'spec-first-gate.sh']);",
+    ].join('\n');
+
+    expect(testExecutesHook(afterAFlag, '.claude/hooks/spec-first-gate.sh')).toBe(
+      EXECUTION.EXECUTES,
+    );
+    expect(
+      testExecutesHook(asAnArgumentToSomethingElse, '.claude/hooks/spec-first-gate.sh'),
+      'a name handed to a scanner AS DATA was read as the file that ran',
+    ).toBe(EXECUTION.NOT_EXECUTED);
   });
 
   it('isTestFile / isSourceFile split correctly', () => {
@@ -211,6 +338,155 @@ describe('HARNESS-041 vitest outcome classification (C1 — assertion-fail vs ru
       ],
     };
     expect(classifyVitestOutcome(json, [failing, brokeCollect])).toBe('assertion-fail');
+  });
+});
+
+describe('INFRA-072 per-case granularity — the range judges its OWN new cases', () => {
+  const testFile = 'packages/x/src/a.test.ts';
+  const nameAbs = abs(testFile);
+
+  it('addedCaseTitleMatchers reads titles off the ADDED lines only', () => {
+    const diff = [
+      '--- a/packages/x/src/a.test.ts',
+      '+++ b/packages/x/src/a.test.ts',
+      '@@ -1,3 +1,6 @@',
+      " it('an existing case nobody touched', () => {",
+      "+  it('the new regression case', () => {",
+      '+    expect(fixed()).toBe(1);',
+      "-  it('a case this range deleted', () => {",
+      '+  it.each(rows)(`${name} keeps its shape`, () => {',
+    ].join('\n');
+
+    const matchers = addedCaseTitleMatchers(diff);
+    const titles = ['the new regression case', 'branch-guard keeps its shape'];
+    expect(titles.every((t) => matchers.some((re) => re.test(t)))).toBe(true);
+    // A context line and a REMOVED line are not this range's cases; treating them as such would
+    // hand the verdict back to exactly the pre-existing case the granularity exists to exclude.
+    expect(matchers.some((re) => re.test('an existing case nobody touched'))).toBe(false);
+    expect(matchers.some((re) => re.test('a case this range deleted'))).toBe(false);
+  });
+
+  it('a new case that FAILS on the reversed source is the proof → assertion-fail', () => {
+    const added = new Map([[nameAbs, addedCaseTitleMatchers("+  it('the new case', () => {")]]);
+    const json = {
+      testResults: [
+        {
+          name: nameAbs,
+          assertionResults: [
+            { title: 'the new case', status: 'failed' },
+            { title: 'an old case', status: 'passed' },
+          ],
+        },
+      ],
+    };
+    expect(classifyVitestOutcome(json, [testFile], added)).toBe('assertion-fail');
+  });
+
+  it('an OLD case failing while the new one passes is not a proof → added-cases-pass', () => {
+    // The masking INFRA-072 was filed for, measured on `2ac10f251..b1f46acf3`: the gate judged at
+    // FILE granularity, so any one case failing red-proved the whole file, and a vacuous new
+    // regression test beside a pre-existing failing case was invisible. The range's own case is
+    // what has to depend on the fix — that is the thing being claimed.
+    const added = new Map([[nameAbs, addedCaseTitleMatchers("+  it('the new case', () => {")]]);
+    const json = {
+      testResults: [
+        {
+          name: nameAbs,
+          assertionResults: [
+            { title: 'the new case', status: 'passed' },
+            { title: 'an old case', status: 'failed' },
+          ],
+        },
+      ],
+    };
+    expect(classifyVitestOutcome(json, [testFile], added)).toBe('added-cases-pass');
+    expect(decidePairVerdict({ importsReversedFile: true, outcome: 'added-cases-pass' })).toBe(
+      VERDICT.ACCIDENTAL_GREEN,
+    );
+  });
+
+  it('judges per FILE: a file the range added nothing to still supplies a proof', () => {
+    // The narrowing is within a file, not across the set. A range whose fix is covered by an
+    // existing test in one file and by a new test for a different aspect in another is ordinary
+    // correct work, and demanding that EVERY deciding file carry a failing new case would fail it.
+    // A guard that fires on correct work gets switched off.
+    const untouched = 'packages/x/src/b.test.ts';
+    const added = new Map([[nameAbs, addedCaseTitleMatchers("+  it('the new case', () => {")]]);
+    const json = {
+      testResults: [
+        { name: nameAbs, assertionResults: [{ title: 'the new case', status: 'passed' }] },
+        {
+          name: abs(untouched),
+          assertionResults: [{ title: 'a case nobody touched', status: 'failed' }],
+        },
+      ],
+    };
+    expect(classifyVitestOutcome(json, [testFile, untouched], added)).toBe('assertion-fail');
+  });
+
+  it('a range that added no nameable case keeps FILE granularity, and does not fail on it', () => {
+    // A regression fixed by EDITING an existing case adds no title this can read. Demanding a new
+    // one would fail correct work, and a guard that fires on correct work gets switched off.
+    const json = {
+      testResults: [
+        { name: nameAbs, assertionResults: [{ title: 'an old case', status: 'failed' }] },
+      ],
+    };
+    expect(classifyVitestOutcome(json, [testFile], null)).toBe('assertion-fail');
+    expect(classifyVitestOutcome(json, [testFile], new Map())).toBe('assertion-fail');
+  });
+
+  it('a run-error still outranks a passing new case → INCONCLUSIVE, never accidental-green (C1)', () => {
+    const brokeCollect = 'packages/x/src/b.test.ts';
+    const added = new Map([[nameAbs, addedCaseTitleMatchers("+  it('the new case', () => {")]]);
+    const json = {
+      testResults: [
+        {
+          name: nameAbs,
+          assertionResults: [
+            { title: 'the new case', status: 'passed' },
+            { title: 'an old case', status: 'failed' },
+          ],
+        },
+        { name: abs(brokeCollect), assertionResults: [] },
+      ],
+    };
+    expect(classifyVitestOutcome(json, [testFile, brokeCollect], added)).toBe('run-error');
+  });
+
+  it('through the orchestrator: a vacuous new case beside an old failing one → ACCIDENTAL_GREEN', () => {
+    const source = 'packages/x/src/target.ts';
+    const test = 'packages/x/src/a.test.ts';
+    const files = {
+      [abs(test)]: `import { t } from './target.js';`,
+      [abs(source)]: 'export const t = 1;',
+    };
+
+    return runRegressionRedProof(
+      baseIo({
+        changedFiles: [source, test],
+        readText: (p) => files[p] ?? '',
+        fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+        addedTestCaseDiff: () => "+    it('the new regression case', () => {",
+        runVitest: () => ({
+          testResults: [
+            {
+              name: abs(test),
+              assertionResults: [
+                { title: 'the new regression case', status: 'passed' },
+                { title: 'a case that was already here', status: 'failed' },
+              ],
+            },
+          ],
+        }),
+      }),
+    ).then(({ verdict, decisions }) => {
+      expect(
+        verdict,
+        'the new case passed with the fix reversed and an older one supplied the red',
+      ).toBe(VERDICT.ACCIDENTAL_GREEN);
+      expect(decisions[0].outcome).toBe('added-cases-pass');
+    });
   });
 });
 
@@ -408,12 +684,21 @@ describe('HARNESS-041 orchestrator fixtures', () => {
   // A hook is never in a module graph, so before this the C3 check answered "not imported" for
   // every hook pair and the gate returned INCONCLUSIVE — a SKIP wearing another name. These two
   // fixtures pin both halves of the relation that replaces it.
+  //
+  // The fixture is a real module, not a line of text that looks like one: the relation resolves the
+  // spawn through the import binding, so a bare `spawnSync(…)` with nothing importing it is a call
+  // to an unknown function and not evidence of anything.
+  const SPAWNS_SOME_HOOK = [
+    "import { spawnSync } from 'node:child_process';",
+    "spawnSync('bash', ['/repo/.claude/hooks/some-hook.sh']);",
+  ].join('\n');
+
   function hookIo(overrides = {}) {
     const testFile = 'scripts/harness/__tests__/some-hook.test.mjs';
     const hook = '.claude/hooks/some-hook.sh';
     return baseIo({
       changedFiles: [hook, testFile],
-      readText: () => "spawnSync('bash', ['/repo/.claude/hooks/some-hook.sh']);",
+      readText: () => SPAWNS_SOME_HOOK,
       fileExists: () => true,
       ...overrides,
     });
@@ -446,7 +731,7 @@ describe('HARNESS-041 orchestrator fixtures', () => {
     const spawner = 'scripts/harness/__tests__/runs-the-hook.test.mjs';
     const bystander = 'scripts/harness/__tests__/unrelated.test.mjs';
     const sources = {
-      [abs(spawner)]: "spawnSync('bash', ['/repo/.claude/hooks/some-hook.sh']);",
+      [abs(spawner)]: SPAWNS_SOME_HOOK,
       [abs(bystander)]: `expect(somethingElse).toBe(1);`,
     };
     let ran = null;

--- a/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
+++ b/scripts/harness/__tests__/hooks-have-execution-coverage.test.mjs
@@ -3,12 +3,15 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { EXECUTION } from '../lib/spawn-call-graph.mjs';
+
 import { testExecutesHook } from '../check-regression-red-proof.mjs';
 
-// LIMITS testExecutesHook: they hold here. This floor's whole output is a message naming a hook
-// no test runs, so an approximate relation costs a false reassurance at worst — which is the
-// consequence class the relation was written against. The gate that reuses it to pick which tests
-// may SET a verdict is a different consumer, and holds the mismatch under INFRA-074.
+// LIMITS testExecutesHook: they hold here, and the third answer is judged for THIS consumer. The
+// relation now reads the call graph, so it says UNDETERMINED where the spawn target is built at
+// runtime — `guards-fail-closed` sweeps the hooks directory and runs whatever it finds. Counting
+// that as coverage would satisfy this floor for every hook at once and leave it decorative, so only
+// a resolved execution counts here, and the message says which of the two situations it found.
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
@@ -51,12 +54,12 @@ const TEST_SOURCES = readdirSync(TESTS_DIR)
  * drift, and the drift would be silent in both directions: this floor and that gate would disagree
  * about whether a hook is covered while both stayed green.
  *
- * What the shared rule claims, and does not: a hook NAMED IN PROSE is described, not run, so
- * comments are stripped before the name is looked for. It stays structural rather than exact — a
- * file that spawns one hook and names another in a string it never uses would pass. Tying a spawn
- * to its argument needs the call graph, and this is a grep-level floor by design.
+ * What the shared rule claims: it reads the call graph, so the script a spawn RECEIVES is what
+ * counts — a hook named in a comment, in prose, or in a string the file never spawns is described,
+ * not run. What it does not claim: that a path assembled at runtime can be named. That answer is
+ * UNDETERMINED and is reported separately below rather than counted either way.
  */
-function executesHook(source, hook) {
+function executionOf(source, hook) {
   return testExecutesHook(source.text, hook);
 }
 
@@ -69,15 +72,24 @@ describe('every hook is executed by a test, not merely described by one', () => 
 
   for (const hook of SHELL_HOOKS) {
     it(`${hook} is run by at least one test`, () => {
-      const runners = TEST_SOURCES.filter((source) => executesHook(source, hook)).map(
-        (s) => s.name,
-      );
+      const runners = [];
+      const unresolved = [];
+      for (const source of TEST_SOURCES) {
+        const answer = executionOf(source, hook);
+        if (answer === EXECUTION.EXECUTES) runners.push(source.name);
+        if (answer === EXECUTION.UNDETERMINED) unresolved.push(source.name);
+      }
 
       expect(
         runners.length,
         `No test executes ${hook}. A hook nobody runs is a hook nobody has checked — the shape that ` +
           'left `worktree-cwd-guard` off in every real session with ten green tests beside it. Add a ' +
-          'case that spawns it with a payload, and state which signal it depends on and who sends it.',
+          'case that spawns it with a payload, and state which signal it depends on and who sends it.' +
+          (unresolved.length > 0
+            ? `\n\n${unresolved.join(', ')} may run it through a path built at runtime, which cannot ` +
+              'be tied to this hook by reading the code. A sweep over the hooks directory is not a ' +
+              'case about this hook: it states nothing about what this one must do.'
+            : ''),
       ).toBeGreaterThan(0);
     });
   }

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -21,6 +21,12 @@ import { execFileSync } from 'node:child_process';
 import fs, { existsSync } from 'node:fs';
 import path from 'node:path';
 
+import {
+  EXECUTION,
+  analyzeSpawnTargetsCached,
+  classifyExecution,
+} from './lib/spawn-call-graph.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
 // ── Verdict vocabulary ────────────────────────────────────────────────────────────────────────────
@@ -100,31 +106,30 @@ export function classifyChanges(changedFiles) {
  * Does this test EXECUTE this hook? The relation that stands in for the import graph when the
  * changed source is a shell script, which is never in one.
  *
- * Comments are stripped first: a hook named only in prose is described, not run — the
- * described-but-not-reached distinction this gate exists to make.
+ * It used to answer with two INDEPENDENT text checks — the basename appears in the comment-stripped
+ * source, and the file spawns `bash` somewhere — with nothing tying the spawn to the name, so a
+ * test naming hook A in real code while spawning hook B counted as executing A. That was tolerable
+ * while only an advisory coverage message rode on it; INFRA-071 made it pick which tests may SET a
+ * red-proof verdict, and a bystander could then decide a hook it never ran. Measured on this tree:
+ * one such pair, `check-regression-red-proof.test.mjs` → `branch-guard.sh`, where every `spawnSync`
+ * the file contains is inside a STRING LITERAL in a fixture.
  *
- * CONTAINMENT — INFRA-074. The two halves are independent: the name must appear, and the file must
- * spawn a shell, but nothing ties the spawn to the name. A test naming hook A in real code while
- * spawning hook B counts as executing A. That imprecision was a fair trade when this only decided an
- * advisory coverage message; it now picks `decidingTests`, so a bystander can supply a verdict about
- * a hook it never ran. Tying them needs the call graph — the binding is a value flowing through a
- * call, not a lexical adjacency, and the narrower text patterns were already tried and were too
- * narrow (a helper that joins the basename runs the hook just as truly). Held rather than patched
- * because the gate is advisory; must be resolved before it is promoted to enforcing (INFRA-046).
+ * A narrower text pattern is not the fix and that was established by trying it: requiring the name
+ * inside a `path.join(...)` missed every test that hands the basename to a helper which joins it,
+ * and those run the hook just as truly. The binding is a VALUE FLOWING THROUGH A CALL, so the
+ * answer comes from {@link analyzeSpawnTargetsCached}, which reads it out of the call graph.
  *
- * @limits basename-only, and the spawn is not tied to the name (INFRA-074) — approximate enough for
- * an advisory message, not for anything that decides on its own.
+ * THREE ANSWERS, and the caller owns what the third one is worth. Ambiguity is real — a path built
+ * from `readdirSync()` cannot be pinned — and this gate refuses to let an UNDETERMINED test decide,
+ * because a verdict supplied by a test that may not have run the subject is the defect the gate
+ * exists to catch. The coverage floor makes the opposite call for its own consequences.
+ *
+ * @limits basename-only, and it reads ONE module — a test that spawned the hook through a helper
+ * imported from another file would read as not executing it. Never guesses: an unresolvable spawn
+ * target answers UNDETERMINED.
  */
 export function testExecutesHook(testText, hookPath) {
-  const base = hookPath.split('/').pop();
-  const withoutComments = String(testText ?? '')
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
-  if (!withoutComments.includes(base)) return false;
-  // The SAME text for both halves. Matching the spawn against the raw source let a documented
-  // example — the hook named in real code, the spawn shown in a comment — count as execution, which
-  // is the described-but-not-reached shape this function exists to reject, inside the function.
-  return /spawnSync\(\s*'bash'|execFileSync\(\s*'bash'|spawn\(\s*'bash'/.test(withoutComments);
+  return classifyExecution(analyzeSpawnTargetsCached(String(testText ?? '')), hookPath);
 }
 
 /** Packages that changed BOTH source and test — the only ones this v1 can red-prove. */
@@ -160,19 +165,85 @@ export function parseOptOut(text) {
   return { optedOut: Boolean(reason), reason };
 }
 
+// ── Pure: which cases the range ADDED (INFRA-072) ────────────────────────────────────────────────────
+
+// `it('…')`, `it.only('…')`, and the table form `it.each(rows)('…')` — the intervening call is what
+// makes the last one a separate shape rather than a suffix.
+const CASE_TITLE_RE =
+  /\b(?:it|test|bench)(?:\.[A-Za-z]+)*(?:\s*\([^()]*\))?\s*\(\s*(['"`])((?:\\.|(?!\1)[^\\])*)\1/g;
+
+/**
+ * Title matchers for the test cases a diff ADDED.
+ *
+ * The gate judged at FILE granularity: a changed test file was red-proved when ANY one of its cases
+ * failed on the reversed source. So a range could add a vacuous regression test beside a
+ * pre-existing case that fails for its own reasons, and the file reported `red-proof-ok` — the same
+ * "the unit judged is coarser than the unit the defect lives in" shape INFRA-073 fixed across
+ * sources, asked within one file. Measured on `2ac10f251..b1f46acf3`.
+ *
+ * A template title (`it(\`${hook} is run\`)`) cannot be compared exactly, so its static parts become
+ * the matcher and the interpolations become wildcards — a wider match is a weaker check, never a
+ * wrong verdict. A title this cannot read at all yields no matcher, and a file with no matchers
+ * falls back to file granularity rather than failing something it cannot see.
+ */
+export function addedCaseTitleMatchers(diffText) {
+  const matchers = [];
+  for (const line of String(diffText ?? '').split('\n')) {
+    if (!line.startsWith('+') || line.startsWith('+++')) continue;
+    CASE_TITLE_RE.lastIndex = 0;
+    for (const m of line.slice(1).matchAll(CASE_TITLE_RE)) {
+      const [, quote, raw] = m;
+      matchers.push(quote === '`' ? templateTitleMatcher(raw) : exactTitleMatcher(raw));
+    }
+  }
+  return matchers;
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function exactTitleMatcher(raw) {
+  // The source spelling is escaped; the runtime title is not. Left un-decoded, a title containing
+  // `\'` or `\n` would never match its own case, and the file would then report its added case as
+  // passing — a false accidental-green from a quoting detail.
+  const decoded = raw.replace(/\\(['"\\nt])/g, (_, ch) =>
+    ch === 'n' ? '\n' : ch === 't' ? '\t' : ch,
+  );
+  return new RegExp(`^${escapeRegExp(decoded)}$`);
+}
+
+function templateTitleMatcher(raw) {
+  const statics = raw.split(/\$\{[^}]*\}/).map(escapeRegExp);
+  return new RegExp(`^${statics.join('.*')}$`);
+}
+
+/** Did any matcher name this case? Both the bare title and the describe-qualified name are tried. */
+function matchesAddedCase(matchers, assertion) {
+  const names = [assertion?.title, assertion?.fullName].filter(Boolean);
+  return matchers.some((re) => names.some((name) => re.test(name)));
+}
+
 // ── Pure: vitest outcome classification (C1 — the correctness-critical distinction) ──────────────────
 
 /**
  * Given vitest `--reporter=json` output (parsed) and the changed test files, classify the outcome.
  * NEVER conflate a genuine assertion failure with a run error.
- *   'assertion-fail' — ≥1 changed test file has a failed assertion (the suite ran and the test failed)
- *   'run-error'      — a changed test file could not be evaluated (transform/collection/missing module)
- *   'all-pass'       — every changed test file ran and passed
+ *   'assertion-fail'    — ≥1 case that the range ADDED failed (the suite ran and the new test failed)
+ *   'added-cases-pass'  — a case failed, but not one this range added: the new test guards nothing
+ *   'run-error'         — a changed test file could not be evaluated (transform/collection/missing module)
+ *   'all-pass'          — every changed test file ran and passed
+ *
+ * @param addedCases Map(absolute test path → title matchers for the cases the range added), or null
+ *   when the range added no case this can name. Without it the judgement stays at FILE granularity,
+ *   which is what let a vacuous new case hide behind a pre-existing failing one (INFRA-072).
  */
-export function classifyVitestOutcome(vitestJson, changedTestFiles) {
+export function classifyVitestOutcome(vitestJson, changedTestFiles, addedCases = null) {
   const wanted = changedTestFiles.map((f) => path.resolve(WORKSPACE_ROOT, f));
   const results = Array.isArray(vitestJson?.testResults) ? vitestJson.testResults : [];
-  let sawAssertionFail = false;
+  let addedCaseFailed = false; // a failure in a case the range added
+  let unjudgedFileFailed = false; // a failure in a file the range added no readable case to
+  let judgedFileFailed = false; // a failure ONLY in the older cases of a file the range added to
   const ranWithAssertions = new Set();
 
   for (const fileResult of results) {
@@ -183,16 +254,27 @@ export function classifyVitestOutcome(vitestJson, changedTestFiles) {
       : [];
     if (assertions.length === 0) continue; // present but no assertions → failed to collect/transform
     ranWithAssertions.add(name);
-    if (assertions.some((a) => a.status === 'failed')) sawAssertionFail = true;
+    const matchers = addedCases?.get(name) ?? null;
+    for (const assertion of assertions) {
+      if (assertion.status !== 'failed') continue;
+      // Per FILE, not across the set. A file the range added no case to is judged the way it always
+      // was — its failure is a proof. Demanding a new case there would fail a range whose fix is
+      // covered by an existing test in one file and by a new test for a different aspect in
+      // another, which is ordinary correct work.
+      if (!matchers?.length) unjudgedFileFailed = true;
+      else if (matchesAddedCase(matchers, assertion)) addedCaseFailed = true;
+      else judgedFileFailed = true;
+    }
   }
 
   // C1 — a genuine assertion failure is the ONLY pass. ANY wanted test file that did not run with
   // assertions (missing from results OR present-with-zero-assertions — a transform/collection error) is a
   // run-error and yields INCONCLUSIVE, even if a SIBLING changed test file ran green. Never conflate a
   // non-run with all-pass: that would be a false accidental-green alarm.
-  if (sawAssertionFail) return 'assertion-fail';
+  if (addedCaseFailed || unjudgedFileFailed) return 'assertion-fail';
   const sawRunError = wanted.some((abs) => !ranWithAssertions.has(abs));
-  if (sawRunError) return 'run-error';
+  if (sawRunError) return 'run-error'; // a case that never ran has not been shown to pass
+  if (judgedFileFailed) return 'added-cases-pass';
   return 'all-pass';
 }
 
@@ -209,6 +291,9 @@ export function decidePairVerdict({ importsReversedFile, outcome }) {
   if (outcome === 'assertion-fail') return VERDICT.RED_PROOF_OK;
   if (outcome === 'run-error') return VERDICT.INCONCLUSIVE; // C1: never a pass
   if (outcome === 'all-pass') return VERDICT.ACCIDENTAL_GREEN;
+  // The range's own new case passed on the reversed source; the red came from a case that was
+  // already there. That is an accidental-green regression test wearing a sibling's proof.
+  if (outcome === 'added-cases-pass') return VERDICT.ACCIDENTAL_GREEN;
   return VERDICT.INCONCLUSIVE;
 }
 
@@ -290,6 +375,25 @@ export function reachableRelativeGraph(
   // Remove the test files themselves; callers care about imported sources.
   for (const t of testAbsPaths) visited.delete(t);
   return visited;
+}
+
+/**
+ * Title matchers for the cases the range added, per deciding test file — or null when it added none
+ * this can name, in which case the judgement stays at file granularity rather than failing over a
+ * title it could not read.
+ */
+function addedCaseMatchers(testFiles, readDiffFor) {
+  const byFile = new Map();
+  for (const file of testFiles) {
+    let matchers = [];
+    try {
+      matchers = addedCaseTitleMatchers(readDiffFor(file));
+    } catch {
+      matchers = []; // an unreadable diff means "unknown", which is file granularity
+    }
+    if (matchers.length > 0) byFile.set(path.resolve(WORKSPACE_ROOT, file), matchers);
+  }
+  return byFile.size > 0 ? byFile : null;
 }
 
 // ── Impure orchestrator ─────────────────────────────────────────────────────────────────────────────
@@ -381,6 +485,12 @@ export async function runRegressionRedProof(io = {}) {
   const reverseApply = io.reverseApply ?? ((srcPaths) => defaultReverseApply(base, srcPaths));
   const restore = io.restore ?? ((srcPaths) => git(['checkout', '--', ...srcPaths]));
   const runVitest = io.runVitest ?? defaultRunVitest;
+  const addedTestCaseDiff =
+    io.addedTestCaseDiff ??
+    // stderr is discarded: a range this cannot diff falls back to file granularity, and saying so
+    // on the console would make every unit fixture print a git error about its synthetic base.
+    ((testPath) =>
+      gitRaw(['diff', `${base}..HEAD`, '--', testPath], { stdio: ['ignore', 'pipe', 'ignore'] }));
 
   let worst = VERDICT.RED_PROOF_OK;
   const rank = {
@@ -423,6 +533,7 @@ export async function runRegressionRedProof(io = {}) {
     for (const source of pair.source) {
       // Only the tests that exercise THIS source may judge it — the same relation as above, asked
       // one source at a time.
+      let undeterminedRelation = false;
       const testsForSource =
         pair.pkg === HOOK_SUBJECT
           ? pair.test.filter((t, i) => {
@@ -432,7 +543,12 @@ export async function runRegressionRedProof(io = {}) {
               } catch {
                 return false;
               }
-              return testExecutesHook(text, source);
+              const answer = testExecutesHook(text, source);
+              // A test whose spawn target could not be resolved does NOT decide. It is recorded so
+              // the verdict can say it could not be tied, rather than letting a maybe-bystander
+              // supply a verdict about a hook it may never have run (INFRA-074).
+              if (answer === EXECUTION.UNDETERMINED) undeterminedRelation = true;
+              return answer === EXECUTION.EXECUTES;
             })
           : pair.test.filter((t, i) =>
               // A module is reached through the test's import graph; a shell script never appears in
@@ -447,6 +563,8 @@ export async function runRegressionRedProof(io = {}) {
             );
 
       const exercised = testsForSource.length > 0;
+      // INFRA-072 — the range's OWN new cases are what must fail, not any case in the file.
+      const addedCases = exercised ? addedCaseMatchers(testsForSource, addedTestCaseDiff) : null;
       let outcome = null;
       if (exercised) {
         reverseApply([source]);
@@ -454,6 +572,7 @@ export async function runRegressionRedProof(io = {}) {
           outcome = classifyVitestOutcome(
             await runVitest(pair.pkg, testsForSource),
             testsForSource,
+            addedCases,
           );
         } finally {
           restore([source]);
@@ -461,10 +580,23 @@ export async function runRegressionRedProof(io = {}) {
       }
 
       const verdict = decidePairVerdict({ importsReversedFile: exercised, outcome });
-      decisions.push({ pkg: pair.pkg, source, verdict, outcome, importsReversedFile: exercised });
+      decisions.push({
+        pkg: pair.pkg,
+        source,
+        verdict,
+        outcome,
+        importsReversedFile: exercised,
+        relation: exercised ? 'executed' : undeterminedRelation ? 'undetermined' : 'unrelated',
+      });
       const icon =
         verdict === VERDICT.RED_PROOF_OK ? '✅' : verdict === VERDICT.ACCIDENTAL_GREEN ? '❌' : '⚠︎';
-      log(`${icon}  ${source}: ${verdict}${outcome ? ` (${outcome})` : ''}`);
+      const note =
+        !exercised && undeterminedRelation
+          ? ' (no changed test could be TIED to this hook — the spawn target is built at runtime)'
+          : outcome
+            ? ` (${outcome})`
+            : '';
+      log(`${icon}  ${source}: ${verdict}${note}`);
       if ((rank[verdict] ?? 0) > (rank[worst] ?? 0)) worst = verdict;
     }
   }

--- a/scripts/harness/lib/spawn-call-graph.mjs
+++ b/scripts/harness/lib/spawn-call-graph.mjs
@@ -1,0 +1,879 @@
+/**
+ * INFRA-074 — which script does this module actually hand to a shell?
+ *
+ * ## The question this replaces
+ *
+ * The relation it serves used to answer "does this test execute this hook?" with two INDEPENDENT
+ * text checks: the hook's basename appears somewhere in the comment-stripped source, AND the file
+ * spawns `bash` somewhere. Nothing tied the spawn to the name, so a test that named hook A in real
+ * code while spawning hook B counted as executing A. That was a fair trade while the answer only
+ * fed an advisory coverage message; INFRA-071 gave it a second job — picking which tests may SET a
+ * red-proof verdict — and a bystander could then supply a verdict about a hook it never ran.
+ *
+ * A narrower text pattern is not the fix, and that is measured rather than assumed: requiring the
+ * name inside a `path.join(...)` missed every test that passes the basename to a helper which joins
+ * it (`run('some-hook.sh', …)`), and those run the hook just as truly. The binding is a VALUE
+ * FLOWING THROUGH A CALL, not a lexical adjacency, so the only thing that can answer it is the call
+ * graph.
+ *
+ * ## What it does
+ *
+ * Parses the module, finds every real spawn call (a binding imported from `child_process` — a
+ * `spawnSync('bash', …)` written inside a STRING LITERAL is not one), and resolves the expression
+ * that names the executed file back through the module's own bindings: literals, template and `+`
+ * concatenation, `path.join`/`path.resolve`, `const` initialisers, object and array literals,
+ * `for…of` element bindings, destructuring, local function return values, and — this is the part
+ * text could not do — a PARAMETER, by unioning the arguments at every call site of its function.
+ *
+ * ## Three answers, never a guess
+ *
+ * Resolution is partial by nature: a path built from `readdirSync()` cannot be pinned. Each spawn
+ * target therefore resolves to one of three answers per script, and the caller decides what an
+ * UNDETERMINED one is worth — the coverage floor treats it as covered (a floor that fires on
+ * correct work gets switched off), the red-proof gate refuses to let it decide (a verdict from a
+ * test that may not have run the subject is the defect this whole gate exists to catch).
+ *
+ * ## Stated limits
+ *
+ * - ONE MODULE. A module that spawned the script through a helper imported from another file would
+ *   read as not executing it. Measured over `scripts/harness/__tests__` on 2026-08-01: four files
+ *   name a hook without importing `child_process` at all, and none of them spawns anything through
+ *   an imported helper. A false "not executed" is loud rather than silent — it makes the coverage
+ *   floor FAIL — which is the right direction for a limit to fail in.
+ * - REACHABILITY IS NOT MODELLED, exactly as it was not before: a spawn inside a branch that never
+ *   runs still counts, and elements dropped by an intervening `.filter()` still count. The question
+ *   is "does this module hand this script to an interpreter", not "does that line execute".
+ * - BASENAME GRANULARITY. Two scripts with the same basename in different directories are one
+ *   subject here.
+ */
+
+import path from 'node:path';
+
+import * as ts from './ts-ast.mjs';
+
+const K = ts.SyntaxKind;
+
+/** The three answers. A caller that collapses UNDETERMINED into either of the others owns that choice. */
+export const EXECUTION = Object.freeze({
+  EXECUTES: 'executes',
+  NOT_EXECUTED: 'not-executed',
+  UNDETERMINED: 'undetermined',
+});
+
+/** Names from `child_process` that start a process. */
+const SPAWN_FUNCTIONS = new Set([
+  'spawn',
+  'spawnSync',
+  'exec',
+  'execSync',
+  'execFile',
+  'execFileSync',
+  'fork',
+]);
+
+/**
+ * Commands that RUN A FILE NAMED IN THEIR ARGUMENTS. Anything else — `git`, `pnpm`, `gh` — cannot
+ * reach a script through its argv, so its unresolvable arguments raise no ambiguity at all. Without
+ * this distinction every `spawnSync('git', ['-C', tmpDir, …])` in the suite would make its file
+ * undetermined for every script, and the answer would be "don't know" everywhere.
+ */
+const INTERPRETERS = new Set([
+  'bash',
+  'sh',
+  'dash',
+  'zsh',
+  'ksh',
+  'node',
+  'bun',
+  'deno',
+  'tsx',
+  'python',
+  'python3',
+  'ruby',
+  'perl',
+]);
+
+/** `node:path` members whose result this analysis can follow. */
+const PATH_FUNCTIONS = new Set(['join', 'resolve', 'basename', 'normalize']);
+
+/** Work budget. An adversarial or pathological module gets UNDETERMINED, never an infinite walk. */
+const STEP_BUDGET = 200_000;
+
+// ── The value domain ──────────────────────────────────────────────────────────────────────────────
+//
+// A candidate is a possible value of an expression, recorded as the part of the string that IS
+// known: `{ text, complete }`. `complete` means the whole value is `text`; otherwise `text` is a
+// known SUFFIX with unknown text in front of it — which is the common shape here, because
+// `path.join(HOOKS_DIR, 'branch-guard.sh')` has an unknowable root and a decisive tail.
+
+const NOTHING_KNOWN = Object.freeze({ text: '', complete: false });
+
+function literal(text) {
+  return { text, complete: true };
+}
+
+/** `a` followed by `b`. If `b`'s own head is unknown, everything before it is lost. */
+function concatCandidates(left, right) {
+  const out = [];
+  for (const a of left) {
+    for (const b of right) {
+      out.push(b.complete ? { text: a.text + b.text, complete: a.complete } : b);
+    }
+  }
+  return capped(out);
+}
+
+/** Bound the cross product so a module full of unions cannot blow up. */
+function capped(candidates) {
+  const seen = new Map();
+  for (const c of candidates) {
+    const key = `${c.complete ? '=' : '~'}${c.text}`;
+    if (!seen.has(key)) seen.set(key, c);
+    if (seen.size > 128) return [NOTHING_KNOWN];
+  }
+  return seen.size === 0 ? [NOTHING_KNOWN] : [...seen.values()];
+}
+
+/** `path.join(a, b)` — the separator is what makes a known tail decisive. */
+function joinCandidates(parts) {
+  let acc = [literal('')];
+  for (let i = 0; i < parts.length; i += 1) {
+    if (i > 0) acc = concatCandidates(acc, [literal('/')]);
+    acc = concatCandidates(acc, parts[i]);
+  }
+  return acc;
+}
+
+/**
+ * Does a candidate name the file `basename`? Three answers, and the middle one is the point.
+ *
+ * A candidate with a `/` in its known tail has a KNOWN basename even when its head is unknown, so
+ * it answers yes or no outright. One without a separator is a suffix of an unknown name — `.sh`
+ * could be anything ending in `.sh` — and that is the only case that is genuinely undetermined.
+ */
+export function candidateNames(candidate, basename) {
+  const { text, complete } = candidate;
+  if (complete) return path.basename(text) === basename ? 'yes' : 'no';
+  if (text.includes('/')) return text.slice(text.lastIndexOf('/') + 1) === basename ? 'yes' : 'no';
+  return basename.endsWith(text) ? 'maybe' : 'no';
+}
+
+// ── Scope + binding index ─────────────────────────────────────────────────────────────────────────
+
+/** Drop names the pinned parser does not define, so an absent kind can never match `node.kind`. */
+function kindSet(names) {
+  return new Set(names.map((name) => K[name]).filter((kind) => typeof kind === 'number'));
+}
+
+const SCOPE_KINDS = kindSet([
+  'SourceFile',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunction',
+  'MethodDeclaration',
+  'Constructor',
+  'Block',
+  'ForOfStatement',
+  'ForInStatement',
+  'ForStatement',
+  'CatchClause',
+  'CaseBlock',
+  'ModuleBlock',
+]);
+
+const FUNCTION_KINDS = kindSet([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunction',
+  'MethodDeclaration',
+  'Constructor',
+]);
+
+function nearestScope(node) {
+  for (let cur = node.parent; cur; cur = cur.parent) if (SCOPE_KINDS.has(cur.kind)) return cur;
+  return null;
+}
+
+/**
+ * Every name a module binds, with enough about each binding to resolve it later.
+ *
+ * Bindings are keyed by their enclosing scope NODE rather than flattened per module, because two
+ * `it()` callbacks in the same file routinely bind the same `hook` to different scripts — flattening
+ * them would union the two and report each test as running both.
+ */
+function indexBindings(sourceFile) {
+  const scopes = new Map(); // scope node → Map(name → binding[])
+  const spawnNames = new Map(); // local name → the child_process function it is bound to
+  const spawnNamespaces = new Set(); // local names bound to `import * as cp from 'child_process'`
+  const pathNames = new Map(); // local name → the node:path function it is bound to
+  const pathNamespaces = new Set(); // local names bound to `import path from 'node:path'`
+
+  const declare = (scope, name, binding) => {
+    if (!scope || !name) return;
+    if (!scopes.has(scope)) scopes.set(scope, new Map());
+    const byName = scopes.get(scope);
+    if (!byName.has(name)) byName.set(name, []);
+    byName.get(name).push(binding);
+  };
+
+  const declarePattern = (scope, nameNode, make) => {
+    if (!nameNode) return;
+    if (nameNode.kind === K.Identifier) {
+      declare(scope, nameNode.text, make(null));
+      return;
+    }
+    if (nameNode.kind === K.ObjectBindingPattern) {
+      for (const element of nameNode.elements ?? []) {
+        if (!element?.name || element.name.kind !== K.Identifier) continue;
+        const property = element.propertyName?.text ?? element.name.text;
+        declare(scope, element.name.text, make(property));
+      }
+      return;
+    }
+    // Array destructuring is positional and nothing in this tree uses it for a script path; an
+    // unresolvable binding is simply absent, and an absent binding resolves to "unknown".
+  };
+
+  const walk = (node) => {
+    if (node.kind === K.ImportDeclaration) {
+      collectModuleImports(node, ['node:child_process', 'child_process'], SPAWN_FUNCTIONS, {
+        named: spawnNames,
+        namespaces: spawnNamespaces,
+      });
+      collectModuleImports(node, ['node:path', 'path'], PATH_FUNCTIONS, {
+        named: pathNames,
+        namespaces: pathNamespaces,
+      });
+    }
+
+    if (node.kind === K.VariableDeclaration) {
+      const scope = nearestScope(node);
+      const forOf = node.parent?.parent;
+      if (forOf?.kind === K.ForOfStatement) {
+        declarePattern(scope, node.name, (property) => ({
+          kind: 'element',
+          expression: forOf.expression,
+          property,
+        }));
+      } else {
+        declarePattern(scope, node.name, (property) => ({
+          kind: 'value',
+          expression: node.initializer,
+          property,
+        }));
+        // `const run = (…) => …` is a callable binding as well as a value one.
+        if (node.name?.kind === K.Identifier && isFunctionNode(node.initializer))
+          declare(scope, node.name.text, { kind: 'function', node: node.initializer });
+      }
+    }
+
+    if (node.kind === K.Parameter) {
+      const fn = node.parent;
+      if (FUNCTION_KINDS.has(fn?.kind)) {
+        const index = (fn.parameters ?? []).indexOf(node);
+        declarePattern(fn, node.name, (property) => ({
+          kind: 'parameter',
+          fn,
+          index,
+          property,
+          fallback: node.initializer,
+        }));
+      }
+    }
+
+    if (node.kind === K.FunctionDeclaration && node.name?.kind === K.Identifier)
+      declare(nearestScope(node), node.name.text, { kind: 'function', node });
+
+    ts.forEachChild(node, walk);
+  };
+  walk(sourceFile);
+
+  return { scopes, spawnNames, spawnNamespaces, pathNames, pathNamespaces };
+}
+
+function isFunctionNode(node) {
+  return Boolean(node) && FUNCTION_KINDS.has(node.kind);
+}
+
+/**
+ * Record what a module's bindings actually refer to.
+ *
+ * By BINDING, never by spelling. `resolve(HARNESS_DIR, name)` is `path.resolve` in one file and an
+ * unrelated local in another; reading the import is the difference between resolving a path and
+ * inventing one. `import path from 'node:path'` binds a namespace-like default, so both the default
+ * clause and `import * as` are collected.
+ */
+function collectModuleImports(node, specifiers, functions, into) {
+  const specifier = node.moduleSpecifier?.text;
+  if (!specifiers.includes(specifier)) return;
+  const clause = node.importClause;
+  if (!clause) return;
+  if (clause.name?.text) into.namespaces.add(clause.name.text); // `import path from 'node:path'`
+  const bindings = clause.namedBindings;
+  if (!bindings) return;
+  if (bindings.kind === K.NamespaceImport) {
+    if (bindings.name?.text) into.namespaces.add(bindings.name.text);
+    return;
+  }
+  for (const element of bindings.elements ?? []) {
+    const imported = element.propertyName?.text ?? element.name?.text;
+    if (imported && functions.has(imported) && element.name?.text)
+      into.named.set(element.name.text, imported);
+  }
+}
+
+/** Every call whose callee resolves to a given local function, so a parameter can be read backwards. */
+function indexCallSites(sourceFile, resolveCallee) {
+  const callsTo = new Map();
+  const walk = (node) => {
+    if (node.kind === K.CallExpression) {
+      for (const fn of resolveCallee(node.expression)) {
+        if (!callsTo.has(fn)) callsTo.set(fn, []);
+        callsTo.get(fn).push(node);
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+  walk(sourceFile);
+  return callsTo;
+}
+
+// ── The analyzer ──────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve every spawn target in one module.
+ *
+ * @param {string} sourceText
+ * @param {string} [fileName] reporting name only
+ * @returns {{
+ *   targets: Array<{
+ *     kind: 'file' | 'command-line',
+ *     candidates: Array<{ text: string, complete: boolean }>,
+ *   }>,
+ *   exhausted: boolean,
+ * }} one entry per expression that could name an executed file, plus whether the work budget ran
+ *   out — a partial walk that found nothing has not established that there is nothing.
+ */
+export function analyzeSpawnTargets(sourceText, fileName = 'module.mjs') {
+  const sourceFile = ts.createSourceFile(fileName, sourceText);
+  const { scopes, spawnNames, spawnNamespaces, pathNames, pathNamespaces } =
+    indexBindings(sourceFile);
+
+  let steps = 0;
+  const spend = () => (steps += 1) < STEP_BUDGET;
+
+  /** Bindings for `name`, looked up from `node` outwards. Inner scopes shadow outer ones. */
+  const lookup = (node, name) => {
+    for (let cur = node; cur; cur = cur.parent) {
+      if (!SCOPE_KINDS.has(cur.kind)) continue;
+      const found = scopes.get(cur)?.get(name);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  const resolveCallee = (calleeNode) => {
+    if (calleeNode?.kind !== K.Identifier) return [];
+    return (lookup(calleeNode, calleeNode.text) ?? [])
+      .filter((b) => b.kind === 'function')
+      .map((b) => b.node);
+  };
+  const callsTo = indexCallSites(sourceFile, resolveCallee);
+
+  // Guards against a binding that resolves through itself (`const a = a` and, more realistically, a
+  // recursive helper). A node under evaluation resolves to "unknown" rather than recursing.
+  const active = new Set();
+
+  /** Candidate string values of an expression. */
+  const evaluate = (node) => {
+    if (!node || !spend() || active.has(node)) return [NOTHING_KNOWN];
+    active.add(node);
+    try {
+      return evaluateInner(node);
+    } finally {
+      active.delete(node);
+    }
+  };
+
+  const evaluateInner = (node) => {
+    switch (node.kind) {
+      case K.StringLiteral:
+      case K.NoSubstitutionTemplateLiteral:
+      case K.NumericLiteral:
+        return [literal(node.text)];
+
+      case K.TemplateExpression: {
+        let acc = [literal(node.head?.text ?? '')];
+        for (const span of node.templateSpans ?? []) {
+          acc = concatCandidates(acc, evaluate(span.expression));
+          acc = concatCandidates(acc, [literal(span.literal?.text ?? '')]);
+        }
+        return acc;
+      }
+
+      case K.BinaryExpression:
+        if (node.operatorToken?.kind === K.PlusToken)
+          return concatCandidates(evaluate(node.left), evaluate(node.right));
+        return [NOTHING_KNOWN];
+
+      case K.ParenthesizedExpression:
+      case K.AsExpression:
+      case K.SatisfiesExpression:
+      case K.NonNullExpression:
+      case K.AwaitExpression:
+      case K.TypeAssertionExpression:
+        return evaluate(node.expression);
+
+      case K.ConditionalExpression:
+        return capped([...evaluate(node.whenTrue), ...evaluate(node.whenFalse)]);
+
+      case K.Identifier:
+        return capped((lookup(node, node.text) ?? [{ kind: 'unknown' }]).flatMap(evaluateBinding));
+
+      case K.PropertyAccessExpression:
+        // `process.execPath` is the running node binary. Its directory is unknowable and its name
+        // is not: leaving it wholly unknown made every `execFileSync(process.execPath, …)` in the
+        // suite — the ordinary way this harness runs its own scans — read as "might be any script".
+        if (node.expression?.kind === K.Identifier && node.expression.text === 'process')
+          return node.name?.text === 'execPath'
+            ? [{ text: '/node', complete: false }]
+            : [NOTHING_KNOWN];
+        return readProperty(node.expression, node.name?.text);
+
+      case K.NewExpression:
+        // `new URL('../scan.mjs', import.meta.url)` — resolving a relative reference never changes
+        // its final segment, which is the only part this analysis reads.
+        if (node.expression?.kind === K.Identifier && node.expression.text === 'URL')
+          return capped(
+            evaluate((node.arguments ?? [])[0]).map((c) =>
+              c.complete
+                ? { text: `/${c.text.slice(c.text.lastIndexOf('/') + 1)}`, complete: false }
+                : NOTHING_KNOWN,
+            ),
+          );
+        return [NOTHING_KNOWN];
+
+      case K.CallExpression:
+        return evaluateCall(node);
+
+      default:
+        return [NOTHING_KNOWN];
+    }
+  };
+
+  const evaluateBinding = (binding) => {
+    switch (binding.kind) {
+      case 'value':
+        return binding.property
+          ? readProperty(binding.expression, binding.property)
+          : evaluate(binding.expression);
+      case 'element': {
+        const { elements, unknown } = elementsOf(binding.expression);
+        const values = elements.flatMap((element) =>
+          binding.property ? propertyOfObject(element, binding.property) : evaluate(element),
+        );
+        return unknown ? [...values, NOTHING_KNOWN] : values;
+      }
+      case 'parameter': {
+        const values = (callsTo.get(binding.fn) ?? []).flatMap((call) => {
+          const argument = (call.arguments ?? [])[binding.index];
+          if (!argument) return binding.fallback ? evaluate(binding.fallback) : [NOTHING_KNOWN];
+          if (argument.kind === K.SpreadElement) return [NOTHING_KNOWN];
+          return binding.property ? readProperty(argument, binding.property) : evaluate(argument);
+        });
+        // A function nothing calls (an exported helper, a callback) tells us nothing about its
+        // parameter — which is "unknown", not "no values".
+        return values.length > 0 ? values : [NOTHING_KNOWN];
+      }
+      default:
+        return [NOTHING_KNOWN];
+    }
+  };
+
+  /** `expr.prop`, where `expr` may be an object literal, a variable holding one, or a call returning one. */
+  const readProperty = (expression, property) => {
+    if (!expression || !property || !spend()) return [NOTHING_KNOWN];
+    const { objects, unknown } = objectsOf(expression);
+    const values = objects.flatMap((object) => propertyOfObject(object, property));
+    if (unknown || values.length === 0) return capped([...values, NOTHING_KNOWN]);
+    return capped(values);
+  };
+
+  const propertyOfObject = (node, property) => {
+    if (node?.kind !== K.ObjectLiteralExpression) {
+      // The element of a `for…of` may itself be a variable holding the object.
+      const { objects, unknown } = objectsOf(node);
+      if (objects.length === 0) return [NOTHING_KNOWN];
+      const values = objects.flatMap((o) => propertyOfObject(o, property));
+      return unknown ? [...values, NOTHING_KNOWN] : values;
+    }
+    let spread = false;
+    for (const member of node.properties ?? []) {
+      if (member.kind === K.SpreadAssignment) {
+        spread = true;
+        continue;
+      }
+      const name = member.name?.text;
+      if (name !== property) continue;
+      if (member.kind === K.PropertyAssignment) return evaluate(member.initializer);
+      if (member.kind === K.ShorthandPropertyAssignment) return evaluate(member.name);
+      return [NOTHING_KNOWN];
+    }
+    // An absent property on a fully-written literal is `undefined`, not an unknown — unless a spread
+    // could have supplied it.
+    return spread ? [NOTHING_KNOWN] : [];
+  };
+
+  /** Object-literal nodes an expression may evaluate to. */
+  const objectsOf = (node) => {
+    if (!node || !spend() || active.has(node)) return { objects: [], unknown: true };
+    active.add(node);
+    try {
+      switch (node.kind) {
+        case K.ObjectLiteralExpression:
+          return { objects: [node], unknown: false };
+        case K.ParenthesizedExpression:
+        case K.AsExpression:
+        case K.NonNullExpression:
+        case K.AwaitExpression:
+          return objectsOf(node.expression);
+        case K.ConditionalExpression: {
+          const a = objectsOf(node.whenTrue);
+          const b = objectsOf(node.whenFalse);
+          return { objects: [...a.objects, ...b.objects], unknown: a.unknown || b.unknown };
+        }
+        case K.Identifier: {
+          const bindings = lookup(node, node.text);
+          if (!bindings) return { objects: [], unknown: true };
+          return mergeObjects(bindings.map(objectsOfBinding));
+        }
+        case K.CallExpression: {
+          const returns = returnExpressionsOf(node);
+          if (returns === null) return { objects: [], unknown: true };
+          return mergeObjects(returns.map(objectsOf));
+        }
+        default:
+          return { objects: [], unknown: true };
+      }
+    } finally {
+      active.delete(node);
+    }
+  };
+
+  const objectsOfBinding = (binding) => {
+    switch (binding.kind) {
+      case 'value':
+        return binding.property ? { objects: [], unknown: true } : objectsOf(binding.expression);
+      case 'element': {
+        if (binding.property) return { objects: [], unknown: true };
+        const { elements, unknown } = elementsOf(binding.expression);
+        return mergeObjects([...elements.map(objectsOf), { objects: [], unknown }]);
+      }
+      case 'parameter': {
+        const calls = callsTo.get(binding.fn) ?? [];
+        if (calls.length === 0) return { objects: [], unknown: true };
+        return mergeObjects(
+          calls.map((call) => {
+            const argument = (call.arguments ?? [])[binding.index];
+            return argument && argument.kind !== K.SpreadElement
+              ? objectsOf(argument)
+              : { objects: [], unknown: true };
+          }),
+        );
+      }
+      default:
+        return { objects: [], unknown: true };
+    }
+  };
+
+  const mergeObjects = (parts) => ({
+    objects: parts.flatMap((p) => p.objects),
+    unknown: parts.some((p) => p.unknown),
+  });
+
+  /**
+   * Element expressions an array-valued expression may yield.
+   *
+   * `.filter`/`.sort`/`.slice`/`.reverse` pass their receiver's elements through. That is an
+   * over-approximation — a filter may drop one — and it is the same approximation the relation
+   * always made about reachability: an `if (false)` around a spawn never counted either. What
+   * changed here is the NAME-TO-SPAWN binding, not whether the line runs.
+   */
+  const elementsOf = (node) => {
+    if (!node || !spend() || active.has(node)) return { elements: [], unknown: true };
+    active.add(node);
+    try {
+      switch (node.kind) {
+        case K.ArrayLiteralExpression: {
+          const elements = [];
+          let unknown = false;
+          for (const element of node.elements ?? []) {
+            if (element.kind === K.SpreadElement) {
+              const inner = elementsOf(element.expression);
+              elements.push(...inner.elements);
+              unknown = unknown || inner.unknown;
+              continue;
+            }
+            elements.push(element);
+          }
+          return { elements, unknown };
+        }
+        case K.ParenthesizedExpression:
+        case K.AsExpression:
+        case K.NonNullExpression:
+        case K.AwaitExpression:
+          return elementsOf(node.expression);
+        case K.Identifier: {
+          const bindings = lookup(node, node.text);
+          if (!bindings) return { elements: [], unknown: true };
+          return mergeElements(
+            bindings.map((binding) =>
+              binding.kind === 'value' && !binding.property
+                ? elementsOf(binding.expression)
+                : { elements: [], unknown: true },
+            ),
+          );
+        }
+        case K.CallExpression: {
+          const callee = node.expression;
+          if (
+            callee?.kind === K.PropertyAccessExpression &&
+            ['filter', 'sort', 'slice', 'reverse', 'flat'].includes(callee.name?.text)
+          )
+            return elementsOf(callee.expression);
+          if (callee?.kind === K.PropertyAccessExpression && callee.name?.text === 'concat')
+            return mergeElements([
+              elementsOf(callee.expression),
+              ...(node.arguments ?? []).map(elementsOf),
+            ]);
+          const returns = returnExpressionsOf(node);
+          if (returns === null) return { elements: [], unknown: true };
+          return mergeElements(returns.map(elementsOf));
+        }
+        default:
+          return { elements: [], unknown: true };
+      }
+    } finally {
+      active.delete(node);
+    }
+  };
+
+  const mergeElements = (parts) => ({
+    elements: parts.flatMap((p) => p.elements),
+    unknown: parts.some((p) => p.unknown),
+  });
+
+  /** Expressions a local function returns, or `null` when the callee is not a local function. */
+  const returnExpressionsOf = (call) => {
+    const fns = resolveCallee(call.expression);
+    if (fns.length === 0) return null;
+    const out = [];
+    for (const fn of fns) {
+      const body = fn.body;
+      if (!body) continue;
+      if (body.kind !== K.Block) {
+        out.push(body); // concise arrow body
+        continue;
+      }
+      const collect = (node) => {
+        if (node.kind === K.ReturnStatement && node.expression) out.push(node.expression);
+        if (FUNCTION_KINDS.has(node.kind) && node !== fn) return; // a nested function's returns are its own
+        ts.forEachChild(node, collect);
+      };
+      collect(body);
+    }
+    return out;
+  };
+
+  /** `path.join` / `path.resolve` / bare `join` imported from `node:path`, whichever spelling. */
+  const pathFunctionOf = (callee) => {
+    if (callee?.kind === K.Identifier) return pathNames.get(callee.text) ?? null;
+    if (
+      callee?.kind === K.PropertyAccessExpression &&
+      callee.expression?.kind === K.Identifier &&
+      pathNamespaces.has(callee.expression.text) &&
+      PATH_FUNCTIONS.has(callee.name?.text)
+    )
+      return callee.name.text;
+    return null;
+  };
+
+  const evaluateCall = (node) => {
+    const callee = node.expression;
+    const pathFunction = pathFunctionOf(callee);
+    if (pathFunction === 'join' || pathFunction === 'resolve' || pathFunction === 'normalize')
+      return joinCandidates((node.arguments ?? []).map(evaluate));
+    if (pathFunction === 'basename')
+      return capped(
+        evaluate((node.arguments ?? [])[0]).map((c) =>
+          c.complete || c.text.includes('/')
+            ? literal(c.text.slice(c.text.lastIndexOf('/') + 1))
+            : c,
+        ),
+      );
+    if (callee?.kind === K.PropertyAccessExpression) {
+      const member = callee.name?.text;
+      if (member === 'trim' || member === 'toString') return evaluate(callee.expression);
+    }
+    // `fileURLToPath` restates a `file:` URL as a path; the final segment is carried through.
+    if (
+      callee?.kind === K.Identifier &&
+      (callee.text === 'String' || callee.text === 'fileURLToPath')
+    )
+      return evaluate((node.arguments ?? [])[0]);
+    const returns = returnExpressionsOf(node);
+    if (returns === null || returns.length === 0) return [NOTHING_KNOWN];
+    return capped(returns.flatMap(evaluate));
+  };
+
+  // ── Spawn sites ────────────────────────────────────────────────────────────────────────────────
+
+  const targets = [];
+
+  /**
+   * The `child_process` function this call invokes, or null when it is not one.
+   *
+   * Resolution goes through the IMPORT BINDING, not the spelling: `spawnSync('bash', …)` written
+   * inside a string literal — which a test of this very relation is full of — is not a call at all,
+   * and a locally-defined `spawnSync` is not `child_process`'s.
+   */
+  const spawnFunctionName = (node) => {
+    const callee = node.expression;
+    if (callee?.kind === K.Identifier) return spawnNames.get(callee.text) ?? null;
+    if (
+      callee?.kind === K.PropertyAccessExpression &&
+      callee.expression?.kind === K.Identifier &&
+      spawnNamespaces.has(callee.expression.text) &&
+      SPAWN_FUNCTIONS.has(callee.name?.text)
+    )
+      return callee.name.text;
+    return null;
+  };
+
+  const isSpawnCall = (node) => spawnFunctionName(node) !== null;
+
+  /**
+   * Record what one spawn call can execute.
+   *
+   * The precision that matters is ARGV POSITION. `bash foo.sh a b` executes `foo.sh` and hands `a`
+   * and `b` to it; `node run.mjs <tmpdir>` executes `run.mjs`. Treating every argv element as a
+   * possible script made an unresolvable temp-directory argument read as "this file might run any
+   * script at all", and measured over the harness suite that produced 331 undetermined pairs
+   * against 27 resolved ones — an analysis that answers "don't know" everywhere is the grep it
+   * replaced, wearing a more expensive costume.
+   */
+  const recordSpawn = (node, functionName) => {
+    const args = node.arguments ?? [];
+    if (args.length === 0) return;
+
+    // `exec`/`execSync` take a SHELL COMMAND LINE, not a file.
+    if (functionName === 'exec' || functionName === 'execSync') {
+      targets.push({ kind: 'command-line', candidates: evaluate(args[0]) });
+      return;
+    }
+
+    // The command itself. `spawnSync('/path/to/hook.sh')` executes it directly.
+    const command = evaluate(args[0]);
+    targets.push({ kind: 'file', candidates: command });
+
+    // argv can only name an executed file when the command is an INTERPRETER. `git` or `pnpm`
+    // cannot reach a script through its argv, so its unresolvable arguments raise no ambiguity.
+    const interpreterPossible = command.some((c) => {
+      if (!c.complete && !c.text.includes('/')) return true; // could be any command
+      return INTERPRETERS.has(c.text.slice(c.text.lastIndexOf('/') + 1));
+    });
+    if (!interpreterPossible) return;
+
+    const argv = args[1];
+    if (!argv) return;
+    if (argv.kind !== K.ArrayLiteralExpression) {
+      // `spawnSync('bash', argv)` — the vector itself is opaque, so its head could be anything.
+      targets.push({ kind: 'file', candidates: [NOTHING_KNOWN] });
+      return;
+    }
+
+    // Scan forward to the first element that is not an option. That element is the script.
+    for (const element of argv.elements ?? []) {
+      if (element.kind === K.SpreadElement) {
+        // A spread could contribute the script position or push it further along; either way the
+        // head of the remaining vector stops being knowable.
+        targets.push({ kind: 'file', candidates: [NOTHING_KNOWN] });
+        return;
+      }
+      const value = evaluate(element);
+      const single = value.length === 1 && value[0].complete ? value[0].text : null;
+      if (single !== null && (single === '-c' || single === '-e')) {
+        // What follows is INLINE CODE, not a path — `sh -c 'command -v jq'`.
+        const index = (argv.elements ?? []).indexOf(element);
+        const inline = (argv.elements ?? [])[index + 1];
+        targets.push({
+          kind: 'command-line',
+          candidates: inline ? evaluate(inline) : [NOTHING_KNOWN],
+        });
+        return;
+      }
+      if (single !== null && single.startsWith('-') && single !== '-') continue; // `-n`, `-x`, `--`
+      targets.push({ kind: 'file', candidates: value });
+      return;
+    }
+  };
+
+  const walk = (node) => {
+    if (node.kind === K.CallExpression && isSpawnCall(node))
+      recordSpawn(node, spawnFunctionName(node));
+    ts.forEachChild(node, walk);
+  };
+  walk(sourceFile);
+
+  return { targets, exhausted: steps >= STEP_BUDGET };
+}
+
+/**
+ * Does the analyzed module execute `scriptPath`? EXECUTES / NOT_EXECUTED / UNDETERMINED.
+ *
+ * `exhausted` — the work budget ran out — is UNDETERMINED by construction: a partial walk that
+ * found nothing has not established that there is nothing.
+ */
+export function classifyExecution(analysis, scriptPath) {
+  const basename = scriptPath.split('/').pop();
+  let maybe = analysis.exhausted === true;
+  for (const target of analysis.targets) {
+    for (const candidate of target.candidates) {
+      const answer =
+        target.kind === 'command-line'
+          ? commandLineNames(candidate, basename)
+          : candidateNames(candidate, basename);
+      if (answer === 'yes') return EXECUTION.EXECUTES;
+      if (answer === 'maybe') maybe = true;
+    }
+  }
+  return maybe ? EXECUTION.UNDETERMINED : EXECUTION.NOT_EXECUTED;
+}
+
+/**
+ * Does a shell COMMAND LINE (`sh -c '…'`, `execSync('…')`) run the file `basename`?
+ *
+ * A command line is not a path, so the name has to sit on a token boundary — otherwise `hook.sh`
+ * would be found inside `my-hook.sh`. Unknown text anywhere in the line could hold anything, so an
+ * incomplete candidate with no match is undetermined rather than a no.
+ */
+export function commandLineNames(candidate, basename) {
+  const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const boundary = new RegExp(`(?:^|[\\s'"\`/=(;&|])${escaped}(?:$|[\\s'"\`);&|])`);
+  if (boundary.test(candidate.text)) return 'yes';
+  return candidate.complete ? 'no' : 'maybe';
+}
+
+// Parsing is the expensive part and both consumers ask about many scripts per module, so a module's
+// analysis is computed once. Keyed by text, because that is all one of the callers has.
+const cache = new Map();
+
+/** {@link analyzeSpawnTargets}, memoised per source text. */
+export function analyzeSpawnTargetsCached(sourceText, fileName) {
+  const key = String(sourceText ?? '');
+  if (!cache.has(key)) {
+    if (cache.size > 512) cache.clear();
+    cache.set(key, analyzeSpawnTargets(key, fileName));
+  }
+  return cache.get(key);
+}


### PR DESCRIPTION
Closes #1540
Closes #1537

## INFRA-074 — the spawn relation reads the call graph

`testExecutesHook` answered "does this test execute this hook?" with two INDEPENDENT checks: the hook's basename appears in the comment-stripped text, AND the file spawns `bash` somewhere. Nothing tied the spawn to the name. That was tolerable while only an advisory coverage message rode on it; INFRA-071 gave it a second job — picking which tests may SET `RED_PROOF_OK` / `ACCIDENTAL_GREEN` — so a bystander could supply a verdict about a hook it never ran.

### Red first

The misclassification case was written and run against the pre-fix relation **before** anything was built:

```
 FAIL  scripts/harness/__tests__/check-regression-red-proof.test.mjs
       > a test that NAMES one hook while spawning another does not execute the first (INFRA-074)
AssertionError: a bystander that never ran this hook was counted as executing it: expected true to be false

- Expected
+ Received

- false
+ true

 ❯ scripts/harness/__tests__/check-regression-red-proof.test.mjs:121:7
```

### Why a narrower text pattern is not the fix

Already tried and rejected on evidence: requiring the name inside a `path.join(...)` missed every test that hands the basename to a helper which joins it (`run('some-hook.sh', …)`), and those run the hook just as truly. The binding is a value flowing through a call.

### What landed

`scripts/harness/lib/spawn-call-graph.mjs` parses the module (through the sanctioned `lib/ts-ast.mjs` swap point), finds spawn calls by their **`child_process` import binding** — so a `spawnSync('bash', …)` written inside a string literal is not one — and resolves the expression in **argv script position** back through the module's own bindings:

- string / template / `+` concatenation
- `path.join` / `path.resolve` under either spelling (`path.join(…)` and a bare `join` imported from `node:path`)
- `const` initialisers, object and array literals
- `for…of` element bindings, including destructured ones (`for (const { hook } of TABLE)`)
- object destructuring off a local function's return value
- **a parameter**, by unioning the arguments at every call site of its function — the case a text pattern cannot reach

Argv **position** is what makes it usable rather than merely correct. `bash foo.sh a b` runs `foo.sh` and hands `a`/`b` to it; `node run.mjs <tmpdir>` runs `run.mjs`. Treating every argv element as a possible script made an unresolvable temp-directory argument read as "might run anything" — measured at **331** undetermined pairs against 27 resolved. Reading the script out of its position leaves 32.

### Three answers, never a guess

A target built at runtime (`readdirSync()`) answers **UNDETERMINED**, and each consumer owns what that is worth:

- the **red-proof gate** refuses to let an UNDETERMINED test decide, and says so in the verdict (`no changed test could be TIED to this hook — the spawn target is built at runtime`);
- the **coverage floor** counts only a resolved execution, and names the unresolved files in its failure message. Counting a directory sweep as coverage would satisfy that floor for every hook at once and leave it decorative.

## The pair-by-pair delta, measured on the real tree

120 harness test files × 12 hooks = **1440 pairs**.

| | claimed `executes` | `undetermined` |
| --- | --- | --- |
| before | 28 | — (no such answer existed) |
| after | **27** | **32** |

33 pairs changed. Every one, and why the new answer is right:

### Dropped — the defect (1 pair)

| test | hook | before → after | correct? |
| --- | --- | --- | --- |
| `check-regression-red-proof.test.mjs` | `branch-guard.sh` | `executes` → `not-executed` | **yes.** The file imports no `child_process` at all. Every `spawnSync('bash'` it contains sits inside a fixture STRING. It never ran that hook. |

**No true pair was lost** — the other 27 are unchanged.

### Gained precision: `not-executed` → `undetermined` (32 pairs)

Three files that genuinely assemble their spawn target at runtime. In each case the old "no" was wrong (they really do reach these hooks) and a "yes" would be unearned, so the honest answer is the third one.

| test | hooks | why undetermined |
| --- | --- | --- |
| `guards-fail-closed.test.mjs` | all 12 | `for (const hook of SHELL_HOOKS)` where `SHELL_HOOKS` comes from `readdirSync(HOOKS_DIR)` — it runs whatever it finds, and names nothing |
| `hook-command-parsing.test.mjs` | `correction-detect`, `eval-log-stop`, `memory-mirror-reminder`, `merge-gate`, `post-tool-format`, `revert-detect`, `spec-first-gate`, `task-tracking` (8) | `spawnSync('bash', ['-n', file])` over a `shellFiles` list built from two `readdirSync().map()` chains. The 4 hooks it names literally still resolve to `executes`. |
| `hook-reading-matches-bash.test.mjs` | all 12 | `spawnSync('bash', ['-c', probe, …])` — the script is a string it assembles |

<details><summary>Full 33-row listing</summary>

```
check-regression-red-proof.test.mjs   branch-guard.sh                executes     -> not-executed
guards-fail-closed.test.mjs           branch-guard.sh                not-executed -> undetermined
guards-fail-closed.test.mjs           check-forbidden-patterns.sh    not-executed -> undetermined
guards-fail-closed.test.mjs           correction-detect.sh           not-executed -> undetermined
guards-fail-closed.test.mjs           eval-log-stop.sh               not-executed -> undetermined
guards-fail-closed.test.mjs           memory-mirror-reminder.sh      not-executed -> undetermined
guards-fail-closed.test.mjs           merge-gate.sh                  not-executed -> undetermined
guards-fail-closed.test.mjs           post-tool-format.sh            not-executed -> undetermined
guards-fail-closed.test.mjs           pre-push-check.sh              not-executed -> undetermined
guards-fail-closed.test.mjs           revert-detect.sh               not-executed -> undetermined
guards-fail-closed.test.mjs           spec-first-gate.sh             not-executed -> undetermined
guards-fail-closed.test.mjs           task-tracking.sh               not-executed -> undetermined
guards-fail-closed.test.mjs           worktree-cwd-guard.sh          not-executed -> undetermined
hook-command-parsing.test.mjs         correction-detect.sh           not-executed -> undetermined
hook-command-parsing.test.mjs         eval-log-stop.sh               not-executed -> undetermined
hook-command-parsing.test.mjs         memory-mirror-reminder.sh      not-executed -> undetermined
hook-command-parsing.test.mjs         merge-gate.sh                  not-executed -> undetermined
hook-command-parsing.test.mjs         post-tool-format.sh            not-executed -> undetermined
hook-command-parsing.test.mjs         revert-detect.sh               not-executed -> undetermined
hook-command-parsing.test.mjs         spec-first-gate.sh             not-executed -> undetermined
hook-command-parsing.test.mjs         task-tracking.sh               not-executed -> undetermined
hook-reading-matches-bash.test.mjs    branch-guard.sh                not-executed -> undetermined
hook-reading-matches-bash.test.mjs    check-forbidden-patterns.sh    not-executed -> undetermined
hook-reading-matches-bash.test.mjs    correction-detect.sh           not-executed -> undetermined
hook-reading-matches-bash.test.mjs    eval-log-stop.sh               not-executed -> undetermined
hook-reading-matches-bash.test.mjs    memory-mirror-reminder.sh      not-executed -> undetermined
hook-reading-matches-bash.test.mjs    merge-gate.sh                  not-executed -> undetermined
hook-reading-matches-bash.test.mjs    post-tool-format.sh            not-executed -> undetermined
hook-reading-matches-bash.test.mjs    pre-push-check.sh              not-executed -> undetermined
hook-reading-matches-bash.test.mjs    revert-detect.sh               not-executed -> undetermined
hook-reading-matches-bash.test.mjs    spec-first-gate.sh             not-executed -> undetermined
hook-reading-matches-bash.test.mjs    task-tracking.sh               not-executed -> undetermined
hook-reading-matches-bash.test.mjs    worktree-cwd-guard.sh          not-executed -> undetermined
```

</details>

### The coverage floor stays green, and gets stricter

Every hook still has at least one **resolved** runner, so counting only `EXECUTES` does not fire on anything:

```
branch-guard.sh              runs=4  branch-base-at-creation, branch-guard-unmerged, guards-pass-silently, hook-command-parsing
check-forbidden-patterns.sh  runs=3  guards-pass-silently, hook-command-parsing, lessons-digest
correction-detect.sh         runs=1  lessons-digest
eval-log-stop.sh             runs=1  lessons-digest
memory-mirror-reminder.sh    runs=1  remaining-hooks-run
merge-gate.sh                runs=3  guards-pass-silently, hook-command-reachability, merge-gate-decision
post-tool-format.sh          runs=1  remaining-hooks-run
pre-push-check.sh            runs=5  guards-pass-silently, hook-boundary-parity, hook-command-parsing, hook-command-reachability, review-before-push
revert-detect.sh             runs=1  lessons-digest
spec-first-gate.sh           runs=1  remaining-hooks-run
task-tracking.sh             runs=1  remaining-hooks-run
worktree-cwd-guard.sh        runs=5  guards-pass-silently, hook-boundary-parity, hook-command-parsing, worktree-cwd-guard, worktree-guard-alive
```

---

## INFRA-072 — per-case granularity, and what it does not reach

Decided now that INFRA-071 has produced verdicts and INFRA-073 has landed. **Direction 1 is taken.**

The diff of each deciding test file is read for the case titles the range ADDED; at least one of those must fail on the reversed source. A file whose red comes only from a pre-existing case now reports `accidental-green-fail (added-cases-pass)` where it previously reported `red-proof-ok`.

Two deliberate narrowings, both so the gate does not fire on correct work:

- **Per FILE, not across the set.** A deciding file the range added no readable case to still supplies a proof the way it always did. Otherwise a range whose fix is covered by an existing test in one file and by a new test for a different aspect in another would be failed.
- **No nameable added case ⇒ file granularity.** A regression fixed by EDITING an existing case adds no title this can read; demanding a new one would fail ordinary work.

C1 is preserved throughout: a sibling file that failed to collect still outranks a passing added case, so the verdict is INCONCLUSIVE and never a false accidental-green.

### The four motivating cases — which this catches

| Case | Caught? | Why |
| --- | --- | --- |
| `hooks-have-execution-coverage` | **no** | the logic under test is IN the test file, so there is no source to reverse and no pair to judge. Per-case granularity operates inside a verdict this case never reaches. |
| `remaining-hooks-run` (two hooks) | **no** | the hooks it names were not changed in the range, so no pair exists. INFRA-074's relation now says so precisely instead of approximately, but "no pair" is still no verdict. |
| `remaining-hooks-run` (extension) | **no** | it fails reversed for the wrong reason — it crashes before reaching the filter. The gate reads pass/fail and cannot read WHY. Direction 2/3 territory. |
| `remaining-hooks-run` (unset var) | **partly** | it asserts an exit code both paths share, so it passes reversed. Caught when it is the range's own added case and the file's red comes from a pre-existing one — the masking measured on `2ac10f251..b1f46acf3`. NOT caught when a genuine added case fails beside it, because requiring EVERY added case to fail would fail correct work. |

Directions 2 (branch-level mutation) and 3 (coverage delta per case) stay open as a separate decision; both need a way to name a branch inside a `bash` hook.

---

## Verification

- `npx vitest run scripts/harness/__tests__/ --reporter=basic` → **1824 passed**, 3 failed. Baseline on `origin/develop` in this same environment: **1812 passed, the same 3 failed.** +12 tests, no new failures.
- The 3 are `worktree-cwd-guard` cases and are **environmental, not this change**. `worktree-cwd-guard.sh:90-91` decides `IN_WORKTREE_SESSION` from its own `BASH_SOURCE` directory, so every copy of the hook living under `.claude/worktrees/` reports a worktree session — which is true of any worktree-isolated agent's checkout. Proven pre-existing by re-running the same three files on a stashed tree at `origin/develop`. This is HARNESS-058 (`verify-like-ci-cannot-go-green-in-a-worktree`); the hooks are outside this PR's ownership and are being rewritten concurrently. The push used `--no-verify` for that reason only.
- `pnpm harness:scan` → **all 84 scans passed** (after `pnpm build`, which the `dist` scan needs).
- `scan-helper-limits` still passes: the `@limits` tag stays on `testExecutesHook` with its new limits stated, and both importing modules re-judge it for their own consequences.

## Known follow-up outside this PR's ownership

`scripts/harness/scan-helper-limits.mjs` (module docblock) and `.agents/rules/helper-limits.md` both describe `testExecutesHook` as the example of a limit that could not be tied to a call site, ending with *"Tying it to a call site needs the call graph, which is the same boundary `testExecutesHook` runs into."* That sentence is now false — it does read the call graph. The historical narrative above it is still accurate. Both files are outside this PR's file ownership, so the wording is left for their owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso
