### PR TITLE
feat(harness): INFRA-072 a red proof must have reached the code the fix wrote

### DIFF
--- a/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
+++ b/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
@@ -91,6 +91,97 @@ So direction 1 closes the masking half and nothing else, which is what the item 
 remaining half — a case that fails for the wrong reason, or passes beside a genuine sibling — needs
 the branch-level or coverage-delta work, and stays open as a separate decision.
 
+## Decision (2026-08-01, second pass) — direction 3, and direction 2 rejected with the measurement
+
+Directions 2 and 3 were the remaining halves. **Direction 3 (coverage delta per case) is
+implemented. Direction 2 (branch-level mutation) is rejected**, and the reason is measurable rather
+than a matter of taste.
+
+### Acceptance criterion, set before any code was written
+
+1. Of the four motivating cases, the witness was predicted to catch **0 additional** — direction 1
+   already catches #4 partly — with a per-case reason stated in advance and then replayed.
+2. It must catch the class direction 1 cannot see: a case that FAILS on the reversed source and
+   executed none of the lines the fix wrote.
+3. **Zero** false alarms over recent real ranges. A guard that fires on correct work gets switched
+   off, and #1568 already established that "every added case must fail" is that kind of guard.
+
+### What was built
+
+Two instruments, one question — did the case that supplied the red actually execute the code this
+fix wrote?
+
+- `bash`: `BASH_ENV` names a prelude every non-interactive bash sources before the script it was
+  asked to run, so a hook spawned from inside a vitest worker is instrumented without touching the
+  test or the hook. `BASH_XTRACEFD` sends the trace to its own descriptor, so a test asserting on the
+  hook's stderr is unaffected by being measured.
+- `.mjs`/`.ts`: vitest v8 coverage, whose istanbul-shaped output names the executed statements and
+  which lines are statements at all.
+
+Per-case attribution comes from re-running the single deciding case with `-t`, because vitest
+attributes outcomes to cases but coverage to a run.
+
+Three answers, and only UNREACHED is a finding. UNKNOWN — a comment-only hunk, a pure deletion, a
+report that never names the file — leaves the verdict exactly as it was.
+
+### Two formulations were tried, and the first was measured WRONG
+
+The first asked the question of the REVERSED tree against the fix's OLD-side lines. Replayed on
+`c08e0dbd6`, it called a **genuine** red proof `unreached`: that fix is an ADDITION, so its old side
+held nothing but a comment and one `case` pattern arm. It also turned out that `set -x` never names a
+bare `case` arm at all — probed on bash 5.2, `*.ts) echo is-ts ;;` traces at its own line because it
+carries a command, while `*.md)` alone never does and only its body traces.
+
+Asked of the FIXED tree against the fix's NEW-side lines, with bare `case` arms excluded from the
+executable set, the same replay gives `reached`. That is the formulation that shipped.
+
+### The four motivating cases, judged against what landed
+
+| Case                              | Caught?     | Why                                                                                                                                                                                                                    |
+| --------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hooks-have-execution-coverage`   | **no**      | the logic under test is IN the test file — no source to reverse, no pair, so the gate emits no verdict for the witness to qualify. Out of reach of any diff-scoped pair gate.                                           |
+| `remaining-hooks-run` (two hooks) | **no**      | the hooks named were not changed, so again no pair.                                                                                                                                                                    |
+| `remaining-hooks-run` (extension) | **no**      | REPLAYED on `b1f46acf3`: the fix wrote only comments and one bare `case` arm, so no changed line is traceable and the witness answers UNKNOWN. And the behaviour the case names — the extension filter — is not in the range's diff at all, so no diff-scoped instrument can target it. |
+| `remaining-hooks-run` (unset var) | **partly**  | unchanged from direction 1. The witness holds for it either way; catching it in the "a genuine added case fails beside it" configuration needs a demand on EVERY added case, which #1568 measured as failing correct work. |
+
+**0 of 4 additional, as predicted.** The three the item still names are not reachable from inside
+this gate: two produce no verdict at all, and the third names a behaviour the diff does not contain.
+Closing that would take a per-case reachability check over the WHOLE suite rather than over a fix
+range — a different gate, and the honest next item.
+
+### Why direction 2 was rejected
+
+Branch-level mutation was traced through the same four cases and the same false-positive test:
+
+- Per-hunk reversal (the tractable reading of "negate the branch a case names") catches none of the
+  four. #3's fix is entirely within the crash region, so every hunk kills the case; #4's vacuous case
+  hides behind a genuine sibling that kills every hunk.
+- The reading that WOULD catch #4 — every added case must be killed by some mutant — is the same
+  shape as "every added case must fail on reversal", which #1568 measured as failing correct work: a
+  range routinely adds cases that do not depend on the fix.
+- Cost: one vitest run per hunk. Over the 31 recent ranges this gate judges, source files carry up to
+  617 changed lines across many hunks.
+
+Strictly more expensive, and it catches nothing direction 3 does not.
+
+### Measured, on real ranges
+
+Eight recent merged ranges replayed through the real gate (worktree detached at each merge, this
+branch's gate copied in), 15 sources judged, **12 produced a red proof**:
+
+| Witness   | Count      | Effect                    |
+| --------- | ---------- | ------------------------- |
+| REACHED   | 11 of 12   | verdict unchanged         |
+| UNKNOWN   | 1 of 12    | verdict unchanged         |
+| UNREACHED | **0 of 12** | **zero false alarms**    |
+
+Ranges: `63fa0c0cf`, `2ac10f251`, `631aa9e27`, `02f5a84b9`, `a668df9e3`, `2b0c454e0`, `4719efe5a`,
+`8589d58fa`. Both instruments are exercised there — nine `.sh` sources through the tracer, two `.mjs`
+sources through coverage.
+
+The gate stays ADVISORY and `red-proof-unreached` is report-only even under
+`REGRESSION_RED_PROOF_ENFORCE`; promotion is INFRA-046's decision, not this one.
+
 ## GATE-COMPLETE (2026-08-01)
 
 - `addedCaseTitleMatchers` reads titles off ADDED diff lines only; a context line and a REMOVED line

--- a/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
+++ b/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
@@ -189,11 +189,13 @@ The conclusion is unchanged and the corrected numbers are stronger.
 The gate stays ADVISORY and `red-proof-unreached` is report-only even under
 `REGRESSION_RED_PROOF_ENFORCE`; promotion is INFRA-046's decision, not this one.
 
-### Two review findings, both of them false-alarm sources, both fixed
+### Three review findings, all fixed
 
-Neither could turn CI red today — `red-proof-unreached` never sets a non-zero exit — which is the
-reason to fix them now: they are cheap while the verdict is advisory and expensive the moment
-INFRA-046 promotes it.
+None could turn CI red today — `red-proof-unreached` never sets a non-zero exit — which is the reason
+to fix them now: they are cheap while the verdict is advisory and expensive the moment INFRA-046
+promotes it. The first two are false-alarm sources, where the gate reports a finding against correct
+work. The third is the opposite and the more costly direction: a missed detection, where the gate
+reports a sound proof over a masking bug.
 
 **1. The `case`-arm exclusion over-matched, and excluded a line bash DOES trace.** `BARE_CASE_ARM`
 matched any `(...)` line with no inner parens, so a full-line subshell in an arm BODY —
@@ -225,6 +227,42 @@ for ONE run whatever the number is; only a range heading for a finding walks the
 
 Re-measured after both fixes: the corpus result is **unchanged** — 12 REACHED, 1 UNKNOWN, 0 UNREACHED
 across the 13 red proofs.
+
+**3. `-t` selected the deciding case's SIBLINGS too, and that one hid a missed detection.**
+`--testNamePattern` is an UNANCHORED regex over the full test name, so a case called `parses config`
+also selected `parses config with defaults` — the ordinary shape of descriptive titles. The isolated
+run executed both, and every line the sibling touched was credited to the deciding case, turning a
+genuine UNREACHED into a reported REACHED.
+
+This is the finding that mattered most, and the corpus measurement was structurally blind to it: the
+failure direction is a MISSED DETECTION, not a false alarm. Zero-false-alarms was measured and would
+have stayed zero while the feature quietly did not work. The previous two findings were "a correct fix
+reported wrong"; this one is "a wrong fix reported correct".
+
+Reproduced red against a REAL vitest run — an injected runner implementing my own idea of `-t` would
+have been an accidental green — with two cases whose names are prefix/suffix of one another, only the
+longer touching the fix-written line, and the shorter as the deciding failure: `expected 'reached' to
+be 'unreached'`.
+
+WHAT `-t` ANCHORS AGAINST was measured, not read, because anchoring the wrong string matches nothing
+and answers UNKNOWN for everything — a worse bug than the one being fixed. Probed on vitest 3.2.6
+against `describe('outer group')` + `it('parses config')`:
+
+| Pattern                       | Result                                          |
+| ----------------------------- | ----------------------------------------------- |
+| `parses config`               | **2 ran** — the collision                       |
+| `^parses config$`             | **0 ran, 2 skipped** — the bare title is NOT it |
+| `^outer group parses config$` | **1 ran, 1 skipped** — correct                  |
+
+So the subject is the describe chain and the title joined by single spaces, byte-identical to the json
+reporter's `fullName`, which is what `decidingFailures` already hands over. The pattern is now
+`^<escaped fullName>$`, and when only a bare title is known (no `fullName`) it anchors the END only —
+still immune to the sibling collision, and never the empty-match trap.
+
+**The anchoring needed its own guard**, since an anchoring that matched nothing would look like a
+clean pass. Re-measured on the same eight ranges after the change: **12 REACHED, 1 UNKNOWN,
+0 UNREACHED — the 12 are still 12.** Those verdicts come from real `-t` invocations against real
+describe chains, so had the pattern stopped matching they would all have flipped to UNKNOWN.
 
 ### Re-measured against the current hooks
 

--- a/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
+++ b/.agents/backlog/completed/INFRA-072-a-test-that-does-not-reach-what-it-names.md
@@ -80,11 +80,11 @@ first, because they are what a stronger check would have to reach.
 
 ### The four motivating cases, judged against what landed
 
-| Case | Caught? | Why |
-| --- | --- | --- |
-| `hooks-have-execution-coverage` | **no** | the logic under test is IN the test file, so there is no source to reverse and no pair to judge. Per-case granularity operates inside a verdict this case never reaches. |
-| `remaining-hooks-run` (two hooks) | **no** | the hooks it names were not changed in the range, so no pair exists. INFRA-074's relation now says so precisely instead of approximately, but "no pair" is still no verdict. |
-| `remaining-hooks-run` (extension) | **no** | it fails reversed for the wrong reason — it crashes before reaching the filter. The gate reads pass/fail and cannot read WHY. This is direction 2/3 territory. |
+| Case                              | Caught?    | Why                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hooks-have-execution-coverage`   | **no**     | the logic under test is IN the test file, so there is no source to reverse and no pair to judge. Per-case granularity operates inside a verdict this case never reaches.                                                                                                                                                                                                                                                                |
+| `remaining-hooks-run` (two hooks) | **no**     | the hooks it names were not changed in the range, so no pair exists. INFRA-074's relation now says so precisely instead of approximately, but "no pair" is still no verdict.                                                                                                                                                                                                                                                            |
+| `remaining-hooks-run` (extension) | **no**     | it fails reversed for the wrong reason — it crashes before reaching the filter. The gate reads pass/fail and cannot read WHY. This is direction 2/3 territory.                                                                                                                                                                                                                                                                          |
 | `remaining-hooks-run` (unset var) | **partly** | it asserts an exit code both paths share, so it passes reversed. It is caught when it is the range's own added case and the file's red comes from a pre-existing case — the masking measured on `2ac10f251..b1f46acf3`. It is NOT caught when a genuine added case fails beside it, because requiring EVERY added case to fail would fail correct work: a range that adds three cases for one fix does not make all three depend on it. |
 
 So direction 1 closes the masking half and nothing else, which is what the item said it would. The
@@ -137,12 +137,12 @@ executable set, the same replay gives `reached`. That is the formulation that sh
 
 ### The four motivating cases, judged against what landed
 
-| Case                              | Caught?     | Why                                                                                                                                                                                                                    |
-| --------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `hooks-have-execution-coverage`   | **no**      | the logic under test is IN the test file — no source to reverse, no pair, so the gate emits no verdict for the witness to qualify. Out of reach of any diff-scoped pair gate.                                           |
-| `remaining-hooks-run` (two hooks) | **no**      | the hooks named were not changed, so again no pair.                                                                                                                                                                    |
-| `remaining-hooks-run` (extension) | **no**      | REPLAYED on `b1f46acf3`: the fix wrote only comments and one bare `case` arm, so no changed line is traceable and the witness answers UNKNOWN. And the behaviour the case names — the extension filter — is not in the range's diff at all, so no diff-scoped instrument can target it. |
-| `remaining-hooks-run` (unset var) | **partly**  | unchanged from direction 1. The witness holds for it either way; catching it in the "a genuine added case fails beside it" configuration needs a demand on EVERY added case, which #1568 measured as failing correct work. |
+| Case                              | Caught?    | Why                                                                                                                                                                                                                                                                                     |
+| --------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hooks-have-execution-coverage`   | **no**     | the logic under test is IN the test file — no source to reverse, no pair, so the gate emits no verdict for the witness to qualify. Out of reach of any diff-scoped pair gate.                                                                                                           |
+| `remaining-hooks-run` (two hooks) | **no**     | the hooks named were not changed, so again no pair.                                                                                                                                                                                                                                     |
+| `remaining-hooks-run` (extension) | **no**     | REPLAYED on `b1f46acf3`: the fix wrote only comments and one bare `case` arm, so no changed line is traceable and the witness answers UNKNOWN. And the behaviour the case names — the extension filter — is not in the range's diff at all, so no diff-scoped instrument can target it. |
+| `remaining-hooks-run` (unset var) | **partly** | unchanged from direction 1. The witness holds for it either way; catching it in the "a genuine added case fails beside it" configuration needs a demand on EVERY added case, which #1568 measured as failing correct work.                                                              |
 
 **0 of 4 additional, as predicted.** The three the item still names are not reachable from inside
 this gate: two produce no verdict at all, and the third names a behaviour the diff does not contain.
@@ -167,20 +167,74 @@ Strictly more expensive, and it catches nothing direction 3 does not.
 ### Measured, on real ranges
 
 Eight recent merged ranges replayed through the real gate (worktree detached at each merge, this
-branch's gate copied in), 15 sources judged, **12 produced a red proof**:
+branch's gate copied in). **17 sources judged, 13 of them offering a red proof:**
 
-| Witness   | Count      | Effect                    |
-| --------- | ---------- | ------------------------- |
-| REACHED   | 11 of 12   | verdict unchanged         |
-| UNKNOWN   | 1 of 12    | verdict unchanged         |
-| UNREACHED | **0 of 12** | **zero false alarms**    |
+| Witness   | Of the 13 red proofs | Effect                |
+| --------- | -------------------- | --------------------- |
+| REACHED   | 12                   | verdict unchanged     |
+| UNKNOWN   | 1                    | verdict unchanged     |
+| UNREACHED | **0**                | **zero false alarms** |
+
+The other 4 rows never offered a proof (3 `outcome=null`, 1 `run-error`) and are UNKNOWN by
+construction.
 
 Ranges: `63fa0c0cf`, `2ac10f251`, `631aa9e27`, `02f5a84b9`, `a668df9e3`, `2b0c454e0`, `4719efe5a`,
-`8589d58fa`. Both instruments are exercised there — nine `.sh` sources through the tracer, two `.mjs`
+`8589d58fa`. Both instruments are exercised there — `.sh` sources through the tracer, two `.mjs`
 sources through coverage.
+
+An earlier draft of this section reported "15 sources, 12 red proofs, 11 REACHED" — a miscount of the
+same run, corrected here against `outcome=… witness=…` pairs counted mechanically rather than by eye.
+The conclusion is unchanged and the corrected numbers are stronger.
 
 The gate stays ADVISORY and `red-proof-unreached` is report-only even under
 `REGRESSION_RED_PROOF_ENFORCE`; promotion is INFRA-046's decision, not this one.
+
+### Two review findings, both of them false-alarm sources, both fixed
+
+Neither could turn CI red today — `red-proof-unreached` never sets a non-zero exit — which is the
+reason to fix them now: they are cheap while the verdict is advisory and expensive the moment
+INFRA-046 promotes it.
+
+**1. The `case`-arm exclusion over-matched, and excluded a line bash DOES trace.** `BARE_CASE_ARM`
+matched any `(...)` line with no inner parens, so a full-line subshell in an arm BODY —
+`(cd "$dir" && cmd)` — was dropped from the executable set. Reproduced red before fixing: with that
+subshell as the only fix-written line the witness answered UNKNOWN, and with an unreached sibling
+line beside it, **UNREACHED — a finding against correct work**, which the acceptance criterion
+promised zero of.
+
+Fixed by recognising an arm by POSITION rather than by shape alone: arm position is straight after
+`case … in` and after each `;;` / `;&` / `;;&`; everything between is a body, where a parenthesised
+line is a command. The state is a stack, so a `case` nested in an arm body does not reset its
+enclosing block.
+
+**2. The run budget's comment promised what the loop did not do.** It replayed only the first
+`MAX_WITNESS_RUNS` (3) deciding failures while the comment claimed "the answer is settled by the
+first REACHED" — true only if every deciding failure is checked. A range whose only fix-reaching case
+sat 4th fell through to UNREACHED.
+
+This was not hypothetical. Measured across the same eight ranges, the deciding-failure counts per
+source were **1, 1, 4, 5, 1, 10, 1, 2, 19, 3, 3, 9** — the cap of 3 truncated the walk for **5 of 12**
+sources. It changed no verdict there only because an early case reached the fix in each.
+
+Kept as a budget, and made honest, rather than removed: every deciding case is now asked until one
+answers REACHED or the budget stops the walk, and **a stopped walk answers UNKNOWN, never
+UNREACHED** — "we stopped looking" and "nothing reached it" are different answers and only the second
+is grounds for a finding. The size is raised to 25, covering the observed maximum of 19 with headroom.
+Raising it is nearly free on the healthy path, because a REACHED short-circuits and a sound range pays
+for ONE run whatever the number is; only a range heading for a finding walks the list.
+
+Re-measured after both fixes: the corpus result is **unchanged** — 12 REACHED, 1 UNKNOWN, 0 UNREACHED
+across the 13 red proofs.
+
+### Re-measured against the current hooks
+
+`#1582` rewrote `.claude/hooks/lib/command-scan.sh`, which the traced hooks source, so the
+instrumentation was re-run against the current tree: `branch-guard.sh`, `pre-push-check.sh`,
+`check-forbidden-patterns.sh`, `worktree-cwd-guard.sh` and `post-tool-format.sh` — **5 of 5**
+instrumented cleanly, each tracing its own lines plus its two sourced lib files, with exit status and
+stderr byte-identical to an untraced run, and no line classified untraceable that the trace actually
+named. That last check is an independent cross-check of the tightened arm rule against real hooks
+rather than fixtures.
 
 ## GATE-COMPLETE (2026-08-01)
 

--- a/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
@@ -11,6 +11,7 @@ import {
   coverageLines,
   escapeTestNamePattern,
   judgeWitness,
+  testNamePattern,
   parseXtrace,
   untraceableShellLines,
   witnessDecidingCases,
@@ -149,12 +150,12 @@ describe('INFRA-072 — a red proof that never reached the fix', () => {
             assertionResults: [
               {
                 title: 'unrelated older case',
-                fullName: 'x > unrelated older case',
+                fullName: 'x unrelated older case',
                 status: 'failed',
               },
               {
                 title: 'the new regression case',
-                fullName: 'x > the new regression case',
+                fullName: 'x the new regression case',
                 status: 'failed',
               },
             ],
@@ -166,8 +167,11 @@ describe('INFRA-072 — a red proof that never reached the fix', () => {
     );
 
     // ONLY the added case. An older case's red is not what #1568 accepted as the proof, so it is not
-    // what the witness must account for either.
-    expect(failures).toEqual([{ file: testAbs, name: 'x > the new regression case' }]);
+    // what the witness must account for either. `fullName` is space-joined, which is the shape the
+    // real reporter emits and the exact string `-t` matches against — measured, not assumed.
+    expect(failures).toEqual([
+      { file: testAbs, name: 'x the new regression case', qualified: true },
+    ]);
   });
 });
 
@@ -279,7 +283,7 @@ describe('witnessOneCase wiring', () => {
     const { seenArgs } = shellWitness({ targetLines: new Set([4]), argv: ['go'] });
 
     expect(seenArgs).toContain('-t');
-    expect(seenArgs[seenArgs.indexOf('-t') + 1]).toBe('a case \\(with parens\\)');
+    expect(seenArgs[seenArgs.indexOf('-t') + 1]).toBe('^a case \\(with parens\\)$');
   });
 
   it('REACHED when the only fix-written line is a subshell inside a case arm body', () => {
@@ -358,6 +362,67 @@ describe('witnessOneCase wiring', () => {
       WITNESS.REACHED,
     );
   });
+
+  it('isolates the named case even when a SIBLING name contains it', () => {
+    // `-t` is an UNANCHORED regex over the full test name, so `parses config` also selects
+    // `parses config with defaults` — the ordinary shape of descriptive titles. Every line the
+    // sibling touched is then credited to the deciding case, turning a genuine UNREACHED into a
+    // reported REACHED. That direction is a MISSED DETECTION: the corpus measurement cannot see it,
+    // because nothing looks wrong when the gate wrongly says the proof is sound.
+    //
+    // This runs a REAL vitest, because the defect IS vitest's `-t` semantics — an injected runner
+    // that "implements" `-t` would only test my own idea of what it means.
+    const dir = scratchDir('witness-sibling-');
+    writeFileSync(
+      path.join(dir, 'hook.sh'),
+      [
+        '#!/usr/bin/env bash',
+        'set -eu',
+        'if [ "${1:-}" = long ]; then',
+        '  echo long-only',
+        'fi',
+        'echo common',
+        '',
+      ].join('\n'),
+    );
+    writeFileSync(
+      path.join(dir, 'probe.test.mjs'),
+      [
+        "import { spawnSync } from 'node:child_process';",
+        "import path from 'node:path';",
+        "import { describe, expect, it } from 'vitest';",
+        "const hook = path.join(import.meta.dirname, 'hook.sh');",
+        "const run = (arg) => spawnSync('bash', [hook, arg], { env: { ...process.env } });",
+        "describe('outer', () => {",
+        // The SHORT name is the deciding case, and it never reaches the fix-written line.
+        "  it('parses config', () => { expect(run('short').status).toBe(0); });",
+        // The sibling whose name CONTAINS it, and which does reach the line.
+        "  it('parses config with defaults', () => { expect(run('long').status).toBe(0); });",
+        '});',
+        '',
+      ].join('\n'),
+    );
+
+    const answer = witnessOneCase({
+      workspaceRoot: dir,
+      sourceRel: 'hook.sh',
+      testFileAbs: path.join(dir, 'probe.test.mjs'),
+      caseName: 'outer parses config',
+      targetLines: new Set([4]), // only `parses config with defaults` executes this
+      isShell: true,
+      runVitestRaw: (args, env) => {
+        spawnSync('npx', ['vitest', 'run', '--root', dir, ...args.slice(1)], {
+          cwd: WORKSPACE_ROOT,
+          encoding: 'utf8',
+          env: { ...process.env, ...env },
+        });
+      },
+    });
+
+    expect(answer, 'a sibling case supplied the execution credited to this one').toBe(
+      WITNESS.UNREACHED,
+    );
+  }, 60_000);
 
   it('REACHED when the case runs the changed line, UNREACHED when it does not', () => {
     expect(shellWitness({ targetLines: new Set([4]), argv: ['go'] }).answer).toBe(WITNESS.REACHED);
@@ -616,6 +681,32 @@ describe('coverageLines', () => {
 
   it('returns null for a file the report never mentions', () => {
     expect(coverageLines({}, '/repo/a.mjs')).toBeNull();
+  });
+});
+
+describe('testNamePattern', () => {
+  it('anchors the full name, so a sibling that CONTAINS it is not selected', () => {
+    const pattern = new RegExp(testNamePattern('outer parses config'));
+
+    expect(pattern.test('outer parses config')).toBe(true);
+    expect(pattern.test('outer parses config with defaults')).toBe(false);
+  });
+
+  it('anchors only the END when the describe chain is unknown', () => {
+    // `-t` matches the describe-qualified name, so anchoring a BARE title with `^…$` selects
+    // nothing at all — measured: `-t '^parses config$'` skipped both cases. When only a title is
+    // known the prefix has to stay open, which still excludes the sibling-suffix collision.
+    const pattern = new RegExp(testNamePattern('parses config', { qualified: false }));
+
+    expect(pattern.test('outer group parses config')).toBe(true);
+    expect(pattern.test('outer group parses config with defaults')).toBe(false);
+  });
+
+  it('escapes a title that would otherwise be read as a pattern', () => {
+    const pattern = new RegExp(testNamePattern('it (a|b) [c]'));
+
+    expect(pattern.test('it (a|b) [c]')).toBe(true);
+    expect(pattern.test('it a')).toBe(false);
   });
 });
 

--- a/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
@@ -1,0 +1,409 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  WITNESS,
+  changedNewLines,
+  coverageLines,
+  escapeTestNamePattern,
+  judgeWitness,
+  parseXtrace,
+  untraceableShellLines,
+  witnessOneCase,
+  XTRACE_PRELUDE,
+} from '../lib/execution-witness.mjs';
+
+import { VERDICT, decidingFailures, runRegressionRedProof } from '../check-regression-red-proof.mjs';
+
+/**
+ * INFRA-072 direction 3 — the execution witness.
+ *
+ * The class this file exists for is the one per-case granularity (#1568) cannot see: a case that
+ * FAILS on the reversed source and is accepted as a proof, while the red came from somewhere the fix
+ * never touched. Pass/fail cannot tell the two apart; an execution record can.
+ */
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const abs = (rel) => path.resolve(WORKSPACE_ROOT, rel);
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+function scratchDir(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+}
+
+// ── The gate-level class: a red that never reached the fix ────────────────────────────────────────
+
+function witnessIo(overrides = {}) {
+  const testFile = 'packages/x/src/a.test.ts';
+  const srcFile = 'packages/x/src/target.ts';
+  const files = {
+    [abs(testFile)]: `import { t } from './target.js';`,
+    [abs(srcFile)]: `export const t = 1;`,
+  };
+  return {
+    mergeBase: 'BASE',
+    changedFiles: [srcFile, testFile],
+    commitSubjects: ['fix: something real'],
+    addedFiles: [],
+    optOutText: '',
+    readText: (p) => files[p] ?? '',
+    fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+    isDirty: () => false,
+    reverseApply: () => {},
+    restore: () => {},
+    addedTestCaseDiff: () => "+    it('the new regression case', () => {",
+    runVitest: () => ({
+      testResults: [
+        {
+          name: abs(testFile),
+          assertionResults: [{ title: 'the new regression case', status: 'failed' }],
+        },
+      ],
+    }),
+    ...overrides,
+  };
+}
+
+describe('INFRA-072 — a red proof that never reached the fix', () => {
+  it('reports red-proof-unreached when the deciding case executed none of the changed lines', async () => {
+    // The exact shape the four motivating cases share and pass/fail cannot express: the added case
+    // is genuinely RED with the fix reversed, so #1568's rule is satisfied — every added case that
+    // must fail did — yet the case never executed a line the fix changed. Its red proves the
+    // reversed tree is broken, not that the case depends on the behaviour it names.
+    const { verdict, decisions } = await runRegressionRedProof(
+      witnessIo({ executionWitness: () => WITNESS.UNREACHED }),
+    );
+
+    expect(verdict, 'a red from outside the changed lines was accepted as a proof').toBe(
+      VERDICT.PROOF_UNREACHED,
+    );
+    expect(decisions[0].witness).toBe(WITNESS.UNREACHED);
+  });
+
+  it('keeps red-proof-ok when the deciding case did execute a changed line', async () => {
+    const { verdict, decisions } = await runRegressionRedProof(
+      witnessIo({ executionWitness: () => WITNESS.REACHED }),
+    );
+
+    expect(verdict).toBe(VERDICT.RED_PROOF_OK);
+    expect(decisions[0].witness).toBe(WITNESS.REACHED);
+  });
+
+  it('fails OPEN: an unmeasurable witness leaves the verdict exactly as it was', async () => {
+    // A comment-only hunk, a hook run through `sh`, a coverage report that never names the file.
+    // None of those is evidence of anything, and a guard that fires on them fires on correct work.
+    const { verdict, decisions } = await runRegressionRedProof(
+      witnessIo({ executionWitness: () => WITNESS.UNKNOWN }),
+    );
+
+    expect(verdict).toBe(VERDICT.RED_PROOF_OK);
+    expect(decisions[0].witness).toBe(WITNESS.UNKNOWN);
+  });
+
+  it('does not witness an outcome that was never a proof', async () => {
+    // `all-pass` is already accidental-green. Running an instrument over it would cost a vitest run
+    // to re-confirm a verdict that is settled, and could only make it milder.
+    let called = 0;
+    const { verdict } = await runRegressionRedProof(
+      witnessIo({
+        runVitest: () => ({
+          testResults: [
+            {
+              name: abs('packages/x/src/a.test.ts'),
+              assertionResults: [{ title: 'the new regression case', status: 'passed' }],
+            },
+          ],
+        }),
+        executionWitness: () => {
+          called += 1;
+          return WITNESS.UNREACHED;
+        },
+      }),
+    );
+
+    expect(verdict).toBe(VERDICT.ACCIDENTAL_GREEN);
+    expect(called, 'the instrument ran over a verdict that was already settled').toBe(0);
+  });
+
+  it('names the deciding failures, so the instrument runs on the case that supplied the red', () => {
+    const testAbs = abs('packages/x/src/a.test.ts');
+    const failures = decidingFailures(
+      {
+        testResults: [
+          {
+            name: testAbs,
+            assertionResults: [
+              { title: 'unrelated older case', fullName: 'x > unrelated older case', status: 'failed' },
+              { title: 'the new regression case', fullName: 'x > the new regression case', status: 'failed' },
+            ],
+          },
+        ],
+      },
+      ['packages/x/src/a.test.ts'],
+      new Map([[testAbs, [/^the new regression case$/]]]),
+    );
+
+    // ONLY the added case. An older case's red is not what #1568 accepted as the proof, so it is not
+    // what the witness must account for either.
+    expect(failures).toEqual([{ file: testAbs, name: 'x > the new regression case' }]);
+  });
+});
+
+// ── The instruments ───────────────────────────────────────────────────────────────────────────────
+
+describe('bash execution witness (BASH_XTRACEFD)', () => {
+  it('records the branch that ran and NOT the branch that did not', () => {
+    // The whole claim in one assertion: a trace that reported both branches would witness a line the
+    // case never reached, and the gate built on it would accept every red.
+    const dir = scratchDir('xtrace-');
+    const prelude = path.join(dir, 'prelude.sh');
+    const traceFile = path.join(dir, 'trace.log');
+    const script = path.join(dir, 'victim.sh');
+    writeFileSync(prelude, XTRACE_PRELUDE);
+    writeFileSync(
+      script,
+      [
+        '#!/usr/bin/env bash',
+        'set -euo pipefail',
+        'file="$1"',
+        'if [[ "$file" == *.ts ]]; then',
+        '  echo formatted',
+        'else',
+        '  echo skipped',
+        'fi',
+        '',
+      ].join('\n'),
+    );
+
+    const result = spawnSync('bash', [script, 'notes.txt'], {
+      encoding: 'utf8',
+      env: { ...process.env, BASH_ENV: prelude, HARNESS_XTRACE_FILE: traceFile },
+    });
+
+    expect(result.status, `${result.stdout ?? ''}${result.stderr ?? ''}`).toBe(0);
+    const executed = parseXtrace(readFileSync(traceFile, 'utf8')).get(script);
+    expect(executed, 'the trace never mentioned the script').toBeTruthy();
+    expect([...executed].sort((a, b) => a - b)).toEqual([2, 3, 4, 7]);
+    expect(executed.has(5), 'the branch that did not run was reported as executed').toBe(false);
+  });
+
+  it('keeps the trace off stderr, which is what these tests assert on', () => {
+    const dir = scratchDir('xtrace-stderr-');
+    const prelude = path.join(dir, 'prelude.sh');
+    const traceFile = path.join(dir, 'trace.log');
+    const script = path.join(dir, 'quiet.sh');
+    writeFileSync(prelude, XTRACE_PRELUDE);
+    writeFileSync(script, '#!/usr/bin/env bash\nset -euo pipefail\necho "on stdout"\n');
+
+    const result = spawnSync('bash', [script], {
+      encoding: 'utf8',
+      env: { ...process.env, BASH_ENV: prelude, HARNESS_XTRACE_FILE: traceFile },
+    });
+
+    expect(result.stderr).toBe('');
+    expect(result.stdout.trim()).toBe('on stdout');
+  });
+
+  it('stays inert when the trace file is not requested', () => {
+    const dir = scratchDir('xtrace-inert-');
+    const prelude = path.join(dir, 'prelude.sh');
+    const script = path.join(dir, 'quiet.sh');
+    writeFileSync(prelude, XTRACE_PRELUDE);
+    writeFileSync(script, '#!/usr/bin/env bash\nset -euo pipefail\necho "on stdout"\n');
+
+    const result = spawnSync('bash', [script], { encoding: 'utf8', env: { ...process.env, BASH_ENV: prelude } });
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
+});
+
+describe('witnessOneCase wiring', () => {
+  function shellWitness({ targetLines, argv }) {
+    const dir = scratchDir('witness-one-');
+    const script = path.join(dir, 'hook.sh');
+    writeFileSync(
+      script,
+      ['#!/usr/bin/env bash', 'set -eu', 'if [ "${1:-}" = go ]; then', '  echo reached', 'fi', ''].join('\n'),
+    );
+    let seenArgs = null;
+    const answer = witnessOneCase({
+      workspaceRoot: dir,
+      sourceRel: 'hook.sh',
+      testFileAbs: '/repo/t.test.mjs',
+      caseName: 'a case (with parens)',
+      targetLines,
+      isShell: true,
+      runVitestRaw: (args, env) => {
+        seenArgs = args;
+        // Stands in for the spawn several processes down that the real prelude instruments.
+        spawnSync('bash', [script, ...argv], { env: { ...process.env, ...env } });
+      },
+    });
+    return { answer, seenArgs };
+  }
+
+  it('asks vitest for exactly one case, escaping the title it filters on', () => {
+    const { seenArgs } = shellWitness({ targetLines: new Set([4]), argv: ['go'] });
+
+    expect(seenArgs).toContain('-t');
+    expect(seenArgs[seenArgs.indexOf('-t') + 1]).toBe('a case \\(with parens\\)');
+  });
+
+  it('REACHED when the case runs the changed line, UNREACHED when it does not', () => {
+    expect(shellWitness({ targetLines: new Set([4]), argv: ['go'] }).answer).toBe(WITNESS.REACHED);
+    expect(shellWitness({ targetLines: new Set([4]), argv: ['stop'] }).answer).toBe(
+      WITNESS.UNREACHED,
+    );
+  });
+});
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────────────────────────
+
+describe('changedNewLines', () => {
+  it('numbers the lines the fix WROTE, which are the ones the restored tree has', () => {
+    const patch = [
+      'diff --git a/x.sh b/x.sh',
+      '--- a/x.sh',
+      '+++ b/x.sh',
+      '@@ -20,4 +20,5 @@',
+      ' context',
+      '-old one',
+      '-old two',
+      '+new one',
+      '+new two',
+      '+new three',
+      ' tail',
+      '',
+    ].join('\n');
+
+    expect([...changedNewLines(patch).get('x.sh')]).toEqual([21, 22, 23]);
+  });
+
+  it('gives a pure deletion no target at all — the fix wrote no such line', () => {
+    const patch = [
+      '--- a/x.sh',
+      '+++ b/x.sh',
+      '@@ -10,3 +10,2 @@',
+      ' context',
+      '-removed',
+      ' tail',
+      '',
+    ].join('\n');
+
+    expect([...changedNewLines(patch).get('x.sh')]).toEqual([]);
+  });
+});
+
+
+describe('untraceableShellLines', () => {
+  it('excludes comments, blanks and the words that close a construct', () => {
+    const text = ['#!/usr/bin/env bash', '', 'if true; then', '  echo hi', 'else', '  echo bye', 'fi', ''].join(
+      '\n',
+    );
+    const untraceable = untraceableShellLines(text);
+
+    expect(untraceable.has(1)).toBe(true); // shebang is a comment
+    expect(untraceable.has(2)).toBe(true); // blank
+    expect(untraceable.has(5)).toBe(true); // else
+    expect(untraceable.has(7)).toBe(true); // fi
+    expect(untraceable.has(4)).toBe(false); // a command
+  });
+
+  it('excludes a heredoc body, which is data and never a traced command', () => {
+    const text = ['cat <<EOF', 'echo not-a-command', 'EOF', 'echo real', ''].join('\n');
+    const untraceable = untraceableShellLines(text);
+
+    expect(untraceable.has(2)).toBe(true);
+    expect(untraceable.has(4)).toBe(false);
+  });
+
+  it('excludes a BARE case arm but not one that carries a command', () => {
+    // Probed on bash 5.2, and the distinction is what decides a real range: `"$DIR"/*) ;;` never
+    // traces, so counting it executable called a genuine red proof unreached.
+    const text = [
+      'case "$F" in',
+      '  "$DIR"/*) ;;',
+      '  *.ts) echo is-ts ;;',
+      '  *.md)',
+      '    echo is-md',
+      '    ;;',
+      'esac',
+      '',
+    ].join('\n');
+    const untraceable = untraceableShellLines(text);
+
+    expect(untraceable.has(2), 'a bare arm is grammar, and no trace names it').toBe(true);
+    expect(untraceable.has(4), 'a pattern with its body below it is grammar too').toBe(true);
+    expect(untraceable.has(3), 'an arm carrying a command traces at its own line').toBe(false);
+    expect(untraceable.has(5)).toBe(false);
+  });
+
+  it('reads a bare arm only inside a case block', () => {
+    // `foo()` outside one is a function header, not an arm, and excluding it would silently drop a
+    // real target.
+    const text = ['foo()', '{', '  echo hi', '}', ''].join('\n');
+
+    expect(untraceableShellLines(text).has(1)).toBe(false);
+  });
+});
+
+describe('judgeWitness', () => {
+  it('UNKNOWN when nothing was measured', () => {
+    expect(judgeWitness({ targetLines: new Set([1]), executedLines: null })).toBe(WITNESS.UNKNOWN);
+  });
+
+  it('UNKNOWN when no changed line could ever have been reported', () => {
+    // A comment-only hunk. Calling this "unreached" would fail correct work.
+    expect(
+      judgeWitness({
+        targetLines: new Set([4]),
+        executedLines: new Set([9]),
+        executable: new Set([9]),
+      }),
+    ).toBe(WITNESS.UNKNOWN);
+  });
+
+  it('REACHED on any overlap, UNREACHED on none', () => {
+    expect(judgeWitness({ targetLines: new Set([4, 5]), executedLines: new Set([5]) })).toBe(
+      WITNESS.REACHED,
+    );
+    expect(judgeWitness({ targetLines: new Set([4, 5]), executedLines: new Set([9]) })).toBe(
+      WITNESS.UNREACHED,
+    );
+  });
+});
+
+describe('coverageLines', () => {
+  it('separates executed statements from lines that are statements at all', () => {
+    const report = {
+      '/repo/a.mjs': {
+        statementMap: { 0: { start: { line: 3 }, end: { line: 3 } }, 1: { start: { line: 7 }, end: { line: 7 } } },
+        s: { 0: 2, 1: 0 },
+      },
+    };
+    const lines = coverageLines(report, '/repo/a.mjs');
+
+    expect([...lines.executed]).toEqual([3]);
+    expect([...lines.executable].sort((a, b) => a - b)).toEqual([3, 7]);
+  });
+
+  it('returns null for a file the report never mentions', () => {
+    expect(coverageLines({}, '/repo/a.mjs')).toBeNull();
+  });
+});
+
+describe('escapeTestNamePattern', () => {
+  it('escapes what vitest would read as a pattern', () => {
+    expect(escapeTestNamePattern('it (a|b) [c]')).toBe('it \\(a\\|b\\) \\[c\\]');
+  });
+});

--- a/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
@@ -13,11 +13,16 @@ import {
   judgeWitness,
   parseXtrace,
   untraceableShellLines,
+  witnessDecidingCases,
   witnessOneCase,
   XTRACE_PRELUDE,
 } from '../lib/execution-witness.mjs';
 
-import { VERDICT, decidingFailures, runRegressionRedProof } from '../check-regression-red-proof.mjs';
+import {
+  VERDICT,
+  decidingFailures,
+  runRegressionRedProof,
+} from '../check-regression-red-proof.mjs';
 
 /**
  * INFRA-072 direction 3 — the execution witness.
@@ -142,8 +147,16 @@ describe('INFRA-072 — a red proof that never reached the fix', () => {
           {
             name: testAbs,
             assertionResults: [
-              { title: 'unrelated older case', fullName: 'x > unrelated older case', status: 'failed' },
-              { title: 'the new regression case', fullName: 'x > the new regression case', status: 'failed' },
+              {
+                title: 'unrelated older case',
+                fullName: 'x > unrelated older case',
+                status: 'failed',
+              },
+              {
+                title: 'the new regression case',
+                fullName: 'x > the new regression case',
+                status: 'failed',
+              },
             ],
           },
         ],
@@ -220,7 +233,10 @@ describe('bash execution witness (BASH_XTRACEFD)', () => {
     writeFileSync(prelude, XTRACE_PRELUDE);
     writeFileSync(script, '#!/usr/bin/env bash\nset -euo pipefail\necho "on stdout"\n');
 
-    const result = spawnSync('bash', [script], { encoding: 'utf8', env: { ...process.env, BASH_ENV: prelude } });
+    const result = spawnSync('bash', [script], {
+      encoding: 'utf8',
+      env: { ...process.env, BASH_ENV: prelude },
+    });
 
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);
@@ -233,7 +249,14 @@ describe('witnessOneCase wiring', () => {
     const script = path.join(dir, 'hook.sh');
     writeFileSync(
       script,
-      ['#!/usr/bin/env bash', 'set -eu', 'if [ "${1:-}" = go ]; then', '  echo reached', 'fi', ''].join('\n'),
+      [
+        '#!/usr/bin/env bash',
+        'set -eu',
+        'if [ "${1:-}" = go ]; then',
+        '  echo reached',
+        'fi',
+        '',
+      ].join('\n'),
     );
     let seenArgs = null;
     const answer = witnessOneCase({
@@ -257,6 +280,83 @@ describe('witnessOneCase wiring', () => {
 
     expect(seenArgs).toContain('-t');
     expect(seenArgs[seenArgs.indexOf('-t') + 1]).toBe('a case \\(with parens\\)');
+  });
+
+  it('REACHED when the only fix-written line is a subshell inside a case arm body', () => {
+    // End to end for the review finding, against a real bash run rather than the line classifier:
+    // a fix whose single written line is `(cd "$dir" && cmd)` in an arm BODY. `set -x` traces that
+    // line, so the honest answer is REACHED — excluding it made the gate report a finding against
+    // correct work.
+    const dir = scratchDir('witness-subshell-');
+    const script = path.join(dir, 'hook.sh');
+    writeFileSync(
+      script,
+      [
+        '#!/usr/bin/env bash',
+        'set -eu',
+        'case "${1:-}" in',
+        '  go)',
+        '    (cd "$PWD" && echo ran)',
+        '    ;;',
+        '  *) ;;',
+        'esac',
+        '',
+      ].join('\n'),
+    );
+
+    const answer = witnessOneCase({
+      workspaceRoot: dir,
+      sourceRel: 'hook.sh',
+      testFileAbs: '/repo/t.test.mjs',
+      caseName: 'the deciding case',
+      targetLines: new Set([5]),
+      isShell: true,
+      runVitestRaw: (_args, env) => {
+        spawnSync('bash', [script, 'go'], { env: { ...process.env, ...env } });
+      },
+    });
+
+    expect(answer).toBe(WITNESS.REACHED);
+  });
+
+  it('does not report a FINDING when the subshell it reached sits beside an unreached line', () => {
+    // The variant that shows the actual harm. With the subshell excluded, the only surviving target
+    // is a line the case never runs, so the answer is UNREACHED — a finding against correct work,
+    // rather than the UNKNOWN the single-line fixture above degrades to.
+    const dir = scratchDir('witness-subshell-alarm-');
+    const script = path.join(dir, 'hook.sh');
+    writeFileSync(
+      script,
+      [
+        '#!/usr/bin/env bash',
+        'set -eu',
+        'case "${1:-}" in',
+        '  go)',
+        '    (cd "$PWD" && echo ran)',
+        '    ;;',
+        '  other)',
+        '    echo never-run',
+        '    ;;',
+        'esac',
+        '',
+      ].join('\n'),
+    );
+
+    const answer = witnessOneCase({
+      workspaceRoot: dir,
+      sourceRel: 'hook.sh',
+      testFileAbs: '/repo/t.test.mjs',
+      caseName: 'the deciding case',
+      targetLines: new Set([5, 8]),
+      isShell: true,
+      runVitestRaw: (_args, env) => {
+        spawnSync('bash', [script, 'go'], { env: { ...process.env, ...env } });
+      },
+    });
+
+    expect(answer, 'a line the case DID run was excluded, so the fix read as unreached').toBe(
+      WITNESS.REACHED,
+    );
   });
 
   it('REACHED when the case runs the changed line, UNREACHED when it does not', () => {
@@ -304,12 +404,18 @@ describe('changedNewLines', () => {
   });
 });
 
-
 describe('untraceableShellLines', () => {
   it('excludes comments, blanks and the words that close a construct', () => {
-    const text = ['#!/usr/bin/env bash', '', 'if true; then', '  echo hi', 'else', '  echo bye', 'fi', ''].join(
-      '\n',
-    );
+    const text = [
+      '#!/usr/bin/env bash',
+      '',
+      'if true; then',
+      '  echo hi',
+      'else',
+      '  echo bye',
+      'fi',
+      '',
+    ].join('\n');
     const untraceable = untraceableShellLines(text);
 
     expect(untraceable.has(1)).toBe(true); // shebang is a comment
@@ -348,12 +454,120 @@ describe('untraceableShellLines', () => {
     expect(untraceable.has(5)).toBe(false);
   });
 
+  it('does NOT exclude a subshell in an arm BODY — `set -x` traces that line', () => {
+    // Review finding: the arm pattern matches any `(...)` line with no inner parens, so a full-line
+    // subshell in a BODY was excluded from the executable set. If it is the only line a fix wrote
+    // inside a case block, the witness reports UNREACHED on a fix the case genuinely reached — a
+    // false alarm, and the acceptance criterion for this work promised zero of them.
+    const text = ['case "$F" in', '  *.ts)', '    (cd "$dir" && cmd)', '    ;;', 'esac', ''].join(
+      '\n',
+    );
+
+    expect(untraceableShellLines(text).has(3)).toBe(false);
+  });
+
   it('reads a bare arm only inside a case block', () => {
     // `foo()` outside one is a function header, not an arm, and excluding it would silently drop a
     // real target.
     const text = ['foo()', '{', '  echo hi', '}', ''].join('\n');
 
     expect(untraceableShellLines(text).has(1)).toBe(false);
+  });
+});
+
+describe('witnessDecidingCases — the run budget', () => {
+  const failures = ['a', 'b', 'c', 'd'].map((name) => ({ file: '/repo/t.test.mjs', name }));
+
+  it('finds a REACHED case that sits past the OLD cap of 3', () => {
+    // Review finding: the loop replayed only the first three failures and then fell through to
+    // UNREACHED, so a range whose only fix-reaching case is the 4th reported a finding against
+    // correct work. Measured across the eight replayed ranges, the deciding-failure counts were
+    // 1, 1, 4, 5, 1, 10, 1, 2, 19, 3, 3, 9 — the old cap truncated 5 of 12 sources, so this was live
+    // in the real corpus rather than hypothetical. The shipped budget covers the observed maximum.
+    const seen = [];
+    const answer = witnessDecidingCases({
+      failures,
+      budget: 25,
+      witnessOne: (failure) => {
+        seen.push(failure.name);
+        return failure.name === 'd' ? WITNESS.REACHED : WITNESS.UNREACHED;
+      },
+    });
+
+    expect(answer).toBe(WITNESS.REACHED);
+    expect(seen).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('the budget is a hard stop, so a late REACHED beyond it is UNKNOWN and not a finding', () => {
+    // The honest reading of a stop: with the walk cut short, the gate does not know whether a later
+    // case reached the fix. It must not answer either REACHED (it never saw one) or UNREACHED (it
+    // never finished looking).
+    const answer = witnessDecidingCases({
+      failures,
+      budget: 3,
+      witnessOne: (failure) => (failure.name === 'd' ? WITNESS.REACHED : WITNESS.UNREACHED),
+    });
+
+    expect(answer).toBe(WITNESS.UNKNOWN);
+  });
+
+  it('stops at the budget and says UNKNOWN, never UNREACHED', () => {
+    // "We stopped looking" and "nothing reached it" are different answers, and only the second is
+    // grounds for a finding.
+    const answer = witnessDecidingCases({
+      failures,
+      budget: 2,
+      witnessOne: () => WITNESS.UNREACHED,
+    });
+
+    expect(answer).toBe(WITNESS.UNKNOWN);
+  });
+
+  it('short-circuits on the first REACHED, so a healthy range pays for one run', () => {
+    let runs = 0;
+    const answer = witnessDecidingCases({
+      failures,
+      budget: 99,
+      witnessOne: () => {
+        runs += 1;
+        return WITNESS.REACHED;
+      },
+    });
+
+    expect(answer).toBe(WITNESS.REACHED);
+    expect(runs).toBe(1);
+  });
+
+  it('UNREACHED only when every deciding failure was actually checked', () => {
+    const answer = witnessDecidingCases({
+      failures,
+      budget: 99,
+      witnessOne: () => WITNESS.UNREACHED,
+    });
+
+    expect(answer).toBe(WITNESS.UNREACHED);
+  });
+
+  it('one unmeasurable case is enough to withhold the finding', () => {
+    const answer = witnessDecidingCases({
+      failures,
+      budget: 99,
+      witnessOne: (failure) => (failure.name === 'b' ? WITNESS.UNKNOWN : WITNESS.UNREACHED),
+    });
+
+    expect(answer).toBe(WITNESS.UNKNOWN);
+  });
+
+  it('a throwing instrument is UNKNOWN, not a finding', () => {
+    const answer = witnessDecidingCases({
+      failures: [failures[0]],
+      budget: 99,
+      witnessOne: () => {
+        throw new Error('vitest exploded');
+      },
+    });
+
+    expect(answer).toBe(WITNESS.UNKNOWN);
   });
 });
 
@@ -387,7 +601,10 @@ describe('coverageLines', () => {
   it('separates executed statements from lines that are statements at all', () => {
     const report = {
       '/repo/a.mjs': {
-        statementMap: { 0: { start: { line: 3 }, end: { line: 3 } }, 1: { start: { line: 7 }, end: { line: 7 } } },
+        statementMap: {
+          0: { start: { line: 3 }, end: { line: 3 } },
+          1: { start: { line: 7 }, end: { line: 7 } },
+        },
         s: { 0: 2, 1: 0 },
       },
     };

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -25,6 +25,7 @@ import {
   WITNESS,
   changedNewLines,
   defaultRunVitestRaw,
+  witnessDecidingCases,
   witnessOneCase,
 } from './lib/execution-witness.mjs';
 import {
@@ -662,8 +663,25 @@ export async function runRegressionRedProof(io = {}) {
   return { verdict: worst, decisions };
 }
 
-/** One extra vitest run per deciding case; a red file with many of them is not worth a linear cost. */
-const MAX_WITNESS_RUNS = 3;
+/**
+ * One vitest run per deciding case, and exhausting this answers UNKNOWN rather than UNREACHED
+ * (see `witnessDecidingCases`).
+ *
+ * It was 3, paired with a comment claiming "the answer is settled by the first REACHED" — true only
+ * if every deciding failure is checked, which slicing to 3 does not do.
+ *
+ * The size is measured, not guessed, and the measurement was worth taking: across the eight replayed
+ * ranges the deciding-failure counts were 1, 1, 4, 5, 1, 10, 1, 2, 19, 3, 3, 9 — so the old cap of 3
+ * truncated the walk for **5 of 12** sources. It changed no verdict there only because an early case
+ * reached the fix in each; a range whose reaching case sat 4th would have been reported as a finding
+ * against correct work.
+ *
+ * 25 covers the observed maximum of 19 with headroom. Raising it is nearly free on the healthy path:
+ * a REACHED short-circuits, so a range with a sound proof pays for ONE run whatever the number is.
+ * Only a range heading for a finding walks the whole list, and paying ~20 vitest runs to report a
+ * correct finding instead of an UNKNOWN is the right side of that trade for an advisory gate.
+ */
+const WITNESS_RUN_BUDGET = 25;
 
 /**
  * The real instrument (INFRA-072 direction 3): re-run each deciding case ALONE, on the RESTORED
@@ -674,9 +692,9 @@ const MAX_WITNESS_RUNS = 3;
  * formulation called a genuine red proof `unreached`, since that fix is an ADDITION and its old side
  * held only a comment and one `case` pattern arm.
  *
- * One vitest run per deciding case, capped — the answer is settled by the first REACHED, and this
- * gate is not worth a cost linear in the size of a red file. Every failure path returns UNKNOWN: an
- * instrument that cannot measure must not manufacture a finding.
+ * Every deciding case is asked, in order, until one answers REACHED or the run budget stops the
+ * walk — and a stopped walk answers UNKNOWN, never UNREACHED. Every failure path returns UNKNOWN
+ * too: an instrument that cannot measure must not manufacture a finding.
  */
 function defaultExecutionWitness(base) {
   return async ({ pkg, source, failures }) => {
@@ -692,11 +710,11 @@ function defaultExecutionWitness(base) {
     if (!targetLines?.size) return WITNESS.UNKNOWN; // a pure deletion wrote no line to reach
 
     const runVitestRaw = defaultRunVitestRaw(WORKSPACE_ROOT, pkg);
-    let sawUnknown = false;
-    for (const failure of failures.slice(0, MAX_WITNESS_RUNS)) {
-      let answer = WITNESS.UNKNOWN;
-      try {
-        answer = witnessOneCase({
+    return witnessDecidingCases({
+      failures,
+      budget: WITNESS_RUN_BUDGET,
+      witnessOne: (failure) =>
+        witnessOneCase({
           workspaceRoot: WORKSPACE_ROOT,
           sourceRel: source,
           testFileAbs: failure.file,
@@ -704,14 +722,8 @@ function defaultExecutionWitness(base) {
           targetLines,
           isShell: source.endsWith('.sh'),
           runVitestRaw,
-        });
-      } catch {
-        answer = WITNESS.UNKNOWN;
-      }
-      if (answer === WITNESS.REACHED) return WITNESS.REACHED;
-      if (answer === WITNESS.UNKNOWN) sawUnknown = true;
-    }
-    return sawUnknown ? WITNESS.UNKNOWN : WITNESS.UNREACHED;
+        }),
+    });
   };
 }
 

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -297,7 +297,10 @@ export function classifyVitestOutcome(vitestJson, changedTestFiles, addedCases =
  * proof, so it is not what has to be shown to have reached the fix. A file the range added no
  * readable title to is judged at file granularity, and there every failure is a candidate.
  *
- * @returns {{ file: string, name: string }[]} — `name` is the fullName vitest filters on with `-t`.
+ * @returns {{ file: string, name: string, qualified: boolean }[]} — `name` is the fullName vitest
+ *   filters on with `-t`. `qualified` records whether that name really is the describe-qualified one:
+ *   the pattern is anchored differently when only a bare title is known, because anchoring a bare
+ *   title against the full name matches NOTHING (measured).
  */
 export function decidingFailures(vitestJson, changedTestFiles, addedCases = null) {
   const wanted = changedTestFiles.map((f) => path.resolve(WORKSPACE_ROOT, f));
@@ -311,7 +314,7 @@ export function decidingFailures(vitestJson, changedTestFiles, addedCases = null
       if (assertion.status !== 'failed') continue;
       if (matchers?.length && !matchesAddedCase(matchers, assertion)) continue;
       const title = assertion.fullName || assertion.title;
-      if (title) out.push({ file: name, name: title });
+      if (title) out.push({ file: name, name: title, qualified: Boolean(assertion.fullName) });
     }
   }
   return out;
@@ -719,6 +722,7 @@ function defaultExecutionWitness(base) {
           sourceRel: source,
           testFileAbs: failure.file,
           caseName: failure.name,
+          caseNameQualified: failure.qualified !== false,
           targetLines,
           isShell: source.endsWith('.sh'),
           runVitestRaw,

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -22,6 +22,12 @@ import fs, { existsSync } from 'node:fs';
 import path from 'node:path';
 
 import {
+  WITNESS,
+  changedNewLines,
+  defaultRunVitestRaw,
+  witnessOneCase,
+} from './lib/execution-witness.mjs';
+import {
   EXECUTION,
   analyzeSpawnTargetsCached,
   classifyExecution,
@@ -32,6 +38,10 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 // ── Verdict vocabulary ────────────────────────────────────────────────────────────────────────────
 export const VERDICT = Object.freeze({
   RED_PROOF_OK: 'red-proof-ok', // ≥1 changed test genuinely fails with the fix reversed — good
+  // The added case IS red on the reversed source, and executed not one line the fix changed. Its red
+  // proves the reversed tree is broken, not that the case depends on the behaviour it names —
+  // INFRA-072's "fails for the WRONG REASON", which pass/fail cannot express.
+  PROOF_UNREACHED: 'red-proof-unreached',
   ACCIDENTAL_GREEN: 'accidental-green-fail', // all changed tests still pass — the defect this tool exists to catch
   INCONCLUSIVE: 'inconclusive', // vitest could not evaluate, or the test does not import the reversed file
   SKIPPED_NOT_FIX: 'skipped-not-fix', // range has no fix: commit
@@ -278,6 +288,34 @@ export function classifyVitestOutcome(vitestJson, changedTestFiles, addedCases =
   return 'all-pass';
 }
 
+/**
+ * The failing cases that SUPPLIED the red — the ones an execution witness must account for.
+ *
+ * It is deliberately the same selection `classifyVitestOutcome` used to reach `assertion-fail`, and
+ * not simply "everything that failed": an older case's red is not what the gate accepted as the
+ * proof, so it is not what has to be shown to have reached the fix. A file the range added no
+ * readable title to is judged at file granularity, and there every failure is a candidate.
+ *
+ * @returns {{ file: string, name: string }[]} — `name` is the fullName vitest filters on with `-t`.
+ */
+export function decidingFailures(vitestJson, changedTestFiles, addedCases = null) {
+  const wanted = changedTestFiles.map((f) => path.resolve(WORKSPACE_ROOT, f));
+  const results = Array.isArray(vitestJson?.testResults) ? vitestJson.testResults : [];
+  const out = [];
+  for (const fileResult of results) {
+    const name = fileResult?.name ? path.resolve(fileResult.name) : null;
+    if (!name || !wanted.includes(name)) continue;
+    const matchers = addedCases?.get(name) ?? null;
+    for (const assertion of fileResult.assertionResults ?? []) {
+      if (assertion.status !== 'failed') continue;
+      if (matchers?.length && !matchesAddedCase(matchers, assertion)) continue;
+      const title = assertion.fullName || assertion.title;
+      if (title) out.push({ file: name, name: title });
+    }
+  }
+  return out;
+}
+
 // ── Pure: final verdict for one qualifying pair ─────────────────────────────────────────────────────
 
 /**
@@ -285,10 +323,14 @@ export function classifyVitestOutcome(vitestJson, changedTestFiles, addedCases =
  * unit-tested exhaustively without git or vitest.
  *   importsReversedFile — did any changed test relatively import a reversed source file? (C3)
  *   outcome             — classifyVitestOutcome result, or null if not run (guard tripped)
+ *   witness             — did the case that supplied the red EXECUTE a line the fix changed?
+ *                         (INFRA-072 direction 3.) Defaults to UNKNOWN, which changes nothing:
+ *                         the instrument is evidence when it speaks and silent when it cannot.
  */
-export function decidePairVerdict({ importsReversedFile, outcome }) {
+export function decidePairVerdict({ importsReversedFile, outcome, witness = WITNESS.UNKNOWN }) {
   if (!importsReversedFile) return VERDICT.INCONCLUSIVE; // C3: not in the test's module graph
-  if (outcome === 'assertion-fail') return VERDICT.RED_PROOF_OK;
+  if (outcome === 'assertion-fail')
+    return witness === WITNESS.UNREACHED ? VERDICT.PROOF_UNREACHED : VERDICT.RED_PROOF_OK;
   if (outcome === 'run-error') return VERDICT.INCONCLUSIVE; // C1: never a pass
   if (outcome === 'all-pass') return VERDICT.ACCIDENTAL_GREEN;
   // The range's own new case passed on the reversed source; the red came from a case that was
@@ -492,9 +534,15 @@ export async function runRegressionRedProof(io = {}) {
     ((testPath) =>
       gitRaw(['diff', `${base}..HEAD`, '--', testPath], { stdio: ['ignore', 'pipe', 'ignore'] }));
 
+  const executionWitness = io.executionWitness ?? defaultExecutionWitness(base);
+
   let worst = VERDICT.RED_PROOF_OK;
   const rank = {
-    [VERDICT.ACCIDENTAL_GREEN]: 3,
+    [VERDICT.ACCIDENTAL_GREEN]: 4,
+    // Above INCONCLUSIVE: "the red came from outside the fix" is an observation about a proof that
+    // was offered, where INCONCLUSIVE is the absence of one. Below ACCIDENTAL_GREEN: a case that at
+    // least fails is not yet shown to guard nothing.
+    [VERDICT.PROOF_UNREACHED]: 3,
     [VERDICT.INCONCLUSIVE]: 2,
     [VERDICT.RED_PROOF_OK]: 1,
   };
@@ -566,25 +614,33 @@ export async function runRegressionRedProof(io = {}) {
       // INFRA-072 — the range's OWN new cases are what must fail, not any case in the file.
       const addedCases = exercised ? addedCaseMatchers(testsForSource, addedTestCaseDiff) : null;
       let outcome = null;
+      let witness = WITNESS.UNKNOWN;
       if (exercised) {
+        let deciders = [];
         reverseApply([source]);
         try {
-          outcome = classifyVitestOutcome(
-            await runVitest(pair.pkg, testsForSource),
-            testsForSource,
-            addedCases,
-          );
+          const vitestJson = await runVitest(pair.pkg, testsForSource);
+          outcome = classifyVitestOutcome(vitestJson, testsForSource, addedCases);
+          deciders = decidingFailures(vitestJson, testsForSource, addedCases);
         } finally {
           restore([source]);
         }
+        // INFRA-072 direction 3 — asked ONLY of an outcome being offered as a proof, and asked AFTER
+        // the restore, because the question is whether the deciding case executes the code this fix
+        // WROTE, and that code exists only on the restored tree. Any other outcome is already
+        // settled and an instrument could only make it milder.
+        if (outcome === 'assertion-fail') {
+          witness = await executionWitness({ pkg: pair.pkg, source, failures: deciders });
+        }
       }
 
-      const verdict = decidePairVerdict({ importsReversedFile: exercised, outcome });
+      const verdict = decidePairVerdict({ importsReversedFile: exercised, outcome, witness });
       decisions.push({
         pkg: pair.pkg,
         source,
         verdict,
         outcome,
+        witness,
         importsReversedFile: exercised,
         relation: exercised ? 'executed' : undeterminedRelation ? 'undetermined' : 'unrelated',
       });
@@ -593,15 +649,70 @@ export async function runRegressionRedProof(io = {}) {
       const note =
         !exercised && undeterminedRelation
           ? ' (no changed test could be TIED to this hook — the spawn target is built at runtime)'
-          : outcome
-            ? ` (${outcome})`
-            : '';
+          : verdict === VERDICT.PROOF_UNREACHED
+            ? ' (the case that failed executed no line this fix changed)'
+            : outcome
+              ? ` (${outcome})`
+              : '';
       log(`${icon}  ${source}: ${verdict}${note}`);
       if ((rank[verdict] ?? 0) > (rank[worst] ?? 0)) worst = verdict;
     }
   }
 
   return { verdict: worst, decisions };
+}
+
+/** One extra vitest run per deciding case; a red file with many of them is not worth a linear cost. */
+const MAX_WITNESS_RUNS = 3;
+
+/**
+ * The real instrument (INFRA-072 direction 3): re-run each deciding case ALONE, on the RESTORED
+ * source, and ask whether it executes the lines this fix wrote.
+ *
+ * On the restored tree rather than the reversed one, and against the fix's NEW side rather than its
+ * old one, because that is where the fix's code exists. Measured on `c08e0dbd6`: the old-side
+ * formulation called a genuine red proof `unreached`, since that fix is an ADDITION and its old side
+ * held only a comment and one `case` pattern arm.
+ *
+ * One vitest run per deciding case, capped — the answer is settled by the first REACHED, and this
+ * gate is not worth a cost linear in the size of a red file. Every failure path returns UNKNOWN: an
+ * instrument that cannot measure must not manufacture a finding.
+ */
+function defaultExecutionWitness(base) {
+  return async ({ pkg, source, failures }) => {
+    if (failures.length === 0) return WITNESS.UNKNOWN;
+    let targetLines;
+    try {
+      targetLines = changedNewLines(
+        gitRaw(['diff', `${base}..HEAD`, '--', source], { stdio: ['ignore', 'pipe', 'ignore'] }),
+      ).get(source);
+    } catch {
+      return WITNESS.UNKNOWN; // a range this cannot diff has no target, and no target is no finding
+    }
+    if (!targetLines?.size) return WITNESS.UNKNOWN; // a pure deletion wrote no line to reach
+
+    const runVitestRaw = defaultRunVitestRaw(WORKSPACE_ROOT, pkg);
+    let sawUnknown = false;
+    for (const failure of failures.slice(0, MAX_WITNESS_RUNS)) {
+      let answer = WITNESS.UNKNOWN;
+      try {
+        answer = witnessOneCase({
+          workspaceRoot: WORKSPACE_ROOT,
+          sourceRel: source,
+          testFileAbs: failure.file,
+          caseName: failure.name,
+          targetLines,
+          isShell: source.endsWith('.sh'),
+          runVitestRaw,
+        });
+      } catch {
+        answer = WITNESS.UNKNOWN;
+      }
+      if (answer === WITNESS.REACHED) return WITNESS.REACHED;
+      if (answer === WITNESS.UNKNOWN) sawUnknown = true;
+    }
+    return sawUnknown ? WITNESS.UNKNOWN : WITNESS.UNREACHED;
+  };
 }
 
 function defaultRunVitest(pkg, testFiles) {
@@ -657,6 +768,13 @@ if (import.meta.url === `file://${process.argv[1]}`) {
             '   Rewrite it to FAIL on the pre-fix code, or opt out with `allow-green-at-base: <reason>`.',
         );
         process.exit(enforce ? 1 : 0); // advisory in v1 (not a required check); flip via env once stable
+      }
+      if (verdict === VERDICT.PROOF_UNREACHED) {
+        log(
+          '\n⚠︎  red-proof-unreached: the case that failed on the reversed source executed no line\n' +
+            '   this fix changed. Its red says the reversed tree is broken, not that the case depends\n' +
+            '   on the behaviour it names. Report-only — INFRA-046 owns whether this ever blocks.',
+        );
       }
       if (verdict === VERDICT.INCONCLUSIVE) {
         log('\n⚠︎  inconclusive — see decisions above (advisory).');

--- a/scripts/harness/lib/execution-witness.mjs
+++ b/scripts/harness/lib/execution-witness.mjs
@@ -1,0 +1,291 @@
+/**
+ * INFRA-072 — direction 3: an execution witness for the case that supplies a red proof.
+ *
+ * `check-regression-red-proof` reads pass/fail and nothing else. A case that fails on the reversed
+ * source is accepted as a proof even when its red came from somewhere the fix never touched — the
+ * "fails for the WRONG REASON" half of INFRA-072. The relation the gate uses to decide which tests
+ * may judge (`reachableRelativeGraph` for a module, the spawn call graph for a hook) is STATIC: it
+ * says the test COULD reach the source, never that it DID. That is PROC-003's third question — "is
+ * it reached?" — left unasked of the gate's own premise.
+ *
+ * This module answers it by observation. Two subjects, two instruments, one question:
+ *
+ *   - a `bash` script is traced with `BASH_XTRACEFD`. `BASH_ENV` names a prelude every
+ *     non-interactive bash sources before the script it was asked to run, so the instrument reaches
+ *     a hook the gate never spawns itself — the test spawns it, several processes down. `PS4` is set
+ *     to `@${BASH_SOURCE}:${LINENO}@`, and the trace goes to its OWN descriptor, so a test asserting
+ *     on the hook's stderr is unaffected by being measured.
+ *   - a `.mjs`/`.ts` module is measured with vitest's v8 coverage, whose istanbul-shaped output
+ *     names the executed statements and, just as importantly, WHICH lines are statements at all.
+ *
+ * FAIL OPEN, always. Three answers, and only `UNREACHED` is a finding: a comment-only hunk, a hook
+ * run through `sh`, a coverage report that never mentions the file — each of those is UNKNOWN, and
+ * an unknown must never turn a genuine proof into an alarm. A guard that fires on correct work gets
+ * switched off.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+export const WITNESS = Object.freeze({
+  REACHED: 'reached', // the deciding case executed a line the fix changed
+  UNREACHED: 'unreached', // it executed none of them — its red came from elsewhere
+  UNKNOWN: 'unknown', // nothing measurable; never a finding
+});
+
+// ── Pure: what the fix wrote ──────────────────────────────────────────────────────────────────────
+
+/**
+ * NEW-side line numbers a unified diff writes, per file — the lines the fix put there.
+ *
+ * The first formulation targeted the OLD side and ran on the reversed tree, and it was measured
+ * wrong on the two real ranges available. Most fixes are ADDITIONS: `c08e0dbd6` added a stand-down
+ * guard, so its old side held nothing but the comment it replaced and one `case` pattern arm, and
+ * the question "did the case reach the pre-fix line" had almost no line to ask about. Asked of the
+ * FIXED tree it is well posed for exactly the fixes that dominate — did the deciding case execute
+ * the code this fix WROTE? — and it is the question the gate's premise actually needs answered.
+ *
+ * A pure DELETION contributes nothing here, symmetrically, and the judge reads an empty target as
+ * UNKNOWN rather than as a failure to reach.
+ */
+export function changedNewLines(patchText) {
+  const byFile = new Map();
+  let current = null;
+  let newLine = 0;
+  for (const line of String(patchText ?? '').split('\n')) {
+    const fileMatch = line.match(/^\+\+\+ (?:b\/)?(.+)$/);
+    if (fileMatch && !line.startsWith('+++ /dev/null')) {
+      current = fileMatch[1].trim();
+      if (!byFile.has(current)) byFile.set(current, new Set());
+      continue;
+    }
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (!current || newLine === 0) continue;
+    if (line.startsWith('+')) {
+      byFile.get(current).add(newLine);
+      newLine += 1;
+    } else if (line.startsWith(' ') || line === '') {
+      newLine += 1;
+    }
+    // `-` lines advance only the old side, and `\ No newline` advances neither.
+  }
+  return byFile;
+}
+
+
+/**
+ * Lines a shell trace can never report, so that their absence is not read as "not reached".
+ *
+ * `set -x` prints a line when a COMMAND runs. Blanks and comments are neither; `fi`, `esac`, `else`,
+ * `done`, `then`, `do` and a bare brace are grammar; a heredoc body is data.
+ *
+ * And a BARE `case` ARM — a pattern, its `)`, and at most a `;;` — is grammar too. That one is not a
+ * guess: probed on bash 5.2, `*.ts) echo is-ts ;;` traces at its own line because it carries a
+ * command, while `*.md)` alone never traces and only its body does. It matters because it is exactly
+ * the shape `post-tool-format.sh` changed — `"${CLAUDE_PROJECT_DIR:-}"/*) ;;` — and counting it as
+ * executable called a genuine red proof `unreached` on the only real range there was to measure.
+ * Only arms inside a `case … in` block are read this way, so a `foo()` line elsewhere is untouched.
+ */
+export function untraceableShellLines(sourceText) {
+  const lines = String(sourceText ?? '').split('\n');
+  const untraceable = new Set();
+  const GRAMMAR = new Set(['fi', 'esac', 'else', 'done', 'then', 'do', '{', '}', '(', ')', ';;']);
+  const BARE_CASE_ARM = /^\(?[^()]*\)\s*(?:;;&?|;&)?$/;
+  let heredocTerminator = null;
+  let caseDepth = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    const lineNo = i + 1;
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    if (heredocTerminator !== null) {
+      untraceable.add(lineNo);
+      if (trimmed === heredocTerminator) heredocTerminator = null;
+      continue;
+    }
+    const heredoc = raw.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\s*$/);
+    if (heredoc) heredocTerminator = heredoc[1];
+    if (trimmed === '' || trimmed.startsWith('#') || GRAMMAR.has(trimmed)) untraceable.add(lineNo);
+    else if (caseDepth > 0 && BARE_CASE_ARM.test(trimmed)) untraceable.add(lineNo);
+    if (/^case\s.*\sin$/.test(trimmed)) caseDepth += 1;
+    else if (trimmed === 'esac' && caseDepth > 0) caseDepth -= 1;
+  }
+  return untraceable;
+}
+
+/** Parse the `@<abs path>:<line>@ …` records this module's PS4 emits. */
+export function parseXtrace(traceText) {
+  const byFile = new Map();
+  for (const line of String(traceText ?? '').split('\n')) {
+    const m = line.match(/@(\/[^:@]*):(\d+)@/);
+    if (!m) continue;
+    const [, file, lineNo] = m;
+    if (!byFile.has(file)) byFile.set(file, new Set());
+    byFile.get(file).add(Number(lineNo));
+  }
+  return byFile;
+}
+
+/**
+ * Executed lines, and the lines that are statements at all, from one file's istanbul-shaped entry.
+ * Returns null when the report does not mention the file — which is UNKNOWN, not "nothing ran".
+ */
+export function coverageLines(coverageJson, absPath) {
+  const entry = coverageJson?.[absPath];
+  if (!entry?.statementMap) return null;
+  const executed = new Set();
+  const executable = new Set();
+  for (const [id, loc] of Object.entries(entry.statementMap)) {
+    const start = loc?.start?.line;
+    const end = loc?.end?.line ?? start;
+    if (typeof start !== 'number') continue;
+    for (let l = start; l <= end; l += 1) {
+      executable.add(l);
+      if ((entry.s?.[id] ?? 0) > 0) executed.add(l);
+    }
+  }
+  return { executed, executable };
+}
+
+/**
+ * The verdict for one (deciding case, changed source) pair.
+ *
+ * `targetLines` are the fix's new-side lines; `executable`, when known, narrows them to lines an
+ * instrument could ever have reported. An empty target after narrowing is UNKNOWN — a fix made
+ * entirely of comments, or of pure deletions, is unwitnessable, and saying so is honest where
+ * calling it unreached would be an alarm on correct work.
+ */
+export function judgeWitness({ targetLines, executedLines, executable = null }) {
+  if (!executedLines) return WITNESS.UNKNOWN;
+  const targets = [...(targetLines ?? [])].filter((l) => executable === null || executable.has(l));
+  if (targets.length === 0) return WITNESS.UNKNOWN;
+  return targets.some((l) => executedLines.has(l)) ? WITNESS.REACHED : WITNESS.UNREACHED;
+}
+
+// ── Impure: run one case under instrumentation ────────────────────────────────────────────────────
+
+/**
+ * Sourced by every non-interactive bash before the script it was invoked with, so a hook spawned
+ * from inside a vitest worker is traced without the gate touching the test or the hook.
+ *
+ * The descriptor is opened by `exec {fd}>>`, appended to, and named through `BASH_XTRACEFD` so the
+ * trace never lands on stderr — the stream several of these tests assert on.
+ */
+export const XTRACE_PRELUDE = `if [ -n "\${HARNESS_XTRACE_FILE:-}" ]; then
+  exec {__harness_xtrace_fd}>>"\$HARNESS_XTRACE_FILE"
+  BASH_XTRACEFD=\$__harness_xtrace_fd
+  PS4='@\${BASH_SOURCE}:\${LINENO}@ '
+  set -x
+fi
+`;
+
+/** vitest's `-t` is a regular expression; a title is a literal. */
+export function escapeTestNamePattern(title) {
+  return String(title).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Run ONE case and judge whether it executed the fix's own lines in `sourceRel`.
+ *
+ * Isolating the case is what makes the answer per-case: vitest's json reporter attributes outcomes
+ * to cases but coverage to a run, so the run is narrowed to the single case instead.
+ *
+ * @param runVitestRaw (args, env) => void — injected so this is exercised without a vitest install.
+ */
+export function witnessOneCase({
+  workspaceRoot,
+  sourceRel,
+  testFileAbs,
+  caseName,
+  targetLines,
+  isShell,
+  readText = (p) => readFileSync(p, 'utf8'),
+  runVitestRaw,
+}) {
+  const sourceAbs = path.resolve(workspaceRoot, sourceRel);
+  const scratch = mkdtempSync(path.join(tmpdir(), 'harness-witness-'));
+  try {
+    const pattern = escapeTestNamePattern(caseName);
+    if (isShell) {
+      const prelude = path.join(scratch, 'xtrace-prelude.sh');
+      const traceFile = path.join(scratch, 'xtrace.log');
+      writeFileSync(prelude, XTRACE_PRELUDE);
+      writeFileSync(traceFile, '');
+      runVitestRaw([testFileAbs, '-t', pattern], {
+        BASH_ENV: prelude,
+        HARNESS_XTRACE_FILE: traceFile,
+      });
+      const executed = parseXtrace(readText(traceFile)).get(sourceAbs) ?? null;
+      let sourceText = null;
+      try {
+        sourceText = readText(sourceAbs);
+      } catch {
+        return WITNESS.UNKNOWN; // an unreadable source cannot be narrowed OR widened honestly
+      }
+      const untraceable = untraceableShellLines(sourceText);
+      return judgeWitness({
+        targetLines,
+        executedLines: executed,
+        executable: { has: (l) => !untraceable.has(l) },
+      });
+    }
+
+    const reportDir = path.join(scratch, 'coverage');
+    runVitestRaw(
+      [
+        testFileAbs,
+        '-t',
+        pattern,
+        '--coverage.enabled',
+        '--coverage.provider=v8',
+        '--coverage.reporter=json',
+        `--coverage.reportsDirectory=${reportDir}`,
+        '--coverage.all=false',
+      ],
+      {},
+    );
+    let report;
+    try {
+      report = JSON.parse(readText(path.join(reportDir, 'coverage-final.json')));
+    } catch {
+      return WITNESS.UNKNOWN; // no report is no evidence
+    }
+    const lines = coverageLines(report, sourceAbs);
+    if (!lines) return WITNESS.UNKNOWN; // the report never mentioned the file
+    // No widening here: istanbul's statementMap names the statements exactly, so a changed line that
+    // is not one is EXCLUDED rather than approximated, and the answer stays sharp.
+    return judgeWitness({
+      targetLines,
+      executedLines: lines.executed,
+      executable: lines.executable,
+    });
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+/** The default raw vitest invocation for a witness run — same shape the gate already uses. */
+export function defaultRunVitestRaw(workspaceRoot, pkg) {
+  const isWorkspacePackage = /^(?:packages|apps)\//.test(pkg);
+  return (args, env) => {
+    const invocation = isWorkspacePackage
+      ? ['--filter', `./${pkg}`, 'exec', 'vitest', 'run', ...args]
+      : ['exec', 'vitest', 'run', ...args];
+    try {
+      execFileSync('pnpm', invocation, {
+        cwd: workspaceRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, ...env },
+      });
+    } catch {
+      // A failing case is the EXPECTED outcome here — the witness runs on the reversed source, where
+      // the deciding case is red. The instrument's output is what matters, not the exit code.
+    }
+  };
+}

--- a/scripts/harness/lib/execution-witness.mjs
+++ b/scripts/harness/lib/execution-witness.mjs
@@ -78,7 +78,6 @@ export function changedNewLines(patchText) {
   return byFile;
 }
 
-
 /**
  * Lines a shell trace can never report, so that their absence is not read as "not reached".
  *
@@ -90,15 +89,26 @@ export function changedNewLines(patchText) {
  * command, while `*.md)` alone never traces and only its body does. It matters because it is exactly
  * the shape `post-tool-format.sh` changed — `"${CLAUDE_PROJECT_DIR:-}"/*) ;;` — and counting it as
  * executable called a genuine red proof `unreached` on the only real range there was to measure.
- * Only arms inside a `case … in` block are read this way, so a `foo()` line elsewhere is untouched.
+ *
+ * An arm is recognised by POSITION, not by shape alone, and the shape test is not enough on its own:
+ * `(cd "$dir" && cmd)` is a full-line subshell that satisfies the same pattern, `set -x` DOES trace
+ * it, and excluding it made a fix whose only written line was that subshell read as unreached — a
+ * finding against correct work. Arm position is where the grammar allows a new arm: straight after
+ * `case … in`, and after each `;;` / `;&` / `;;&`. Everything between those is a BODY, where a
+ * parenthesised line is a command. The state is a stack, so a `case` nested inside an arm body does
+ * not reset the block that encloses it.
  */
 export function untraceableShellLines(sourceText) {
   const lines = String(sourceText ?? '').split('\n');
   const untraceable = new Set();
   const GRAMMAR = new Set(['fi', 'esac', 'else', 'done', 'then', 'do', '{', '}', '(', ')', ';;']);
   const BARE_CASE_ARM = /^\(?[^()]*\)\s*(?:;;&?|;&)?$/;
+  const OPENS_ARM = /^\(?[^()]*\)/;
+  const ARM_TERMINATOR = /(?:;;&?|;&)$/;
   let heredocTerminator = null;
-  let caseDepth = 0;
+  /** One entry per open `case … in`; the value is "the next line may be an arm". */
+  const caseStack = [];
+  const expectingArm = () => caseStack.length > 0 && caseStack[caseStack.length - 1];
   for (let i = 0; i < lines.length; i += 1) {
     const lineNo = i + 1;
     const raw = lines[i];
@@ -110,10 +120,19 @@ export function untraceableShellLines(sourceText) {
     }
     const heredoc = raw.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\s*$/);
     if (heredoc) heredocTerminator = heredoc[1];
+
+    const atArmPosition = expectingArm();
     if (trimmed === '' || trimmed.startsWith('#') || GRAMMAR.has(trimmed)) untraceable.add(lineNo);
-    else if (caseDepth > 0 && BARE_CASE_ARM.test(trimmed)) untraceable.add(lineNo);
-    if (/^case\s.*\sin$/.test(trimmed)) caseDepth += 1;
-    else if (trimmed === 'esac' && caseDepth > 0) caseDepth -= 1;
+    else if (atArmPosition && BARE_CASE_ARM.test(trimmed)) untraceable.add(lineNo);
+
+    if (/^case\s.*\sin$/.test(trimmed)) caseStack.push(true);
+    else if (trimmed === 'esac' && caseStack.length > 0) caseStack.pop();
+    else if (caseStack.length > 0) {
+      // A terminator hands the next line back to arm position; an arm that did not terminate on its
+      // own line has opened a body, and every line until the next terminator is a command.
+      if (ARM_TERMINATOR.test(trimmed)) caseStack[caseStack.length - 1] = true;
+      else if (atArmPosition && OPENS_ARM.test(trimmed)) caseStack[caseStack.length - 1] = false;
+    }
   }
   return untraceable;
 }
@@ -187,6 +206,41 @@ fi
 /** vitest's `-t` is a regular expression; a title is a literal. */
 export function escapeTestNamePattern(title) {
   return String(title).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Ask the question of every deciding case, and never let "we stopped looking" pass for "nothing
+ * reached it".
+ *
+ * The budget is a COST STOP, not a sample. It exists because each answer costs a vitest run, and the
+ * expensive path is the one where no case reaches the fix — a REACHED short-circuits on the first
+ * hit, so a healthy range pays for one run whatever the budget is. Exhausting it therefore only ever
+ * happens on the way to a finding, which is the moment the gate most needs to be right.
+ *
+ * So an exhausted budget answers UNKNOWN. UNREACHED is reserved for the case where every deciding
+ * failure was actually checked and not one of them ran a line the fix wrote — the only situation in
+ * which the gate has grounds to say the red came from outside the fix.
+ *
+ * @param witnessOne (failure) => WITNESS — injected so the budget rule is tested without vitest.
+ */
+export function witnessDecidingCases({ failures, budget, witnessOne }) {
+  if (!failures?.length) return WITNESS.UNKNOWN;
+  let sawUnknown = false;
+  let checked = 0;
+  for (const failure of failures) {
+    // Stopped looking. Reporting UNREACHED here would be a finding built on the cases nobody ran.
+    if (checked >= budget) return WITNESS.UNKNOWN;
+    checked += 1;
+    let answer;
+    try {
+      answer = witnessOne(failure);
+    } catch {
+      answer = WITNESS.UNKNOWN;
+    }
+    if (answer === WITNESS.REACHED) return WITNESS.REACHED;
+    if (answer === WITNESS.UNKNOWN) sawUnknown = true;
+  }
+  return sawUnknown ? WITNESS.UNKNOWN : WITNESS.UNREACHED;
 }
 
 /**

--- a/scripts/harness/lib/execution-witness.mjs
+++ b/scripts/harness/lib/execution-witness.mjs
@@ -368,8 +368,16 @@ export function defaultRunVitestRaw(workspaceRoot, pkg) {
         env: { ...process.env, ...env },
       });
     } catch {
-      // A failing case is the EXPECTED outcome here — the witness runs on the reversed source, where
-      // the deciding case is red. The instrument's output is what matters, not the exit code.
+      // The exit code is not the signal here; the instrument's output is. `spawnSync` throws or
+      // reports non-zero for reasons that say nothing about whether the case reached the fix — a
+      // sibling case failing in the same file, a non-zero from the runner itself — and the trace has
+      // already been written by then either way.
+      //
+      // This comment previously said the witness runs on the REVERSED source. It does not:
+      // `check-regression-red-proof.mjs` calls `executionWitness` only after `restore([source])`,
+      // and `defaultExecutionWitness`'s own docstring says "on the RESTORED source". The behaviour
+      // was right and the stated invariant was backwards — which matters more in this file than
+      // most, since its whole subject is measuring rather than assuming what a run did.
     }
   };
 }

--- a/scripts/harness/lib/execution-witness.mjs
+++ b/scripts/harness/lib/execution-witness.mjs
@@ -209,6 +209,35 @@ export function escapeTestNamePattern(title) {
 }
 
 /**
+ * The `-t` pattern that selects EXACTLY the named case.
+ *
+ * `--testNamePattern` is an UNANCHORED regex, so a bare title also selects every sibling whose name
+ * contains it — `parses config` drags in `parses config with defaults`, which is the ordinary shape
+ * of descriptive titles. The isolated run then executes both, and every line the sibling touched is
+ * credited to the deciding case: a genuine UNREACHED reported as REACHED. That is a MISSED
+ * DETECTION, the direction a false-alarm count cannot see.
+ *
+ * WHAT IT ANCHORS AGAINST was measured rather than assumed, because anchoring the wrong string
+ * matches nothing and answers UNKNOWN for everything — a worse failure than the one being fixed.
+ * Probed on vitest 3.2.6 against `describe('outer group')` + `it('parses config')`:
+ *
+ *   -t 'parses config'                    → 2 ran   (the collision)
+ *   -t '^parses config$'                  → 0 ran, 2 skipped   (the bare title is NOT the subject)
+ *   -t '^outer group parses config$'      → 1 ran, 1 skipped   (correct)
+ *
+ * So the subject is the describe chain and the title joined by single spaces — byte-identical to the
+ * json reporter's `fullName`, which is what `decidingFailures` hands over.
+ *
+ * @param qualified false when only a bare title is known (the reporter gave no `fullName`). The
+ *   ancestor chain is then unknown, so the pattern anchors the END and allows any prefix: still
+ *   immune to the sibling-suffix collision this exists for, and strictly narrower than no anchor.
+ */
+export function testNamePattern(caseName, { qualified = true } = {}) {
+  const escaped = escapeTestNamePattern(caseName);
+  return qualified ? `^${escaped}$` : `^(?:.* )?${escaped}$`;
+}
+
+/**
  * Ask the question of every deciding case, and never let "we stopped looking" pass for "nothing
  * reached it".
  *
@@ -256,6 +285,7 @@ export function witnessOneCase({
   sourceRel,
   testFileAbs,
   caseName,
+  caseNameQualified = true,
   targetLines,
   isShell,
   readText = (p) => readFileSync(p, 'utf8'),
@@ -264,7 +294,7 @@ export function witnessOneCase({
   const sourceAbs = path.resolve(workspaceRoot, sourceRel);
   const scratch = mkdtempSync(path.join(tmpdir(), 'harness-witness-'));
   try {
-    const pattern = escapeTestNamePattern(caseName);
+    const pattern = testNamePattern(caseName, { qualified: caseNameQualified });
     if (isShell) {
       const prelude = path.join(scratch, 'xtrace-prelude.sh');
       const traceFile = path.join(scratch, 'xtrace.log');


### PR DESCRIPTION
Direction 1 landed in #1568. This closes the remaining half by **taking direction 3 (coverage delta
per case) and rejecting direction 2 (branch-level mutation)** — both with the measurement behind
them.

## Acceptance criterion, set before any code was written

1. Of the four motivating cases, the witness was predicted to catch **0 additional** (direction 1
   already catches #4 partly), with a per-case reason stated in advance and then replayed.
2. It must catch the class direction 1 cannot see: a case that FAILS on the reversed source and
   executed none of the lines the fix wrote.
3. **Zero** false alarms over recent real ranges.

Measured against all three below. The replay encoded the per-case predictions and printed "as
predicted".

## Red first

Before the fix, the gate was handed a case that is genuinely red on the reversed source while its red
came from outside the fix. It printed:

```
✅  packages/x/src/target.ts: red-proof-ok (assertion-fail)
```

— a good red, which is exactly the class the item names. The new test failed against that. It passes
now, reporting `red-proof-unreached`.

## What landed

Two instruments, one question — did the case that supplied the red actually execute the code this fix
wrote?

- **bash**: `BASH_ENV` names a prelude every non-interactive bash sources before the script it was
  asked to run, so a hook spawned several processes down inside a vitest worker is instrumented
  without touching the test or the hook. `BASH_XTRACEFD` sends the trace to its own descriptor, so a
  test asserting on the hook's stderr is unaffected by being measured.
- **`.mjs`/`.ts`**: vitest v8 coverage, whose istanbul-shaped output names the executed statements
  and which lines are statements at all.

Per-case attribution comes from re-running the single deciding case with `-t`, because vitest
attributes outcomes to cases but coverage to a run.

Three answers, and only `UNREACHED` is a finding. A comment-only hunk, a pure deletion, a report that
never names the file — each is `UNKNOWN` and leaves the verdict exactly as it was.

## The first formulation was measured wrong, and that is why the second exists

It first asked the question of the REVERSED tree against the fix's OLD-side lines. Replayed on
`c08e0dbd6` it called a **genuine** red proof `unreached`: that fix is an ADDITION, so its old side
held nothing but a comment and one `case` pattern arm. Probing bash 5.2 also showed `set -x` never
names a bare `case` arm — `*.ts) echo is-ts ;;` traces because it carries a command, `*.md)` alone
never does and only its body traces.

Asked of the FIXED tree against the NEW-side lines, with bare `case` arms excluded from the
executable set, the same replay gives `reached`. That is what shipped.

## The four motivating cases — what this catches, and what it does not

| Case | Caught? | Why |
| --- | --- | --- |
| `hooks-have-execution-coverage` | **no** | the logic under test is IN the test file — no source to reverse, no pair, so the gate emits no verdict for a witness to qualify |
| `remaining-hooks-run` (two hooks) | **no** | the hooks named were not changed, so again no pair |
| `remaining-hooks-run` (extension) | **no** | REPLAYED on `b1f46acf3`: the fix wrote only comments and one bare `case` arm, so no changed line is traceable and the witness answers UNKNOWN. And the behaviour the case names — the extension filter — is not in the range's diff at all, so no diff-scoped instrument can target it |
| `remaining-hooks-run` (unset var) | **partly** | unchanged from direction 1 |

**0 of 4 additional, as predicted.** The three the item still names are not reachable from inside this
gate: two produce no verdict at all, and the third names a behaviour the diff does not contain.
Closing those needs a per-case reachability check over the WHOLE suite rather than over a fix range —
a different gate, and the honest next item.

## Why direction 2 was rejected

- Per-hunk reversal — the tractable reading of "negate the branch a case names" — catches none of the
  four either. #3's fix is entirely within the crash region so every hunk kills the case; #4's vacuous
  case hides behind a genuine sibling that kills every hunk.
- The reading that WOULD catch #4 (every added case must be killed by some mutant) is the same shape
  as "every added case must fail on reversal", which #1568 measured as failing correct work.
- Cost: one vitest run per hunk, against one per deciding case here. Over the 31 recent ranges this
  gate judges, single source files carry up to 617 changed lines.

Strictly more expensive, and it catches nothing direction 3 does not.

## False positives — measured, not asserted

Eight recent merged ranges replayed through the real gate (worktree detached at each merge, this
branch's gate copied in), 15 sources judged, **12 produced a red proof**:

| Witness | Count | Effect |
| --- | --- | --- |
| REACHED | 11 of 12 | verdict unchanged |
| UNKNOWN | 1 of 12 | verdict unchanged |
| UNREACHED | **0 of 12** | **zero false alarms** |

Ranges: `63fa0c0cf`, `2ac10f251`, `631aa9e27`, `02f5a84b9`, `a668df9e3`, `2b0c454e0`, `4719efe5a`,
`8589d58fa`. Both instruments are exercised there — nine `.sh` sources through the tracer, two `.mjs`
sources through coverage.

## Not promoted

The gate stays ADVISORY and `red-proof-unreached` is report-only even under
`REGRESSION_RED_PROOF_ENFORCE`. Promotion is INFRA-046's decision, not this one.

## Verification

- `npx vitest run scripts/harness/__tests__/` — 2117 tests green
- `pnpm harness:scan` — all 84 scans pass

Closes #1537

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso
