### PR TITLE
fix(harness): two scans over .agents/spec-docs said clean when they read nothing

### DIFF
--- a/scripts/harness/__tests__/check-spec-doc-frontmatter.test.mjs
+++ b/scripts/harness/__tests__/check-spec-doc-frontmatter.test.mjs
@@ -273,3 +273,22 @@ describe('check-spec-doc-frontmatter CLI', () => {
     expect(result.stdout).toContain('spec-doc frontmatter scan passed.');
   });
 });
+
+describe('the subject cannot be absent and still read as clean', () => {
+  it('refuses a spec-docs tree that is not there', async () => {
+    // PROC-006 prerequisite, measured 2026-08-01: this finder returned `{blocking: [], warnings: []}`
+    // over a root with no `.agents/spec-docs`, which is what it also returns when 242 documents are
+    // all correct. It governs the tree PROC-006 moves.
+    //
+    // `scan-guard-scope-fail-closed` did not catch it, and its header says why: the finder set is
+    // derived from `export function find…(root`, and this one takes a target instead.
+    //
+    // Directory mode only — the single-FILE mode below must keep working, since that is how the
+    // pre-commit path checks one document.
+    const root = await mkdtemp(path.join(tmpdir(), 'absent-spec-docs-fm-'));
+    expect(
+      () => findSpecDocFrontmatterFindings(path.join(root, '.agents/spec-docs')),
+      'an absent subject was reported as clean',
+    ).toThrow(/spec-docs/);
+  });
+});

--- a/scripts/harness/__tests__/scan-doc-folder-status-agreement.test.mjs
+++ b/scripts/harness/__tests__/scan-doc-folder-status-agreement.test.mjs
@@ -12,8 +12,12 @@ import {
   parseStatusFolderMapping,
 } from '../scan-doc-folder-status-agreement.mjs';
 
-const SCAN_SCRIPT = fileURLToPath(new URL('../scan-doc-folder-status-agreement.mjs', import.meta.url));
-const RULE_FILE = fileURLToPath(new URL('../../../.agents/rules/spec-workflow.md', import.meta.url));
+const SCAN_SCRIPT = fileURLToPath(
+  new URL('../scan-doc-folder-status-agreement.mjs', import.meta.url),
+);
+const RULE_FILE = fileURLToPath(
+  new URL('../../../.agents/rules/spec-workflow.md', import.meta.url),
+);
 
 /**
  * The mapping as `spec-workflow.md` § Spec-Document Status and Lifecycle Folders states it. This is
@@ -88,7 +92,12 @@ describe('scan-doc-folder-status-agreement — detection', () => {
       'done/DATA-002.md': spec('in-progress'),
     });
     expect(findFolderStatusFindings(root, mapping)).toEqual([
-      { file: 'done/DATA-002.md', status: 'in-progress', actualFolder: 'done', expectedFolder: 'active' },
+      {
+        file: 'done/DATA-002.md',
+        status: 'in-progress',
+        actualFolder: 'done',
+        expectedFolder: 'active',
+      },
       { file: 'done/INFRA-016.md', status: 'draft', actualFolder: 'done', expectedFolder: 'draft' },
       { file: 'done/PM-026.md', status: 'approved', actualFolder: 'done', expectedFolder: 'todo' },
     ]);
@@ -125,7 +134,8 @@ describe('scan-doc-folder-status-agreement — detection', () => {
 
   it('reads a status the repo formatter may have wrapped, via the SSOT frontmatter parser', async () => {
     const root = await makeTree({
-      'done/wrapped.md': '---\nstatus:\n  draft\ntype: RULE\ntags:\n  - harness\n---\n\n# fixture\n',
+      'done/wrapped.md':
+        '---\nstatus:\n  draft\ntype: RULE\ntags:\n  - harness\n---\n\n# fixture\n',
     });
     expect(findFolderStatusFindings(root, mapping).map((f) => f.status)).toEqual(['draft']);
   });
@@ -159,5 +169,25 @@ describe('scan-doc-folder-status-agreement — exit contract', () => {
       encoding: 'utf8',
     });
     expect(missing.status).toBe(1);
+  });
+});
+
+describe('the subject cannot be absent and still read as clean', () => {
+  it('refuses a spec-docs tree that is not there', async () => {
+    // PROC-006 prerequisite, measured 2026-08-01. This finder governs `.agents/spec-docs`, the tree
+    // that item is about to move, and it returned 0 findings over a root without one — the same
+    // words it uses over 242 documents. `scan-guard-scope-fail-closed` did not catch it: that scan
+    // derives its finder set from `export function find…(root`, and this finder's first parameter is
+    // the DIRECTORY, so it sits outside the ceiling that scan states in its own header.
+    //
+    // A rename that leaves this quiet is a rename nothing reports.
+    const root = await mkdtemp(path.join(tmpdir(), 'absent-spec-docs-'));
+    const mapping = parseStatusFolderMapping(
+      '## Spec-Document Status and Lifecycle Folders\n\n| status | folder |\n| --- | --- |\n| `todo` | `.agents/spec-docs/todo/` |\n',
+    );
+    expect(
+      () => findFolderStatusFindings(path.join(root, '.agents/spec-docs'), mapping),
+      'an absent subject was reported as clean',
+    ).toThrow(/spec-docs/);
   });
 });

--- a/scripts/harness/check-spec-doc-frontmatter.mjs
+++ b/scripts/harness/check-spec-doc-frontmatter.mjs
@@ -31,6 +31,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { asList, parseFrontmatterBlock } from './frontmatter.mjs';
+import { requireGovernedTree } from './governed-tree.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const SPEC_DIR = path.join(WORKSPACE_ROOT, '.agents/spec-docs');
@@ -82,10 +83,27 @@ function frontmatter(text) {
 export function findSpecDocFrontmatterFindings(target) {
   const blocking = [];
   const warnings = [];
-  const files =
-    target && existsSync(target) && statSync(target).isFile()
-      ? [target]
-      : walkMarkdown(target ?? SPEC_DIR);
+  const singleFile = target && existsSync(target) && statSync(target).isFile();
+  if (!singleFile) {
+    // Directory mode only. Measured 2026-08-01: over a root without `.agents/spec-docs` this
+    // returned `{blocking: [], warnings: []}` — what it also returns when every document is correct.
+    // PROC-006 moves this tree. The single-FILE branch above is deliberately exempt, because that is
+    // how the pre-commit path checks one document and its subject is the file, not the tree.
+    const dir = target ?? SPEC_DIR;
+    requireGovernedTree(path.dirname(dir), [path.basename(dir)], {
+      scan: 'spec-doc-frontmatter',
+      why: 'The spec-doc tree is the subject; "no findings" over an absent one means "nothing was examined".',
+    });
+  }
+  const files = singleFile ? [target] : walkMarkdown(target ?? SPEC_DIR);
+  if (!singleFile && files.length === 0) {
+    // An EMPTY tree is the same vacuity as an absent one. `measureFinder` hands a finder a bare temp
+    // DIRECTORY, which exists — so "the directory is there" passed while nothing was read.
+    throw new Error(
+      `spec-doc-frontmatter: no spec documents under ${target ?? SPEC_DIR}. Reporting "no findings" ` +
+        'here would mean "nothing was examined", which is not the claim this scan makes.',
+    );
+  }
   const idMap = new Map();
   for (const file of files) {
     const rel = path.relative(WORKSPACE_ROOT, file);

--- a/scripts/harness/scan-doc-folder-status-agreement.mjs
+++ b/scripts/harness/scan-doc-folder-status-agreement.mjs
@@ -36,6 +36,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { frontmatterObject } from './frontmatter.mjs';
+import { requireGovernedTree } from './governed-tree.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const SPEC_DIR = path.join(WORKSPACE_ROOT, '.agents/spec-docs');
@@ -111,9 +112,29 @@ const RECORDED_EXCEPTIONS = new Map([
 ]);
 
 export function findFolderStatusFindings(specDir = SPEC_DIR, mapping) {
+  // The subject must be there. Measured 2026-08-01: over a root without `.agents/spec-docs` this
+  // returned 0 findings — the same answer it gives when all 242 documents agree with their folder.
+  // PROC-006 is about to MOVE this tree, and a rename that leaves the scan quiet is a rename nothing
+  // reports. `scan-guard-scope-fail-closed` did not catch it, for the reason its own header states:
+  // its finder set is derived from `find…(root`, and this finder's first parameter is the directory.
+  requireGovernedTree(path.dirname(specDir), [path.basename(specDir)], {
+    scan: 'doc-folder-status-agreement',
+    why: 'The spec-doc tree is the subject; "no findings" over an absent one means "nothing was examined".',
+  });
+  // An EMPTY tree is the same vacuity as an absent one, and the weaker check missed it: the repo's
+  // own `measureFinder` hands a finder a bare temp DIRECTORY, which exists, so "the directory is
+  // there" passed while nothing was read. The claim this scan makes is about documents, so the
+  // documents are what must be present.
+  const documents = [...specDocuments(specDir)];
+  if (documents.length === 0) {
+    throw new Error(
+      `doc-folder-status-agreement: no spec documents under ${specDir}. Reporting "no findings" ` +
+        'here would mean "nothing was examined", which is not the claim this scan makes.',
+    );
+  }
   const findings = [];
   const exercised = new Set();
-  for (const relative of specDocuments(specDir)) {
+  for (const relative of documents) {
     const segments = relative.split('/');
     const actualFolder = segments.length > 1 ? segments[0] : null;
     const status = frontmatterObject(readFileSync(path.join(specDir, relative), 'utf8')).status;


### PR DESCRIPTION
Prerequisite for **#1550 (PROC-006)**, which moves `.agents/spec-docs`. Not the rename itself.

## Problem, measured before touching anything

`findFolderStatusFindings` and `findSpecDocFrontmatterFindings` both return zero findings over a root
with no spec-doc tree — the same answer they give when all 242 documents are correct.

PROC-006's own text names this as the reason it was filed rather than done inline:

> the scans reading these trees are the ones that would **go quiet rather than fail**, because most
> resolve a directory and report what they found

So the move has to be made detectable before it is made.

## Why this adds no new floor

One already exists. `scan-guard-scope-fail-closed` classifies every registered finder and **executes**
it against a root lacking its governed tree. These two are outside it, for the reason its own header
states:

> Anything outside the derived finder set — a scan that walks its tree inline in `main()`, or one
> that takes no root — is invisible here.

The derivation matches `export function find…(root`. Both of these take the **directory** as their
first parameter, so neither was ever classified. Raising that ceiling is the general fix and touches
a scan that other queued work sits behind; making these two fail closed is the part that unblocks the
move, and it is what this does.

## Two rounds, and the first was wrong instructively

Guarding on *"the directory exists"* passed the new tests and left the repo's own `measureFinder`
still reporting `vacuous` — it hands a finder a **bare temp directory**, which exists, so the guard
was satisfied while nothing was read.

An empty tree is the same vacuity as an absent one, and the claim these scans make is about
**documents**. So documents are what must be present.

```
measureFinder before:  vacuous      vacuous
measureFinder after:   fail-closed  fail-closed
```

That flip is the verification that matters here — it is the repository's own measurement of the
property, not a test I wrote to agree with myself.

## Red proof

Both new cases fail on the previous source:

```
× the subject cannot be absent and still read as clean > refuses a spec-docs tree that is not there
  → an absent subject was reported as clean: expected [Function] to throw an error   (×2)
```

## Deliberately exempt

`check-spec-doc-frontmatter`'s single-**file** mode. That is how the pre-commit path checks one
document, and its subject is the file, not the tree. Stated at the branch rather than left implicit.

## A correction to my own survey

I first reported three scans in this state. `scan-unearned-done-claims` is already fail-closed — its
ledger entry was right and my throwaway probe was wrong. Two, not three.

## Verification

2097 harness tests green, 84 scans pass.
