### PR TITLE
fix(hooks): INFRA-081 one reader, one answer, whatever the host has installed

### DIFF
--- a/.claude/hooks/check-forbidden-patterns.sh
+++ b/.claude/hooks/check-forbidden-patterns.sh
@@ -101,10 +101,12 @@ if [[ "$RELATIVE_PATH" == /* ]]; then
     */apps/*) RELATIVE_PATH="apps/${FILE_PATH#*/apps/}" ;;
   esac
 fi
-# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
-# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
-# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
-SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || true)
+# A session id and a transcript path are TEXT, or they are absent — there is no third answer, and
+# `hook_json_string` is the single owner of that rule: a field that is not a JSON string reads as "",
+# on a host with jq and on a host without, byte for byte (INFRA-081, #1574). This used to call
+# `hook_json_text`, which existed only because the rule was true in one file and not in the other;
+# once it was true in both, that name was an alias and is gone. See lib/command-scan.sh.
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || true)
 BLOCKED=false
 BLOCK_MESSAGES=""
 

--- a/.claude/hooks/correction-detect.sh
+++ b/.claude/hooks/correction-detect.sh
@@ -24,10 +24,12 @@ fi
 # LESSON-010: only REAL user turns are correction signals. Subagent/eval prompts (session ids
 # like "agent_1") and events with no session id are agent-authored text — counting them
 # inflated the one genuinely useful metric with false positives.
-# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
-# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
-# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
-SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || printf '')
+# A session id and a transcript path are TEXT, or they are absent — there is no third answer, and
+# `hook_json_string` is the single owner of that rule: a field that is not a JSON string reads as "",
+# on a host with jq and on a host without, byte for byte (INFRA-081, #1574). This used to call
+# `hook_json_text`, which existed only because the rule was true in one file and not in the other;
+# once it was true in both, that name was an alias and is gone. See lib/command-scan.sh.
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
 case "$SESSION_ID" in
   '' | agent*) exit 0 ;;
 esac
@@ -48,7 +50,7 @@ if [ -z "$KEYWORD" ]; then
   exit 0
 fi
 
-TRANSCRIPT_PATH=$(hook_json_text "$INPUT" 'transcript_path' || printf '')
+TRANSCRIPT_PATH=$(hook_json_string "$INPUT" 'transcript_path' || printf '')
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 PREVIOUS_ASSISTANT_HASH=""
 

--- a/.claude/hooks/eval-log-stop.sh
+++ b/.claude/hooks/eval-log-stop.sh
@@ -31,10 +31,12 @@ git_project() {
 BRANCH=$(hook_current_branch "$PROJECT_DIR" "unknown")
 # It carried no `read_json()`, so it looked unlike its three siblings, and it read the payload with
 # a bare `jq -r` and wrote its record with `jq -cn` all the same. Same defect, different spelling.
-# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
-# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
-# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
-SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || printf '')
+# A session id and a transcript path are TEXT, or they are absent — there is no third answer, and
+# `hook_json_string` is the single owner of that rule: a field that is not a JSON string reads as "",
+# on a host with jq and on a host without, byte for byte (INFRA-081, #1574). This used to call
+# `hook_json_text`, which existed only because the rule was true in one file and not in the other;
+# once it was true in both, that name was an alias and is gone. See lib/command-scan.sh.
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
 
 if [ -f "$HOOK_DIR/revert-detect.sh" ]; then
   printf '%s' "$INPUT" | bash "$HOOK_DIR/revert-detect.sh" >/dev/null 2>&1 || true

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -51,8 +51,10 @@
 # THE ANSWER IS "" — a field that is not a string is not that field — for three reasons, and the
 # alternative (a reader that returns non-zero on a non-string) was rejected for the third:
 #
-#   1. It is the rule `hook_json_text` already states, with its own measurement, for the text fields
-#      #1566 could reach. Two spellings of one rule is what INFRA-077 spent a PR removing.
+#   1. It is the rule `hook-facts.sh` had already measured and adopted for the text fields #1566
+#      could reach, in a second reader it wrote beside this one because it could not reach THIS one.
+#      Two spellings of one rule is what INFRA-077 spent a PR removing; that second reader is gone
+#      now, and its six callers ask this function directly.
 #   2. `hook-facts.sh` states the reader/caller split explicitly: a READER collapses absent and empty
 #      into "", and the CALLER names what empty means for it. A refusing reader would break that for
 #      one function out of the set.

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -32,10 +32,44 @@
 # jq first, python3 second, refuse third. Both parse JSON properly, which is the entire point: the
 # payload is JSON and every hand-rolled decoder in this directory has been wrong about it.
 # `\uXXXX`, `\"`, `\\` and `\n` all come back as the characters they denote.
+#
+# ONE RULE, NOT ONE PER INSTALLED TOOL (INFRA-081, #1574). The two arms used to answer the same
+# question differently, and the difference reached a VERDICT. Measured end-to-end on `branch-guard.sh`
+# against a scratch repository, same payload both times, only `PATH` differing:
+#
+#   {"tool_name":"Bash","cwd":"<scratch>","tool_input":{"command":{"a":"git push origin main"}}}
+#     with jq      exit 0   (jq -r printed the pretty-printed OBJECT, whose `git push` sits inside
+#                            quotes, so the tokenizer masked it as data and no verb was found)
+#     without jq   exit 2   (the python3 arm writes "" for a non-string, and an empty command is a
+#                            refusal)
+#
+# One host permitted and the other refused, and neither answer was reached by a decision. Two more
+# divergences were measured in the same arm and are closed here with it: `jq -r ".a.b"` ERRORS when
+# `a` is not an object (so a jq-only host returned "could not decode" where a python3 host returned
+# ""), and `jq -r` appends a newline the python3 arm does not write.
+#
+# THE ANSWER IS "" — a field that is not a string is not that field — for three reasons, and the
+# alternative (a reader that returns non-zero on a non-string) was rejected for the third:
+#
+#   1. It is the rule `hook_json_text` already states, with its own measurement, for the text fields
+#      #1566 could reach. Two spellings of one rule is what INFRA-077 spent a PR removing.
+#   2. `hook-facts.sh` states the reader/caller split explicitly: a READER collapses absent and empty
+#      into "", and the CALLER names what empty means for it. A refusing reader would break that for
+#      one function out of the set.
+#   3. The VERDICT is fail-closed either way, and that is the property that matters. Every caller
+#      here already converts empty into a refusal or a fallback — `hook_command_of` returns non-zero
+#      on an empty command, `hook_tool_name_of` falls through to its no-tools parse — so both arms
+#      now exit 2 on the payload above. Measured, both directions.
+#
+# The path is passed as `--arg`, not interpolated into the filter: a field name is data, and the
+# reduce below is total, so no shape of path or payload makes this arm error where the other returns.
 hook_json_string() {
   local json="$1" path="$2"
   if command -v jq >/dev/null 2>&1; then
-    printf '%s' "$json" | jq -r ".${path} // \"\"" 2>/dev/null && return 0
+    printf '%s' "$json" | jq -j --arg p "$path" '
+      reduce ($p | split(".")[]) as $k (.; if type == "object" then .[$k] else null end)
+      | if type == "string" then . else "" end
+    ' 2>/dev/null && return 0
   fi
   if command -v python3 >/dev/null 2>&1; then
     printf '%s' "$json" | python3 -c '
@@ -95,14 +129,30 @@ hook_tool_name_of() {
 # machine without jq produced empty content and the forbidden-pattern check exited 0 on content it
 # would otherwise have refused: the silent bypass this file exists to remove, surviving in the one
 # hook that guards a different tool. Review caught it.
+#
+# The arms are held to the SAME rule as `hook_json_string` above, and for the same reason
+# (INFRA-081): a field that is not a string is not that field. Fixing the divergence one function up
+# and leaving it here is how this directory keeps producing "corrected in one place, live in the
+# sibling". Four shapes were measured disagreeing before this, each reachable from an ordinary
+# payload: a numeric `content` (jq printed the number, python3 skipped to `new_string`), a
+# `tool_input` that is not an object (jq ERRORED, python3 raised, both then answered differently
+# depending on which tools were present), an `edits` list that is not a list, and an edit whose
+# `new_string` is not a string (python3 raised inside `join` and the whole read became "could not
+# decode"). Both arms now walk the same three steps and stop at the first STRING.
 hook_edit_content_of() {
-  local content
   if command -v jq >/dev/null 2>&1; then
-    content=$(printf '%s' "$1" | jq -r '
-      .tool_input.content
-      // .tool_input.new_string
-      // ([.tool_input.edits[]?.new_string] | join("\n"))
-      // ""' 2>/dev/null) && { printf '%s' "$content"; return 0; }
+    printf '%s' "$1" | jq -j '
+      (if type == "object" then .tool_input else null end) as $ti
+      | if ($ti | type) != "object" then ""
+        elif ($ti.content | type) == "string" then $ti.content
+        elif ($ti.new_string | type) == "string" then $ti.new_string
+        else [ ($ti.edits | if type == "array" then .[] else empty end)
+               | if type == "object"
+                 then (.new_string | if type == "string" then . else "" end)
+                 else empty end ]
+             | join("\n")
+        end
+    ' 2>/dev/null && return 0
   fi
   if command -v python3 >/dev/null 2>&1; then
     printf '%s' "$1" | python3 -c '
@@ -111,15 +161,25 @@ try:
     doc = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-ti = doc.get("tool_input") or {}
+ti = doc.get("tool_input") if isinstance(doc, dict) else None
+if not isinstance(ti, dict):
+    ti = {}
+out = None
 for key in ("content", "new_string"):
     if isinstance(ti.get(key), str):
-        sys.stdout.write(ti[key])
+        out = ti[key]
         break
-else:
-    edits = ti.get("edits") or []
-    parts = [e.get("new_string", "") for e in edits if isinstance(e, dict)]
-    sys.stdout.write("\n".join(parts))
+if out is None:
+    edits = ti.get("edits")
+    if not isinstance(edits, list):
+        edits = []
+    parts = []
+    for edit in edits:
+        if isinstance(edit, dict):
+            value = edit.get("new_string")
+            parts.append(value if isinstance(value, str) else "")
+    out = "\n".join(parts)
+sys.stdout.write(out)
 ' 2>/dev/null && return 0
   fi
   return 1

--- a/.claude/hooks/lib/hook-facts.sh
+++ b/.claude/hooks/lib/hook-facts.sh
@@ -156,37 +156,33 @@ hook_current_branch() {
 # is allowed to contain a quote or a backslash, JSON escapes both, and a `[^"]*` grep stops at the
 # escape and hands back a path that does not exist.
 #
-# Through `hook_json_text`, so this reader and `hook_prompt_of` answer the same question the same
-# way. Measured on `{"tool_input": {"file_path": 123}}` before INFRA-081: `hook_json_string` returned
-# `123` where jq was installed and "" where it was not, so the rule would otherwise have been
-# one-per-function instead of one rule. A path is text or it is not a path. Since #1574 both readers
-# ARE one function, and this line records which rule won rather than which function to call.
+# A path that is not a JSON string is not a path, so a non-string reads as absent — which
+# `hook_json_string` is now the single owner of. Measured on `{"tool_input": {"file_path": 123}}`
+# before INFRA-081: it returned `123` where jq was installed and "" where it was not.
 hook_file_path_of() {
-  hook_json_text "$1" 'tool_input.file_path'
+  hook_json_string "$1" 'tool_input.file_path'
 }
 
-# A field, but ONLY when it holds a JSON string. Anything else reads as absent.
+# `hook_json_text` STOOD HERE AND IS GONE (INFRA-081, #1574).
 #
-# THIS IS NOW `hook_json_string`, AND THE NAME IS ALL THAT REMAINS OF THE DIFFERENCE (INFRA-081,
-# #1574).
+# It existed because `hook_json_string` did not promise the type test and its two arms DISAGREED
+# without it. Measured on `{"message": {"role": "user", "content": "hello"}}`, the ordinary
+# transcript shape: with jq installed `jq -r ".message // \"\""` printed the object's pretty-printed
+# JSON, and with jq absent the python3 arm wrote "" because the node is not a `str`. #1566 could not
+# fix that where it lived — `command-scan.sh` was owned by concurrent work — so it wrote a second
+# reader with the right rule beside it and stated the limit.
 #
-# It was written here because `hook_json_string` did not promise the type test and its two arms
-# DISAGREED without it. Measured on `{"message": {"role": "user", "content": "hello"}}`, which is the
-# ordinary transcript shape and not an exotic one: with jq installed, `jq -r ".message // \"\""`
-# printed the object's pretty-printed JSON; with jq absent, the python3 arm wrote "" because the node
-# is not a `str`. #1566 could not fix that where it lived, because `command-scan.sh` was owned by
-# concurrent work, so it wrote a second reader with the right rule and stated the limit.
+# #1574 fixed the original and adopted that rule for it: a field that is not a string is not that
+# field, on both arms, byte for byte. What was left here was a one-line delegate with an identical
+# contract — which is an ALIAS, and an alias is a second name for one fact. That is the same defect
+# this directory has spent a week removing, one level up from a second implementation: a reader
+# meeting two names has to ask which one to use, and there is no answer. So the name goes with the
+# body, and its six callers ask `hook_json_string` directly.
 #
-# #1574 fixed the original and adopted THIS rule for it: a field that is not a string is not that
-# field, on both arms, byte for byte. Keeping a second implementation of a rule that now has one
-# owner would be the defect this whole directory has spent a week removing — so the body is gone and
-# the NAME stays, because four hooks call it and their reason for calling it is unchanged: a
-# structured node is not prompt TEXT, and returning the JSON blob would have `correction-detect` grep
-# it for correction keywords and log it as `prompt_excerpt`, and `spec-first-gate` scan it for
+# The reason those callers wanted the type test is unchanged and now lives where the rule does: a
+# structured node is not TEXT, and returning the JSON blob would have `correction-detect` grep it for
+# correction keywords and log it as `prompt_excerpt`, and `spec-first-gate` scan it for
 # implementation intent.
-hook_json_text() {
-  hook_json_string "$1" "$2"
-}
 
 # The user's prompt text, under whichever of the three keys the event carries it.
 #
@@ -216,7 +212,7 @@ hook_json_text() {
 hook_prompt_of() {
   local key value
   for key in prompt user_prompt message; do
-    if ! value=$(hook_json_text "$1" "$key"); then
+    if ! value=$(hook_json_string "$1" "$key"); then
       return 1
     fi
     if [[ -n "$value" ]]; then

--- a/.claude/hooks/lib/hook-facts.sh
+++ b/.claude/hooks/lib/hook-facts.sh
@@ -156,52 +156,36 @@ hook_current_branch() {
 # is allowed to contain a quote or a backslash, JSON escapes both, and a `[^"]*` grep stops at the
 # escape and hands back a path that does not exist.
 #
-# Through `hook_json_text`, not `hook_json_string`, so this reader and `hook_prompt_of` answer the
-# same question the same way. Measured on `{"tool_input": {"file_path": 123}}`: `hook_json_string`
-# returns `123` where jq is installed and "" where it is not, so the rule would otherwise have been
-# one-per-function instead of one rule. A path is text or it is not a path.
+# Through `hook_json_text`, so this reader and `hook_prompt_of` answer the same question the same
+# way. Measured on `{"tool_input": {"file_path": 123}}` before INFRA-081: `hook_json_string` returned
+# `123` where jq was installed and "" where it was not, so the rule would otherwise have been
+# one-per-function instead of one rule. A path is text or it is not a path. Since #1574 both readers
+# ARE one function, and this line records which rule won rather than which function to call.
 hook_file_path_of() {
   hook_json_text "$1" 'tool_input.file_path'
 }
 
-# A top-level field, but ONLY when it holds a JSON string. Anything else reads as absent.
+# A field, but ONLY when it holds a JSON string. Anything else reads as absent.
 #
-# `hook_json_string` next door does not promise this, and its two arms DISAGREE without it. Measured
-# on `{"message": {"role": "user", "content": "hello"}}`, which is the ordinary transcript shape and
-# not an exotic one: with jq installed, `jq -r '.message // ""'` prints the object's pretty-printed
-# JSON; with jq absent, the python3 arm writes "" because the node is not a `str`. Same payload, same
-# function, two answers depending on which tool the host happens to have — the exact defect class
-# this directory spent INFRA-077 removing, one function to the left.
+# THIS IS NOW `hook_json_string`, AND THE NAME IS ALL THAT REMAINS OF THE DIFFERENCE (INFRA-081,
+# #1574).
 #
-# `hook_json_string` lives in `command-scan.sh`, which INFRA-077 deliberately did not touch, so this
-# is stated rather than fixed there: the disagreement is still reachable through any OTHER caller of
-# that function. Filed in the PR body for whoever owns that file next.
+# It was written here because `hook_json_string` did not promise the type test and its two arms
+# DISAGREED without it. Measured on `{"message": {"role": "user", "content": "hello"}}`, which is the
+# ordinary transcript shape and not an exotic one: with jq installed, `jq -r ".message // \"\""`
+# printed the object's pretty-printed JSON; with jq absent, the python3 arm wrote "" because the node
+# is not a `str`. #1566 could not fix that where it lived, because `command-scan.sh` was owned by
+# concurrent work, so it wrote a second reader with the right rule and stated the limit.
 #
-# The answer chosen here is "": a structured node is not prompt TEXT, and returning the JSON blob
-# would have `correction-detect` grep it for correction keywords and log it as `prompt_excerpt`,
-# and `spec-first-gate` scan it for implementation intent.
+# #1574 fixed the original and adopted THIS rule for it: a field that is not a string is not that
+# field, on both arms, byte for byte. Keeping a second implementation of a rule that now has one
+# owner would be the defect this whole directory has spent a week removing — so the body is gone and
+# the NAME stays, because four hooks call it and their reason for calling it is unchanged: a
+# structured node is not prompt TEXT, and returning the JSON blob would have `correction-detect` grep
+# it for correction keywords and log it as `prompt_excerpt`, and `spec-first-gate` scan it for
+# implementation intent.
 hook_json_text() {
-  local json="$1" path="$2"
-  if command -v jq >/dev/null 2>&1; then
-    printf '%s' "$json" | jq -r "if (.${path} | type) == \"string\" then .${path} else \"\" end" 2>/dev/null && return 0
-  fi
-  if command -v python3 >/dev/null 2>&1; then
-    printf '%s' "$json" | python3 -c '
-import json, sys
-try:
-    doc = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-node = doc
-for key in sys.argv[1].split("."):
-    if not isinstance(node, dict):
-        node = None
-        break
-    node = node.get(key)
-sys.stdout.write(node if isinstance(node, str) else "")
-' "$path" 2>/dev/null && return 0
-  fi
-  return 1
+  hook_json_string "$1" "$2"
 }
 
 # The user's prompt text, under whichever of the three keys the event carries it.

--- a/.claude/hooks/revert-detect.sh
+++ b/.claude/hooks/revert-detect.sh
@@ -61,11 +61,13 @@ is_workflow_multi_edit_path() {
 }
 
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-# Through `hook_json_text`, so this reads the same on a host with jq and one without: measured,
-# `hook_json_string` hands back a non-string node's JSON where jq is installed and "" where it is
-# not. A session id and a transcript path are text or they are absent. See lib/hook-facts.sh.
-SESSION_ID=$(hook_json_text "$INPUT" 'session_id' || printf '')
-TRANSCRIPT_PATH=$(hook_json_text "$INPUT" 'transcript_path' || printf '')
+# A session id and a transcript path are TEXT, or they are absent — there is no third answer, and
+# `hook_json_string` is the single owner of that rule: a field that is not a JSON string reads as "",
+# on a host with jq and on a host without, byte for byte (INFRA-081, #1574). This used to call
+# `hook_json_text`, which existed only because the rule was true in one file and not in the other;
+# once it was true in both, that name was an alias and is gone. See lib/command-scan.sh.
+SESSION_ID=$(hook_json_string "$INPUT" 'session_id' || printf '')
+TRANSCRIPT_PATH=$(hook_json_string "$INPUT" 'transcript_path' || printf '')
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH/#\~/$HOME}"
 
 # `git_project()` was defined here and, byte-identically, in eval-log-stop — two copies of the one

--- a/scripts/harness/__tests__/helpers/path-without.mjs
+++ b/scripts/harness/__tests__/helpers/path-without.mjs
@@ -1,0 +1,49 @@
+import { mkdtempSync, readdirSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll } from 'vitest';
+
+const farms = [];
+afterAll(() => {
+  while (farms.length > 0) rmSync(farms.pop(), { recursive: true, force: true });
+});
+
+/**
+ * A PATH in which the named tools genuinely do not exist.
+ *
+ * A shim that merely FAILS is a different scenario — the hooks branch on `command -v`, so a
+ * present-but-broken tool exercises a path a tool-less host never takes. The farm therefore
+ * symlinks every executable the real PATH offers except the hidden ones, which is the only way to
+ * ask "what does this hook do on a host without jq" and get the host's answer.
+ *
+ * It is a module because two test files need the same farm and the question it answers — "do the
+ * two arms of a reader agree" — is the subject of INFRA-081. A second copy of the thing that
+ * decides which arm runs, in the PR whose subject is "one rule rather than one per installed tool",
+ * would be the defect wearing the fix as a costume.
+ */
+export function pathWithout(hidden) {
+  const dir = realpathSync(mkdtempSync(path.join(tmpdir(), 'path-without-')));
+  farms.push(dir);
+  const seen = new Set();
+  for (const entry of (process.env.PATH ?? '').split(':')) {
+    if (!entry) continue;
+    let names;
+    try {
+      names = readdirSync(entry);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      if (hidden.includes(name)) continue;
+      try {
+        symlinkSync(path.join(entry, name), path.join(dir, name));
+      } catch {
+        // A duplicate or an unreadable entry is not the subject of any case here.
+      }
+    }
+  }
+  return dir;
+}

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -6,13 +6,17 @@ import {
   readdirSync,
   realpathSync,
   rmSync,
-  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
+
+// One owner for the farm too. Both this file and `hook-json-reader-agrees.test.mjs` need "a PATH
+// where jq genuinely does not exist", and a second copy of the thing that decides WHICH ARM RUNS,
+// in a directory whose subject is one-rule-not-one-per-tool, is the defect wearing the fix.
+import { pathWithout } from './helpers/path-without.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
@@ -78,39 +82,6 @@ function initRepo(dir, branch) {
   writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
   git('add', '-A');
   git('commit', '--quiet', '-m', 'chore: root');
-  return dir;
-}
-
-/**
- * A PATH in which the named tools genuinely do not exist.
- *
- * A shim that merely FAILS is a different scenario — the hooks branch on `command -v`, so a
- * present-but-broken tool exercises a path a tool-less host never takes. The farm therefore
- * symlinks every executable the real PATH offers except the hidden ones, which is the only way to
- * ask "what does this hook do on a host without jq" and get the host's answer.
- */
-function pathWithout(hidden) {
-  const dir = scratchDir('hook-facts-path-');
-  const seen = new Set();
-  for (const entry of (process.env.PATH ?? '').split(':')) {
-    if (!entry) continue;
-    let names;
-    try {
-      names = readdirSync(entry);
-    } catch {
-      continue;
-    }
-    for (const name of names) {
-      if (seen.has(name)) continue;
-      seen.add(name);
-      if (hidden.includes(name)) continue;
-      try {
-        symlinkSync(path.join(entry, name), path.join(dir, name));
-      } catch {
-        // A duplicate or an unreadable entry is not the subject of any case here.
-      }
-    }
-  }
   return dir;
 }
 

--- a/scripts/harness/__tests__/hook-facts.test.mjs
+++ b/scripts/harness/__tests__/hook-facts.test.mjs
@@ -270,13 +270,15 @@ describe('fact 2 — reading a JSON field has one reader', () => {
 
   it('reads a prompt to the same answer whether or not jq is installed', () => {
     // The reported finding one function to the left, and the same class this file exists for.
-    // `hook_json_string`'s two arms DISAGREE on a field that is not a string: measured, `jq -r` on
-    // `{"message": {...}}` prints the object's pretty-printed JSON, while the python3 arm writes "".
-    // So `hook_prompt_of` returned a JSON blob as "the user's prompt" on a host with jq and nothing
-    // on a host without — and `{"message": {"role": …, "content": …}}` is the ordinary transcript
-    // shape, not an exotic one. correction-detect would then grep a JSON blob for correction
-    // keywords and log it as `prompt_excerpt`; spec-first-gate would scan it for implementation
-    // intent. A structured node is not prompt TEXT, so the answer is "" — on both hosts.
+    // `hook_json_string`'s two arms USED TO DISAGREE on a field that is not a string: measured,
+    // `jq -r` on `{"message": {...}}` printed the object's pretty-printed JSON while the python3 arm
+    // wrote "". So `hook_prompt_of` returned a JSON blob as "the user's prompt" on a host with jq and
+    // nothing on a host without — and `{"message": {"role": …, "content": …}}` is the ordinary
+    // transcript shape, not an exotic one. correction-detect would then grep a JSON blob for
+    // correction keywords and log it as `prompt_excerpt`; spec-first-gate would scan it for
+    // implementation intent. A structured node is not prompt TEXT, so the answer is "" — on both
+    // hosts. INFRA-081 (#1574) closed that in `hook_json_string` itself; this case stays because the
+    // property it pins is the reader's contract, not the history of one defect.
     const payload = { message: { role: 'user', content: 'hello' } };
     const withJq = promptOf(payload);
     const withoutJq = promptOf(payload, { PATH: noJq });

--- a/scripts/harness/__tests__/hook-json-reader-agrees.test.mjs
+++ b/scripts/harness/__tests__/hook-json-reader-agrees.test.mjs
@@ -1,0 +1,230 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { pathWithout } from './helpers/path-without.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+// `hook-facts.sh`, not `command-scan.sh`: it sources the other, so one probe reaches all three
+// readers — and whether `hook_json_text` still answers as `hook_json_string` does is exactly the
+// invariant that stops them forking again.
+const LIB = path.join(HOOKS_DIR, 'lib/hook-facts.sh');
+
+/**
+ * INFRA-081 (#1574) — one reader, one answer, whatever the host happens to have installed.
+ *
+ * `hook_json_string` had two implementations of one question, picked by `command -v`. They agreed on
+ * the shape that actually arrives and disagreed on every other, and the disagreement reached a
+ * VERDICT: measured on `branch-guard.sh` against a scratch repository, same payload both times,
+ * only `PATH` differing, `{"tool_input":{"command":{"a":"git push origin main"}}}` exited 0 with jq
+ * installed and 2 without. One host permitted and the other refused, and neither answer was reached
+ * by a decision.
+ *
+ * The cases below are written against the READERS and against a real hook's VERDICT, because
+ * #1572 exists precisely because a corpus that measures a function says nothing about whether the
+ * guards consult it.
+ *
+ * Ten of the seventeen shapes below disagreed before the fix. They are not all exotic: the trailing
+ * newline `jq -r` appends and python3 does not is on EVERY read, including `tool_name` and the
+ * ordinary string command.
+ */
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchDir(prefix) {
+  const dir = realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+  scratch.push(dir);
+  return dir;
+}
+
+const noJq = pathWithout(['jq']);
+
+/**
+ * The probe writes the exit status on its own first line and then the reader's output BYTE FOR
+ * BYTE, so a difference of one trailing newline is a difference this case can see. Comparing
+ * `$(…)`-captured values would have hidden it, because command substitution strips exactly that.
+ *
+ * The payload reaches the probe through the ENVIRONMENT, never interpolated into a command line: a
+ * JSON document is full of quotes and braces, and building one into a shell string is how a probe
+ * ends up measuring its own quoting instead of the function.
+ */
+const PROBE = path.join(scratchDir('json-reader-probe-'), 'probe.sh');
+writeFileSync(
+  PROBE,
+  [
+    'source "$1"',
+    'out=$(mktemp)',
+    'case "$2" in',
+    '  string) hook_json_string "$PAYLOAD" "$3" > "$out" ;;',
+    '  text) hook_json_text "$PAYLOAD" "$3" > "$out" ;;',
+    '  *) hook_edit_content_of "$PAYLOAD" > "$out" ;;',
+    'esac',
+    'rc=$?',
+    'printf \'%s\\n\' "$rc"',
+    'cat "$out"',
+    'rm -f "$out"',
+    '',
+  ].join('\n'),
+);
+
+function read(payload, reader, field, env = {}) {
+  const result = spawnSync('/bin/bash', [PROBE, LIB, reader, field], {
+    encoding: 'utf8',
+    env: { ...process.env, PAYLOAD: JSON.stringify(payload), ...env },
+  });
+  return result.stdout ?? '';
+}
+
+/** Every shape below is a JSON document a payload could carry, not a shape invented for the test. */
+const SHAPES = [
+  [
+    'command as a string — the shape that really arrives',
+    { tool_input: { command: 'git push' } },
+    'string',
+    'tool_input.command',
+  ],
+  [
+    'command as an object',
+    { tool_input: { command: { a: 'git push origin main' } } },
+    'string',
+    'tool_input.command',
+  ],
+  ['command as a number', { tool_input: { command: 123 } }, 'string', 'tool_input.command'],
+  [
+    'command as an array',
+    { tool_input: { command: ['git', 'push'] } },
+    'string',
+    'tool_input.command',
+  ],
+  ['command as null', { tool_input: { command: null } }, 'string', 'tool_input.command'],
+  ['command absent', { tool_input: {} }, 'string', 'tool_input.command'],
+  ['the path walks through a non-object', { tool_input: 'x' }, 'string', 'tool_input.command'],
+  ['the path walks through an array', { tool_input: ['x'] }, 'string', 'tool_input.command'],
+  ['the whole payload is an array', ['x'], 'string', 'tool_input.command'],
+  ['tool_name as a string', { tool_name: 'Bash' }, 'string', 'tool_name'],
+  ['cwd absent', { tool_name: 'Bash' }, 'string', 'cwd'],
+  ['content as a string', { tool_input: { content: 'x' } }, 'content', ''],
+  [
+    'content as a number, with a real new_string beside it',
+    { tool_input: { content: 5, new_string: 'real' } },
+    'content',
+    '',
+  ],
+  [
+    'an edit whose new_string is not a string',
+    { tool_input: { edits: [{ new_string: 'a' }, { new_string: 7 }] } },
+    'content',
+    '',
+  ],
+  ['edits that is not a list', { tool_input: { edits: 'nope' } }, 'content', ''],
+  ['tool_input that is not an object', { tool_input: 'nope' }, 'content', ''],
+  [
+    'edits as they normally arrive',
+    { tool_input: { edits: [{ new_string: 'a' }, { new_string: 'b' }] } },
+    'content',
+    '',
+  ],
+];
+
+describe('a JSON field reads the same whether or not jq is installed (INFRA-081)', () => {
+  it('the farm hides jq and keeps python3', () => {
+    // Stated because every case below is vacuous if the farm is wrong: with jq still reachable both
+    // sides would run the same arm and agree for the wrong reason.
+    expect(
+      spawnSync('/bin/bash', ['-c', 'command -v jq'], { env: { PATH: noJq } }).status,
+    ).not.toBe(0);
+    expect(
+      spawnSync('/bin/bash', ['-c', 'command -v python3'], { env: { PATH: noJq } }).status,
+    ).toBe(0);
+    expect(spawnSync('/bin/bash', ['-c', 'command -v jq']).status).toBe(0);
+  });
+
+  for (const [name, payload, reader, field] of SHAPES) {
+    it(name, () => {
+      expect(read(payload, reader, field, { PATH: noJq })).toBe(read(payload, reader, field));
+    });
+  }
+
+  it('reads the ordinary string command as itself, so the agreement is not agreement on nothing', () => {
+    // A reader that returned "" for everything would satisfy every case above. This one pins the
+    // answer, not just its consistency.
+    const payload = { tool_input: { command: 'git push origin main' } };
+    expect(read(payload, 'string', 'tool_input.command')).toBe('0\ngit push origin main');
+    expect(read(payload, 'string', 'tool_input.command', { PATH: noJq })).toBe(
+      '0\ngit push origin main',
+    );
+  });
+
+  it('gives `hook_json_text` and `hook_json_string` the same answer for every shape', () => {
+    // The two readers were two implementations of one rule, in two files, because #1566 could not
+    // reach the one it needed. #1574 gave that rule a single owner and left `hook_json_text` as the
+    // NAME four hooks call. This case is what stops them forking again — it compares the readers
+    // themselves, on both hosts, over the shapes that used to tell them apart.
+    for (const [name, payload, reader, field] of SHAPES) {
+      if (reader !== 'string') continue;
+      expect(read(payload, 'text', field), name).toBe(read(payload, 'string', field));
+      expect(read(payload, 'text', field, { PATH: noJq }), name).toBe(
+        read(payload, 'string', field, { PATH: noJq }),
+      );
+    }
+  });
+
+  it('answers "" for a field that is not a string, on both hosts', () => {
+    // The DECISION, pinned. A field that is not a string is not that field — the rule
+    // `hook_json_text` already states for the text fields, rather than a second rule for this one.
+    // The verdict stays fail-closed because the CALLER names what empty means for it, which is the
+    // reader/caller split `hook-facts.sh` states: `hook_command_of` refuses an empty command.
+    const payload = { tool_input: { command: { a: 'git push origin main' } } };
+    expect(read(payload, 'string', 'tool_input.command')).toBe('0\n');
+    expect(read(payload, 'string', 'tool_input.command', { PATH: noJq })).toBe('0\n');
+  });
+});
+
+describe('the VERDICT of a real guard does not depend on the installed tool (INFRA-081)', () => {
+  function repoOn(branch) {
+    const dir = path.join(scratchDir('json-reader-repo-'), 'repo');
+    mkdirSync(dir, { recursive: true });
+    const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+    git('init', '--quiet', `--initial-branch=${branch}`);
+    git('config', 'user.email', 'harness@example.test');
+    git('config', 'user.name', 'Harness');
+    git('commit', '--quiet', '--allow-empty', '-m', 'chore: root');
+    return dir;
+  }
+
+  function branchGuard(command, cwd, env = {}) {
+    const result = spawnSync('/bin/bash', [path.join(HOOKS_DIR, 'branch-guard.sh')], {
+      input: JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } }),
+      encoding: 'utf8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: cwd, ...env },
+    });
+    return result.status ?? 1;
+  }
+
+  it('refuses a command it cannot read as a command, with jq and without it', () => {
+    // The measured divergence, end to end. `command` arrives as an OBJECT: with jq the guard used to
+    // receive that object pretty-printed, whose `git push` sits inside quotes, so the tokenizer
+    // masked it as data, no verb was found, and the call was ALLOWED. Without jq the guard refused.
+    const repo = repoOn('main');
+    expect(branchGuard({ a: 'git push origin main' }, repo)).toBe(2);
+    expect(branchGuard({ a: 'git push origin main' }, repo, { PATH: noJq })).toBe(2);
+  });
+
+  it('still refuses the bare control and still permits ordinary work, on both hosts', () => {
+    // Controls, so the case above is not "this guard refuses everything now".
+    const onMain = repoOn('main');
+    expect(branchGuard('git push origin main', onMain)).toBe(2);
+    expect(branchGuard('git push origin main', onMain, { PATH: noJq })).toBe(2);
+
+    const onFeature = repoOn('feat/x');
+    expect(branchGuard('git commit -m "ordinary work"', onFeature)).toBe(0);
+    expect(branchGuard('git commit -m "ordinary work"', onFeature, { PATH: noJq })).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/hook-json-reader-agrees.test.mjs
+++ b/scripts/harness/__tests__/hook-json-reader-agrees.test.mjs
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -9,9 +17,8 @@ import { pathWithout } from './helpers/path-without.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
-// `hook-facts.sh`, not `command-scan.sh`: it sources the other, so one probe reaches all three
-// readers — and whether `hook_json_text` still answers as `hook_json_string` does is exactly the
-// invariant that stops them forking again.
+// `hook-facts.sh`, not `command-scan.sh`: it sources the other, so one probe reaches every reader
+// a hook can call — which is what makes "there is only one of them" a question this file can ask.
 const LIB = path.join(HOOKS_DIR, 'lib/hook-facts.sh');
 
 /**
@@ -63,7 +70,6 @@ writeFileSync(
     'out=$(mktemp)',
     'case "$2" in',
     '  string) hook_json_string "$PAYLOAD" "$3" > "$out" ;;',
-    '  text) hook_json_text "$PAYLOAD" "$3" > "$out" ;;',
     '  *) hook_edit_content_of "$PAYLOAD" > "$out" ;;',
     'esac',
     'rc=$?',
@@ -162,23 +168,38 @@ describe('a JSON field reads the same whether or not jq is installed (INFRA-081)
     );
   });
 
-  it('gives `hook_json_text` and `hook_json_string` the same answer for every shape', () => {
-    // The two readers were two implementations of one rule, in two files, because #1566 could not
-    // reach the one it needed. #1574 gave that rule a single owner and left `hook_json_text` as the
-    // NAME four hooks call. This case is what stops them forking again — it compares the readers
-    // themselves, on both hosts, over the shapes that used to tell them apart.
-    for (const [name, payload, reader, field] of SHAPES) {
-      if (reader !== 'string') continue;
-      expect(read(payload, 'text', field), name).toBe(read(payload, 'string', field));
-      expect(read(payload, 'text', field, { PATH: noJq }), name).toBe(
-        read(payload, 'string', field, { PATH: noJq }),
-      );
-    }
+  it('leaves exactly ONE reader for the rule, by name as well as by body', () => {
+    // `hook_json_text` was a SECOND reader of this one rule, written in `hook-facts.sh` because
+    // #1566 could not reach the function that needed fixing. #1574 fixed that function and adopted
+    // the rule, which left the second reader a one-line delegate — an ALIAS, and an alias is a
+    // second name for one fact: a reader meeting two names has to ask which to use and there is no
+    // answer. So the name went with the body.
+    //
+    // Checked mechanically rather than described, because "there is one owner" is a claim a future
+    // convenience wrapper falsifies in one line. If a reader legitimately needs to come back, it
+    // must come back with a DIFFERENT contract and this case must be rewritten to say what it is.
+    const sources = readdirSync(HOOKS_DIR)
+      .filter((name) => name.endsWith('.sh'))
+      .map((name) => path.join(HOOKS_DIR, name))
+      .concat([
+        path.join(HOOKS_DIR, 'lib/command-scan.sh'),
+        path.join(HOOKS_DIR, 'lib/hook-facts.sh'),
+      ]);
+    const callers = sources.filter((file) =>
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .some((line) => line.includes('hook_json_text')),
+    );
+    expect(
+      callers.map((file) => path.relative(HOOKS_DIR, file)),
+      'hook_json_text is back. One rule, one owner, one name — INFRA-081.',
+    ).toStrictEqual([]);
   });
 
   it('answers "" for a field that is not a string, on both hosts', () => {
-    // The DECISION, pinned. A field that is not a string is not that field — the rule
-    // `hook_json_text` already states for the text fields, rather than a second rule for this one.
+    // The DECISION, pinned. A field that is not a string is not that field — the rule `hook-facts.sh`
+    // had already measured for the text fields, adopted here rather than restated as a second rule.
     // The verdict stays fail-closed because the CALLER names what empty means for it, which is the
     // reader/caller split `hook-facts.sh` states: `hook_command_of` refuses an empty command.
     const payload = { tool_input: { command: { a: 'git push origin main' } } };


### PR DESCRIPTION
## The defect, measured end to end

`hook_json_string` had two implementations of one question, picked by which tool the host happens to
have. They agreed on the shape that actually arrives and disagreed on every other — and the
disagreement reached a **verdict**. `branch-guard.sh` on a scratch repository, same payload both
times, only `PATH` differing:

```
payload: {"tool_name":"Bash","cwd":"<scratch>","tool_input":{"command":{"a":"git push origin main"}}}

--- with jq on PATH ---
exit=0

--- WITHOUT jq on PATH (python3 present) ---
[branch-guard] Blocked: the tool command could not be decoded, so it cannot be judged.
exit=2

--- direct field readings ---
jq-arm       hook_json_string tool_input.command -> [{
  "a": "git push origin main"
}]
python3-arm  hook_json_string tool_input.command -> []
```

One host permitted and the other refused, and neither answer was reached by a decision.

## The decision

**Both arms are string-only. A field that is not a string is not that field.**

The issue offered two answers and asked for a choice rather than a match. This is the first one, and
the reasoning is not "it matches `hook_json_text`":

1. It is the rule `hook_json_text` already states, **with its own measurement**, for the text fields
   #1566 could reach. Two spellings of one rule is what INFRA-077 spent a PR removing.
2. `hook-facts.sh` states the reader/caller split explicitly — *a READER collapses absent and empty
   into `""`, and the CALLER names what empty means for it*. A refusing reader would break that
   written, tested rule for one function out of the set.
3. **The verdict is fail-closed either way, and that is the property that matters.** Every caller
   already turns empty into a refusal or a fallback — `hook_command_of` returns non-zero on an empty
   command, `hook_tool_name_of` falls through to its no-tools parse — so the refusing-reader
   alternative would have produced the *same observable behaviour at every present call site*. It was
   measured, not assumed. Both hosts now exit 2 on the payload above.

## What else was closed with it

Two divergences in the same arm that the report did not name, both measured:

- `jq -r ".a.b"` **errors** when `a` is not an object, so a jq-only host answered "could not decode"
  where a python3 host answered `""`.
- `jq -r` appends a trailing **newline** the python3 arm does not write. Invisible to every caller
  (they all read through a command substitution) — and invisible is how a divergence survives to
  matter later. Both arms are now byte-identical, `-j` and all.

`hook_edit_content_of` next door carried four more of the same class, each reachable from an ordinary
payload, and is held to the same rule rather than left as the sibling that was not fixed.

`hook_json_text` is now `hook_json_string`. It existed only because #1566 could not reach the
function it needed; its body is gone and its **name** stays, because four hooks call it and their
reason for calling it is unchanged.

**`lib/hook-facts.sh` is touched, and that is why**: leaving a second implementation of the rule this
PR gives a single owner would be the defect wearing the fix as a costume.

## Measurements

| | before | after |
| --- | --- | --- |
| payload shapes whose answer depends on the installed tool | **10 of 17** | **0 of 17** |
| `branch-guard` verdict on the object-command payload | 0 with jq / 2 without | 2 / 2 |

**Red-first.** With `command-scan.sh` reverse-applied, 13 of the 23 new cases fail — including the
end-to-end verdict case — and the two control cases (bare `git push origin main` on `main` refused,
an ordinary commit on a feature branch permitted) stay green.

**False-positive sweep against `origin/develop`.** 625 real command lines taken from this tree (every
fenced `git`/`gh`/`pnpm`/`npx`/`node` line in 1782 documents under `.agents/` and `docs/`, plus the
root `package.json` scripts), each run through all three Bash guards end to end under both the
baseline hooks and these:

```
0 verdict(s) moved out of 1875 runs.
NEWLY SEEN (the baseline allowed it, this refuses it): 0
NEWLY BLIND (the baseline refused it, this allows it): 0
```

Closes #1574
