### PR TITLE
fix(hooks): INFRA-075 one reading of a command, and it is the one the guards use

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -47,9 +47,19 @@ fi
 # guard off — `git commit -m "note: BRANCH_GUARD_ALLOW_DELETE=1 was tried" && git push origin
 # --delete develop` did exactly that, disarming the check that exists because develop was once
 # deleted by accident.
-COMMAND_EXEC=$(hook_executable_part "$COMMAND")
-# Verb detection reads the same command with quoted ARGUMENTS blanked; extraction below keeps them,
-# because branch names and `-C` paths are routinely quoted.
+# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: `COMMAND_VERBS` from
+# the tokenizer and `COMMAND_EXEC` from two line-oriented passes that did no quote masking at all,
+# and every EXTRACTION below read the second one — the branch name, the start point, the deleted
+# branch, the `-C` target. Measured on a scratch repository, each with the bare form refused:
+#   git push origin --delete develop                        -> exit 2
+#   echo "see <<EOF" ; git push origin --delete develop     -> exit 0
+#   git checkout -b BAD_NAME                                -> exit 2
+#   echo "see <<EOF" ; git checkout -b BAD_NAME             -> exit 0
+# The quoted `<<EOF` opened a heredoc the old reading never saw close, so everything after it was
+# deleted from the string the extractions read; they came back empty, and a check with no subject
+# does not refuse. Verb detection reads this command with quoted ARGUMENTS blanked; the extractors
+# mask it themselves and read the value from the ORIGINAL at the same offset, because branch names
+# and `-C` paths are routinely quoted.
 COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 
 # One reading for all five, and it is POSITIONAL. Read as a token anywhere, an unquoted mention
@@ -158,7 +168,7 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # a single check runs. That is a total bypass wearing the costume of a passing guard.
 # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
 # redirect this guard at another repository. See lib/command-scan.sh.
-GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
+GIT_C_PATH=$(hook_git_c_path "$COMMAND" || true)
 # One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
 # `validated`: it must name SOME repository, because its verdict is about the branch that
 # repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside
@@ -227,10 +237,13 @@ fi
 # a confirmed merged PR. Matches: `gh api -X DELETE .../git/refs/heads/<name>`,
 # `git push <remote> --delete <name>`, `git push <remote> :<name>`.
 DELETE_BRANCH_NAME=""
-# Scan only the command up to the first heredoc opener (`<<`): everything after it is DATA
-# (e.g. a `git commit -F - <<'EOF' …` message that may legitimately mention `git push --delete`
-# or `refs/heads/`), not an executed command. This prevents a commit message from tripping the guard.
-DELETE_BRANCH_NAME=$(hook_deleted_branch "$COMMAND_EXEC" || true)
+# The RAW command. A heredoc BODY is data — a `git commit -F - <<'EOF' …` message may legitimately
+# mention `git push --delete` or `refs/heads/` — and so is a quoted argument, and the tokenizer
+# inside `hook_deleted_branch` knows both. It used to be handed a string that had been pre-cut by a
+# line-oriented pass, which looked for a heredoc opener with a regex that did not know about quoting:
+# a `<<EOF` inside a quoted string opened a body that never closed, and the real delete that followed
+# it was deleted from the string this check reads. (INFRA-075, #1572)
+DELETE_BRANCH_NAME=$(hook_deleted_branch "$COMMAND" || true)
 
 if [[ -n "$DELETE_BRANCH_NAME" && "${BRANCH_GUARD_ALLOW_DELETE:-0}" != "1" ]]; then
   if printf '%s' "$DELETE_BRANCH_NAME" | grep -qE '^(main|master|develop|gh-pages)$'; then
@@ -456,7 +469,7 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
   # Read the name from the ORIGINAL, positioned by a match in the masked text — the same rule the
   # `-C` target and the delete name follow. Pulling it straight out of the masked string returned
   # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
-  NEW_BRANCH=$(hook_match_extract "$COMMAND_EXEC" \
+  NEW_BRANCH=$(hook_match_extract "$COMMAND" \
     '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+' || true)
   # --- the base the branch is cut from (INFRA-067) ---------------------------------------------
   #
@@ -480,7 +493,7 @@ if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
     # origin/main` puts `--track` where the start point was being read, so the check compared HEAD
     # instead and passed while the branch came from `origin/main` — the exact creation this exists to
     # refuse, waved through by one common flag.
-    START_POINT=$(hook_match_extract "$COMMAND_EXEC" \
+    START_POINT=$(hook_match_extract "$COMMAND" \
       '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+[^ \t\n]+[ \t]+(-[^ \t\n]+[ \t]+)*' || true)
     # A start point is a git ref, and the token holding it may be glued to what follows.
     #

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -130,141 +130,39 @@ hook_cwd_of() {
   hook_json_string "$1" 'cwd'
 }
 
-# Remove heredoc BODIES from a command, keeping everything else — including whatever follows the
-# terminator, which is the part `%%<<*` discarded.
+# ONE READING OF A COMMAND, NOT TWO (INFRA-075, #1572).
 #
-# The body is data the shell feeds to a program; it is never executed, so a guard reading it is
-# reading text and calling it a command. Everything outside the body IS a command, including the
-# commands after the heredoc closes, so a guard not reading those is blind to them. Both halves
-# matter and each was gotten wrong separately.
+# Three functions stood here: `hook_strip_heredocs`, `hook_strip_comments`, and the
+# `hook_executable_part` that piped one into the other. They were the reading this file had BEFORE
+# #1565 gave it a tokenizer, and they survived that PR because retiring them is a caller-side change
+# and the hooks were owned by other work in flight. So the library offered two answers to "what does
+# this command do", three guards held both at once, and each grep site picked whichever variable was
+# in scope.
 #
-# Known limit, stated rather than hidden: only the first opener on a line is tracked, so
-# `cmd <<A <<B` strips A's body and treats B's opener as ordinary text. Multiple heredocs on one
-# line do not occur in commands this guards, and a wrong guess here would drop real commands.
-hook_strip_heredocs() {
-  awk '
-    BEGIN { inbody = 0 }
-    inbody {
-      line = $0
-      # Only `<<-` lets the terminator be indented. Stripping indentation unconditionally means an
-      # indented body line that happens to equal the terminator ends the body early, and the rest of
-      # the body is then scanned as if it were commands.
-      if (dashed) { sub(/^[ \t]+/, "", line) }
-      if (line == term) { inbody = 0; next }
-
-      # `<<EOF` — an UNQUOTED delimiter — is expanded by the shell, so `$(…)` and backticks in the
-      # body genuinely run. `<<\047EOF\047` and `<<"EOF"` are literal and stay data. Treating every
-      # body as data meant `git commit -F- <<EOF` with `$(git push --force …)` inside executed the
-      # push while no guard saw it — the same principle applied elsewhere in this file to quoted
-      # strings, and not here. Only the substitution spans are emitted; the prose around them is
-      # still data.
-      if (!quoted) {
-        out = ""
-        n = length($0)
-        for (i = 1; i <= n; i++) {
-          if (substr($0, i, 2) == "$(") {
-            depth = 0
-            for (j = i + 1; j <= n; j++) {
-              cj = substr($0, j, 1)
-              if (cj == "(") { depth++ } else if (cj == ")") { depth--; if (depth == 0) { break } }
-            }
-            stop = (j <= n) ? j : n
-            out = out substr($0, i, stop - i + 1) " "
-            i = stop
-          } else if (substr($0, i, 1) == "`") {
-            for (j = i + 1; j <= n; j++) { if (substr($0, j, 1) == "`") { break } }
-            stop = (j <= n) ? j : n
-            out = out substr($0, i, stop - i + 1) " "
-            i = stop
-          }
-        }
-        if (out != "") { print out }
-      }
-      next
-    }
-    {
-      # A herestring is not a heredoc. `<<< "x"` has no body and no terminator, but the pattern
-      # below matches from the SECOND `<`, so everything after it was swallowed as body and never
-      # came back — every later command in that call went unexamined. Neutralising `<<<` first is
-      # length-preserving, so offsets into $0 stay valid.
-      probe = $0
-      gsub(/<<</, "\002\002\002", probe)
-      if (match(probe, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/)) {
-        term = substr(probe, RSTART, RLENGTH)
-        dashed = (substr(term, 3, 1) == "-")
-        quoted = (term ~ /[\047"]/)
-        sub(/^<<-?[ \t]*/, "", term)
-        gsub(/[\047"]/, "", term)
-        inbody = 1
-        $0 = substr($0, 1, RSTART - 1)   # keep the command, drop the opener and its tail
-      }
-      print
-    }
-  '
-}
-
-# Strip shell comments — quote-aware, because a comment is only a comment outside quotes.
+# The gap was not academic. Measured against real bash over the 202-shape differential corpus, with a
+# recording `git` stub on PATH:
 #
-# This was `sed 's/[[:space:]]#[^"]*$//'`. The `[^"]*` was there so a `#` inside a quoted string
-# would not be treated as a comment, and it worked by refusing to match whenever a quote appeared
-# anywhere after the `#` — including inside the comment itself. So `echo ok # a "half-open remark`
-# stripped nothing, the stray quote opened a string the masker never saw closed, and EVERY LINE
-# AFTER IT was masked away: a `git push origin --delete develop` on the next line was invisible to
-# all four guards. A new instance of the class this library exists to close, in the one helper that
-# had no state machine.
+#   hook_verb_scan        agreed with bash on 199 of 202
+#   hook_executable_part  agreed with bash on 111 of 202  (3 bypasses, 88 refusals of correct work)
 #
-# A `#` starts a comment when it is outside quotes and begins a word — which is what the shell
-# does, and what the masker already knows how to determine.
-hook_strip_comments() {
-  awk '
-    { lines[NR] = $0 }
-    END {
-      # Quote state carries ACROSS lines, exactly as the masker does. Resetting it per line meant a
-      # `#` on the continuation line of a multi-line quoted argument was read as a comment start,
-      # and the rest of that line — the real closing quote, and anything chained after it — was
-      # discarded. That removed a real command from what the guards see: the same defect class, via
-      # the opposite mechanism, in the fix for it.
-      q = ""
-      for (n = 1; n <= NR; n++) {
-        s = lines[n]
-        out = ""
-        # `q` carries across lines; `esc` does NOT. A trailing backslash escapes the NEWLINE — the
-        # shell joins the two physical lines and the backslash-newline vanishes — it does not leave
-        # the first character of the next line escaped. Sharing the flag made that character bypass
-        # the quote-open and comment-start decisions entirely.
-        esc = 0
-        len = length(s)
-        for (i = 1; i <= len; i++) {
-          c = substr(s, i, 1)
-          if (esc) { esc = 0; out = out c; continue }
-          if (c == "\\" && q != "\047") { esc = 1; out = out c; continue }
-          if (q == "") {
-            if (c == "\"" || c == "\047") { q = c; out = out c; continue }
-            # A word-initial `#` outside quotes begins a comment; the rest of the line is prose.
-            if (c == "#" && (i == 1 || substr(s, i - 1, 1) ~ /[ \t;&|(]/)) { break }
-            out = out c
-          } else {
-            if (c == q) { q = "" }
-            out = out c
-          }
-        }
-        print out
-      }
-    }
-  '
-}
-
-# What a guard should actually examine: the command with heredoc bodies and comments removed.
+# and it reached VERDICTS, which is the part #1565 did not measure. `hook_strip_heredocs` looks for
+# a heredoc opener with a regex that does not know about quoting, so a `<<EOF` written INSIDE a
+# quoted string opened a body that never closed and every command after it was deleted from the
+# string the guards then examined. Three hooks, each with a bare control that is refused correctly:
 #
-# This is the WEAKER of the two readings in this file, and callers that use both should know which
-# is which. It removes heredoc bodies and comments with the two line-oriented passes above and
-# leaves quoting alone; `hook_verb_scan` reads the same command by the grammar. Where they differ
-# the tokenizer is right, so a guard deciding whether a VERB is present must use `hook_verb_scan` —
-# this one is for the surrounding text a guard still needs to look at. Collapsing the two is a
-# caller-side change and is left to the item that owns those hooks.
-hook_executable_part() {
-  printf '%s\n' "$1" | hook_strip_heredocs | hook_strip_comments
-}
+#   worktree-cwd-guard  git -C <MAIN> reset --hard                                   -> exit 2
+#                       echo "see <<EOF for details" ; git -C <MAIN> reset --hard    -> exit 0
+#   pre-push-check      git -C <unreviewed> push                                     -> exit 2
+#                       echo "see <<EOF for details" ; git -C <unreviewed> push      -> exit 0
+#   branch-guard        git push origin --delete develop                             -> exit 2
+#                       echo "see <<EOF" ; git push origin --delete develop          -> exit 0
+#   branch-guard        git checkout -b BAD_NAME                                     -> exit 2
+#                       echo "see <<EOF" ; git checkout -b BAD_NAME                  -> exit 0
+#
+# The tokenizer below already answers what those two passes were approximating — a heredoc body and
+# a comment both come back as \001 in its mask, and it knows the grammar they were guessing at. So
+# every caller reads the RAW command now and `hook_match_*` masks it properly, and the third
+# quote-state machine in this file is gone with them.
 
 # Quoted contents are masked one character for one — EXCEPT the string an interpreter is told to
 # run, which is a command and is left intact.
@@ -719,13 +617,14 @@ hook_match_extract_after() {
   printf '%s\n' "$1" | awk -v MODE=after -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="$3" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
-# What a verb-detection matcher should read.
+# What a verb-detection matcher should read — and, since #1572, the ONLY reading of a command this
+# file offers.
 #
-# The raw command goes in, not `hook_executable_part`'s output. Heredoc bodies and comments used to
-# be cut out by two line-oriented passes BEFORE masking, which meant the masker was handed a string
-# whose structure had already been altered by a reader that did not know the grammar. The tokenizer
-# knows both, and reading them together is what lets a comment inside a substitution end at its own
-# newline rather than at the substitution's closing paren.
+# The RAW command goes in. Heredoc bodies and comments used to be cut out by two line-oriented passes
+# BEFORE masking, which meant the masker was handed a string whose structure had already been altered
+# by a reader that did not know the grammar. The tokenizer knows both, and reading them together is
+# what lets a comment inside a substitution end at its own newline rather than at the substitution's
+# closing paren. Those passes are gone; see the note where they stood.
 hook_verb_scan() {
   printf '%s\n' "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="" -v VRE="" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -37,9 +37,14 @@ if ! COMMAND=$(hook_command_of "$INPUT"); then
   exit 2
 fi
 
-# Heredoc bodies and comments are text; only the rest is a command. Shared with the other Bash
-# hooks so all three answer "what will run" the same way.
-COMMAND_EXEC=$(hook_executable_part "$COMMAND")
+# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: `COMMAND_VERBS` from
+# the tokenizer and `COMMAND_EXEC` from two line-oriented passes that did no quote masking, and the
+# `-C` extraction below read the second one. Measured, with the bare form refused correctly:
+#   git -C <a repo with no review record> push                                 -> exit 2
+#   echo "see <<EOF for details" ; git -C <that repo> push                     -> exit 0
+# The quoted `<<EOF` opened a heredoc the old reading never saw close, so everything after it was
+# deleted from the string this guard examined; the `-C` vanished, the gate judged the SESSION
+# repository instead, and an unreviewed push walked through.
 COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 
 # Only intercept git push commands (tolerating env prefixes + global git flags like `git -C <path>`).
@@ -87,8 +92,10 @@ printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:
 # in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.
 HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
-# redirect this guard at another repository. See lib/command-scan.sh.
-GIT_C_PATH=$(hook_git_c_path "$COMMAND_EXEC" || true)
+# redirect this guard at another repository. The RAW command goes in: `hook_git_c_path` masks it
+# itself, by the grammar, and handing it a string a second reader had already mangled was the
+# bypass above. See lib/command-scan.sh.
+GIT_C_PATH=$(hook_git_c_path "$COMMAND" || true)
 # One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
 # `validated`: it must name SOME repository, because its verdict is about the branch that
 # repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -99,9 +99,14 @@ if [[ "$IN_WORKTREE_SESSION" != "true" ]]; then
 fi
 
 # --- Detect destructive git commands ------------------------------------------------------------
-# Scan only up to the first heredoc opener (`<<`) and strip trailing comments, so a commit message
-# or echoed text mentioning these commands cannot trip the guard (same defense as branch-guard).
-SCAN=$(hook_executable_part "$COMMAND")
+# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: `VERBS` from the
+# tokenizer and `SCAN` from two line-oriented passes that did no quote masking at all, and the `-C`
+# extraction below read `SCAN`. Measured on a worktree session, with the bare form refused correctly:
+#   git -C <MAIN> reset --hard                                 -> exit 2
+#   echo "see <<EOF for details" ; git -C <MAIN> reset --hard  -> exit 0
+# The quoted `<<EOF` opened a heredoc the old reading never saw close, so the `git -C <MAIN>` after it
+# was deleted from the string this guard examined, the effective repo fell back to the worktree, and a
+# `git reset --hard` on the MAIN checkout — the incident this file exists for — was allowed.
 VERBS=$(hook_verb_scan "$COMMAND")
 
 # GITPFX tolerates env prefixes and global git flags before the subcommand (`git -C <path> reset`,
@@ -176,8 +181,10 @@ HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 # `|| true` is load-bearing: grep exits 1 when there is no `-C`, and under `set -euo pipefail` a
 # failed command substitution aborts the hook silently before any check runs.
 # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
-# redirect this guard at another repository. See lib/command-scan.sh.
-GIT_C_PATH=$(hook_git_c_path "$SCAN" || true)
+# redirect this guard at another repository. The RAW command goes in: `hook_git_c_path` masks it
+# itself, by the grammar, and handing it a string a second reader had already mangled was the
+# bypass above. See lib/command-scan.sh.
+GIT_C_PATH=$(hook_git_c_path "$COMMAND" || true)
 # The `first-nonempty` mode, named rather than flattened into the validating one its siblings use.
 # It is this guard's FAIL-SAFE and the paragraph above is its reason: this hook blocks only on
 # POSITIVE confirmation, so naming an unresolvable `-C` target and then declining to block is the

--- a/scripts/harness/__tests__/branch-guard-reads-nested-commands.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-reads-nested-commands.test.mjs
@@ -20,11 +20,12 @@ const HOOKS_SRC = path.join(WORKSPACE_ROOT, '.claude/hooks');
  * The guard's VERDICT, not the reading behind it.
  *
  * `hook-reading-matches-bash.test.mjs` proves `hook_verb_scan` agrees with bash. That is not the
- * same claim as "the guard decides correctly", and the difference is not academic: `branch-guard.sh`
- * takes `COMMAND_VERBS` from `hook_verb_scan` but `COMMAND_EXEC` from `hook_executable_part`, and
- * greps different checks against different strings. A reading can be fixed while every decision that
- * consults the OTHER string stays exactly as wrong — the "registered, never reached" shape this
- * repository keeps meeting, where a mechanism is green about something nothing calls.
+ * same claim as "the guard decides correctly", and the difference was not academic: `branch-guard.sh`
+ * took `COMMAND_VERBS` from `hook_verb_scan` but `COMMAND_EXEC` from a second, quote-blind reading,
+ * and greps different checks against different strings. A reading can be fixed while every decision
+ * that consults the OTHER string stays exactly as wrong — the "registered, never reached" shape this
+ * repository keeps meeting, where a mechanism is green about something nothing calls. That second
+ * reading is gone (INFRA-075, #1572); this file is the reason it was possible to notice.
  *
  * So this file asks the hook itself. Every case runs `branch-guard.sh` end to end on a scratch
  * repository, with every `BRANCH_GUARD_ALLOW_*` override scrubbed out of the environment, and

--- a/scripts/harness/__tests__/helpers/command-corpus.mjs
+++ b/scripts/harness/__tests__/helpers/command-corpus.mjs
@@ -1,0 +1,193 @@
+/**
+ * The differential corpus: ways of writing a shell command that a person might plausibly write.
+ *
+ * It lived inside `hook-reading-matches-bash.test.mjs`, where exactly one consumer could reach it —
+ * and that consumer measured a FUNCTION. #1572 was filed because a corpus that only ever reaches
+ * `hook_verb_scan` proves the tokenizer is right and says nothing about whether the guards consult
+ * it; two hooks went on reading the weaker string and stayed green through #1565. So the corpus is
+ * a module now, and the file that measures the hooks' VERDICTS reads the same shapes as the file
+ * that measures the reading.
+ *
+ * Every entry is here for a CONSTRUCT the reading has to get right, not for a variation on one
+ * shape.
+ */
+
+export const SQ = String.fromCharCode(39);
+export const BT = String.fromCharCode(96);
+export const NL = '\n';
+
+const HANDWRITTEN = [
+  // -- plain invocations, and the boundary immediately after the verb --
+  'git push',
+  'git push;',
+  'git push; echo done',
+  'git push&',
+  'git push|cat',
+  '(git push)',
+  '{ git push; }',
+  'if true; then git push; fi',
+  'for i in 1; do git push; done',
+  'case x in x) git push;; esac',
+  // -- separators, assignments, global flags --
+  'cd /tmp && git push',
+  'cd /tmp \\\n  && git push',
+  'true; git push',
+  'FOO=1 git push',
+  'FOO=1 BAR=2 git push',
+  'git -C /tmp push',
+  'git -c user.name=x push',
+  // -- a backslash-newline joins two physical lines into one command --
+  'git \\\n  push',
+  'git push \\\n  origin main',
+  // -- quoted mentions: text, not commands --
+  `echo ${SQ}git push${SQ}`,
+  'echo "git push"',
+  `git commit -m ${SQ}about to git push later${SQ}`,
+  'git commit -m "about to git push later"',
+  `printf ${SQ}%s${SQ} ${SQ}git push${SQ}`,
+  'grep -r "git push" /dev/null',
+  // -- comments --
+  '# git push',
+  'echo hi # git push',
+  'echo hi #git push',
+  'echo "a" # git push',
+  'echo "# git push"',
+  `echo ${SQ}a # b${SQ} ; git push`,
+  `echo $(echo hi # comment${NL}) ; echo done`,
+  `x=$(echo hi # git push${NL}); echo done`,
+  `echo ok # a half-open remark ${SQ}${NL}git push`,
+  // -- the INFRA-075 reproduction, verbatim, and its family --
+  `out=$(printf ${SQ}x git push -m y${SQ} | bash h.sh); echo done`,
+  `out=$(echo ${SQ}git push${SQ}); echo $out`,
+  'out=$(printf "x git push -m y"); echo done',
+  // -- substitutions that really do run, at depth --
+  'a=$(git push)',
+  'a=$(echo "$(git push)")',
+  'a=$(echo "$(echo "$(git push)")")',
+  `a=$(echo "$(printf ${SQ}git push${SQ})")`,
+  `echo "$(echo ${SQ}git push${SQ}) done"`,
+  `echo "$(echo ${SQ}safe${SQ}) git push"`,
+  // -- backticks --
+  `x=${BT}git push${BT}`,
+  `x=${BT}echo ${SQ}git push${SQ}${BT}`,
+  `echo "${BT}echo ${SQ}git push${SQ}${BT}"`,
+  `x=${BT}echo "$(printf ${SQ}git push${SQ})"${BT}`,
+  // -- interpreter strings: shell-family ones are read as shell, the rest are read whole --
+  'bash -c "git push"',
+  `sh -c ${SQ}git push${SQ}`,
+  'bash -x -c "git push"',
+  '/bin/bash -c "git push"',
+  `bash -c "echo ${SQ}git push${SQ}"`,
+  `bash -c ${SQ}echo "git push"${SQ}`,
+  `bash -c "printf ${SQ}%s\\n${SQ} ${SQ}git push${SQ}"`,
+  'eval "git push"',
+  `python3 -c ${SQ}print(1)${SQ} "git push is a mention"`,
+  // -- ANSI-C and locale quoting --
+  `echo $${SQ}git push${SQ}`,
+  `echo $${SQ}a\\tgit push${SQ}`,
+  `printf $${SQ}x\\${SQ}y git push${SQ}`,
+  'echo $"git push"',
+  // -- escapes --
+  'echo \\"git push\\"',
+  'echo "he said \\"git push\\" ok"',
+  'echo "\\$(git push)"',
+  `echo ${SQ}\\${SQ} ; echo ${SQ}git push${SQ}`,
+  `git commit -m "use \\${BT}git push\\${BT} here" 2>/dev/null || true`,
+  // -- heredocs --
+  `cat <<EOF${NL}git push${NL}EOF`,
+  `cat <<${SQ}EOF${SQ}${NL}git push${NL}EOF`,
+  `cat <<EOF${NL}$(git push)${NL}EOF`,
+  `cat <<${SQ}EOF${SQ}${NL}$(git push)${NL}EOF`,
+  `cat <<EOF${NL}text${NL}EOF${NL}git push`,
+  `cat <<-EOF${NL}\tgit push${NL}\tEOF`,
+  `cat <<EOF${NL}a ${SQ}git push${SQ} b${NL}EOF`,
+  `cat <<EOF${NL}$(echo "$(git push)")${NL}EOF`,
+  `cat <<A${NL}git push${NL}A${NL}cat <<B${NL}text${NL}B${NL}git push`,
+  `cat <<EOF${NL}text${NL}  EOF${NL}git push${NL}EOF`,
+  // -- herestrings: no body, no terminator, and an operand that is an ordinary word --
+  `cat <<< ${SQ}git push${SQ}`,
+  'cat <<< "$(git push)"',
+  'cat <<< "git push"',
+  // -- redirections and process substitution --
+  'echo x > /dev/null; git push',
+  'echo x 2>&1 | cat; git push',
+  `cat <(echo ${SQ}git push${SQ})`,
+  'cat <(git push)',
+  `echo ${SQ}a>b${SQ} ; echo ${SQ}git push${SQ}`,
+  // -- parameter expansion --
+  'echo ${HOME:-git push}',
+  'echo ${UNSET_VAR_X:-$(git push)}',
+  'echo "${UNSET_VAR_X:-$(git push)}"',
+  `echo \${#HOME} ; echo ${SQ}git push${SQ}`,
+  // -- arithmetic, including the left shift that looks like a heredoc opener --
+  `echo $(( 1 + 1 )) ; echo ${SQ}git push${SQ}`,
+  'echo $(( 1 + 1 )) ; git push',
+  'echo $(( 2 << 1 )) ; git push',
+  // -- arithmetic NESTED IN arithmetic, which the corpus had no shape for. Reached three ways,
+  // because a context that reads its own nesting wrong reads it wrong however it was entered.
+  'echo $(( $((1+2)) + 1 ))',
+  'echo $(( $(( git push )) ))',
+  'echo "$(( $(( git push )) ))"',
+  `cat <<EOF${NL}$(( $(( git push )) ))${NL}EOF`,
+  'echo $(( $(( 1 + 2 )) )) ; git push',
+  // -- a quoted argument spanning lines --
+  `git commit -m "line one${NL}git push${NL}line three" 2>/dev/null || true`,
+  // -- quoted single-word tokens are tokens, not payloads --
+  'git "push"',
+  `git ${SQ}push${SQ}`,
+  'git push "--force"',
+  `echo ${SQ}push${SQ}`,
+  // -- git is not the first word of the command, and still runs --
+  'env git push',
+  `echo ${SQ}git push${SQ} && git push`,
+  // -- argument position: a word the shell never runs as a command --
+  'echo git push',
+  `eval ${SQ}echo git push${SQ}`,
+  // -- a different verb entirely: must not read as a push --
+  'git pushd-something',
+  'git push-tags-please',
+];
+
+/**
+ * Generated shapes: a base command wrapped in layers of substitution and quoting, so the corpus
+ * reaches nesting depths a hand list never does. This is the half that answers "the next spelling
+ * is not on the list" — it enumerates spellings nobody wrote down.
+ */
+function generated() {
+  const bases = [
+    'git push',
+    `printf ${SQ}x git push y${SQ}`,
+    'echo no-verb-here',
+    'echo "git push"',
+  ];
+  const wordOf = [(c) => `$(${c})`, (c) => `${BT}${c}${BT}`];
+  const cmdOf = [
+    (w) => `v=${w}`,
+    (w) => `echo ${w}`,
+    (w) => `echo "${w}"`,
+    (w) => `printf ${SQ}%s${SQ} ${w}`,
+  ];
+  const out = [];
+  for (const base of bases) {
+    for (let depth = 1; depth <= 3; depth++) {
+      for (const wrapWord of wordOf) {
+        for (const wrapCmd of cmdOf) {
+          let cmd = base;
+          let usable = true;
+          for (let d = 0; d < depth; d++) {
+            // Nested backticks need an escaping the shell does not forgive, so only the outermost
+            // layer may be one.
+            const word = d === depth - 1 ? wrapWord(cmd) : `$(${cmd})`;
+            if (word.includes(BT) && cmd.includes(BT)) usable = false;
+            cmd = wrapCmd(word);
+          }
+          if (usable) out.push(cmd);
+        }
+      }
+    }
+  }
+  return [...new Set(out)];
+}
+
+export const GENERATED = generated();
+export const CORPUS = [...new Set([...HANDWRITTEN, ...GENERATED])];

--- a/scripts/harness/__tests__/hook-command-parsing.test.mjs
+++ b/scripts/harness/__tests__/hook-command-parsing.test.mjs
@@ -950,8 +950,42 @@ describe('the command parse has one owner', () => {
       expect(
         truncatesAtHeredoc,
         `${hook} discards everything from the first heredoc opener onward, so a command written ` +
-          'after the terminator is never examined. Use hook_strip_heredocs.',
+          'after the terminator is never examined. Read the command with hook_verb_scan, which ' +
+          'masks a heredoc BODY without losing what follows the terminator.',
       ).toBe(false);
     }
+  });
+
+  it('offers exactly one reading of a command', () => {
+    // INFRA-075 (#1572). `command-scan.sh` used to offer two: the tokenizer, and two line-oriented
+    // passes that did no quote masking at all. Three hooks held both strings at once and each grep
+    // site read whichever variable was in scope, so a reading could be fixed while every decision
+    // built on the OTHER one stayed exactly as wrong — which is what happened through #1565.
+    //
+    // Named rather than described: a second reading is cheap to reintroduce and expensive to
+    // notice, and the shape it comes back in is a helper that pre-chews the command before the
+    // tokenizer sees it.
+    const RETIRED = ['hook_executable_part', 'hook_strip_heredocs', 'hook_strip_comments'];
+    const offenders = [];
+    const files = [
+      ...bashHooks.map((name) => path.join(HOOKS_DIR, name)),
+      path.join(HOOKS_DIR, 'lib/command-scan.sh'),
+      path.join(HOOKS_DIR, 'lib/hook-facts.sh'),
+    ];
+    for (const file of files) {
+      const code = readFileSync(file, 'utf8')
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .join('\n');
+      for (const name of RETIRED) {
+        if (code.includes(name)) offenders.push(`${path.basename(file)} uses ${name}`);
+      }
+    }
+    expect(
+      offenders,
+      'a second reading of a command is back. Every guard must read hook_verb_scan, and every ' +
+        'extractor masks the RAW command itself — handing it a string another reader already ' +
+        'altered is the bypass #1572 measured.',
+    ).toStrictEqual([]);
   });
 });

--- a/scripts/harness/__tests__/hook-decoy-text-cannot-move-a-verdict.test.mjs
+++ b/scripts/harness/__tests__/hook-decoy-text-cannot-move-a-verdict.test.mjs
@@ -1,0 +1,234 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { hooksOutsideAWorktree } from './helpers/hooks-outside-a-worktree.mjs';
+
+/**
+ * INFRA-075 (#1572) — one reading of a command, measured where it is USED.
+ *
+ * `hook-reading-matches-bash.test.mjs` proves `hook_verb_scan` agrees with bash. That is a claim
+ * about a FUNCTION, and #1572 exists because it is not the same claim as "the guards consult it":
+ * `command-scan.sh` offered a second reading — two line-oriented passes that did no quote masking at
+ * all — and all three Bash guards held both strings at once, with every EXTRACTION reading the
+ * weaker one. The corpus stayed green through #1565 while the decisions built on that string stayed
+ * exactly as wrong.
+ *
+ * So this file states a PROPERTY of the verdicts rather than a list of shapes:
+ *
+ *     Adding text the shell will not execute cannot change what a guard decides.
+ *
+ * That is what "one reading" MEANS operationally, it is generative rather than a case list, and it
+ * is what the old reading violated. `hook_strip_heredocs` looked for a heredoc opener with a regex
+ * that did not know about quoting, so a `<<EOF` written inside a quoted string opened a body it
+ * never saw close — and every command after it vanished from the string the guards examined.
+ * Measured on develop, each with the bare control refused correctly:
+ *
+ *   worktree-cwd-guard  git -C <MAIN> reset --hard                                -> exit 2
+ *                       echo "see <<EOF for details" ; git -C <MAIN> reset --hard -> exit 0
+ *   pre-push-check      git -C <unreviewed> push                                  -> exit 2
+ *                       echo "see <<EOF for details" ; git -C <unreviewed> push   -> exit 0
+ *   branch-guard        git push origin --delete develop                          -> exit 2
+ *                       echo "see <<EOF" ; git push origin --delete develop       -> exit 0
+ *   branch-guard        git checkout -b BAD_NAME                                  -> exit 2
+ *                       echo "see <<EOF" ; git checkout -b BAD_NAME               -> exit 0
+ *
+ * Hermetic in the sense #1567 established: the hooks tree is copied OUTSIDE `.claude/worktrees/`, so
+ * a guard that reads its own path does not answer differently depending on where the suite is
+ * checked out, and the worktree-session marker is supplied explicitly by the case that wants it.
+ */
+
+const HOOKS = hooksOutsideAWorktree();
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * A `pnpm` that does nothing, ahead of the real one.
+ *
+ * `pre-push-check` shells out to `pnpm install … || true` on its way to the checks under
+ * measurement. Installing for real in a scratch repository is not deterministic, costs seconds per
+ * case, and rewrites a lockfile nobody here is asking about. Every case in this file is decided by
+ * WHICH REPOSITORY the guard resolved, which the install cannot affect either way — stubbing it out
+ * removes a variable rather than hiding a verdict, and no assertion below is about the lockfile.
+ */
+function pnpmStub() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'decoy-verdict-bin-'));
+  scratch.push(dir);
+  writeFileSync(path.join(dir, 'pnpm'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  return `${dir}:${process.env.PATH}`;
+}
+
+const GUARD_PATH = pnpmStub();
+
+function git(dir, ...args) {
+  return execFileSync('git', ['-C', dir, '-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+}
+
+function initRepo(dir, branch) {
+  mkdirSync(dir, { recursive: true });
+  git(dir, 'init', '-q', `--initial-branch=${branch}`);
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'chore: root');
+  return dir;
+}
+
+function runHook(hook, { command, cwd, env = {} }) {
+  const result = spawnSync('bash', [path.join(HOOKS, hook)], {
+    input: JSON.stringify({ tool_name: 'Bash', cwd, tool_input: { command } }),
+    encoding: 'utf8',
+    // A scrubbed environment: an override or a marker is present only when a case sets it.
+    env: { PATH: GUARD_PATH, HOME: process.env.HOME, ...env },
+    timeout: 120_000,
+  });
+  return result.status ?? 1;
+}
+
+/**
+ * Text the shell will NOT execute, written the way a person writes it.
+ *
+ * Each entry is prepended to a guarded command as its own statement. The invariant is that none of
+ * them may change the verdict, and the first case below proves each one is inert on its own — an
+ * "invariant" over decoys that were themselves refused would hold for the wrong reason.
+ */
+const SQ = String.fromCharCode(39);
+const DECOYS = [
+  ['a quoted heredoc opener', 'echo "see <<EOF for details"'],
+  ['the same in single quotes', `echo ${SQ}see <<EOF for details${SQ}`],
+  ['a heredoc opener inside a commit message', 'git commit -m "note: <<EOF is a heredoc"'],
+  ['a heredoc opener in a printf argument', `printf ${SQ}%s${SQ} "a <<EOF b"`],
+  ['a comment naming a destructive command', 'echo hi # git -C /elsewhere reset --hard'],
+  ['a quoted hash', 'echo "a # b"'],
+  [
+    'a closed heredoc whose body names a delete',
+    `cat <<${SQ}EOF${SQ}\ngit push origin --delete develop\nEOF`,
+  ],
+  [
+    'a closed heredoc whose body names a reset',
+    `cat <<${SQ}EOF${SQ}\ngit -C /elsewhere reset --hard\nEOF`,
+  ],
+];
+
+let root;
+let mainRepo;
+let worktreeRepo;
+let sessionRepo;
+let unreviewedRepo;
+let branchRepo;
+
+beforeAll(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'decoy-verdict-'));
+  scratch.push(root);
+
+  // worktree-cwd-guard: a MAIN checkout and an assigned worktree beside it.
+  mainRepo = initRepo(path.join(root, 'mainrepo'), 'develop');
+  worktreeRepo = initRepo(path.join(root, 'mainrepo/.claude/worktrees/agent-test'), 'feat/w');
+
+  // pre-push-check: a session on develop (which the review gate exempts) and a feature branch that
+  // carries a merge commit over origin/develop (which the branch-hygiene check refuses).
+  sessionRepo = initRepo(path.join(root, 'session'), 'develop');
+  unreviewedRepo = initRepo(path.join(root, 'unreviewed'), 'develop');
+  git(unreviewedRepo, 'update-ref', 'refs/remotes/origin/develop', 'HEAD');
+  git(unreviewedRepo, 'checkout', '-q', '-b', 'side');
+  git(unreviewedRepo, 'commit', '-q', '--allow-empty', '-m', 'chore: side');
+  git(unreviewedRepo, 'checkout', '-q', '-b', 'feat/y', 'develop');
+  git(unreviewedRepo, 'merge', '-q', '--no-ff', '-m', 'chore: merge side', 'side');
+
+  // branch-guard: a repository whose HEAD is origin/develop, so a creation from HEAD has the right
+  // base and the NAME is the only thing left to judge. Checked out on a FEATURE branch, not on
+  // develop: one of the decoys is an ordinary `git commit`, and a commit on a protected branch is
+  // something this guard refuses on purpose — the decoy would then be inert for the wrong reason.
+  branchRepo = initRepo(path.join(root, 'branchrepo'), 'develop');
+  git(branchRepo, 'update-ref', 'refs/remotes/origin/develop', 'HEAD');
+  git(branchRepo, 'checkout', '-q', '-b', 'feat/base');
+});
+
+/**
+ * Each row is [hook, name, guarded command, cwd, extra env]. Every guarded command is refused when
+ * written bare — asserted below — so "the decoy did not change the verdict" is a statement about a
+ * refusal that really happens, not about a check that never fires.
+ */
+function cases() {
+  return [
+    [
+      'worktree-cwd-guard.sh',
+      'a destructive command aimed at the MAIN checkout',
+      `git -C ${mainRepo} reset --hard`,
+      worktreeRepo,
+      { ROBOTA_AGENT_WORKTREE: worktreeRepo },
+    ],
+    [
+      'pre-push-check.sh',
+      'a push aimed at a branch that carries foreign merge commits',
+      `git -C ${unreviewedRepo} push`,
+      sessionRepo,
+      { CLAUDE_PROJECT_DIR: sessionRepo },
+    ],
+    [
+      'branch-guard.sh',
+      'a protected-branch delete',
+      'git push origin --delete develop',
+      branchRepo,
+      { CLAUDE_PROJECT_DIR: branchRepo },
+    ],
+    [
+      'branch-guard.sh',
+      'a branch name that breaks the convention',
+      'git checkout -b BAD_NAME',
+      branchRepo,
+      { CLAUDE_PROJECT_DIR: branchRepo, BRANCH_GUARD_ALLOW_OPEN_BRANCHES: '1' },
+    ],
+  ];
+}
+
+describe('text the shell will not execute cannot move a guard verdict (INFRA-075)', () => {
+  it('every guarded command is refused when written bare', () => {
+    // The controls. Without these the invariant below is satisfied by a guard that refuses nothing.
+    for (const [hook, name, command, cwd, env] of cases()) {
+      expect(runHook(hook, { command, cwd, env }), `${hook}: ${name}`).toBe(2);
+    }
+  });
+
+  it('every decoy is inert on its own', () => {
+    // And these. A decoy that is itself refused would make the invariant hold for the wrong reason.
+    const refused = [];
+    for (const [decoyName, decoy] of DECOYS) {
+      for (const [hook, , , cwd, env] of cases()) {
+        const status = runHook(hook, { command: decoy, cwd, env });
+        if (status !== 0) refused.push(`${hook} refused ${decoyName} (exit ${status})`);
+      }
+    }
+    expect(refused, 'a decoy that is itself refused proves nothing about the decoy').toStrictEqual(
+      [],
+    );
+  });
+
+  for (const [decoyName, decoy] of DECOYS) {
+    it(`${decoyName} in front of a guarded command changes nothing`, () => {
+      // Every hook is measured and the mismatches are reported TOGETHER. Asserting inside the loop
+      // stops at the first hook that moved, so a run would name one guard while two others were
+      // just as blind — and "which guards does this reach" is the whole question #1572 asks.
+      const moved = [];
+      for (const [hook, name, command, cwd, env] of cases()) {
+        const status = runHook(hook, { command: `${decoy}\n${command}`, cwd, env });
+        if (status !== 2)
+          moved.push(`${hook} — ${name} — refused bare, exit ${status} with the decoy`);
+      }
+      expect(
+        moved,
+        'The guard read something other than what will run. The decoy is data by the shell ' +
+          'grammar, so it cannot change a verdict — where it does, the string being examined is ' +
+          'not the command being run.',
+      ).toStrictEqual([]);
+    });
+  }
+});

--- a/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
+++ b/scripts/harness/__tests__/hook-reading-matches-bash.test.mjs
@@ -5,6 +5,13 @@ import path from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
 
+// The corpus is a MODULE now (#1572). It lived in this file, where exactly one consumer could reach
+// it — and that consumer measured a FUNCTION. `hook-decoy-text-cannot-move-a-verdict.test.mjs`
+// measures the same subject at the level of a hook's decision, and the two must read the same
+// shapes or "the reading is right" and "the guards consult it" drift apart again.
+import { CORPUS, GENERATED, SQ } from './helpers/command-corpus.mjs';
+import { hooksOutsideAWorktree } from './helpers/hooks-outside-a-worktree.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const LIB = path.join(WORKSPACE_ROOT, '.claude/hooks/lib/command-scan.sh');
 
@@ -118,191 +125,6 @@ function maskerSees(command, verb) {
   return answer;
 }
 
-const SQ = String.fromCharCode(39);
-const BT = String.fromCharCode(96);
-const NL = '\n';
-
-/**
- * Hand-written shapes. Every entry is a way of writing a command that a person might plausibly
- * write, and the point of each is a CONSTRUCT the reading has to get right — not a variation on one
- * shape.
- */
-const HANDWRITTEN = [
-  // -- plain invocations, and the boundary immediately after the verb --
-  'git push',
-  'git push;',
-  'git push; echo done',
-  'git push&',
-  'git push|cat',
-  '(git push)',
-  '{ git push; }',
-  'if true; then git push; fi',
-  'for i in 1; do git push; done',
-  'case x in x) git push;; esac',
-  // -- separators, assignments, global flags --
-  'cd /tmp && git push',
-  'cd /tmp \\\n  && git push',
-  'true; git push',
-  'FOO=1 git push',
-  'FOO=1 BAR=2 git push',
-  'git -C /tmp push',
-  'git -c user.name=x push',
-  // -- a backslash-newline joins two physical lines into one command --
-  'git \\\n  push',
-  'git push \\\n  origin main',
-  // -- quoted mentions: text, not commands --
-  `echo ${SQ}git push${SQ}`,
-  'echo "git push"',
-  `git commit -m ${SQ}about to git push later${SQ}`,
-  'git commit -m "about to git push later"',
-  `printf ${SQ}%s${SQ} ${SQ}git push${SQ}`,
-  'grep -r "git push" /dev/null',
-  // -- comments --
-  '# git push',
-  'echo hi # git push',
-  'echo hi #git push',
-  'echo "a" # git push',
-  'echo "# git push"',
-  `echo ${SQ}a # b${SQ} ; git push`,
-  `echo $(echo hi # comment${NL}) ; echo done`,
-  `x=$(echo hi # git push${NL}); echo done`,
-  `echo ok # a half-open remark ${SQ}${NL}git push`,
-  // -- the INFRA-075 reproduction, verbatim, and its family --
-  `out=$(printf ${SQ}x git push -m y${SQ} | bash h.sh); echo done`,
-  `out=$(echo ${SQ}git push${SQ}); echo $out`,
-  'out=$(printf "x git push -m y"); echo done',
-  // -- substitutions that really do run, at depth --
-  'a=$(git push)',
-  'a=$(echo "$(git push)")',
-  'a=$(echo "$(echo "$(git push)")")',
-  `a=$(echo "$(printf ${SQ}git push${SQ})")`,
-  `echo "$(echo ${SQ}git push${SQ}) done"`,
-  `echo "$(echo ${SQ}safe${SQ}) git push"`,
-  // -- backticks --
-  `x=${BT}git push${BT}`,
-  `x=${BT}echo ${SQ}git push${SQ}${BT}`,
-  `echo "${BT}echo ${SQ}git push${SQ}${BT}"`,
-  `x=${BT}echo "$(printf ${SQ}git push${SQ})"${BT}`,
-  // -- interpreter strings: shell-family ones are read as shell, the rest are read whole --
-  'bash -c "git push"',
-  `sh -c ${SQ}git push${SQ}`,
-  'bash -x -c "git push"',
-  '/bin/bash -c "git push"',
-  `bash -c "echo ${SQ}git push${SQ}"`,
-  `bash -c ${SQ}echo "git push"${SQ}`,
-  `bash -c "printf ${SQ}%s\\n${SQ} ${SQ}git push${SQ}"`,
-  'eval "git push"',
-  `python3 -c ${SQ}print(1)${SQ} "git push is a mention"`,
-  // -- ANSI-C and locale quoting --
-  `echo $${SQ}git push${SQ}`,
-  `echo $${SQ}a\\tgit push${SQ}`,
-  `printf $${SQ}x\\${SQ}y git push${SQ}`,
-  'echo $"git push"',
-  // -- escapes --
-  'echo \\"git push\\"',
-  'echo "he said \\"git push\\" ok"',
-  'echo "\\$(git push)"',
-  `echo ${SQ}\\${SQ} ; echo ${SQ}git push${SQ}`,
-  `git commit -m "use \\${BT}git push\\${BT} here" 2>/dev/null || true`,
-  // -- heredocs --
-  `cat <<EOF${NL}git push${NL}EOF`,
-  `cat <<${SQ}EOF${SQ}${NL}git push${NL}EOF`,
-  `cat <<EOF${NL}$(git push)${NL}EOF`,
-  `cat <<${SQ}EOF${SQ}${NL}$(git push)${NL}EOF`,
-  `cat <<EOF${NL}text${NL}EOF${NL}git push`,
-  `cat <<-EOF${NL}\tgit push${NL}\tEOF`,
-  `cat <<EOF${NL}a ${SQ}git push${SQ} b${NL}EOF`,
-  `cat <<EOF${NL}$(echo "$(git push)")${NL}EOF`,
-  `cat <<A${NL}git push${NL}A${NL}cat <<B${NL}text${NL}B${NL}git push`,
-  `cat <<EOF${NL}text${NL}  EOF${NL}git push${NL}EOF`,
-  // -- herestrings: no body, no terminator, and an operand that is an ordinary word --
-  `cat <<< ${SQ}git push${SQ}`,
-  'cat <<< "$(git push)"',
-  'cat <<< "git push"',
-  // -- redirections and process substitution --
-  'echo x > /dev/null; git push',
-  'echo x 2>&1 | cat; git push',
-  `cat <(echo ${SQ}git push${SQ})`,
-  'cat <(git push)',
-  `echo ${SQ}a>b${SQ} ; echo ${SQ}git push${SQ}`,
-  // -- parameter expansion --
-  'echo ${HOME:-git push}',
-  'echo ${UNSET_VAR_X:-$(git push)}',
-  'echo "${UNSET_VAR_X:-$(git push)}"',
-  `echo \${#HOME} ; echo ${SQ}git push${SQ}`,
-  // -- arithmetic, including the left shift that looks like a heredoc opener --
-  `echo $(( 1 + 1 )) ; echo ${SQ}git push${SQ}`,
-  'echo $(( 1 + 1 )) ; git push',
-  'echo $(( 2 << 1 )) ; git push',
-  // -- arithmetic NESTED IN arithmetic, which the corpus had no shape for. Reached three ways,
-  // because a context that reads its own nesting wrong reads it wrong however it was entered.
-  'echo $(( $((1+2)) + 1 ))',
-  'echo $(( $(( git push )) ))',
-  'echo "$(( $(( git push )) ))"',
-  `cat <<EOF${NL}$(( $(( git push )) ))${NL}EOF`,
-  'echo $(( $(( 1 + 2 )) )) ; git push',
-  // -- a quoted argument spanning lines --
-  `git commit -m "line one${NL}git push${NL}line three" 2>/dev/null || true`,
-  // -- quoted single-word tokens are tokens, not payloads --
-  'git "push"',
-  `git ${SQ}push${SQ}`,
-  'git push "--force"',
-  `echo ${SQ}push${SQ}`,
-  // -- git is not the first word of the command, and still runs --
-  'env git push',
-  `echo ${SQ}git push${SQ} && git push`,
-  // -- argument position: a word the shell never runs as a command --
-  'echo git push',
-  `eval ${SQ}echo git push${SQ}`,
-  // -- a different verb entirely: must not read as a push --
-  'git pushd-something',
-  'git push-tags-please',
-];
-
-/**
- * Generated shapes: a base command wrapped in layers of substitution and quoting, so the corpus
- * reaches nesting depths a hand list never does. This is the half that answers "the next spelling
- * is not on the list" — it enumerates spellings nobody wrote down.
- */
-function generated() {
-  const bases = [
-    'git push',
-    `printf ${SQ}x git push y${SQ}`,
-    'echo no-verb-here',
-    'echo "git push"',
-  ];
-  const wordOf = [(c) => `$(${c})`, (c) => `${BT}${c}${BT}`];
-  const cmdOf = [
-    (w) => `v=${w}`,
-    (w) => `echo ${w}`,
-    (w) => `echo "${w}"`,
-    (w) => `printf ${SQ}%s${SQ} ${w}`,
-  ];
-  const out = [];
-  for (const base of bases) {
-    for (let depth = 1; depth <= 3; depth++) {
-      for (const wrapWord of wordOf) {
-        for (const wrapCmd of cmdOf) {
-          let cmd = base;
-          let usable = true;
-          for (let d = 0; d < depth; d++) {
-            // Nested backticks need an escaping the shell does not forgive, so only the outermost
-            // layer may be one.
-            const word = d === depth - 1 ? wrapWord(cmd) : `$(${cmd})`;
-            if (word.includes(BT) && cmd.includes(BT)) usable = false;
-            cmd = wrapCmd(word);
-          }
-          if (usable) out.push(cmd);
-        }
-      }
-    }
-  }
-  return [...new Set(out)];
-}
-
-const GENERATED = generated();
-const CORPUS = [...new Set([...HANDWRITTEN, ...GENERATED])];
-
 /**
  * Known-open disagreements, each naming the item that owns it. An exemption carries a reason and an
  * ID — an unexplained one is how a corpus becomes decorative.
@@ -390,4 +212,77 @@ describe('the reading of a command matches what bash does with it', () => {
       'every disagreement must be a listed known-open shape',
     ).toStrictEqual([...KNOWN_OPEN.keys()].sort());
   });
+});
+
+/**
+ * The same corpus, run through a GUARD'S VERDICT rather than through a function (#1572, step 4).
+ *
+ * As it stood, this file proved the tokenizer is right and said nothing about whether the guards
+ * consult it — and that is exactly the gap that let a second, weaker reading survive #1565 wired
+ * into live checks. A corpus that measures a function can stay green while every decision built on
+ * the other string stays as wrong as it was.
+ *
+ * `branch-guard.sh` on a scratch repository checked out on `main` refuses exactly three verbs —
+ * `push`, `commit` and `merge` — and permits everything else, so its exit code is the answer to
+ * "did this guard see one of those run". The oracle is asked the same question, verb by verb, and
+ * the two answers must match for every shape. The claim the cases above make about a shell
+ * function, asked of a process.
+ *
+ * Asking only about `push` is what the first version of this did, and four corpus shapes then
+ * "disagreed" because they carry a real `git commit -m "…"` that the guard refuses on `main` for a
+ * reason that is correct. A measurement whose expectation is narrower than the thing measured
+ * reports the subject as broken; the fix is a complete expectation, not an exemption.
+ */
+const GUARDED_VERBS = ['push', 'commit', 'merge'];
+describe('the guards VERDICT on the same corpus matches what bash does with it', () => {
+  const hooks = hooksOutsideAWorktree();
+  const repo = mkdtempSync(path.join(tmpdir(), 'verdict-corpus-'));
+  scratch.push(repo);
+  for (const args of [
+    ['init', '-q', '--initial-branch=main'],
+    ['config', 'user.email', 'harness@example.test'],
+    ['config', 'user.name', 'Harness'],
+    ['commit', '-q', '--allow-empty', '-m', 'chore: root'],
+  ]) {
+    spawnSync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+  }
+
+  function guardRefuses(command) {
+    const result = spawnSync('bash', [path.join(hooks, 'branch-guard.sh')], {
+      input: JSON.stringify({ tool_name: 'Bash', cwd: repo, tool_input: { command } }),
+      encoding: 'utf8',
+      // Scrubbed: an override reaching this from the developer's shell would silence the guard for
+      // every shape at once and the whole describe would pass over nothing.
+      env: { PATH: process.env.PATH, HOME: process.env.HOME, CLAUDE_PROJECT_DIR: repo },
+      timeout: 60_000,
+    });
+    return result.status === 2;
+  }
+
+  it('the fixture refuses each guarded verb on main and permits ordinary work', () => {
+    // Fail closed: without this the agreement below is satisfied by a guard that decides nothing.
+    for (const verb of GUARDED_VERBS) {
+      expect(guardRefuses(`git ${verb} something`), `bare git ${verb} on main`).toBe(true);
+    }
+    expect(guardRefuses('echo hello')).toBe(false);
+    expect(guardRefuses('git status')).toBe(false);
+  });
+
+  it('agrees with bash on every corpus shape it is not already pinned as open on', () => {
+    const disagreements = CORPUS.filter((command) => {
+      if (KNOWN_OPEN.has(command)) return false;
+      const ranGuarded = GUARDED_VERBS.some((verb) => bashRuns(command, verb));
+      return ranGuarded !== guardRefuses(command);
+    });
+    expect(
+      disagreements,
+      `${disagreements.length} of ${CORPUS.length} shapes are DECIDED differently from what bash ` +
+        'does with them. A reading that agrees with bash while the guard built on it does not is ' +
+        'the defect #1572 was filed for:\n' +
+        disagreements.map((c) => `  ${JSON.stringify(c)}`).join('\n'),
+    ).toStrictEqual([]);
+    // One hook process and three oracle runs per shape. The default 10s budget is for a case that
+    // computes; this one SPAWNS, and spawning is the price of asking a real guard a real question
+    // instead of asking a function what it would have said.
+  }, 300_000);
 });


### PR DESCRIPTION
## The state

`lib/command-scan.sh` offered **two answers** to "what does this command do": the tokenizer #1565
added, and two line-oriented passes (`hook_strip_heredocs | hook_strip_comments`) that removed
heredoc bodies and comments and did **no quote masking at all**. All three Bash guards held both
strings at once and each grep site read whichever variable was in scope.

Measured against real bash over the 202-shape differential corpus, with a recording `git` stub on
`PATH`:

| reading | agrees with bash |
| --- | --- |
| `hook_verb_scan` | **199 / 202** |
| `hook_executable_part` | **111 / 202** — 3 bypasses, 88 refusals of correct work |

(The issue quotes 177/197, which is the #1565-era masker. Measured today against
`hook_executable_part` as it actually stands, the gap is wider, not narrower.)

## The part that was never measured: the VERDICTS

#1565 measured the **function**. #1572 was filed because that is not the same claim, and the other
two hooks' decisions had never been measured at all. So they were, before anything was changed —
every row is a hook process on a scratch repository, every group carries a bare control:

```
=== worktree-cwd-guard.sh — `git reset --hard` aimed at the MAIN checkout from a worktree session ===
  exit=2  BLOCKED  CONTROL bare
  exit=0  ALLOWED  a quoted `<<EOF` mention before the -C
  exit=0  ALLOWED  the same mention in single quotes
  exit=0  ALLOWED  a `<<EOF` inside a commit message

=== pre-push-check.sh — a push aimed with -C at an unreviewed feature branch ===
  exit=2  BLOCKED  CONTROL bare
  exit=0  ALLOWED  a quoted `<<EOF` mention before the -C
  exit=0  ALLOWED  the same mention in single quotes
  exit=0  ALLOWED  a `<<EOF` inside a commit message

=== branch-guard.sh — a protected-branch delete and a malformed branch name ===
  exit=2  BLOCKED  CONTROL bare protected-branch delete
  exit=0  ALLOWED  a quoted `<<EOF` mention before the delete
  exit=2  BLOCKED  CONTROL bare bad branch name
  exit=0  ALLOWED  a quoted `<<EOF` mention before the creation
```

**Eight verdict-level bypasses, on all three hooks, none carrying an override.**
`hook_strip_heredocs` looks for a heredoc opener with a regex that does not know about quoting, so a
`<<EOF` inside a quoted string opens a body it never sees close — and every command after it is
deleted from the string the guards examine. The extractions come back empty, and a check with no
subject does not refuse.

After this change all twelve rows are `exit=2`.

## What changed

`hook_executable_part`, `hook_strip_heredocs` and `hook_strip_comments` are **deleted** — the third
quote-state machine in the file goes with them — and all six call sites read the **raw** command,
which `hook_verb_scan` and `hook_match_*` mask themselves, by the grammar.

## The mechanism (step 4, the part that makes the rest non-recurring)

- The corpus is a **module**, so the file that measures the reading and the file that measures the
  decisions read the same shapes.
- `hook-reading-matches-bash.test.mjs` now runs the whole corpus through `branch-guard.sh`
  **end to end** and requires its verdict to agree with what bash actually ran. As it stood it proved
  the tokenizer is right and said nothing about whether the guards consult it — the gap that let this
  survive #1565.
- A new invariant replaces a case list, because the next spelling is by definition not on the list:

  > **Text the shell will not execute cannot move a verdict.**

  Eight decoys, each proved inert on its own; four guarded commands, each proved refused when bare.
  Against the unfixed hooks 4 of the 8 fail, and the failure reports all sixteen moved verdicts
  together rather than stopping at the first:

  ```
  +   "worktree-cwd-guard.sh — a destructive command aimed at the MAIN checkout — refused bare, exit 0 with the decoy",
  +   "pre-push-check.sh — a push aimed at a branch that carries foreign merge commits — refused bare, exit 0 with the decoy",
  +   "branch-guard.sh — a protected-branch delete — refused bare, exit 0 with the decoy",
  +   "branch-guard.sh — a branch name that breaks the convention — refused bare, exit 0 with the decoy",
        Tests  4 failed | 6 passed (10)
  ```
- `hook-command-parsing.test.mjs` refuses to let a second reading back in by name.

## False-positive sweep

A guard that refuses correct work gets switched off, so the other direction was measured too: 625
real command lines taken from this tree (every fenced `git`/`gh`/`pnpm`/`npx`/`node` line in 1782
documents under `.agents/` and `docs/`, plus the root `package.json` scripts), each run through all
three Bash guards under both the baseline hooks and these.

```
0 verdict(s) moved out of 1875 runs.
NEWLY SEEN (the baseline allowed it, this refuses it): 0
NEWLY BLIND (the baseline refused it, this allows it): 0
```

Nothing the repository actually tells people to run changes verdict; the newly-seen direction is the
sixteen rows above.

Closes #1572
