### PR TITLE
fix(harness): HARNESS-058 an unprepared tree names its prerequisite instead of blaming the change

### DIFF
--- a/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
+++ b/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
@@ -33,6 +33,63 @@ Three separate agents hit the same wall this session and each resolved it differ
 recorded them as real. The verification story for a fresh worktree is undefined, so every agent
 invents one. That is the defect; the stage order is only its most visible instance.
 
+## The fresh-worktree contract
+
+This is the answer that used to live in whoever last worked it out. The **executable** copy is
+`scripts/harness/tree-prerequisites.mjs` — it is what every entry point prints when the contract is
+unmet, so the contract cannot drift away from what the gate enforces. This section is its prose
+statement.
+
+### What a fresh worktree owes, before any verification
+
+| #   | Prerequisite   | Command                          | Who needs it                                          |
+| --- | -------------- | -------------------------------- | ----------------------------------------------------- |
+| 1   | `install`      | `pnpm install --frozen-lockfile` | every gate — they all shell out to workspace binaries |
+| 2   | `build-output` | `pnpm build`                     | every stage declaring `needsBuildOutput: true`        |
+
+Both must be run **inside the worktree itself**. Measured cost of step 1 on a warm pnpm store: ~3s.
+
+### Why "the parent clone has them" is not an answer
+
+A `git worktree` shares the object database, not the install. A pnpm workspace places a
+`node_modules` in **every package**, so there is nothing for a worktree to borrow.
+
+The two worktree layouts fail in **opposite directions**, which is why neither one ever taught
+anybody the contract:
+
+| Layout                                                  | Symptom without an install                          | Why it misleads                                                                                          |
+| ------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Sibling** (outside the repo, e.g. `/tmp/wt`)          | nothing starts: `Could not resolve 'vitest/config'` | looks catastrophic, so it gets diagnosed as a broken worktree rather than a missing step                 |
+| **Nested** (inside the repo, e.g. `.claude/worktrees/`) | gets much further, then `sh: 1: tsgo: not found`    | Node's resolver walks **UP** into the parent clone's `node_modules`, so imports work and binaries do not |
+
+The nested case is the dangerous one: it produces a _partial_ success whose failures land deep in a
+stage and read as defects in the change under test.
+
+### The distinction that must appear in the output
+
+**Failed because the code is wrong** vs **failed because this tree was never prepared.** The second
+is not a verdict on the change. Every entry point now refuses to produce one it cannot support, and
+says which prerequisite is missing and the command that satisfies it. It is a **failure**, never a
+skip — the gate still blocks.
+
+### Where it is enforced
+
+| Entry point                             | Requires                   | Behaviour when unmet                                                      |
+| --------------------------------------- | -------------------------- | ------------------------------------------------------------------------- |
+| `pnpm harness:pre-push`                 | `install` + `build-output` | blocks the push with the naming message, before any check runs            |
+| `pnpm harness:verify-like-ci`           | `install`                  | refuses to run any stage; `build-output` is left to its own `build` stage |
+| any `verify-like-ci` build-output stage | `build-output`             | that stage FAILS naming the prerequisite, instead of a downstream error   |
+
+`verify-change.mjs` (`pnpm harness:verify`) deliberately does **not** assert the contract itself: its
+root is `process.cwd()` and it is legitimately run against synthetic workspace fixtures with no
+install. It is reached as a gate only through the two entry points above, which own a real
+repository root.
+
+`ci-mirror-map.mjs` carries a `needsBuildOutput` declaration per stage, and
+`__tests__/ci-mirror-map.test.mjs` pins the declaration to the order: a stage that reads build
+output may not be listed before `build`, and a stage that declares nothing fails the test rather
+than silently sorting as "needs nothing".
+
 ## Proposed direction
 
 - Order stages so a prerequisite runs before what needs it, or make the dependent stage state its

--- a/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
+++ b/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
@@ -93,6 +93,30 @@ repository root.
 output may not be listed before `build`, and a stage that declares nothing fails the test rather
 than silently sorting as "needs nothing".
 
+### When the build itself fails
+
+Build output being absent has two different causes, and they need two different messages:
+
+| Cause          | When                                                         | What the message says                                                                       |
+| -------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `unprepared`   | no `build` stage will run in this run, and nothing is built  | name the prerequisite, and the command: `pnpm build`                                        |
+| `build-failed` | `build` ran in this run and FAILED, so dist is still missing | point at the build failure already reported; **do not** tell the reader to run `pnpm build` |
+
+The distinction exists because "a build was ATTEMPTED" is not "build output exists". The state is
+carried through the stage loop (`initialBuildState` / `advanceBuildState` in `verify-like-ci.mjs`)
+and dist is **re-read from disk** after `build` runs, never assumed from the fact that it was
+scheduled. Measured on a fresh worktree with a real build regression, before this was fixed:
+`examples-typecheck` emitted `TS2307: Cannot find module '@robota-sdk/agent-framework'` and a
+spurious "install @types/node" hint, and `binary-e2e` spent 20s waiting for a serve host that was
+never built — the exact noise this item exists to remove, in the scenario the feature is for.
+
+**Is `scan-suite`'s own dist re-check now redundant?** In this code path, yes: the loop-level gate
+runs first and blocks `scan-suite` before `runScanSuite` reads dist, so its inline check can now only
+fire if dist disappears between the two reads. It is deliberately kept — it guards a _different_
+hazard (the dist-dependent scans silently no-op and LOOK like a pass, which is a fail-open, not a
+misattribution) and it is the only check protecting `runScanSuite` if that function is ever called
+from somewhere other than this loop. Removing it is a separate change, not this one.
+
 ## Proposed direction
 
 - Order stages so a prerequisite runs before what needs it, or make the dependent stage state its

--- a/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
+++ b/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
@@ -47,7 +47,10 @@ statement.
 | 1   | `install`      | `pnpm install --frozen-lockfile` | every gate — they all shell out to workspace binaries |
 | 2   | `build-output` | `pnpm build`                     | every stage declaring `needsBuildOutput: true`        |
 
-Both must be run **inside the worktree itself**. Measured cost of step 1 on a warm pnpm store: ~3s.
+Both must be run **inside the worktree itself**. Measured cost of step 1 on a warm pnpm store: 2.9s
+in the freshly-created worktree this contract was proven in. Step 2 does not have to be run by hand
+before `verify-like-ci`: its own `build` stage produces the build output, which is why that entry
+point demands only the install.
 
 ### Why "the parent clone has them" is not an answer
 

--- a/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
+++ b/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
@@ -110,6 +110,13 @@ scheduled. Measured on a fresh worktree with a real build regression, before thi
 spurious "install @types/node" hint, and `binary-e2e` spent 20s waiting for a serve host that was
 never built — the exact noise this item exists to remove, in the scenario the feature is for.
 
+The tradeoff, stated plainly: after a failed build, `typecheck` no longer prints its own diagnostic
+for the regression. Nothing is lost that the `build` failure did not already report, and the stage
+runs normally once the build is fixed — this is the same ordering CI enforces with `needs: build`.
+What it buys is that the other four consumers stop reporting the unbuilt tree as a defect, and stop
+spending minutes doing it: `binary-e2e` alone burned 20.47s waiting for a serve host that was never
+built.
+
 **Is `scan-suite`'s own dist re-check now redundant?** In this code path, yes: the loop-level gate
 runs first and blocks `scan-suite` before `runScanSuite` reads dist, so its inline check can now only
 fire if dist disappears between the two reads. It is deliberately kept — it guards a _different_

--- a/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
+++ b/.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md
@@ -77,11 +77,20 @@ skip — the gate still blocks.
 
 ### Where it is enforced
 
-| Entry point                             | Requires                   | Behaviour when unmet                                                      |
-| --------------------------------------- | -------------------------- | ------------------------------------------------------------------------- |
-| `pnpm harness:pre-push`                 | `install` + `build-output` | blocks the push with the naming message, before any check runs            |
-| `pnpm harness:verify-like-ci`           | `install`                  | refuses to run any stage; `build-output` is left to its own `build` stage |
-| any `verify-like-ci` build-output stage | `build-output`             | that stage FAILS naming the prerequisite, instead of a downstream error   |
+| Entry point                                      | Requires                   | Behaviour when unmet                                                      |
+| ------------------------------------------------ | -------------------------- | ------------------------------------------------------------------------- |
+| `pnpm harness:pre-push`, **when it will verify** | `install` + `build-output` | blocks the push with the naming message, before any check runs            |
+| `pnpm harness:verify-like-ci`                    | `install`                  | refuses to run any stage; `build-output` is left to its own `build` stage |
+| any `verify-like-ci` build-output stage          | `build-output`             | that stage FAILS naming the prerequisite, instead of a downstream error   |
+
+**A prerequisite is owed only by work that is going to happen.** The pre-push gate skips verification
+entirely for a **delete-only push** and for a **re-push with no content delta from its base** — neither
+reads `node_modules` or `dist` — so the tree assertion sits behind that decision, not in front of it.
+Demanding `pnpm install && pnpm build` to delete a remote branch from a fresh worktree is the same
+class of defect as the one this item opened with: a gate refusing work it has no reason to judge.
+`runPrePushGate` in `pre-push.mjs` states the step order once, and
+`__tests__/pre-push-sequence.test.mjs` pins the SEQUENCE — asserting only "a delete-only push is
+allowed" would pass again if the assertion moved back, because a prepared tree passes either way.
 
 `verify-change.mjs` (`pnpm harness:verify`) deliberately does **not** assert the contract itself: its
 root is `process.cwd()` and it is legitimately run against synthetic workspace fixtures with no

--- a/scripts/harness/__tests__/ci-mirror-map.test.mjs
+++ b/scripts/harness/__tests__/ci-mirror-map.test.mjs
@@ -163,6 +163,41 @@ describe('the stage table itself is well-formed', () => {
     expect(new Set(names).size).toBe(names.length);
   });
 
+  /**
+   * HARNESS-058 — a prerequisite must run BEFORE what needs it.
+   *
+   * `typecheck` was stage 5 and `build` stage 6, so a cross-package `tsgo` run resolved to
+   * declaration files nothing had produced yet and the gate went red on a branch that changed no
+   * code. The fix is not a one-off swap: every stage now DECLARES whether it reads build output,
+   * and this pins the declaration to the order. A stage added below `build` needing dist is caught
+   * here rather than by the next agent to run the gate in a fresh worktree.
+   */
+  it('every stage declares whether it reads build output', () => {
+    for (const stage of CI_STAGES) {
+      expect(
+        typeof stage.needsBuildOutput,
+        `stage \`${stage.name}\` must declare needsBuildOutput — the stage order is derived from it, and an undeclared stage silently sorts as "needs nothing".`,
+      ).toBe('boolean');
+    }
+  });
+
+  it('the build stage does not itself read build output', () => {
+    const build = CI_STAGES.find((stage) => stage.name === 'build');
+    expect(build, 'the stage that produces build output must exist').toBeDefined();
+    expect(build.needsBuildOutput).toBe(false);
+  });
+
+  it('every stage that reads build output runs AFTER the stage that produces it', () => {
+    const buildIndex = CI_STAGES.findIndex((stage) => stage.name === 'build');
+    const tooEarly = CI_STAGES.filter(
+      (stage, index) => stage.needsBuildOutput && index < buildIndex,
+    ).map((stage) => stage.name);
+    expect(
+      tooEarly,
+      `stage(s) that read build output are ordered BEFORE \`build\`: ${tooEarly.join(', ')}. On an unbuilt tree they fail on missing declaration files / modules, which reads as a defect in the change under test (HARNESS-058).`,
+    ).toEqual([]);
+  });
+
   it('no stage mirrors a job the ruleset does not require', () => {
     const requiredJobs = new Set(REQUIRED.map((entry) => entry.job));
     for (const stage of CI_STAGES) {

--- a/scripts/harness/__tests__/pre-push-sequence.test.mjs
+++ b/scripts/harness/__tests__/pre-push-sequence.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * HARNESS-058 (second face) — the pre-push gate must not demand a prerequisite for work it has
+ * already decided not to do.
+ *
+ * The defect: `assertTreePrerequisites` ran third, before `decidePrePushVerification` decided
+ * whether anything would be verified at all. Two kinds of push verify nothing — a delete-only push,
+ * and a re-push whose tree has no content delta from its base — and neither reads `node_modules` or
+ * `dist`. Measured in a fresh worktree, both were refused with "run `pnpm install && pnpm build`"
+ * for a push with nothing to check, in exactly the parallel-subagent configuration the item serves.
+ *
+ * These assert the SEQUENCE, not only the two cases. A test that checked only "a delete-only push is
+ * allowed" would go green again the moment someone moved the assertion back ahead of the decision
+ * for an unrelated reason, because a tree that happens to be prepared passes either way. What is
+ * pinned here is that no step which reads build output runs before the decision that makes it
+ * relevant.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { runPrePushGate } from '../pre-push.mjs';
+import { decidePrePushVerification, parsePrePushUpdates } from '../pre-push-updates.mjs';
+
+/** Steps that record their own names instead of touching git, pnpm or the filesystem. */
+function recordingSteps(decision) {
+  const order = [];
+  const record =
+    (name, result) =>
+    (...args) => {
+      order.push(name);
+      return typeof result === 'function' ? result(...args) : result;
+    };
+  return {
+    order,
+    steps: {
+      pruneAndWarnStaleWorktrees: record('prune-worktrees'),
+      assertCleanWorkingTree: record('clean-working-tree'),
+      assertLockfileConsistency: record('lockfile-consistency'),
+      decideVerification: record('decide-verification', decision),
+      reportSkipped: record('report-skipped'),
+      assertTreePrerequisites: record('tree-prerequisites'),
+      runVerification: record('run-verification'),
+    },
+  };
+}
+
+const SKIP_DELETE_ONLY = { shouldRun: false, reason: 'delete-only push' };
+const SKIP_NO_DELTA = { shouldRun: false, reason: 'no content delta from origin/develop' };
+const VERIFY = { shouldRun: true, reason: null };
+
+describe('runPrePushGate step order', () => {
+  it('asserts the tree prerequisites only AFTER deciding to verify', () => {
+    const { order, steps } = recordingSteps(VERIFY);
+    runPrePushGate(steps);
+    expect(order).toEqual([
+      'prune-worktrees',
+      'clean-working-tree',
+      'lockfile-consistency',
+      'decide-verification',
+      'tree-prerequisites',
+      'run-verification',
+    ]);
+  });
+
+  it('never places a build-output-reading step before the decision', () => {
+    const { order, steps } = recordingSteps(VERIFY);
+    runPrePushGate(steps);
+    // Stated as an ordering invariant rather than an index, so it keeps its meaning if steps are
+    // added around it: a prerequisite is owed only by work that is going to happen.
+    expect(order.indexOf('tree-prerequisites')).toBeGreaterThan(
+      order.indexOf('decide-verification'),
+    );
+    expect(order.indexOf('tree-prerequisites')).toBeLessThan(order.indexOf('run-verification'));
+  });
+
+  it.each([
+    ['delete-only push', SKIP_DELETE_ONLY],
+    ['no content delta', SKIP_NO_DELTA],
+  ])('does not assert tree prerequisites when the decision is to skip (%s)', (_label, decision) => {
+    const { order, steps } = recordingSteps(decision);
+    const result = runPrePushGate(steps);
+    expect(order).toEqual([
+      'prune-worktrees',
+      'clean-working-tree',
+      'lockfile-consistency',
+      'decide-verification',
+      'report-skipped',
+    ]);
+    expect(order).not.toContain('tree-prerequisites');
+    expect(order).not.toContain('run-verification');
+    expect(result).toEqual({ verified: false, reason: decision.reason });
+  });
+
+  it('reports the skip reason it was given, so the push says why it verified nothing', () => {
+    const reported = [];
+    const { steps } = recordingSteps(SKIP_NO_DELTA);
+    steps.reportSkipped = (reason) => reported.push(reason);
+    runPrePushGate(steps);
+    expect(reported).toEqual(['no content delta from origin/develop']);
+  });
+
+  it('reports a verified run', () => {
+    const { steps } = recordingSteps(VERIFY);
+    expect(runPrePushGate(steps)).toEqual({ verified: true, reason: null });
+  });
+});
+
+/**
+ * The sequence test above uses a stubbed decision, so these connect it to the REAL predicate: the
+ * two skip reasons are the ones `decidePrePushVerification` actually produces from real hook stdin.
+ * Without this pairing the ordering test could pin a decision shape nothing ever returns.
+ */
+describe('the real decision reaches the gate as a skip', () => {
+  const ZERO = '0'.repeat(40);
+  const SHA = 'a'.repeat(40);
+
+  const gateFor = (input, { baseRef, treeMatchesBase }) => {
+    const decision = decidePrePushVerification({
+      updates: parsePrePushUpdates(input),
+      baseRef,
+      treeMatchesBase,
+    });
+    const { order, steps } = recordingSteps(decision);
+    const result = runPrePushGate(steps);
+    return { order, result, decision };
+  };
+
+  it('a real delete-only hook line skips verification and asserts no prerequisite', () => {
+    const { order, result } = gateFor(`(delete) ${ZERO} refs/heads/gone ${SHA}\n`, {
+      baseRef: 'origin/develop',
+      treeMatchesBase: false,
+    });
+    expect(result).toEqual({ verified: false, reason: 'delete-only push' });
+    expect(order).not.toContain('tree-prerequisites');
+  });
+
+  it('a real no-delta re-push skips verification and asserts no prerequisite', () => {
+    const { order, result } = gateFor(`refs/heads/x ${SHA} refs/heads/x ${ZERO}\n`, {
+      baseRef: 'origin/develop',
+      treeMatchesBase: true,
+    });
+    expect(result).toEqual({ verified: false, reason: 'no content delta from origin/develop' });
+    expect(order).not.toContain('tree-prerequisites');
+  });
+
+  it('a real push WITH a delta still reaches the prerequisite assertion', () => {
+    const { order, result } = gateFor(`refs/heads/x ${SHA} refs/heads/x ${ZERO}\n`, {
+      baseRef: 'origin/develop',
+      treeMatchesBase: false,
+    });
+    expect(result).toEqual({ verified: true, reason: null });
+    expect(order).toContain('tree-prerequisites');
+  });
+});

--- a/scripts/harness/__tests__/tree-prerequisites.test.mjs
+++ b/scripts/harness/__tests__/tree-prerequisites.test.mjs
@@ -240,6 +240,44 @@ describe('formatPrerequisiteFailure', () => {
   it('routes to the written contract rather than to whoever last worked it out', () => {
     expect(formatPrerequisiteFailure('pre-push', unpreparedNested())).toContain(CONTRACT_DOC);
   });
+
+  /**
+   * When `build` ran and FAILED, "run `pnpm build`" is the wrong instruction to hand someone who
+   * just watched it fail, and "nothing has been measured" is untrue — the build measured the change
+   * and rejected it. The message has to point AT that failure or it reads as a competing verdict.
+   */
+  describe('cause `build-failed`', () => {
+    const message = () =>
+      formatPrerequisiteFailure(
+        'verify-like-ci stage `typecheck`',
+        unpreparedNested(),
+        'build-failed',
+      );
+
+    it('names the build failure as the cause, not an unprepared tree', () => {
+      expect(message()).toContain('the `build` stage FAILED earlier in this run');
+    });
+
+    it('sends the reader to the failure already reported, and does NOT tell them to run the build', () => {
+      expect(message()).toContain('Fix the `build` failure reported above');
+      expect(message()).not.toContain('Run this IN THIS TREE');
+    });
+
+    it('does not claim nothing was measured — the build measured it and failed', () => {
+      expect(message()).not.toContain('nothing about the diff has been measured yet');
+      expect(message()).toContain('NOT a second verdict');
+    });
+
+    it('still names the missing build output, so the reader sees the consequence', () => {
+      expect(message()).toContain('MISSING  build-output');
+    });
+  });
+
+  it('refuses a cause it cannot explain rather than printing a generic one', () => {
+    expect(() =>
+      formatPrerequisiteFailure('verify-like-ci', unpreparedNested(), 'mystery'),
+    ).toThrow(/unknown prerequisite cause/);
+  });
 });
 
 describe('checkTreePrerequisites', () => {

--- a/scripts/harness/__tests__/tree-prerequisites.test.mjs
+++ b/scripts/harness/__tests__/tree-prerequisites.test.mjs
@@ -11,7 +11,8 @@
  * is unbuilt and still prints a module-resolution stack trace has fixed nothing.
  */
 
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -91,30 +92,54 @@ describe('listBuildablePackageDirs / findMissingDist', () => {
   });
 });
 
+/**
+ * These use REAL git repositories and REAL `git worktree add`. `describeTree` asks git rather than
+ * inspecting `.git` by hand, so a fixture that fakes the `.git` layout would be testing a heuristic
+ * the code no longer uses.
+ */
+function createGitRepo() {
+  const root = realpathSync(mkdtempSync(path.join(tmpdir(), 'tree-prerequisites-git-')));
+  const git = (...args) => execFileSync('git', ['-C', root, ...args], { stdio: 'pipe' });
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'harness');
+  writeFileSync(path.join(root, 'seed.txt'), 'seed\n');
+  git('add', 'seed.txt');
+  git('commit', '-qm', 'seed');
+  return { root, git };
+}
+
 describe('describeTree', () => {
   it('calls the main clone a clone', () => {
-    const root = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
+    const { root } = createGitRepo();
     expect(describeTree(root).kind).toBe('clone');
   });
 
   it('resolves a linked worktree to its parent clone and marks it nested', () => {
-    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
-    const nested = path.join(parent, '.claude', 'worktrees', 'agent-x');
-    mkdirSync(nested, { recursive: true });
-    writeFileSync(path.join(nested, '.git'), `gitdir: ${parent}/.git/worktrees/agent-x\n`);
+    const { root, git } = createGitRepo();
+    const nested = path.join(root, 'nested-wt');
+    git('worktree', 'add', '-q', '-b', 'nested-branch', nested);
     const described = describeTree(nested);
     expect(described.kind).toBe('worktree');
-    expect(described.parent).toBe(parent);
+    expect(described.parent).toBe(root);
     expect(described.nested).toBe(true);
   });
 
   it('marks a worktree outside the parent clone as NOT nested', () => {
-    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
-    const sibling = createFixture({});
-    writeFileSync(path.join(sibling, '.git'), `gitdir: ${parent}/.git/worktrees/agent-y\n`);
+    const { root, git } = createGitRepo();
+    const sibling = path.join(
+      realpathSync(mkdtempSync(path.join(tmpdir(), 'tree-prerequisites-sibling-'))),
+      'wt',
+    );
+    git('worktree', 'add', '-q', '-b', 'sibling-branch', sibling);
     const described = describeTree(sibling);
+    expect(described.kind).toBe('worktree');
+    expect(described.parent).toBe(root);
     expect(described.nested).toBe(false);
-    expect(described.parent).toBe(parent);
+  });
+
+  it('calls a path outside any repository unknown', () => {
+    expect(describeTree(createFixture({ 'package.json': '{}' })).kind).toBe('unknown');
   });
 });
 
@@ -163,11 +188,12 @@ describe('inspectTree', () => {
 // ---------------------------------------------------------------------------
 
 describe('formatPrerequisiteFailure', () => {
+  /** A real nested worktree, installed by nobody and built by nobody. */
   const unpreparedNested = () => {
-    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
-    const nested = path.join(parent, '.claude', 'worktrees', 'agent-x');
+    const { root, git } = createGitRepo();
+    const nested = path.join(root, 'nested-wt');
+    git('worktree', 'add', '-q', '-b', `nested-${Date.now()}`, nested);
     mkdirSync(path.join(nested, 'packages', 'unbuilt'), { recursive: true });
-    writeFileSync(path.join(nested, '.git'), `gitdir: ${parent}/.git/worktrees/agent-x\n`);
     writeFileSync(path.join(nested, 'packages', 'unbuilt', 'package.json'), BUILDABLE_MANIFEST);
     return inspectTree(nested);
   };
@@ -201,9 +227,12 @@ describe('formatPrerequisiteFailure', () => {
   });
 
   it('explains a sibling worktree by the opposite symptom', () => {
-    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
-    const sibling = createFixture({});
-    writeFileSync(path.join(sibling, '.git'), `gitdir: ${parent}/.git/worktrees/agent-y\n`);
+    const { git } = createGitRepo();
+    const sibling = path.join(
+      realpathSync(mkdtempSync(path.join(tmpdir(), 'tree-prerequisites-sibling-'))),
+      'wt',
+    );
+    git('worktree', 'add', '-q', '-b', `sibling-${Date.now()}`, sibling);
     const message = formatPrerequisiteFailure('verify-like-ci', inspectTree(sibling));
     expect(message).toContain("Could not resolve 'vitest/config'");
   });

--- a/scripts/harness/__tests__/tree-prerequisites.test.mjs
+++ b/scripts/harness/__tests__/tree-prerequisites.test.mjs
@@ -1,0 +1,234 @@
+/**
+ * HARNESS-058 — an unprepared tree must produce a message NAMING the prerequisite.
+ *
+ * The defect these pin: a fresh `git worktree` has no install and no build output, and every gate
+ * that needed one reported the absence as a defect in the branch under test (`tsgo: not found`,
+ * `Cannot find package '@typescript/native-preview'`, `Cannot find module '…/dist/node/index.js'`).
+ * Four sub-agents each spent real effort proving those reds were not their own, and all four then
+ * pushed with `--no-verify`.
+ *
+ * So the assertions here are about the OUTPUT, not only the boolean: a detector that knows the tree
+ * is unbuilt and still prints a module-resolution stack trace has fixed nothing.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkTreePrerequisites,
+  CONTRACT_DOC,
+  describeTree,
+  findMissingDist,
+  formatPrerequisiteFailure,
+  inspectTree,
+  isInstalled,
+  listBuildablePackageDirs,
+  PREREQUISITE_ORDER,
+  remedyCommands,
+} from '../tree-prerequisites.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+function createFixture(files) {
+  const root = mkdtempSync(path.join(tmpdir(), 'tree-prerequisites-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return root;
+}
+
+const BUILDABLE_MANIFEST = JSON.stringify({ scripts: { 'build:js': 'tsdown' } });
+
+// ---------------------------------------------------------------------------
+// detection
+// ---------------------------------------------------------------------------
+
+describe('isInstalled', () => {
+  it('is false when the tree has no pnpm install marker of its OWN', () => {
+    const root = createFixture({ 'package.json': '{}' });
+    expect(isInstalled(root)).toBe(false);
+  });
+
+  it('is false for a bare node_modules directory with no pnpm marker', () => {
+    // A nested worktree can inherit stray directories; only the marker proves `pnpm install` ran here.
+    const root = createFixture({ 'node_modules/left-over/index.js': '' });
+    expect(isInstalled(root)).toBe(false);
+  });
+
+  it('is true once pnpm has written its install marker', () => {
+    const root = createFixture({ 'node_modules/.modules.yaml': 'hoistPattern: []\n' });
+    expect(isInstalled(root)).toBe(true);
+  });
+
+  it('recognises this repository checkout as installed', () => {
+    expect(isInstalled(WORKSPACE_ROOT)).toBe(true);
+  });
+});
+
+describe('listBuildablePackageDirs / findMissingDist', () => {
+  it('lists only packages that declare build:js, including the nested dag-nodes family', () => {
+    const root = createFixture({
+      'packages/built/package.json': BUILDABLE_MANIFEST,
+      'packages/no-build/package.json': JSON.stringify({ scripts: { test: 'vitest' } }),
+      'packages/dag-nodes/nested/package.json': BUILDABLE_MANIFEST,
+    });
+    expect(listBuildablePackageDirs(root)).toEqual(['packages/built', 'packages/dag-nodes/nested']);
+  });
+
+  it('reports the dirs with no dist/', () => {
+    const root = createFixture({
+      'packages/built/dist/index.js': '',
+      'packages/unbuilt/package.json': BUILDABLE_MANIFEST,
+    });
+    expect(findMissingDist(['packages/built', 'packages/unbuilt'], undefined, root)).toEqual([
+      'packages/unbuilt',
+    ]);
+  });
+});
+
+describe('describeTree', () => {
+  it('calls the main clone a clone', () => {
+    const root = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
+    expect(describeTree(root).kind).toBe('clone');
+  });
+
+  it('resolves a linked worktree to its parent clone and marks it nested', () => {
+    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
+    const nested = path.join(parent, '.claude', 'worktrees', 'agent-x');
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(path.join(nested, '.git'), `gitdir: ${parent}/.git/worktrees/agent-x\n`);
+    const described = describeTree(nested);
+    expect(described.kind).toBe('worktree');
+    expect(described.parent).toBe(parent);
+    expect(described.nested).toBe(true);
+  });
+
+  it('marks a worktree outside the parent clone as NOT nested', () => {
+    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
+    const sibling = createFixture({});
+    writeFileSync(path.join(sibling, '.git'), `gitdir: ${parent}/.git/worktrees/agent-y\n`);
+    const described = describeTree(sibling);
+    expect(described.nested).toBe(false);
+    expect(described.parent).toBe(parent);
+  });
+});
+
+describe('inspectTree', () => {
+  it('reports install BEFORE build-output — install produces what build needs', () => {
+    const root = createFixture({ 'packages/unbuilt/package.json': BUILDABLE_MANIFEST });
+    expect(inspectTree(root).missing).toEqual(['install', 'build-output']);
+  });
+
+  it('reports only build-output once the tree carries its own install', () => {
+    const root = createFixture({
+      'node_modules/.modules.yaml': '',
+      'packages/unbuilt/package.json': BUILDABLE_MANIFEST,
+    });
+    expect(inspectTree(root).missing).toEqual(['build-output']);
+  });
+
+  it('reports nothing missing for a prepared tree', () => {
+    const root = createFixture({
+      'node_modules/.modules.yaml': '',
+      'packages/built/package.json': BUILDABLE_MANIFEST,
+      'packages/built/dist/index.js': '',
+    });
+    expect(inspectTree(root).missing).toEqual([]);
+  });
+
+  it('does not demand build output from a caller that only requires an install', () => {
+    const root = createFixture({
+      'node_modules/.modules.yaml': '',
+      'packages/unbuilt/package.json': BUILDABLE_MANIFEST,
+    });
+    expect(inspectTree(root, ['install']).missing).toEqual([]);
+  });
+
+  it('PREREQUISITE_ORDER is the dependency order the remedy is printed in', () => {
+    expect(PREREQUISITE_ORDER).toEqual(['install', 'build-output']);
+    expect(remedyCommands(PREREQUISITE_ORDER)).toEqual([
+      'pnpm install --frozen-lockfile',
+      'pnpm build',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// the message — the part that actually closes the item
+// ---------------------------------------------------------------------------
+
+describe('formatPrerequisiteFailure', () => {
+  const unpreparedNested = () => {
+    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
+    const nested = path.join(parent, '.claude', 'worktrees', 'agent-x');
+    mkdirSync(path.join(nested, 'packages', 'unbuilt'), { recursive: true });
+    writeFileSync(path.join(nested, '.git'), `gitdir: ${parent}/.git/worktrees/agent-x\n`);
+    writeFileSync(path.join(nested, 'packages', 'unbuilt', 'package.json'), BUILDABLE_MANIFEST);
+    return inspectTree(nested);
+  };
+
+  it('states it is not a verdict on the change', () => {
+    const message = formatPrerequisiteFailure('verify-like-ci', unpreparedNested());
+    expect(message).toContain('NOT a verdict on your change');
+  });
+
+  it('names every missing prerequisite and the command that satisfies it, in order', () => {
+    const message = formatPrerequisiteFailure('verify-like-ci', unpreparedNested());
+    expect(message).toContain('MISSING  install');
+    expect(message).toContain('MISSING  build-output');
+    expect(message.indexOf('pnpm install --frozen-lockfile')).toBeLessThan(
+      message.indexOf('pnpm build'),
+    );
+  });
+
+  it('names the tree and its parent clone, because "the deps are right there" is the misdiagnosis', () => {
+    const state = unpreparedNested();
+    const message = formatPrerequisiteFailure('verify-like-ci', state);
+    expect(message).toContain(state.root);
+    expect(message).toContain(state.tree.parent);
+    expect(message).toContain('does NOT share');
+  });
+
+  it('explains a nested worktree by the upward module resolution that makes it look installed', () => {
+    const message = formatPrerequisiteFailure('verify-like-ci', unpreparedNested());
+    expect(message).toContain('walks UP into the parent');
+    expect(message).toContain('tsgo: not found');
+  });
+
+  it('explains a sibling worktree by the opposite symptom', () => {
+    const parent = createFixture({ '.git/HEAD': 'ref: refs/heads/develop\n' });
+    const sibling = createFixture({});
+    writeFileSync(path.join(sibling, '.git'), `gitdir: ${parent}/.git/worktrees/agent-y\n`);
+    const message = formatPrerequisiteFailure('verify-like-ci', inspectTree(sibling));
+    expect(message).toContain("Could not resolve 'vitest/config'");
+  });
+
+  it('routes to the written contract rather than to whoever last worked it out', () => {
+    expect(formatPrerequisiteFailure('pre-push', unpreparedNested())).toContain(CONTRACT_DOC);
+  });
+});
+
+describe('checkTreePrerequisites', () => {
+  it('is ok with an empty message on a prepared tree — it must never invent work', () => {
+    const root = createFixture({
+      'node_modules/.modules.yaml': '',
+      'packages/built/package.json': BUILDABLE_MANIFEST,
+      'packages/built/dist/index.js': '',
+    });
+    const result = checkTreePrerequisites('verify-like-ci', root);
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe('');
+  });
+
+  it('is not ok, and carries the naming message, on an unprepared tree', () => {
+    const root = createFixture({ 'packages/unbuilt/package.json': BUILDABLE_MANIFEST });
+    const result = checkTreePrerequisites('verify-like-ci', root);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('missing a verification prerequisite');
+  });
+});

--- a/scripts/harness/__tests__/tree-prerequisites.test.mjs
+++ b/scripts/harness/__tests__/tree-prerequisites.test.mjs
@@ -299,3 +299,25 @@ describe('checkTreePrerequisites', () => {
     expect(result.message).toContain('missing a verification prerequisite');
   });
 });
+
+describe('findMissingDist names the tree it judges', () => {
+  it('refuses to guess which tree, rather than defaulting to one', () => {
+    // Review of #1577. `root` had no default, so a caller that omitted it got
+    // `path.join(undefined, …)` — a TypeError from deep inside `path`, naming nothing.
+    //
+    // The reviewer offered a default OR an assertion. A default is the wrong answer HERE: this
+    // module exists so a verification result is attributed to the right tree, and defaulting to the
+    // workspace root would silently judge a DIFFERENT tree than the caller meant — the exact
+    // misattribution the module was written to end, arriving through its own convenience.
+    expect(
+      () => findMissingDist(['packages/x'], () => false),
+      'an omitted root was guessed at instead of refused',
+    ).toThrow(/root/i);
+  });
+
+  it('still answers when the tree is named', () => {
+    // The other direction, so the refusal above cannot be satisfied by a function that always throws.
+    expect(findMissingDist(['packages/x'], () => false, '/some/tree')).toEqual(['packages/x']);
+    expect(findMissingDist(['packages/x'], () => true, '/some/tree')).toEqual([]);
+  });
+});

--- a/scripts/harness/__tests__/verify-like-ci.test.mjs
+++ b/scripts/harness/__tests__/verify-like-ci.test.mjs
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { describeCiSource } from '../ci-mirror-map.mjs';
 import {
   annotateNotMirrored,
+  blockedByMissingBuildOutput,
   CI_STAGES,
   collectChangedFiles,
   findMissingDist,
@@ -164,6 +165,59 @@ describe('findMissingDist', () => {
   it('returns nothing when every package is built', () => {
     const root = createFixture({ 'packages/built/dist/index.js': '' });
     expect(findMissingDist(['packages/built'], undefined, root)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unbuilt tree (HARNESS-058): a stage must not report on ground the tree lacks
+// ---------------------------------------------------------------------------
+
+describe('blockedByMissingBuildOutput', () => {
+  const consumer = { name: 'typecheck', needsBuildOutput: true };
+  const producer = { name: 'build', needsBuildOutput: false };
+
+  it('blocks a build-output stage when nothing will build and no dist exists', () => {
+    expect(
+      blockedByMissingBuildOutput(consumer, { willBuild: false, missingDist: ['packages/a'] }),
+    ).toBe(true);
+  });
+
+  it('does NOT block when this run will build — the gate produces what the stage reads', () => {
+    expect(
+      blockedByMissingBuildOutput(consumer, { willBuild: true, missingDist: ['packages/a'] }),
+    ).toBe(false);
+  });
+
+  it('does NOT block on a built tree', () => {
+    expect(blockedByMissingBuildOutput(consumer, { willBuild: false, missingDist: [] })).toBe(
+      false,
+    );
+  });
+
+  it('never blocks a stage that reads no build output — the fast tier still runs unbuilt', () => {
+    expect(
+      blockedByMissingBuildOutput(producer, { willBuild: false, missingDist: ['packages/a'] }),
+    ).toBe(false);
+    expect(
+      blockedByMissingBuildOutput(
+        { name: 'format-check', needsBuildOutput: false },
+        {
+          willBuild: false,
+          missingDist: ['packages/a'],
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('blocks every build-output stage the real table declares, so none of them can fake a verdict', () => {
+    const consumers = CI_STAGES.filter((stage) => stage.needsBuildOutput);
+    expect(consumers.length).toBeGreaterThan(0);
+    for (const stage of consumers) {
+      expect(
+        blockedByMissingBuildOutput(stage, { willBuild: false, missingDist: ['packages/a'] }),
+        `\`${stage.name}\` declares it reads build output but would still run on an unbuilt tree`,
+      ).toBe(true);
+    }
   });
 });
 

--- a/scripts/harness/__tests__/verify-like-ci.test.mjs
+++ b/scripts/harness/__tests__/verify-like-ci.test.mjs
@@ -6,8 +6,8 @@ import { describe, expect, it } from 'vitest';
 
 import { describeCiSource } from '../ci-mirror-map.mjs';
 import {
+  advanceBuildState,
   annotateNotMirrored,
-  blockedByMissingBuildOutput,
   CI_STAGES,
   collectChangedFiles,
   findMissingDist,
@@ -22,6 +22,7 @@ import {
   readDistIndependentScanSkips,
   readLintStagedExtensions,
   selectFormatTargets,
+  stageBlockCause,
   stageGate,
   summarize,
 } from '../verify-like-ci.mjs';
@@ -172,52 +173,125 @@ describe('findMissingDist', () => {
 // unbuilt tree (HARNESS-058): a stage must not report on ground the tree lacks
 // ---------------------------------------------------------------------------
 
-describe('blockedByMissingBuildOutput', () => {
-  const consumer = { name: 'typecheck', needsBuildOutput: true };
-  const producer = { name: 'build', needsBuildOutput: false };
+const CONSUMER = { name: 'typecheck', needsBuildOutput: true };
+const PRODUCER = { name: 'build', needsBuildOutput: false };
 
-  it('blocks a build-output stage when nothing will build and no dist exists', () => {
-    expect(
-      blockedByMissingBuildOutput(consumer, { willBuild: false, missingDist: ['packages/a'] }),
-    ).toBe(true);
+/** A run that has not reached `build` yet, on a tree with nothing built. */
+const pendingBuild = { buildPending: true, buildFailed: false, missingDist: ['packages/a'] };
+
+describe('stageBlockCause', () => {
+  it('does NOT block while `build` is still ahead — the output is about to appear', () => {
+    expect(stageBlockCause(CONSUMER, pendingBuild)).toBeNull();
   });
 
-  it('does NOT block when this run will build — the gate produces what the stage reads', () => {
+  it('blocks as `unprepared` when no build will run and nothing is built', () => {
     expect(
-      blockedByMissingBuildOutput(consumer, { willBuild: true, missingDist: ['packages/a'] }),
-    ).toBe(false);
+      stageBlockCause(CONSUMER, {
+        buildPending: false,
+        buildFailed: false,
+        missingDist: ['packages/a'],
+      }),
+    ).toBe('unprepared');
   });
 
-  it('does NOT block on a built tree', () => {
-    expect(blockedByMissingBuildOutput(consumer, { willBuild: false, missingDist: [] })).toBe(
-      false,
-    );
+  /**
+   * The reviewer disagreement this pins, settled by measurement rather than argument. A build that
+   * was ATTEMPTED is not build output. Measured on a fresh worktree with a real build regression:
+   * `examples-typecheck` emitted `TS2307: Cannot find module '@robota-sdk/agent-framework'` and a
+   * spurious "install @types/node" hint; `binary-e2e` spent 20s waiting for a serve host that was
+   * never built. Neither is a verdict on the change.
+   */
+  it('blocks as `build-failed` once `build` ran and FAILED with dist still absent', () => {
+    expect(
+      stageBlockCause(CONSUMER, {
+        buildPending: false,
+        buildFailed: true,
+        missingDist: ['packages/a'],
+      }),
+    ).toBe('build-failed');
+  });
+
+  it('does NOT block after a successful build — dist is there', () => {
+    expect(
+      stageBlockCause(CONSUMER, { buildPending: false, buildFailed: false, missingDist: [] }),
+    ).toBeNull();
   });
 
   it('never blocks a stage that reads no build output — the fast tier still runs unbuilt', () => {
+    expect(stageBlockCause(PRODUCER, { ...pendingBuild, buildPending: false })).toBeNull();
     expect(
-      blockedByMissingBuildOutput(producer, { willBuild: false, missingDist: ['packages/a'] }),
-    ).toBe(false);
-    expect(
-      blockedByMissingBuildOutput(
+      stageBlockCause(
         { name: 'format-check', needsBuildOutput: false },
         {
-          willBuild: false,
-          missingDist: ['packages/a'],
+          ...pendingBuild,
+          buildPending: false,
         },
       ),
-    ).toBe(false);
+    ).toBeNull();
   });
 
-  it('blocks every build-output stage the real table declares, so none of them can fake a verdict', () => {
+  it('blocks every build-output stage the real table declares, so none can fake a verdict', () => {
     const consumers = CI_STAGES.filter((stage) => stage.needsBuildOutput);
     expect(consumers.length).toBeGreaterThan(0);
     for (const stage of consumers) {
       expect(
-        blockedByMissingBuildOutput(stage, { willBuild: false, missingDist: ['packages/a'] }),
-        `\`${stage.name}\` declares it reads build output but would still run on an unbuilt tree`,
-      ).toBe(true);
+        stageBlockCause(stage, {
+          buildPending: false,
+          buildFailed: true,
+          missingDist: ['packages/a'],
+        }),
+        `\`${stage.name}\` declares it reads build output but would still run after a FAILED build`,
+      ).toBe('build-failed');
     }
+  });
+});
+
+describe('advanceBuildState', () => {
+  it('leaves the state alone for any stage that is not `build`', () => {
+    expect(advanceBuildState(pendingBuild, CONSUMER, 0, () => [])).toEqual(pendingBuild);
+  });
+
+  it('re-reads dist from DISK after a successful build rather than assuming it appeared', () => {
+    const next = advanceBuildState(pendingBuild, PRODUCER, 0, () => []);
+    expect(next).toEqual({ buildPending: false, buildFailed: false, missingDist: [] });
+  });
+
+  it('records the failure and keeps the dist it actually found after a FAILED build', () => {
+    const next = advanceBuildState(pendingBuild, PRODUCER, 1, () => ['packages/a']);
+    expect(next).toEqual({
+      buildPending: false,
+      buildFailed: true,
+      missingDist: ['packages/a'],
+    });
+  });
+});
+
+describe('the loop sequence a run actually walks', () => {
+  /** Replay the loop's state transitions over an ordered stage list. */
+  const replay = (stages, buildCode, distAfterBuild) => {
+    let state = { buildPending: true, buildFailed: false, missingDist: ['packages/a'] };
+    const seen = [];
+    for (const stage of stages) {
+      seen.push([stage.name, stageBlockCause(stage, state)]);
+      state = advanceBuildState(state, stage, stage.name === 'build' ? buildCode : 0, () => [
+        ...distAfterBuild,
+      ]);
+    }
+    return seen;
+  };
+
+  it('a FAILED build blocks every consumer that follows it', () => {
+    expect(replay([PRODUCER, CONSUMER], 1, ['packages/a'])).toEqual([
+      ['build', null],
+      ['typecheck', 'build-failed'],
+    ]);
+  });
+
+  it('a successful build blocks nothing that follows it', () => {
+    expect(replay([PRODUCER, CONSUMER], 0, [])).toEqual([
+      ['build', null],
+      ['typecheck', null],
+    ]);
   });
 });
 

--- a/scripts/harness/ci-mirror-map.mjs
+++ b/scripts/harness/ci-mirror-map.mjs
@@ -64,38 +64,50 @@ export const MIRRORED_BRANCH = 'develop';
  * `extra` marks a stage that mirrors no CI job at all; it must say what it covers instead, because a
  * stage nobody can trace to a required check is either valuable for a stated reason or is drift.
  *
- * ORDER IS DELIBERATE: every stage that needs no build output runs first, so a prettier violation
- * or a bad commit subject surfaces in seconds rather than behind the minutes-long `build` and
- * `tui-e2e` stages. No stage is skipped because an earlier one failed.
+ * `needsBuildOutput` is the DECLARATION the order is derived from, and
+ * `__tests__/ci-mirror-map.test.mjs` pins the two together: a stage that reads build output may not
+ * be listed before `build`, and a stage that declares nothing is a test failure rather than a stage
+ * that silently sorts as "needs nothing".
+ *
+ * ORDER IS DELIBERATE, in two tiers (HARNESS-058):
+ *   1. Stages that read NO build output run first, so a prettier violation or a bad commit subject
+ *      surfaces in seconds rather than behind the minutes-long `build` and `tui-e2e` stages.
+ *   2. `build` runs before every stage that consumes build output. `typecheck` used to sit in tier 1
+ *      on the assumption that a type check needs nothing — it needs the cross-package declaration
+ *      files `build` emits, so on a fresh worktree it went red on a branch that changed no code, and
+ *      a missing-declaration error is indistinguishable from a real type error. A prerequisite runs
+ *      before what needs it; a stage that cannot have its prerequisite met says so instead
+ *      (`tree-prerequisites.mjs`).
+ * No stage is skipped because an earlier one failed.
  */
 export const CI_STAGES = [
   {
     name: 'format-check',
+    needsBuildOutput: false,
     extra: '.lintstagedrc.json (prettier via .husky/pre-commit)',
     why: 'no CI job re-checks formatting, and a --no-verify push from a fresh worktree never runs the SSOT formatter',
   },
   {
     name: 'commitlint',
+    needsBuildOutput: false,
     mirrors: [{ job: 'commitlint', steps: ['Lint PR commit messages'] }],
     why: 'a subject over the length limit fails a REQUIRED check after the push, for a defect visible before it',
   },
   {
     name: 'harness-self-test',
+    needsBuildOutput: false,
     mirrors: [{ job: 'scans', steps: ['Harness scan test suite'] }],
     why: 'asserts baseline TIGHTNESS (spec-surface notices == []), which run-all-scans reports as a pass',
   },
   {
     name: 'scan-suite-dist-free',
+    needsBuildOutput: false,
     mirrors: [{ job: 'scans', steps: ['Harness scan suite (dist-independent)'] }],
     why: 'a hardcoded build-output path literal resolves on a built tree and is a GHOST path in CI',
   },
   {
-    name: 'typecheck',
-    extra: 'workspace-wide `pnpm -w typecheck`',
-    why: 'strictly WIDER than the affected-scope typecheck `quality` runs, and ~6s after PERF-004 — cheap over-coverage, not drift',
-  },
-  {
     name: 'build',
+    needsBuildOutput: false,
     mirrors: [
       {
         job: 'build',
@@ -118,27 +130,38 @@ export const CI_STAGES = [
     why: 'CI builds before every job that reads dist; locally a STALE dist passes the presence-only freshness scan',
   },
   {
+    name: 'typecheck',
+    needsBuildOutput: true,
+    extra: 'workspace-wide `pnpm -w typecheck`',
+    why: 'strictly WIDER than the affected-scope typecheck `quality` runs, and ~6s after PERF-004 — cheap over-coverage, not drift',
+  },
+  {
     name: 'scan-suite',
+    needsBuildOutput: true,
     mirrors: [{ job: 'quality', steps: ['Build-output contracts scan (dist-dependent)'] }],
     why: 'the dist-dependent scans silently no-op on an unbuilt tree',
   },
   {
     name: 'affected-verify',
+    needsBuildOutput: true,
     mirrors: [{ job: 'quality', steps: ['Verify affected quality checks'] }],
     why: 'THE package test suites, lint and scoped typecheck — the gates verify-like-ci omitted entirely (INFRA-056)',
   },
   {
     name: 'binary-e2e',
+    needsBuildOutput: true,
     mirrors: [{ job: 'quality', steps: ['Binary e2e (agent-cli bintests, dist-dependent)'] }],
     why: 'black-box e2e over the BUILT robota binary; no unit suite covers the packaged entry point',
   },
   {
     name: 'examples-typecheck',
+    needsBuildOutput: true,
     mirrors: [{ job: 'examples-typecheck', steps: ['Typecheck examples'] }],
     why: 'examples are outside the workspace typecheck; a breaking public-surface change is invisible without them',
   },
   {
     name: 'tui-e2e',
+    needsBuildOutput: true,
     mirrors: [{ job: 'tui-e2e', steps: ['Run the TUI PTY E2E suite against the real binary'] }],
     why: 'the live-TUI behaviours only a real PTY against the built binary can exercise',
   },

--- a/scripts/harness/pre-push.mjs
+++ b/scripts/harness/pre-push.mjs
@@ -189,6 +189,8 @@ function resolvePrePushMode(value) {
  * — a message that reads like a broken import in the change being pushed. It is not a verdict on the
  * change; it is an unprepared tree, and it says so now. The push is still blocked: naming the
  * prerequisite is what changed, not whether the gate holds.
+ *
+ * Called only from the verifying branch of `runPrePushGate` — see the ordering note there.
  */
 function assertTreePrerequisites() {
   const result = checkTreePrerequisites('the pre-push gate', WORKSPACE_ROOT);
@@ -197,48 +199,95 @@ function assertTreePrerequisites() {
   process.exit(1);
 }
 
-pruneAndWarnStaleWorktrees();
-assertCleanWorkingTree();
-assertTreePrerequisites();
-assertLockfileConsistency();
+/**
+ * The gate's step ORDER, stated once and exported so a test can assert the sequence itself.
+ *
+ * HARNESS-058, second face. `assertTreePrerequisites` used to run third — before
+ * `decidePrePushVerification` had decided whether anything would be verified at all. But two kinds
+ * of push run NO verification: a delete-only push, and a re-push whose tree has no content delta
+ * from its base. Neither reads `node_modules` or `dist`, and both were refused in a fresh worktree,
+ * demanding `pnpm install && pnpm build` for a push with nothing to check — in exactly the
+ * parallel-subagent-in-a-fresh-worktree configuration this item exists to serve.
+ *
+ * A prerequisite is owed only by work that is actually going to happen, so it is asserted AFTER the
+ * decision to verify. The steps are INJECTED rather than called directly because the defect was an
+ * ordering defect: a test asserting only "a delete-only push is allowed" would go green again if the
+ * assertion moved back ahead of the decision for some unrelated reason.
+ */
+export function runPrePushGate(steps) {
+  steps.pruneAndWarnStaleWorktrees();
+  steps.assertCleanWorkingTree();
+  steps.assertLockfileConsistency();
 
-const baseRef = resolveGitBaseRef(process.env.HARNESS_BASE_REF ?? null);
-const baseArgs = baseRef ? ['--base-ref', baseRef] : [];
-const prePushMode = resolvePrePushMode(process.env.HARNESS_PRE_PUSH_MODE);
-const scopeExpansionArgs = prePushMode === 'fast' ? ['--skip-dependent-scopes'] : [];
-const updates = parsePrePushUpdates(readPrePushInput());
-const treeMatchesBase =
-  baseRef && !hasWorkingTreeChanges()
-    ? runGitQuiet(['diff', '--quiet', baseRef, 'HEAD', '--'])
-    : false;
-const prePushDecision = decidePrePushVerification({
-  updates,
-  baseRef,
-  treeMatchesBase,
-});
+  const decision = steps.decideVerification();
+  if (!decision.shouldRun) {
+    steps.reportSkipped(decision.reason);
+    return { verified: false, reason: decision.reason };
+  }
 
-if (!prePushDecision.shouldRun) {
-  process.stdout.write(`▶ scoped pre-push verification skipped: ${prePushDecision.reason}\n`);
-  process.exit(0);
+  // Everything below this line reads build output and installed binaries; nothing above it does.
+  steps.assertTreePrerequisites();
+  steps.runVerification();
+  return { verified: true, reason: null };
 }
 
-process.stdout.write(`▶ scoped pre-push verification (${prePushMode})\n`);
-if (baseRef) {
-  process.stdout.write(`base: ${baseRef}\n`);
-} else {
-  process.stdout.write('base: unresolved; using working-tree changes only\n');
+/** The real steps, bound to this process's environment and working tree. */
+function createPrePushSteps() {
+  const baseRef = resolveGitBaseRef(process.env.HARNESS_BASE_REF ?? null);
+  const baseArgs = baseRef ? ['--base-ref', baseRef] : [];
+  const prePushMode = resolvePrePushMode(process.env.HARNESS_PRE_PUSH_MODE);
+  const scopeExpansionArgs = prePushMode === 'fast' ? ['--skip-dependent-scopes'] : [];
+
+  return {
+    pruneAndWarnStaleWorktrees,
+    assertCleanWorkingTree,
+    assertLockfileConsistency,
+    assertTreePrerequisites,
+
+    decideVerification: () =>
+      decidePrePushVerification({
+        updates: parsePrePushUpdates(readPrePushInput()),
+        baseRef,
+        treeMatchesBase:
+          baseRef && !hasWorkingTreeChanges()
+            ? runGitQuiet(['diff', '--quiet', baseRef, 'HEAD', '--'])
+            : false,
+      }),
+
+    reportSkipped: (reason) =>
+      process.stdout.write(`▶ scoped pre-push verification skipped: ${reason}\n`),
+
+    runVerification: () => {
+      process.stdout.write(`▶ scoped pre-push verification (${prePushMode})\n`);
+      process.stdout.write(
+        baseRef ? `base: ${baseRef}\n` : 'base: unresolved; using working-tree changes only\n',
+      );
+      if (prePushMode === 'fast') {
+        process.stdout.write(
+          'dependent scope expansion: skipped; use HARNESS_PRE_PUSH_MODE=full\n',
+        );
+      }
+
+      run('pnpm', ['harness:plan', '--', ...baseArgs, ...scopeExpansionArgs]);
+      run('pnpm', [
+        'harness:verify',
+        '--',
+        ...baseArgs,
+        ...scopeExpansionArgs,
+        '--skip-record-check',
+      ]);
+
+      process.stdout.write('\n▶ CLI smoke check (cli:dev --version)\n');
+      run('pnpm', ['cli:dev', '--version']);
+
+      process.stdout.write('\nRelease-grade verification remains explicit:\n');
+      process.stdout.write('  HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push\n');
+      process.stdout.write('  pnpm harness:verify:release\n');
+    },
+  };
 }
 
-if (prePushMode === 'fast') {
-  process.stdout.write('dependent scope expansion: skipped; use HARNESS_PRE_PUSH_MODE=full\n');
+// Guarded so a test can import `runPrePushGate` without running the gate against its own checkout.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runPrePushGate(createPrePushSteps());
 }
-
-run('pnpm', ['harness:plan', '--', ...baseArgs, ...scopeExpansionArgs]);
-run('pnpm', ['harness:verify', '--', ...baseArgs, ...scopeExpansionArgs, '--skip-record-check']);
-
-process.stdout.write('\n▶ CLI smoke check (cli:dev --version)\n');
-run('pnpm', ['cli:dev', '--version']);
-
-process.stdout.write('\nRelease-grade verification remains explicit:\n');
-process.stdout.write('  HARNESS_PRE_PUSH_MODE=full pnpm harness:pre-push\n');
-process.stdout.write('  pnpm harness:verify:release\n');

--- a/scripts/harness/pre-push.mjs
+++ b/scripts/harness/pre-push.mjs
@@ -17,6 +17,7 @@ import {
   formatLockfileFailureMessage,
   parsePrePushUpdates,
 } from './pre-push-updates.mjs';
+import { checkTreePrerequisites } from './tree-prerequisites.mjs';
 
 function run(command, args) {
   const rendered = [command, ...args].join(' ');
@@ -181,8 +182,24 @@ function resolvePrePushMode(value) {
   return mode;
 }
 
+/**
+ * HARNESS-058: this gate runs `pnpm harness:verify` and then `pnpm cli:dev --version`, and both read
+ * build output it never produces. In a fresh worktree the smoke check died on
+ * `Cannot find module '…/packages/agent-command-workflows/node_modules/@robota-sdk/dag-core/dist/node/index.js'`
+ * — a message that reads like a broken import in the change being pushed. It is not a verdict on the
+ * change; it is an unprepared tree, and it says so now. The push is still blocked: naming the
+ * prerequisite is what changed, not whether the gate holds.
+ */
+function assertTreePrerequisites() {
+  const result = checkTreePrerequisites('the pre-push gate', WORKSPACE_ROOT);
+  if (result.ok) return;
+  process.stderr.write(result.message);
+  process.exit(1);
+}
+
 pruneAndWarnStaleWorktrees();
 assertCleanWorkingTree();
+assertTreePrerequisites();
 assertLockfileConsistency();
 
 const baseRef = resolveGitBaseRef(process.env.HARNESS_BASE_REF ?? null);

--- a/scripts/harness/tree-prerequisites.mjs
+++ b/scripts/harness/tree-prerequisites.mjs
@@ -102,11 +102,16 @@ export function findMissingDist(dirs, exists = existsSync, root) {
  * In a linked worktree `.git` is a FILE containing `gitdir: <parent>/.git/worktrees/<name>`; in the
  * main clone it is a directory. Naming the parent clone matters because the whole misdiagnosis is
  * "but the dependencies are right there" — they are, one directory up, and that is not this tree.
+ *
+ * ONE stat, not `exists()` then `stat()`: a check-then-use pair on the filesystem is a race (CodeQL
+ * js/file-system-race), and `throwIfNoEntry: false` answers both questions — present? directory? —
+ * from a single syscall.
  */
-export function describeTree(root, { exists = existsSync, read = readFileSync } = {}) {
+export function describeTree(root, { read = readFileSync } = {}) {
   const dotGit = path.join(root, '.git');
-  if (!exists(dotGit)) return { kind: 'unknown', root };
-  if (statSync(dotGit).isDirectory()) return { kind: 'clone', root };
+  const stats = statSync(dotGit, { throwIfNoEntry: false });
+  if (!stats) return { kind: 'unknown', root };
+  if (stats.isDirectory()) return { kind: 'clone', root };
   const gitdir = /gitdir:\s*(.+)/.exec(read(dotGit, 'utf8'))?.[1]?.trim();
   const parent = gitdir ? gitdir.replace(/[/\\]\.git[/\\]worktrees[/\\].*$/, '') : undefined;
   return {

--- a/scripts/harness/tree-prerequisites.mjs
+++ b/scripts/harness/tree-prerequisites.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+/**
+ * tree-prerequisites — the ONE place that answers "what does this working tree owe before it can be
+ * verified?", and the one place that says so in a message naming the prerequisite.
+ *
+ * WHY (HARNESS-058). `verify-like-ci` and the husky pre-push gate are named across the rules and
+ * skills as the verification entry points, and they are run from `git worktree` checkouts, because
+ * that is how parallel sub-agents work. A fresh worktree has no `node_modules` and no `dist/`, and
+ * every gate that needed one reported the absence as a defect in the branch under test:
+ *
+ *   sh: 1: tsgo: not found
+ *   Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@typescript/native-preview'
+ *   Cannot find module '…/packages/agent-command-workflows/node_modules/@robota-sdk/dag-core/dist/node/index.js'
+ *   doc-examples scan failed — README code blocks do not typecheck
+ *
+ * None of those is a verdict on a change. All four read like one. On 2026-08-01 four sub-agents in
+ * four worktrees each diagnosed it independently, each correctly, and all four then pushed with
+ * `--no-verify` — the gate had trained them to route around it.
+ *
+ * The distinction this module exists to put in the output: **failed because the code is wrong** vs
+ * **failed because this tree was never prepared**. The second refuses to produce a verdict and names
+ * what to run; it never reports a pass, so nothing here weakens a gate.
+ *
+ * THE FRESH-WORKTREE CONTRACT (the single answer that used to live in whoever last worked it out):
+ *
+ *   1. `pnpm install --frozen-lockfile` — in the worktree ITSELF. A worktree does not share the
+ *      parent clone's install, and a pnpm workspace puts a `node_modules` in every package, so there
+ *      is nothing to share. Measured cost on a warm store: ~3s.
+ *   2. `pnpm build` — for any gate that reads build output.
+ *
+ *   The two worktree layouts fail in OPPOSITE directions, which is why neither one taught anybody
+ *   the contract:
+ *     - A SIBLING worktree (outside the repo) cannot start at all: `Could not resolve 'vitest/config'`
+ *       — the honest failure, and the one that looks catastrophic.
+ *     - A NESTED worktree (e.g. under `.claude/worktrees/`) appears to work, because Node's resolver
+ *       walks UP out of the worktree into the parent clone's `node_modules`. It gets further and then
+ *       fails at the first thing resolution cannot fake — a workspace binary (`tsgo`, `tsdown`,
+ *       `vitest`) or a per-package `node_modules` path — with an error that names neither the tree
+ *       nor the install.
+ *   Both are the same missing step. Neither says so. That is what this module fixes.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/** The prerequisite ids, in the order they must be satisfied — install produces what build needs. */
+export const PREREQUISITE_ORDER = ['install', 'build-output'];
+
+/** pnpm writes this on every successful install; its absence means THIS tree was never installed. */
+const PNPM_INSTALL_MARKER = path.join('node_modules', '.modules.yaml');
+
+/** Where the written contract lives, quoted in every message so the answer has one address. */
+export const CONTRACT_DOC =
+  '.agents/backlog/HARNESS-058-verify-like-ci-cannot-go-green-in-a-worktree.md';
+
+// ---------------------------------------------------------------------------
+// detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether THIS tree carries its own pnpm install.
+ *
+ * Deliberately the pnpm marker rather than "does `node_modules` exist": a nested worktree can be
+ * handed a stray directory, and Node's upward resolution already makes "an import worked" useless as
+ * evidence. The marker is written by the command the contract tells you to run, so it answers the
+ * question actually being asked — was `pnpm install` run HERE.
+ */
+export function isInstalled(root, exists = existsSync) {
+  return exists(path.join(root, PNPM_INSTALL_MARKER));
+}
+
+/**
+ * Workspace dirs that produce build output — a package whose manifest declares `build:js`
+ * (the script the root `pnpm build` fans out to). Mirrors the `packages/*` + `packages/dag-nodes/*`
+ * set ci.yml archives as `package-dist.tgz`.
+ */
+export function listBuildablePackageDirs(root) {
+  const roots = [path.join(root, 'packages'), path.join(root, 'packages', 'dag-nodes')];
+  const dirs = [];
+  for (const base of roots) {
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+      const manifest = path.join(base, entry.name, 'package.json');
+      if (!existsSync(manifest)) continue;
+      const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (pkg?.scripts?.['build:js']) dirs.push(path.relative(root, path.join(base, entry.name)));
+    }
+  }
+  return dirs.sort();
+}
+
+/** Buildable dirs with no `dist/` — CI restores these before the dist-dependent jobs run. */
+export function findMissingDist(dirs, exists = existsSync, root) {
+  return dirs.filter((dir) => !exists(path.join(root, dir, 'dist')));
+}
+
+/**
+ * How this tree relates to the repository, for the message.
+ *
+ * In a linked worktree `.git` is a FILE containing `gitdir: <parent>/.git/worktrees/<name>`; in the
+ * main clone it is a directory. Naming the parent clone matters because the whole misdiagnosis is
+ * "but the dependencies are right there" — they are, one directory up, and that is not this tree.
+ */
+export function describeTree(root, { exists = existsSync, read = readFileSync } = {}) {
+  const dotGit = path.join(root, '.git');
+  if (!exists(dotGit)) return { kind: 'unknown', root };
+  if (statSync(dotGit).isDirectory()) return { kind: 'clone', root };
+  const gitdir = /gitdir:\s*(.+)/.exec(read(dotGit, 'utf8'))?.[1]?.trim();
+  const parent = gitdir ? gitdir.replace(/[/\\]\.git[/\\]worktrees[/\\].*$/, '') : undefined;
+  return {
+    kind: 'worktree',
+    root,
+    parent,
+    nested: Boolean(parent) && root.startsWith(`${parent}${path.sep}`),
+  };
+}
+
+/**
+ * The full prerequisite state of a tree. `required` names which prerequisites the caller depends on,
+ * so an entry point that builds for itself does not demand build output up front.
+ */
+export function inspectTree(root, required = PREREQUISITE_ORDER) {
+  const installed = isInstalled(root);
+  const buildable = required.includes('build-output') ? listBuildablePackageDirs(root) : [];
+  const missingDist = findMissingDist(buildable, existsSync, root);
+  const missing = [];
+  if (required.includes('install') && !installed) missing.push('install');
+  if (required.includes('build-output') && missingDist.length > 0) missing.push('build-output');
+  return { root, installed, buildable, missingDist, missing, tree: describeTree(root) };
+}
+
+// ---------------------------------------------------------------------------
+// the message
+// ---------------------------------------------------------------------------
+
+const RULE = '─'.repeat(78);
+
+function describeLocation(tree) {
+  if (tree.kind !== 'worktree') return `  tree: ${tree.root}`;
+  const layout = tree.nested ? 'NESTED inside' : 'a SIBLING of';
+  return (
+    `  tree: ${tree.root}\n` +
+    `        a git worktree, ${layout} its parent clone ${tree.parent ?? '(unresolved)'}\n` +
+    `        a worktree does NOT share that clone's install — pnpm workspaces put a\n` +
+    `        node_modules in every package, so there is nothing to share.`
+  );
+}
+
+function describeMissing(state) {
+  const lines = [];
+  if (state.missing.includes('install')) {
+    lines.push(
+      `  MISSING  install       no ${PNPM_INSTALL_MARKER} in THIS tree.`,
+      state.tree.nested
+        ? `                         Imports may still resolve here — Node walks UP into the parent\n` +
+            `                         clone. That stops at the first workspace binary, which is why the\n` +
+            `                         error you would have seen is \`tsgo: not found\`, not "no install".`
+        : `                         Nothing resolves here at all (e.g. \`Could not resolve 'vitest/config'\`).`,
+    );
+  }
+  if (state.missing.includes('build-output')) {
+    const sample = state.missingDist.slice(0, 4).join(', ');
+    lines.push(
+      `  MISSING  build-output  ${state.missingDist.length} of ${state.buildable.length} buildable package(s) have no dist/.`,
+      `                         e.g. ${sample}${state.missingDist.length > 4 ? ` … (+${state.missingDist.length - 4})` : ''}`,
+    );
+  }
+  return lines;
+}
+
+/** The commands that satisfy the missing prerequisites, in dependency order. */
+export function remedyCommands(missing) {
+  const commands = [];
+  if (missing.includes('install')) commands.push('pnpm install --frozen-lockfile');
+  if (missing.includes('build-output')) commands.push('pnpm build');
+  return commands;
+}
+
+/**
+ * The message. It leads with "not a verdict on your change" on purpose: the failure mode this closes
+ * is an agent spending real effort proving a red was not its own, four times over in one day.
+ */
+export function formatPrerequisiteFailure(entryPoint, state) {
+  return [
+    '',
+    RULE,
+    `${entryPoint} did NOT run: this tree is missing a verification prerequisite.`,
+    'This is NOT a verdict on your change — nothing about the diff has been measured yet.',
+    '',
+    describeLocation(state.tree),
+    '',
+    ...describeMissing(state),
+    '',
+    '  Run this IN THIS TREE, then re-run the gate:',
+    ...remedyCommands(state.missing).map((command) => `    ${command}`),
+    '',
+    `  The fresh-worktree contract: ${CONTRACT_DOC} § The fresh-worktree contract`,
+    RULE,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Gate an entry point on its prerequisites. Returns the state so the caller decides how to stop —
+ * this module never exits a process it does not own.
+ */
+export function checkTreePrerequisites(entryPoint, root, required = PREREQUISITE_ORDER) {
+  const state = inspectTree(root, required);
+  return {
+    ...state,
+    ok: state.missing.length === 0,
+    message: state.missing.length === 0 ? '' : formatPrerequisiteFailure(entryPoint, state),
+  };
+}

--- a/scripts/harness/tree-prerequisites.mjs
+++ b/scripts/harness/tree-prerequisites.mjs
@@ -41,7 +41,8 @@
  *   Both are the same missing step. Neither says so. That is what this module fixes.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 /** The prerequisite ids, in the order they must be satisfied — install produces what build needs. */
@@ -96,29 +97,36 @@ export function findMissingDist(dirs, exists = existsSync, root) {
   return dirs.filter((dir) => !exists(path.join(root, dir, 'dist')));
 }
 
+/** One `git rev-parse` reading, absolute; empty string when this path is not inside a repository. */
+export function readGitPath(root, name) {
+  const result = spawnSync('git', ['-C', root, 'rev-parse', '--path-format=absolute', name], {
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? (result.stdout ?? '').trim() : '';
+}
+
 /**
  * How this tree relates to the repository, for the message.
  *
- * In a linked worktree `.git` is a FILE containing `gitdir: <parent>/.git/worktrees/<name>`; in the
- * main clone it is a directory. Naming the parent clone matters because the whole misdiagnosis is
- * "but the dependencies are right there" — they are, one directory up, and that is not this tree.
+ * Asked of GIT, not of the filesystem. Inspecting `.git` (a directory in the main clone, a file
+ * containing `gitdir: …` in a linked worktree) means checking a path and then using it — a race
+ * CodeQL flags as js/file-system-race, and a heuristic where git already has the exact answer:
+ * a linked worktree is precisely a tree whose `--git-dir` differs from its `--git-common-dir`.
  *
- * ONE stat, not `exists()` then `stat()`: a check-then-use pair on the filesystem is a race (CodeQL
- * js/file-system-race), and `throwIfNoEntry: false` answers both questions — present? directory? —
- * from a single syscall.
+ * Naming the parent clone matters because the whole misdiagnosis is "but the dependencies are right
+ * there" — they are, one directory up, and that is not this tree.
  */
-export function describeTree(root, { read = readFileSync } = {}) {
-  const dotGit = path.join(root, '.git');
-  const stats = statSync(dotGit, { throwIfNoEntry: false });
-  if (!stats) return { kind: 'unknown', root };
-  if (stats.isDirectory()) return { kind: 'clone', root };
-  const gitdir = /gitdir:\s*(.+)/.exec(read(dotGit, 'utf8'))?.[1]?.trim();
-  const parent = gitdir ? gitdir.replace(/[/\\]\.git[/\\]worktrees[/\\].*$/, '') : undefined;
+export function describeTree(root, readPath = readGitPath) {
+  const gitDir = readPath(root, '--git-dir');
+  const commonDir = readPath(root, '--git-common-dir');
+  if (!gitDir || !commonDir) return { kind: 'unknown', root };
+  if (gitDir === commonDir) return { kind: 'clone', root };
+  const parent = path.dirname(commonDir);
   return {
     kind: 'worktree',
     root,
     parent,
-    nested: Boolean(parent) && root.startsWith(`${parent}${path.sep}`),
+    nested: root.startsWith(`${parent}${path.sep}`),
   };
 }
 

--- a/scripts/harness/tree-prerequisites.mjs
+++ b/scripts/harness/tree-prerequisites.mjs
@@ -92,8 +92,24 @@ export function listBuildablePackageDirs(root) {
   return dirs.sort();
 }
 
-/** Buildable dirs with no `dist/` — CI restores these before the dist-dependent jobs run. */
+/**
+ * Buildable dirs with no `dist/` — CI restores these before the dist-dependent jobs run.
+ *
+ * `root` is required and is NOT defaulted, which is the opposite of the usual convenience and is the
+ * point. Review of #1577 found an omitted `root` producing `path.join(undefined, …)` — a TypeError
+ * raised deep inside `path`, naming nothing a caller could act on. Defaulting it to the workspace
+ * root would have removed the crash and replaced it with something worse: this module exists so a
+ * verification result is attributed to the TREE IT WAS MEASURED IN, and a silent default would judge
+ * a different tree than the caller meant. That misattribution is the whole defect HARNESS-058 is
+ * about, arriving through this module's own convenience.
+ */
 export function findMissingDist(dirs, exists = existsSync, root) {
+  if (typeof root !== 'string' || root === '') {
+    throw new TypeError(
+      'findMissingDist: `root` is required — name the tree being judged. There is no default, ' +
+        'because guessing the tree is the misattribution this module exists to prevent.',
+    );
+  }
   return dirs.filter((dir) => !exists(path.join(root, dir, 'dist')));
 }
 

--- a/scripts/harness/tree-prerequisites.mjs
+++ b/scripts/harness/tree-prerequisites.mjs
@@ -191,23 +191,61 @@ export function remedyCommands(missing) {
   return commands;
 }
 
+/** The causes a prerequisite can be unmet. Anything else is a caller bug, not a default. */
+export const PREREQUISITE_CAUSES = ['unprepared', 'build-failed'];
+
+/**
+ * Why the prerequisite is unmet, and what the reader should do about it.
+ *
+ * `build-failed` exists because "run `pnpm build`" is the wrong instruction to hand someone who has
+ * just watched `pnpm build` fail on their own regression. The missing output is a CONSEQUENCE of a
+ * failure already reported above, and the message has to say so or it reads as a second, competing
+ * verdict.
+ */
+function describeCause(entryPoint, cause) {
+  if (cause === 'build-failed')
+    return {
+      headline: `${entryPoint} did NOT run: the \`build\` stage FAILED earlier in this run.`,
+      subtitle: [
+        'This is NOT a second verdict — the `build` failure reported above IS the verdict. The build',
+        'output this stage reads was never produced, so anything it reported would describe the',
+        'missing output rather than your change.',
+      ],
+      remedy: ['  Fix the `build` failure reported above, then re-run the gate.'],
+    };
+  return {
+    headline: `${entryPoint} did NOT run: this tree is missing a verification prerequisite.`,
+    subtitle: [
+      'This is NOT a verdict on your change — nothing about the diff has been measured yet.',
+    ],
+    remedy: null,
+  };
+}
+
 /**
  * The message. It leads with "not a verdict on your change" on purpose: the failure mode this closes
  * is an agent spending real effort proving a red was not its own, four times over in one day.
  */
-export function formatPrerequisiteFailure(entryPoint, state) {
+export function formatPrerequisiteFailure(entryPoint, state, cause = 'unprepared') {
+  if (!PREREQUISITE_CAUSES.includes(cause))
+    throw new Error(
+      `unknown prerequisite cause \`${cause}\` — the message must state a cause it can explain, not fall back to a generic one.`,
+    );
+  const copy = describeCause(entryPoint, cause);
   return [
     '',
     RULE,
-    `${entryPoint} did NOT run: this tree is missing a verification prerequisite.`,
-    'This is NOT a verdict on your change — nothing about the diff has been measured yet.',
+    copy.headline,
+    ...copy.subtitle,
     '',
     describeLocation(state.tree),
     '',
     ...describeMissing(state),
     '',
-    '  Run this IN THIS TREE, then re-run the gate:',
-    ...remedyCommands(state.missing).map((command) => `    ${command}`),
+    ...(copy.remedy ?? [
+      '  Run this IN THIS TREE, then re-run the gate:',
+      ...remedyCommands(state.missing).map((command) => `    ${command}`),
+    ]),
     '',
     `  The fresh-worktree contract: ${CONTRACT_DOC} § The fresh-worktree contract`,
     RULE,

--- a/scripts/harness/verify-change.mjs
+++ b/scripts/harness/verify-change.mjs
@@ -12,6 +12,11 @@ import {
   renderCommand,
   validateScenarioRecordArtifact,
 } from './scenario-records.mjs';
+// HARNESS-058 note, deliberately NOT a prerequisite gate here: this script's WORKSPACE_ROOT is
+// `process.cwd()`, and it is legitimately run against synthetic workspace fixtures that have no
+// install (see `__tests__/detect-changed-files.test.mjs`). A tree-prerequisite assertion at this
+// layer fails those honest runs. The prerequisite is asserted by the entry points that invoke this
+// one as a GATE — `verify-like-ci.mjs` and `pre-push.mjs` — which own a real repository root.
 import { resolveScenarioVerification } from './scenario-owner-map.mjs';
 import {
   WORKSPACE_ROOT,

--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -63,8 +63,9 @@
  * stack trace, a doc-example "does not typecheck". Four agents in one day each proved those reds
  * were not their own and then pushed with `--no-verify`. So this entry point refuses to produce a
  * verdict it cannot support: `tree-prerequisites.mjs` states which prerequisite is missing and the
- * command that satisfies it. That is a FAILURE, never a skip — see `preflight` and
- * `blockedByMissingBuildOutput`. The fresh-worktree contract itself is written down in that module.
+ * command that satisfies it. That is a FAILURE, never a skip — see `preflight`, `stageBlockCause`
+ * and the build state (`initialBuildState` / `advanceBuildState`) the stage loop carries. The
+ * fresh-worktree contract itself is written down in that module.
  *
  * Usage:
  *   pnpm harness:verify-like-ci
@@ -606,15 +607,48 @@ export function preflight(root = WORKSPACE_ROOT) {
   return checkTreePrerequisites('verify-like-ci', root, ['install']);
 }
 
+/** Build output present on disk RIGHT NOW, re-read rather than remembered. */
+function readMissingDistNow() {
+  return findMissingDist(listBuildablePackageDirs());
+}
+
 /**
- * Whether a stage would be reporting on the TREE rather than on the change.
+ * The build-output state a run carries THROUGH its stage loop — state, not a flag computed once.
  *
- * True only when the stage reads build output, this run will not produce any, and none is present.
- * It is not a way to pass: the stage still FAILS — it fails saying which prerequisite is missing
- * instead of emitting a missing-module stack trace that reads like a broken import in the diff.
+ * The first version of this precomputed `willBuild` from whether the `build` stage would be
+ * ATTEMPTED and never updated it, which is a different claim from "build output exists". Measured on
+ * a fresh worktree with a real build regression: `pnpm build` failed, every consuming stage still
+ * ran, and they reported the unbuilt tree as a defect in the change —
+ * `TS2307: Cannot find module '@robota-sdk/agent-framework'` plus a spurious "install @types/node"
+ * hint from `examples-typecheck`, and 20s of `serve host did not come up` from `binary-e2e`. That is
+ * the exact noise this entry point exists to remove, arriving in the one scenario the feature is for.
  */
-export function blockedByMissingBuildOutput(stage, { willBuild, missingDist }) {
-  return Boolean(stage?.needsBuildOutput) && !willBuild && missingDist.length > 0;
+export function initialBuildState(selected, context) {
+  const buildRuns =
+    selected.some((stage) => stage.name === 'build') && stageGate('build', context).run;
+  return { buildPending: buildRuns, buildFailed: false, missingDist: context.missingDist };
+}
+
+/**
+ * The state after a stage ran. Only `build` moves it, and it moves by RE-READING dist from disk: a
+ * build that failed leaves the tree exactly as unbuilt as it found it.
+ */
+export function advanceBuildState(state, stage, code, readMissingDist = readMissingDistNow) {
+  if (stage.name !== 'build') return state;
+  return { buildPending: false, buildFailed: code !== 0, missingDist: readMissingDist() };
+}
+
+/**
+ * Why a stage cannot be trusted to report on the CHANGE, or null when it can.
+ *
+ * Never a way to pass: a blocked stage still FAILS. What it changes is the message — which
+ * prerequisite is missing, or which earlier failure caused it — instead of a module-resolution
+ * error that reads like a broken import in the diff.
+ */
+export function stageBlockCause(stage, state) {
+  if (!stage?.needsBuildOutput) return null;
+  if (state.buildPending || state.missingDist.length === 0) return null;
+  return state.buildFailed ? 'build-failed' : 'unprepared';
 }
 
 /**
@@ -710,32 +744,36 @@ export async function main(argv = process.argv.slice(2)) {
       `${context.codeChanged ? 'CODE' : 'docs-only'}, ${context.distRequired ? 'build output required' : 'no build output required'}\n`,
   );
 
-  // `--only typecheck` on an unbuilt tree deselects the stage that would have produced the dist it
-  // reads, so the guard below needs to know whether THIS run will build.
-  const willBuild =
-    selected.some((stage) => stage.name === 'build') && stageGate('build', context).run;
+  let buildState = initialBuildState(selected, context);
 
   const results = [];
   for (const stage of selected) {
-    if (blockedByMissingBuildOutput(stage, { willBuild, missingDist: context.missingDist })) {
+    // The gate is asked FIRST: a stage CI would not run at all needs no prerequisite, and reporting
+    // one for it would invent a failure where a skip is the honest answer.
+    const gate = stageGate(stage.name, context);
+    if (!gate.run) {
+      process.stdout.write(`\n===== ${stage.name} (skipped) =====\n${gate.note}\n`);
+      results.push({ name: stage.name, status: 'skip', note: gate.note });
+      continue;
+    }
+    const blocked = stageBlockCause(stage, buildState);
+    if (blocked) {
       process.stdout.write(`\n===== ${stage.name} =====\n`);
       process.stderr.write(
         formatPrerequisiteFailure(
           `verify-like-ci stage \`${stage.name}\``,
           inspectTree(WORKSPACE_ROOT, ['build-output']),
+          blocked,
         ),
       );
       results.push({
         name: stage.name,
         status: 'fail',
-        note: 'unbuilt tree — this stage measured nothing; run `pnpm build`',
+        note:
+          blocked === 'build-failed'
+            ? '`build` failed in this run — this stage measured nothing'
+            : 'unbuilt tree — this stage measured nothing; run `pnpm build`',
       });
-      continue;
-    }
-    const gate = stageGate(stage.name, context);
-    if (!gate.run) {
-      process.stdout.write(`\n===== ${stage.name} (skipped) =====\n${gate.note}\n`);
-      results.push({ name: stage.name, status: 'skip', note: gate.note });
       continue;
     }
     process.stdout.write(`\n===== ${stage.name} =====\nmirrors: ${describeCiSource(stage)}\n`);
@@ -745,6 +783,7 @@ export async function main(argv = process.argv.slice(2)) {
       status: outcome.code === 0 ? 'pass' : 'fail',
       note: outcome.note,
     });
+    buildState = advanceBuildState(buildState, stage, outcome.code);
   }
   const { lines, exitCode } = summarize(results, {
     skippedStages,

--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -57,6 +57,15 @@
  * Every stage below is derived from the real definitions — `.github/workflows/ci.yml` and
  * `.lintstagedrc.json` — not from a hand-copied guess.
  *
+ * WHERE IT IS RUN (HARNESS-058). Increasingly this is a fresh `git worktree`, because that is how
+ * parallel sub-agents work, and a fresh worktree has neither `node_modules` nor `dist/`. Every stage
+ * used to report that absence as a defect in the branch: `sh: 1: tsgo: not found`, a missing-module
+ * stack trace, a doc-example "does not typecheck". Four agents in one day each proved those reds
+ * were not their own and then pushed with `--no-verify`. So this entry point refuses to produce a
+ * verdict it cannot support: `tree-prerequisites.mjs` states which prerequisite is missing and the
+ * command that satisfies it. That is a FAILURE, never a skip — see `preflight` and
+ * `blockedByMissingBuildOutput`. The fresh-worktree contract itself is written down in that module.
+ *
  * Usage:
  *   pnpm harness:verify-like-ci
  *   pnpm harness:verify-like-ci -- --base-ref origin/main
@@ -90,6 +99,13 @@ import {
   detectChangedFiles,
   listWorkspaceScopes,
 } from './shared.mjs';
+import {
+  checkTreePrerequisites,
+  findMissingDist as findMissingDistIn,
+  formatPrerequisiteFailure,
+  inspectTree,
+  listBuildablePackageDirs as listBuildablePackageDirsIn,
+} from './tree-prerequisites.mjs';
 
 export { CI_STAGES, NOT_MIRRORED };
 
@@ -148,29 +164,16 @@ export function parseGitFileList(stdout) {
 // ---------------------------------------------------------------------------
 
 /**
- * Workspace dirs that produce build output — a package whose manifest declares `build:js`
- * (the script the root `pnpm build` fans out to). Mirrors the `packages/*` +
- * `packages/dag-nodes/*` set ci.yml archives as `package-dist.tgz`.
+ * Both helpers now live in `tree-prerequisites.mjs`, which is where the prerequisite question is
+ * answered for every entry point. They are re-exported here with this file's workspace-root default
+ * so the existing call sites and tests keep one import.
  */
 export function listBuildablePackageDirs(root = WORKSPACE_ROOT) {
-  const roots = [path.join(root, 'packages'), path.join(root, 'packages', 'dag-nodes')];
-  const dirs = [];
-  for (const base of roots) {
-    if (!existsSync(base)) continue;
-    for (const entry of readdirSync(base, { withFileTypes: true })) {
-      if (!entry.isDirectory() || entry.name === 'node_modules') continue;
-      const manifest = path.join(base, entry.name, 'package.json');
-      if (!existsSync(manifest)) continue;
-      const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
-      if (pkg?.scripts?.['build:js']) dirs.push(path.relative(root, path.join(base, entry.name)));
-    }
-  }
-  return dirs.sort();
+  return listBuildablePackageDirsIn(root);
 }
 
-/** Buildable dirs with no `dist/` — CI restores these before the dist-dependent scans run. */
 export function findMissingDist(dirs, exists = existsSync, root = WORKSPACE_ROOT) {
-  return dirs.filter((dir) => !exists(path.join(root, dir, 'dist')));
+  return findMissingDistIn(dirs, exists, root);
 }
 
 // ---------------------------------------------------------------------------
@@ -601,6 +604,29 @@ function describeBuildReason({ distRequired, codeChanged, missingDist }) {
  * the plan predicate alone does not see. Without the widening, a `scripts/harness` branch would skip
  * the build and then drive whatever stale binary happened to be in the worktree.
  */
+/**
+ * The prerequisite gate for this entry point (HARNESS-058).
+ *
+ * Only `install` is demanded up front. `build-output` deliberately is NOT: the `build` stage
+ * produces it, and demanding it here would tell an agent to run by hand the very command the gate
+ * is about to run. What must never happen is a stage reporting a verdict on ground the tree could
+ * not provide — `blockedByMissingBuildOutput` covers the runs where `build` will not fill the gap.
+ */
+export function preflight(root = WORKSPACE_ROOT) {
+  return checkTreePrerequisites('verify-like-ci', root, ['install']);
+}
+
+/**
+ * Whether a stage would be reporting on the TREE rather than on the change.
+ *
+ * True only when the stage reads build output, this run will not produce any, and none is present.
+ * It is not a way to pass: the stage still FAILS — it fails saying which prerequisite is missing
+ * instead of emitting a missing-module stack trace that reads like a broken import in the diff.
+ */
+export function blockedByMissingBuildOutput(stage, { willBuild, missingDist }) {
+  return Boolean(stage?.needsBuildOutput) && !willBuild && missingDist.length > 0;
+}
+
 export function stageGate(name, context) {
   switch (name) {
     case 'build':
@@ -657,6 +683,15 @@ export async function main(argv = process.argv.slice(2)) {
     (stage) => stage.name,
   );
 
+  // Before anything is measured: a tree that was never installed cannot produce a verdict on a
+  // change, and every stage's failure would be about the tree instead (HARNESS-058).
+  const prerequisites = preflight();
+  if (!prerequisites.ok) {
+    process.stderr.write(prerequisites.message);
+    process.exitCode = 1;
+    return;
+  }
+
   let context;
   try {
     context = await resolveRunContext(options.baseRef);
@@ -675,8 +710,28 @@ export async function main(argv = process.argv.slice(2)) {
       `${context.codeChanged ? 'CODE' : 'docs-only'}, ${context.distRequired ? 'build output required' : 'no build output required'}\n`,
   );
 
+  // `--only typecheck` on an unbuilt tree deselects the stage that would have produced the dist it
+  // reads, so the guard below needs to know whether THIS run will build.
+  const willBuild =
+    selected.some((stage) => stage.name === 'build') && stageGate('build', context).run;
+
   const results = [];
   for (const stage of selected) {
+    if (blockedByMissingBuildOutput(stage, { willBuild, missingDist: context.missingDist })) {
+      process.stdout.write(`\n===== ${stage.name} =====\n`);
+      process.stderr.write(
+        formatPrerequisiteFailure(
+          `verify-like-ci stage \`${stage.name}\``,
+          inspectTree(WORKSPACE_ROOT, ['build-output']),
+        ),
+      );
+      results.push({
+        name: stage.name,
+        status: 'fail',
+        note: 'unbuilt tree — this stage measured nothing; run `pnpm build`',
+      });
+      continue;
+    }
     const gate = stageGate(stage.name, context);
     if (!gate.run) {
       process.stdout.write(`\n===== ${stage.name} (skipped) =====\n${gate.note}\n`);

--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -595,16 +595,6 @@ function describeBuildReason({ distRequired, codeChanged, missingDist }) {
 }
 
 /**
- * Whether a stage runs, and why not when it does not.
- *
- * A stage skips only where CI's own job would be skipped or would do nothing, so a skip never
- * weakens the PASS line. The `build` gate is deliberately WIDER than ci.yml's `build` job condition:
- * `tui-e2e` and `examples-typecheck` each run `pnpm build:deps` inside their own job and never
- * consume the `build` artifact, and `scan-suite` hard-fails on absent dist — three dist consumers
- * the plan predicate alone does not see. Without the widening, a `scripts/harness` branch would skip
- * the build and then drive whatever stale binary happened to be in the worktree.
- */
-/**
  * The prerequisite gate for this entry point (HARNESS-058).
  *
  * Only `install` is demanded up front. `build-output` deliberately is NOT: the `build` stage
@@ -627,6 +617,16 @@ export function blockedByMissingBuildOutput(stage, { willBuild, missingDist }) {
   return Boolean(stage?.needsBuildOutput) && !willBuild && missingDist.length > 0;
 }
 
+/**
+ * Whether a stage runs, and why not when it does not.
+ *
+ * A stage skips only where CI's own job would be skipped or would do nothing, so a skip never
+ * weakens the PASS line. The `build` gate is deliberately WIDER than ci.yml's `build` job condition:
+ * `tui-e2e` and `examples-typecheck` each run `pnpm build:deps` inside their own job and never
+ * consume the `build` artifact, and `scan-suite` hard-fails on absent dist — three dist consumers
+ * the plan predicate alone does not see. Without the widening, a `scripts/harness` branch would skip
+ * the build and then drive whatever stale binary happened to be in the worktree.
+ */
 export function stageGate(name, context) {
   switch (name) {
     case 'build':


### PR DESCRIPTION
Closes #1571

## The face that was still open

#1567 closed the `worktree-cwd-guard` face. With those three tests fixed the gate got **further** and
died on the next thing a fresh worktree does not have. This closes that face, and the two the issue
names with it: the stage order, and the undocumented worktree contract.

## Red first — the verbatim before, in a real fresh worktree

`pnpm harness:verify-like-ci` on a freshly-created nested worktree at `origin/develop`, **zero
changes**:

```
verify-like-ci summary:
✓ format-check — no formatter-owned files changed vs origin/develop
✓ commitlint — no commits authored vs origin/develop
✗ harness-self-test
✗ scan-suite-dist-free — dist-free worktree of HEAD+changes, skips: dist, build-contracts
✗ typecheck
✗ build — 75 package(s) have no dist/ — the dist-dependent scans would silently no-op
✗ scan-suite — dist missing for 75 package(s) — run `pnpm build`
✓ affected-verify — no package/app scope affected — CI verifies none either
- binary-e2e — ci.yml gates it on `package_dist_required`, which this plan is not
✗ examples-typecheck
✗ tui-e2e
FAIL — 7 of 11 stage(s) failed
```

Seven red stages on a branch that changed nothing. What the reader actually saw:

```
sh: 1: vitest: not found
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@typescript/native-preview' imported from …/lib/ts-ast.mjs
doc-examples scan failed — README code blocks do not typecheck
packages/agent-core typecheck: sh: 1: tsgo: not found
packages/agent-core build:js: sh: 1: tsdown: not found
6 of 82 scans failed
```

Not one of those names a prerequisite. Every one reads as a defect in the change under test — which
is exactly what four agents spent real effort disproving on 2026-08-01 before all four pushed with
`--no-verify`.

Note the second line of the run: `pnpm build` **also failed** (`tsdown: not found`). In a fresh
worktree the primary missing prerequisite is the *install*, not the build; the missing-`dist`
message the issue quotes comes from the worktrees that had been installed and not built. Both are
covered below.

## After — the same tree, the same command

```
──────────────────────────────────────────────────────────────────────────────
verify-like-ci did NOT run: this tree is missing a verification prerequisite.
This is NOT a verdict on your change — nothing about the diff has been measured yet.

  tree: /home/ubuntu/dev/robota/.claude/worktrees/harness-058-proof
        a git worktree, NESTED inside its parent clone /home/ubuntu/dev/robota
        a worktree does NOT share that clone's install — pnpm workspaces put a
        node_modules in every package, so there is nothing to share.

  MISSING  install       no node_modules/.modules.yaml in THIS tree.
                         Imports may still resolve here — Node walks UP into the parent
                         clone. That stops at the first workspace binary, which is why the
                         error you would have seen is `tsgo: not found`, not "no install".

  Run this IN THIS TREE, then re-run the gate:
    pnpm install --frozen-lockfile

  The fresh-worktree contract: .agents/backlog/HARNESS-058-…md § The fresh-worktree contract
──────────────────────────────────────────────────────────────────────────────
```

Then, doing exactly what it says — `pnpm install --frozen-lockfile` (2.9s on a warm store) — and
re-running the identical command on a **docs-only branch in that freshly-created worktree**:

```
mirroring the required checks of `develop` — 1 changed file(s) vs 7593b5df9, docs-only, no build output required

verify-like-ci summary:
✓ format-check — 1 changed file(s) vs 7593b5df9
✓ commitlint — 1 commit(s) vs 7593b5df9
✓ harness-self-test                       (2125 / 2125)
✓ scan-suite-dist-free — dist-free worktree of HEAD+changes, skips: dist, build-contracts   (all 82 scans passed)
✓ build — 75 package(s) have no dist/ — the dist-dependent scans would silently no-op
✓ typecheck
✓ scan-suite — full suite incl. build-contracts + dist (built tree)
✓ affected-verify — no package/app scope affected — CI verifies none either
- binary-e2e — ci.yml gates it on `package_dist_required`, which this plan is not
- examples-typecheck — docs-only diff — ci.yml gates it on `changes.code == true`
- tui-e2e — docs-only diff — ci.yml gates it on `changes.code == true`
PASS — all 11 stage(s) passed; mirrors the required checks of `develop`.
EXIT=0
```

**The gate builds the tree for itself.** `pnpm build` was never run by hand: the `build` stage does
it, which is why `verify-like-ci` demands only the install. That is the whole point of the stage
reorder — the prerequisite now runs before what needs it.

## The pre-push face, on an installed-but-unbuilt worktree

This is the message the issue quotes, replaced. Before, the CLI smoke check died on
`Cannot find module '…/packages/agent-command-workflows/node_modules/@robota-sdk/dag-core/dist/node/index.js'`.
Now, before any check runs:

```
the pre-push gate did NOT run: this tree is missing a verification prerequisite.
This is NOT a verdict on your change — nothing about the diff has been measured yet.
  …
  MISSING  build-output  75 of 75 buildable package(s) have no dist/.
  Run this IN THIS TREE, then re-run the gate:
    pnpm build
```

Same at stage granularity, when `--only` deselects the stage that would have built:

```
verify-like-ci stage `typecheck` did NOT run: this tree is missing a verification prerequisite.
  MISSING  build-output  75 of 75 buildable package(s) have no dist/.
…
FAIL — 1 of 1 stage(s) failed: typecheck
```

It **fails**. It does not skip.

## Proof that a genuine failure still fails

A gate that stops checking is not fixed. On the same prepared tree, with a deliberately ill-typed
file added to `packages/dag-core/src/`:

```
packages/dag-core typecheck: src/__harness-058-red-proof.ts(2,14): error TS2322: Type 'string' is not assignable to type 'number'.
packages/dag-core typecheck: Failed
verify-like-ci summary:
✗ typecheck
```

The real diagnostic, no prerequisite message, exit 1. The file was deleted immediately after.

The stage-order change itself was also red-proved before it was made — the new
`ci-mirror-map.test.mjs` assertion, run against the unreordered table:

```
FAIL scripts/harness/__tests__/ci-mirror-map.test.mjs > every stage that reads build output runs AFTER the stage that produces it
AssertionError: stage(s) that read build output are ordered BEFORE `build`: typecheck. …: expected [ 'typecheck' ] to deeply equal []
```

## What changed

**`scripts/harness/tree-prerequisites.mjs` (new)** — the one place that answers what a tree owes
before verification and the one place that says so. It carries the written fresh-worktree contract,
including why the two layouts fail in opposite directions: a sibling worktree cannot start at all
(`Could not resolve 'vitest/config'`), a nested one gets much further because Node's resolver walks
UP into the parent clone, and then dies at the first workspace binary. Both are the same missing
step; neither said so.

**`ci-mirror-map.mjs`** — every stage now DECLARES `needsBuildOutput`, and `build` runs before
`typecheck`. The declaration is pinned to the order by the map's own test, so this cannot be a
one-off swap: a stage added below `build` that reads dist fails the suite instead of failing the
next agent in a fresh worktree, and a stage that declares nothing fails rather than silently sorting
as "needs nothing".

**`verify-like-ci.mjs`** — a `preflight` that refuses to run without an install, and
`blockedByMissingBuildOutput`, which fails any build-output stage this run will not build for. Both
are FAILURES with a reason.

**`pre-push.mjs`** — asserts install + build output before the CLI smoke check.

**`verify-change.mjs`** — deliberately *not* gated, with the reason recorded inline: its root is
`process.cwd()` and it is legitimately run against synthetic workspace fixtures with no install
(`__tests__/detect-changed-files.test.mjs` proves this — the gate broke that test, and the honest
fix was to remove the gate from that layer, not to weaken the test).

## Where the worktree contract lives

In `scripts/harness/tree-prerequisites.mjs` (the executable copy — it is what the gates print) and
written out in `.agents/backlog/HARNESS-058-…md § The fresh-worktree contract`.

The routing home for this would be `.agents/rules/git-branch.md § Git Worktree`, which already
carries the worktree guardrails and is the file that names `verify-like-ci` as the pre-push gate.
**That file is owned by another agent working concurrently**, so this PR does not edit across the
boundary. A one-paragraph pointer from `git-branch.md § Git Worktree` to the contract section is the
follow-up.

## Verification

- `npx vitest run scripts/harness/__tests__/` — 2125/2125, 126 files
- `pnpm harness:scan` — all green
- `pnpm harness:verify-like-ci` in a fresh worktree — the run above
- The push went through the pre-push gate with **no `--no-verify`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso
