### PR TITLE
fix(hooks): INFRA-079 the statement is the subject of every decision

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -38,19 +38,10 @@ if ! COMMAND=$(hook_command_of "$INPUT"); then
   exit 2
 fi
 
-# Honor inline override tokens written IN the command string (e.g. `BRANCH_GUARD_ALLOW_DELETE=1 git push …`).
-# The `VAR=1` prefix runs in the TOOL's shell, not this hook's process, so a plain env check never sees it —
-# the documented overrides were unusable inline until this. Worktree-parallel subagents rely on
-# BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1 to each carry their own concurrent branch (git-branch.md § Git Worktree).
-# Computed BEFORE the overrides are read, and the overrides read the MASKED form. An override
-# named inside a heredoc body or a quoted argument is text, and text must not be able to switch this
-# guard off — `git commit -m "note: BRANCH_GUARD_ALLOW_DELETE=1 was tried" && git push origin
-# --delete develop` did exactly that, disarming the check that exists because develop was once
-# deleted by accident.
-# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: `COMMAND_VERBS` from
-# the tokenizer and `COMMAND_EXEC` from two line-oriented passes that did no quote masking at all,
-# and every EXTRACTION below read the second one — the branch name, the start point, the deleted
-# branch, the `-C` target. Measured on a scratch repository, each with the bare form refused:
+# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: the tokenizer's, and
+# one from two line-oriented passes that did no quote masking at all — and every EXTRACTION read the
+# second one: the branch name, the start point, the deleted branch, the `-C` target. Measured on a
+# scratch repository, each with the bare form refused:
 #   git push origin --delete develop                        -> exit 2
 #   echo "see <<EOF" ; git push origin --delete develop     -> exit 0
 #   git checkout -b BAD_NAME                                -> exit 2
@@ -60,62 +51,38 @@ fi
 # does not refuse. Verb detection reads this command with quoted ARGUMENTS blanked; the extractors
 # mask it themselves and read the value from the ORIGINAL at the same offset, because branch names
 # and `-C` paths are routinely quoted.
-COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
-
-# One reading for all five, and it is POSITIONAL. Read as a token anywhere, an unquoted mention
-# disarmed the guard — `git commit -m X BRANCH_GUARD_ALLOW_DELETE=1 && git push origin --delete
-# develop` — the same shape fixed in worktree-cwd-guard and not ported here because these were
-# documented as loose. Measured before narrowing them: every documented usage is already the prefix
-# form, and git-branch.md says "inline in the same command". There was no loose usage to break.
 #
-# An override is given TO a command, so it must prefix one. `ALLOW=1 git …`, optionally behind other
-# assignments, and nowhere else. (INFRA-076)
-override_given() {
-  local token="$1" verb_re="$2"
-  # Statement by statement, and the override must prefix THE STATEMENT THAT CARRIES THE COMMAND it
-  # overrides. Anchoring it to "some git call anywhere on the line" is not enough: a decoy in front
-  # turns it into a skeleton key —
-  #   BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git status; git push origin main
-  # set the flag globally and the real push went unchecked. The sibling guard met this exact attack
-  # and split on separators to close it; porting the anchoring without the scoping left the hole
-  # open here. (INFRA-076)
-  #
-  # And "one statement carries it" is still not the question. The action detection below is a set of
-  # booleans over the WHOLE command, so a single global flag answered for every guarded statement:
-  #   BRANCH_GUARD_ALLOW_MAIN_MERGE=1 git merge develop ; git push origin main
-  # is a correctly-overridden merge followed by a push to main that nobody overrode, and it passed.
-  # Making a previously-dead override live over whole-command detection is what opened that one.
-  #
-  # The question is whether EVERY statement carrying this action carries the override — the
-  # invariant the sibling guard already states as DESTRUCTIVE_STATEMENTS == OVERRIDDEN_STATEMENTS.
-  # Requiring "no sibling exists" instead would refuse correctly-overridden work, which is how a
-  # guard earns being switched off.
-  #
-  # CONTAINED, INFRA-079 (#1563). This closes the coarseness in the OVERRIDE reading. It does not
-  # close the coarseness in the ACTION reading, which is a second face of the same defect: the
-  # detection booleans below are still computed over the whole command, and NEW_BRANCH / START_POINT
-  # / DELETE_BRANCH_NAME are still single values taken from the FIRST match anywhere, because
-  # `hook_match_extract` uses awk `match()`. So a command with two branch creations has its second
-  # judged by nothing — measured, with no override token involved and reproducing on develop:
-  #   git checkout -b feat/x develop ; git checkout -b feat/y main    -> exit 0 (wrong base unjudged)
-  #   git checkout -b feat/ok ; git checkout -b BAD_NAME              -> exit 0 (bad name unjudged)
-  # Closing those needs an aligned per-statement split in lib/command-scan.sh, which is a library
-  # change and not this function's subject. Do not add a third override reading here; the remaining
-  # hole is not in the override.
-  #
-  # No pipeline: a `while` on the right of a pipe runs in a SUBSHELL, so its exit status says
-  # nothing about what it found. The statements are split into a variable first and read from a
-  # here-string, which keeps the loop in this shell.
-  local statements stmt guarded=0 overridden=0
-  statements=$(printf '%s\n' "$COMMAND_VERBS" | sed -E 's/(\|\||&&|[;&|])/\n/g')
-  while IFS= read -r stmt; do
-    printf '%s' "$stmt" | grep -qE "$verb_re" || continue
-    guarded=$((guarded + 1))
-    if printf '%s' "$stmt" | grep -qE "^[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$token=1[[:space:]]"; then
-      overridden=$((overridden + 1))
-    fi
-  done <<< "$statements"
-  [[ "$guarded" -gt 0 && "$overridden" -eq "$guarded" ]]
+# The hook `cwd` is a property of the PAYLOAD, not of any statement in it, so it is read once here.
+# Everything that IS a property of a statement is read inside the loop below. (INFRA-079, #1563)
+HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
+
+# An override is given TO a command, so it must PREFIX one — and it excuses THAT statement, nothing
+# else. `ALLOW=1 git …`, optionally behind other assignments, and nowhere else. (INFRA-076)
+#
+# Read off the MASKED statement, so an override named inside a heredoc body or a quoted argument is
+# text and text cannot switch this guard off — `git commit -m "note: BRANCH_GUARD_ALLOW_DELETE=1 was
+# tried" && git push origin --delete develop` did exactly that, disarming the check that exists
+# because develop was once deleted by accident.
+#
+# Four earlier readings of this one question are worth naming, because each repair was correct and
+# each left the next hole: env-only (the documented inline form did nothing), raw text (a mention
+# switched it off), a token anywhere (`git commit -m X ALLOW=1 && git push …`), and prefixing SOME
+# git call (`ALLOW=1 git status; git push origin main` — a skeleton key). #1559 added a counting
+# invariant over the whole command on top of those, because the ACTION detection was still a set of
+# booleans over the whole command and one global flag then answered for every guarded statement.
+#
+# The counting invariant is gone with the thing that needed it. When the subject is the statement,
+# "every guarded statement carries its own override" is not a rule to enforce — it is what asking
+# each statement separately MEANS. (INFRA-079, #1563)
+#
+# This process's ENVIRONMENT still counts. `BRANCH_GUARD_ALLOW_X=1` exported by a wrapper is a
+# deliberate session-wide exception and several tests and worktree launchers rely on it; the inline
+# form is the one git-branch.md documents. Both, not one.
+stmt_override() {
+  local token="$1"
+  [[ "${!token:-0}" == "1" ]] && return 0
+  printf '%s' "$STMT_MASK" |
+    grep -qE "^[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*$token=1[[:space:]]"
 }
 
 # A quote and a backtick are boundaries too: a KEPT region — `bash -c "git push"`, or a backtick
@@ -144,469 +111,521 @@ RE_MERGE="${GITPFX}merge${GITEND}"
 RE_CREATE="${GITPFX}(checkout\s+(-\S+\s+)*-[bB]|switch\s+(-\S+\s+)*-[cC])${GITEND}"
 RE_GH_API="(^|[;&|({\"'\`]|[[:space:]])[[:space:]]*gh[[:space:]]+api${GITEND}"
 
-# Each override is bound to the command it excuses, so a decoy statement cannot stand in for it.
-override_given BRANCH_GUARD_ALLOW_DELETE "($RE_PUSH|$RE_GH_API)" && BRANCH_GUARD_ALLOW_DELETE=1
-override_given BRANCH_GUARD_ALLOW_OPEN_BRANCHES "$RE_CREATE" && BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1
-override_given BRANCH_GUARD_ALLOW_BADNAME "$RE_CREATE" && BRANCH_GUARD_ALLOW_BADNAME=1
-# The base override belongs in this block for the reason the paragraph above gives: an inline
-# `VAR=1 git …` is set in the TOOL's shell and never reaches this process, so reading it only as
-# `${VAR:-0}` means the documented form does nothing.
-override_given BRANCH_GUARD_ALLOW_BASE "$RE_CREATE" && BRANCH_GUARD_ALLOW_BASE=1
-# MAIN_MERGE was the one still read ONLY from this process's environment, which means the form
-# git-branch.md documents could never work, for the two most dangerous operations the guard covers.
-override_given BRANCH_GUARD_ALLOW_MAIN_MERGE "($RE_PUSH|$RE_MERGE)" && BRANCH_GUARD_ALLOW_MAIN_MERGE=1
+# Nothing is resolved here any more. An override belongs to a statement and is asked of that
+# statement, at the point the statement's own action is judged. (INFRA-079, #1563)
 
-# Resolve the git context the COMMAND will actually run in (worktree-aware — parallel-wave lesson):
-# a worktree agent's commit/push was judged against the MAIN clone's branch (CLAUDE_PROJECT_DIR),
-# producing false blocks. Precedence: `git -C <path>` in the command > hook-input `cwd` > project dir.
-HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
-# Unanchored: `git -C <path>` is almost never the first thing on the line (`cd /elsewhere && git -C
-# <repo> commit`). The `^`-anchored version simply never found it, so the hook fired and then judged
-# whichever checkout it happened to sit in — passing a commit it should have refused.
-# `|| true` is load-bearing: grep exits 1 when the command has no `-C`, which is the common case, and
-# under `set -euo pipefail` a failed command substitution ABORTS the hook — silently, exit 1, before
-# a single check runs. That is a total bypass wearing the costume of a passing guard.
-# One extractor, matched against a masked command so a quoted mention of `git -C` cannot
-# redirect this guard at another repository. See lib/command-scan.sh.
-GIT_C_PATH=$(hook_git_c_path "$COMMAND" || true)
-# One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
-# `validated`: it must name SOME repository, because its verdict is about the branch that
-# repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside
-# it (worktree-cwd-guard's first-nonempty fail-safe, and this hook's own `session` base check) stay
-# decisions with a reason instead of four copies that drift apart.
-EFFECTIVE_DIR=$(hook_effective_repo validated "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
-
-# Detect git action type
-IS_COMMIT=false
-IS_PUSH=false
-IS_MERGE=false
-IS_BRANCH_CREATE=false
-IS_GH_DELETE_BRANCH=false
-# GITPFX tolerates global git flags before the subcommand — `git -C <path> commit`, `git -c k=v push` —
-# which previously slipped past every action regex (worktree-blindness, parallel-wave lesson).
+# --- one judgement per STATEMENT ----------------------------------------------------------------
 #
-# It matches at any STATEMENT boundary, not only at the start of the command. The `^`-anchored
-# version fired only when the WHOLE command began with the verb — and a branch is created as
-# `cd <repo> && git checkout -b …`, a commit made after a `cd`, a merge on a later line of a block.
-# Measured 2026-07-28 against a scratch repository on `main`: commit, push, merge, `checkout -b` and
-# `switch -c` were ALL bypassed in 4 of the 5 shapes commands are actually written in here. The
-# branch-create guard had therefore never fired on a real branch creation. Same defect #1510 removed
-# from pre-push-check; it lived here in a variable and was reused for every action. A guard no real
-# invocation reaches is indistinguishable from no guard.
+# A Bash tool call is a SEQUENCE of statements, and each guarded action — commit, push, merge,
+# branch-create, remote-delete — belongs to exactly one of them. This file used to collapse that
+# sequence twice: the detection booleans were computed over the WHOLE command, and NEW_BRANCH /
+# START_POINT / DELETE_BRANCH_NAME were single values taken from the FIRST match anywhere, because
+# `hook_match_extract` uses awk `match()`. One aggregate verdict then answered for N actions, so any
+# action escaped judgement behind any sibling that was well-formed. Measured on a scratch
+# repository, with a bare control refused correctly and NO override token in either command:
 #
-# Boundaries are line start, `;`, `&&`, `||`, `|`, `(`, whitespace and a quote. A newline is one too:
-# the command is decoded as JSON now and carries REAL newlines, so grep's `^` is a line start (a
-# multi-line block
-# keeps its escapes — and that is the shape that slipped through).
-# A heredoc BODY is data, not commands. `git commit -F - <<'EOF' … EOF` carries prose that may
-# quote a git invocation — this hook blocked a commit whose MESSAGE contained
-# "branches are made as `cd <repo> && git checkout -b …`", reading the sentence as the act it
-# describes. Verb detection therefore runs over the command with heredoc bodies removed.
+#   git checkout -b feat/y main                                     -> exit 2
+#   git checkout -b feat/x develop ; git checkout -b feat/y main    -> exit 0   (wrong base unjudged)
+#   git checkout -b BAD_NAME                                        -> exit 2
+#   git checkout -b feat/ok ; git checkout -b BAD_NAME              -> exit 0   (bad name unjudged)
 #
-# Deliberately narrow: it strips only `<<MARKER … MARKER`, whose boundaries are unambiguous. A verb
-# inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
-# quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
+# `worktree-cwd-guard.sh` already had the right shape and says why: each repair to the OVERRIDE
+# reading was correct and each left the next hole, "because the question was being asked about the
+# wrong subject". So the subject is the statement, for every decision and not only for the override.
+#
+# The statements come from `hook_statement_ranges`, which finds separators in the MASK — a `;` inside
+# a quoted argument or a heredoc body is data and splits nothing — and every reader below is given
+# that statement's (START, LENGTH). The command is still masked WHOLE and only the READING is
+# narrowed, so narrowing the question cannot change what counts as data.
+#
+# The ranges are read from a here-string, never from a PIPE: a `while` on the right of a pipe runs in
+# a SUBSHELL, where the `exit 2` of a refusal would end the subshell and the hook would carry on and
+# exit 0 — a refusal that refuses nothing. `worktree-cwd-guard.sh` records the same trap.
+UNMERGED_CHECKED=false
 
-echo "$COMMAND_VERBS" | grep -qE "$RE_COMMIT" && IS_COMMIT=true
-echo "$COMMAND_VERBS" | grep -qE "$RE_PUSH" && IS_PUSH=true
-echo "$COMMAND_VERBS" | grep -qE "$RE_MERGE" && IS_MERGE=true
-echo "$COMMAND_VERBS" | grep -qE "$RE_CREATE" && IS_BRANCH_CREATE=true
-# `gh pr merge --delete-branch` is banned (git-branch.md): it once deleted the
-# develop integration branch. Match ONLY when --delete-branch is an actual argument
-# of a `gh pr merge` invocation — strip shell comments first, then require the flag
-# to sit in the same command segment as `gh pr merge` (no intervening ; | &). This
-# avoids false positives from the flag mentioned in a comment or a separate echo.
-# Delete detection reads the MASKED command, like every other verb check. It was the last pair
-# still scanning quoted text, so a commit message naming `--delete-branch` refused the commit.
-COMMAND_NO_COMMENTS="$COMMAND_VERBS"
-if printf '%s' "$COMMAND_NO_COMMENTS" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge\b[^|;&]*--delete-branch'; then
-  IS_GH_DELETE_BRANCH=true
-fi
-
-if [[ "$IS_GH_DELETE_BRANCH" == "true" ]]; then
-  echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
-  echo "[branch-guard] It once deleted the develop integration branch. Merge without it, then delete" >&2
-  echo "[branch-guard] only on explicit user request: git branch -D <name> (local) /" >&2
-  echo "[branch-guard] gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<name> (remote)." >&2
+# A command that decodes but yields NO statements is not a command with nothing to judge; it means
+# the split did not run — awk missing, the program unparseable, the tokenizer aborting. Left
+# unchecked the loop below simply would not execute and the hook would exit 0, which is the exact
+# shape this directory keeps meeting: "I could not look" wearing the costume of "I looked and it was
+# fine". Measured against origin/develop with awk hidden from PATH: `git push origin main` ON `main`
+# left the guard at exit 127, which the hook protocol treats as NON-blocking, so the push was
+# allowed. Every reachable command has at least one statement, so an empty list is a broken guard.
+STATEMENT_RANGES=$(hook_statement_ranges "$COMMAND" || printf '')
+if [[ -z "${STATEMENT_RANGES//[[:space:]]/}" ]]; then
+  echo "[branch-guard] Blocked: the command could not be split into statements, so nothing in it" >&2
+  echo "[branch-guard] was judged. Nothing was verified; this is not a pass." >&2
   exit 2
 fi
 
-# --- L2: never delete a REMOTE branch until its PR is confirmed MERGED (git-branch.md) ---
-# A branch deleted while its PR is unmerged CLOSES/orphans the PR (this happened once: a delete
-# ran right after a `gh pr merge` that had actually failed DIRTY). Gate remote-branch deletion on
-# a confirmed merged PR. Matches: `gh api -X DELETE .../git/refs/heads/<name>`,
-# `git push <remote> --delete <name>`, `git push <remote> :<name>`.
-DELETE_BRANCH_NAME=""
-# The RAW command. A heredoc BODY is data — a `git commit -F - <<'EOF' …` message may legitimately
-# mention `git push --delete` or `refs/heads/` — and so is a quoted argument, and the tokenizer
-# inside `hook_deleted_branch` knows both. It used to be handed a string that had been pre-cut by a
-# line-oriented pass, which looked for a heredoc opener with a regex that did not know about quoting:
-# a `<<EOF` inside a quoted string opened a body that never closed, and the real delete that followed
-# it was deleted from the string this check reads. (INFRA-075, #1572)
-DELETE_BRANCH_NAME=$(hook_deleted_branch "$COMMAND" || true)
+while read -r STMT_START STMT_LEN; do
+  STMT_MASK=$(hook_verb_scan "$COMMAND" "$STMT_START" "$STMT_LEN")
 
-if [[ -n "$DELETE_BRANCH_NAME" && "${BRANCH_GUARD_ALLOW_DELETE:-0}" != "1" ]]; then
-  if printf '%s' "$DELETE_BRANCH_NAME" | grep -qE '^(main|master|develop|gh-pages)$'; then
-    echo "[branch-guard] Blocked: refusing to delete protected branch '$DELETE_BRANCH_NAME'." >&2
+  # Resolve the git context THIS STATEMENT will actually run in (worktree-aware — parallel-wave
+  # lesson): a worktree agent's commit/push was judged against the MAIN clone's branch
+  # (CLAUDE_PROJECT_DIR), producing false blocks. Precedence: `git -C <path>` in the statement >
+  # hook-input `cwd` > project dir.
+  #
+  # Per STATEMENT, because `-C` belongs to the invocation that carries it. Taken from the first match
+  # anywhere in the command, `git -C /elsewhere status && git commit` judged /elsewhere's branch and
+  # decided the commit — the same first-match-anywhere defect as NEW_BRANCH and DELETE_BRANCH_NAME,
+  # one variable to the left. (INFRA-079, #1563)
+  # Unanchored: `git -C <path>` is almost never the first thing on the line (`cd /elsewhere && git -C
+  # <repo> commit`). The `^`-anchored version simply never found it, so the hook fired and then judged
+  # whichever checkout it happened to sit in — passing a commit it should have refused.
+  # `|| true` is load-bearing: grep exits 1 when the command has no `-C`, which is the common case, and
+  # under `set -euo pipefail` a failed command substitution ABORTS the hook — silently, exit 1, before
+  # a single check runs. That is a total bypass wearing the costume of a passing guard.
+  # One extractor, matched against a masked command so a quoted mention of `git -C` cannot
+  # redirect this guard at another repository. See lib/command-scan.sh.
+  GIT_C_PATH=$(hook_git_c_path "$COMMAND" "$STMT_START" "$STMT_LEN" || true)
+  # One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
+  # `validated`: it must name SOME repository, because its verdict is about the branch that
+  # repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside
+  # it (worktree-cwd-guard's first-nonempty fail-safe, and this hook's own `session` base check) stay
+  # decisions with a reason instead of four copies that drift apart.
+  EFFECTIVE_DIR=$(hook_effective_repo validated "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
+
+  # Detect git action type
+  IS_COMMIT=false
+  IS_PUSH=false
+  IS_MERGE=false
+  IS_BRANCH_CREATE=false
+  IS_GH_DELETE_BRANCH=false
+  # GITPFX tolerates global git flags before the subcommand — `git -C <path> commit`, `git -c k=v push` —
+  # which previously slipped past every action regex (worktree-blindness, parallel-wave lesson).
+  #
+  # It matches at any STATEMENT boundary, not only at the start of the command. The `^`-anchored
+  # version fired only when the WHOLE command began with the verb — and a branch is created as
+  # `cd <repo> && git checkout -b …`, a commit made after a `cd`, a merge on a later line of a block.
+  # Measured 2026-07-28 against a scratch repository on `main`: commit, push, merge, `checkout -b` and
+  # `switch -c` were ALL bypassed in 4 of the 5 shapes commands are actually written in here. The
+  # branch-create guard had therefore never fired on a real branch creation. Same defect #1510 removed
+  # from pre-push-check; it lived here in a variable and was reused for every action. A guard no real
+  # invocation reaches is indistinguishable from no guard.
+  #
+  # Boundaries are line start, `;`, `&&`, `||`, `|`, `(`, whitespace and a quote. A newline is one too:
+  # the command is decoded as JSON now and carries REAL newlines, so grep's `^` is a line start (a
+  # multi-line block
+  # keeps its escapes — and that is the shape that slipped through).
+  # A heredoc BODY is data, not commands. `git commit -F - <<'EOF' … EOF` carries prose that may
+  # quote a git invocation — this hook blocked a commit whose MESSAGE contained
+  # "branches are made as `cd <repo> && git checkout -b …`", reading the sentence as the act it
+  # describes. Verb detection therefore runs over the command with heredoc bodies removed.
+  #
+  # Deliberately narrow: it strips only `<<MARKER … MARKER`, whose boundaries are unambiguous. A verb
+  # inside an ordinary quoted argument (`-m 'run git checkout -b x'`) still matches, because telling
+  # quoting apart needs the shell-aware extraction filed as HARNESS-061, not a longer regex here.
+
+  printf '%s' "$STMT_MASK" | grep -qE "$RE_COMMIT" && IS_COMMIT=true
+  printf '%s' "$STMT_MASK" | grep -qE "$RE_PUSH" && IS_PUSH=true
+  printf '%s' "$STMT_MASK" | grep -qE "$RE_MERGE" && IS_MERGE=true
+  printf '%s' "$STMT_MASK" | grep -qE "$RE_CREATE" && IS_BRANCH_CREATE=true
+  # `gh pr merge --delete-branch` is banned (git-branch.md): it once deleted the
+  # develop integration branch. Match ONLY when --delete-branch is an actual argument
+  # of a `gh pr merge` invocation — strip shell comments first, then require the flag
+  # to sit in the same command segment as `gh pr merge` (no intervening ; | &). This
+  # avoids false positives from the flag mentioned in a comment or a separate echo.
+  # Delete detection reads the MASKED command, like every other verb check. It was the last pair
+  # still scanning quoted text, so a commit message naming `--delete-branch` refused the commit.
+  COMMAND_NO_COMMENTS="$STMT_MASK"
+  if printf '%s' "$COMMAND_NO_COMMENTS" | grep -qE 'gh[[:space:]]+pr[[:space:]]+merge\b[^|;&]*--delete-branch'; then
+    IS_GH_DELETE_BRANCH=true
+  fi
+
+  if [[ "$IS_GH_DELETE_BRANCH" == "true" ]]; then
+    echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
+    echo "[branch-guard] It once deleted the develop integration branch. Merge without it, then delete" >&2
+    echo "[branch-guard] only on explicit user request: git branch -D <name> (local) /" >&2
+    echo "[branch-guard] gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<name> (remote)." >&2
     exit 2
   fi
-  MERGED_COUNT=""
-  if command -v gh >/dev/null 2>&1; then
-    MERGED_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state merged --json number --jq 'length' 2>/dev/null || echo "")
+
+  # --- L2: never delete a REMOTE branch until its PR is confirmed MERGED (git-branch.md) ---
+  # A branch deleted while its PR is unmerged CLOSES/orphans the PR (this happened once: a delete
+  # ran right after a `gh pr merge` that had actually failed DIRTY). Gate remote-branch deletion on
+  # a confirmed merged PR. Matches: `gh api -X DELETE .../git/refs/heads/<name>`,
+  # `git push <remote> --delete <name>`, `git push <remote> :<name>`.
+  DELETE_BRANCH_NAME=""
+  # The RAW command. A heredoc BODY is data — a `git commit -F - <<'EOF' …` message may legitimately
+  # mention `git push --delete` or `refs/heads/` — and so is a quoted argument, and the tokenizer
+  # inside `hook_deleted_branch` knows both. It used to be handed a string that had been pre-cut by a
+  # line-oriented pass, which looked for a heredoc opener with a regex that did not know about quoting:
+  # a `<<EOF` inside a quoted string opened a body that never closed, and the real delete that followed
+  # it was deleted from the string this check reads. (INFRA-075, #1572)
+  DELETE_BRANCH_NAME=$(hook_deleted_branch "$COMMAND" "$STMT_START" "$STMT_LEN" || true)
+
+  if [[ -n "$DELETE_BRANCH_NAME" ]] && ! stmt_override BRANCH_GUARD_ALLOW_DELETE; then
+    if printf '%s' "$DELETE_BRANCH_NAME" | grep -qE '^(main|master|develop|gh-pages)$'; then
+      echo "[branch-guard] Blocked: refusing to delete protected branch '$DELETE_BRANCH_NAME'." >&2
+      exit 2
+    fi
+    MERGED_COUNT=""
+    if command -v gh >/dev/null 2>&1; then
+      MERGED_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state merged --json number --jq 'length' 2>/dev/null || echo "")
+    fi
+    if [[ -z "$MERGED_COUNT" ]]; then
+      echo "[branch-guard] Blocked: cannot confirm a MERGED PR for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
+      echo "[branch-guard] Verify the merge landed (gh pr view <n> --json state == MERGED), then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+      exit 2
+    fi
+    if [[ "$MERGED_COUNT" == "0" ]]; then
+      echo "[branch-guard] Blocked: branch '$DELETE_BRANCH_NAME' has NO merged PR — deleting it now would orphan/close an unmerged PR." >&2
+      echo "[branch-guard] Confirm the merge FIRST: gh pr view <n> --json state must be MERGED." >&2
+      echo "[branch-guard] Intentional abandon of an unmerged branch? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+      exit 2
+    fi
+
+    # A merged PR in the branch's history is NOT proof that nothing is open on it NOW.
+    #
+    # Measured 2026-07-26: `fix/d4-scope-calculator` carried two merged PRs (#1484, #1485) from earlier
+    # reuses of the same branch name. #1483 was open and CONFLICTING at the time — never merged. The
+    # merged-count check saw `2`, allowed the deletion, and GitHub closed #1483 as a result. The exact
+    # outcome this guard exists to prevent, waved through by the guard itself.
+    #
+    # So ask the question that actually matters: is anything OPEN on this branch right now?
+    OPEN_COUNT=""
+    if command -v gh >/dev/null 2>&1; then
+      OPEN_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null || echo "")
+    fi
+    if [[ -z "$OPEN_COUNT" ]]; then
+      echo "[branch-guard] Blocked: cannot confirm whether an OPEN PR exists for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
+      echo "[branch-guard] Unable to determine is not the same as safe. Check by hand, then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+      exit 2
+    fi
+    if [[ "$OPEN_COUNT" != "0" ]]; then
+      OPEN_LIST=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number,mergeStateStatus \
+        --jq '[.[] | "#\(.number) (\(.mergeStateStatus))"] | join(", ")' 2>/dev/null || echo "")
+      echo "[branch-guard] Blocked: '$DELETE_BRANCH_NAME' still has an OPEN PR — $OPEN_LIST." >&2
+      echo "[branch-guard] Deleting it now CLOSES that PR. A merged PR earlier in this branch's history does not make deletion safe." >&2
+      echo "[branch-guard] Merge or close it deliberately first. Intentional abandon? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+      exit 2
+    fi
+    # A merged PR exists AND nothing is open on the branch → deletion is safe. Fall through.
   fi
-  if [[ -z "$MERGED_COUNT" ]]; then
-    echo "[branch-guard] Blocked: cannot confirm a MERGED PR for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
-    echo "[branch-guard] Verify the merge landed (gh pr view <n> --json state == MERGED), then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
+
+  if [[ "$IS_COMMIT" == "false" && "$IS_PUSH" == "false" && "$IS_MERGE" == "false" && "$IS_BRANCH_CREATE" == "false" ]]; then
+    continue
+  fi
+
+  # Get current branch of the EFFECTIVE context (worktree-aware, see resolution above)
+  PROJECT_DIR="$EFFECTIVE_DIR"
+
+  # A guard fails CLOSED. When nothing resolvable is a repository, the branch read below came back
+  # empty, an empty branch matched no protected name, and the hook exited 0 — "I could not verify"
+  # wearing the costume of "I verified this is fine", which the hook protocol reads as a pass.
+  # A detached HEAD is deliberately NOT this case: there the repository IS readable and the branch is
+  # genuinely nameless, and the checks below already handle that.
+  if ! hook_is_work_tree "$PROJECT_DIR"; then
+    echo "[branch-guard] Blocked: '$PROJECT_DIR' is no git repository, so the branch this command" >&2
+    echo "[branch-guard] would act on cannot be read. Nothing was verified; this is not a pass." >&2
+    echo "[branch-guard] Run the command from the checkout it belongs to." >&2
     exit 2
   fi
-  if [[ "$MERGED_COUNT" == "0" ]]; then
-    echo "[branch-guard] Blocked: branch '$DELETE_BRANCH_NAME' has NO merged PR — deleting it now would orphan/close an unmerged PR." >&2
-    echo "[branch-guard] Confirm the merge FIRST: gh pr view <n> --json state must be MERGED." >&2
-    echo "[branch-guard] Intentional abandon of an unmerged branch? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
-    exit 2
+  # One branch reader, with the default on the VALUE. `git branch --show-current` exits 0 and prints
+  # NOTHING on a detached HEAD, so an `|| echo …` arm here never runs — three hooks wrote one and all
+  # three were dead code. THIS caller wants the empty value: the checks below key on emptiness to
+  # recognise a detached HEAD, which is why the default is the caller's to name.
+  CURRENT_BRANCH=$(hook_current_branch "$PROJECT_DIR" "")
+
+  # A detached HEAD has no branch name, so the protected-branch checks below have nothing to compare
+  # and the guard used to stop here. Branch CREATION is different: creating `feat/x` while detached at
+  # `main` is precisely the wrong base this guard refuses, and stopping first made that unreachable —
+  # the base check could never run in the one state where nobody notices the base.
+  if [[ -z "$CURRENT_BRANCH" && "$IS_BRANCH_CREATE" != "true" ]]; then
+    continue
   fi
 
-  # A merged PR in the branch's history is NOT proof that nothing is open on it NOW.
-  #
-  # Measured 2026-07-26: `fix/d4-scope-calculator` carried two merged PRs (#1484, #1485) from earlier
-  # reuses of the same branch name. #1483 was open and CONFLICTING at the time — never merged. The
-  # merged-count check saw `2`, allowed the deletion, and GitHub closed #1483 as a result. The exact
-  # outcome this guard exists to prevent, waved through by the guard itself.
-  #
-  # So ask the question that actually matters: is anything OPEN on this branch right now?
-  OPEN_COUNT=""
-  if command -v gh >/dev/null 2>&1; then
-    OPEN_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null || echo "")
-  fi
-  if [[ -z "$OPEN_COUNT" ]]; then
-    echo "[branch-guard] Blocked: cannot confirm whether an OPEN PR exists for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
-    echo "[branch-guard] Unable to determine is not the same as safe. Check by hand, then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
-    exit 2
-  fi
-  if [[ "$OPEN_COUNT" != "0" ]]; then
-    OPEN_LIST=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number,mergeStateStatus \
-      --jq '[.[] | "#\(.number) (\(.mergeStateStatus))"] | join(", ")' 2>/dev/null || echo "")
-    echo "[branch-guard] Blocked: '$DELETE_BRANCH_NAME' still has an OPEN PR — $OPEN_LIST." >&2
-    echo "[branch-guard] Deleting it now CLOSES that PR. A merged PR earlier in this branch's history does not make deletion safe." >&2
-    echo "[branch-guard] Merge or close it deliberately first. Intentional abandon? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
-    exit 2
-  fi
-  # A merged PR exists AND nothing is open on the branch → deletion is safe. Fall through.
-fi
+  # Block new branch creation when local branches have commits not yet in the INTEGRATION branch.
+  # `git-branch.md` § One-Branch-At-A-Time names the comparison itself — `git branch --no-merged
+  # develop` — and this compared against `main`. `main` trails `develop` between promotions, so 53 of
+  # 140 local branches here were counted unmerged while already being in `develop`. Measured, and a
+  # straight contradiction of the rule this check enforces.
+  # This correctly handles squash-merged branches (their commits appear reachable
+  # from main after squash) as long as the local branch pointer is deleted post-merge.
+  if [[ "$IS_BRANCH_CREATE" == "true" && "$UNMERGED_CHECKED" == "false" ]] &&
+      ! stmt_override BRANCH_GUARD_ALLOW_OPEN_BRANCHES; then
+  # Once per COMMAND, not once per creating statement. The query below is a network call and the
+  # question it asks — "does this checkout have unmerged local branches" — is about the repository,
+  # not about which statement asked. Marked before the checks run, so a second creation does not pay
+  # for it again after the first one passed.
+  UNMERGED_CHECKED=true
+    # Prefer the remote-tracking integration head; fall back to local `develop` when offline.
+    INTEGRATION_REF=origin/develop
+    hook_git_in "$PROJECT_DIR" rev-parse --verify --quiet "$INTEGRATION_REF" >/dev/null 2>&1 || INTEGRATION_REF=develop
+    # A branch whose PR was SQUASH-merged keeps commits git cannot find in the integration branch, so
+    # ancestry alone calls it unmerged forever. Measured 2026-07-28: 83 branches reported, 73 of them
+    # with a MERGED PR — an 88% false-positive rate. A guard wrong seven times out of eight is one
+    # that gets overridden as a reflex, and it was: twice in one session, by me. The message under
+    # this loop already told people to delete squash-merged branches; the check never used what the
+    # message knew.
+    #
+    # Matched on NAME AND COMMIT, never name alone. A branch name gets reused: merge `feat/x`, leave the
+    # local branch, and stack new work on it, and a name-only match would wave those new commits through
+    # — silently disabling the very rule this check enforces. The delete-guard below already carries that
+    # lesson ("a merged PR earlier in this branch's history does not make deletion safe"); this path was
+    # written without it.
+    MERGED_REFS=""
+    MERGED_REFS_READ=false
+    MERGED_LIMIT=500
+    #
+    # Bounded, because this runs on every branch creation. Before this check the path was entirely
+    # local; it now makes a network call, and a SLOW response is not a failed one — without a limit a
+    # stalled connection would hang the hook indefinitely instead of taking the fallback below.
+    #
+    # The bound is hand-rolled rather than delegated to `timeout`, which is absent on a stock macOS.
+    # Branching on whether it exists would leave the promise above true on one platform and silently
+    # false on another, with the untested path being the one nobody runs — the shape of defect this
+    # directory has spent the week removing. One path, everywhere.
+    GH_TIMEOUT=10
+    bounded_merged_refs() {
+      local out pid watcher rc
+      out=$(mktemp) || return 1
+      (gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
+        --jq '.[] | "\(.headRefName) \(.headRefOid)"' >"$out" 2>/dev/null) &
+      pid=$!
 
-if [[ "$IS_COMMIT" == "false" && "$IS_PUSH" == "false" && "$IS_MERGE" == "false" && "$IS_BRANCH_CREATE" == "false" ]]; then
-  exit 0
-fi
+      # A watchdog rather than a `kill -0` polling loop. Polling asks "is the child still alive", and a
+      # child that has exited but not yet been reaped can still answer yes — on a shell where it does,
+      # every successful query would burn the whole deadline and then be thrown away as a timeout, so
+      # the feature would always fall back and every branch creation would cost ten seconds. Measured
+      # here at 1.2s with the polling version, so it did not reproduce on this bash; `wait` removes the
+      # question rather than leaving it to the platform, and returns the instant the query finishes.
+      # stdout detached deliberately. This function runs inside a command substitution, and a command
+      # substitution does not return until EVERY process holding the write end of its pipe is gone —
+      # so a watchdog inheriting that pipe kept it open for the full deadline even after the query had
+      # answered and the watchdog itself was killed, because the `sleep` it spawned still held the fd.
+      # Measured: the success path took 10.2s that way, worse than the polling it replaced.
+      (
+        sleep "$GH_TIMEOUT"
+        kill -TERM "$pid" 2>/dev/null || true
+      ) >/dev/null 2>&1 &
+      watcher=$!
 
-# Get current branch of the EFFECTIVE context (worktree-aware, see resolution above)
-PROJECT_DIR="$EFFECTIVE_DIR"
+      if wait "$pid"; then rc=0; else rc=1; fi
+      kill -TERM "$watcher" 2>/dev/null || true
+      wait "$watcher" 2>/dev/null || true
 
-# A guard fails CLOSED. When nothing resolvable is a repository, the branch read below came back
-# empty, an empty branch matched no protected name, and the hook exited 0 — "I could not verify"
-# wearing the costume of "I verified this is fine", which the hook protocol reads as a pass.
-# A detached HEAD is deliberately NOT this case: there the repository IS readable and the branch is
-# genuinely nameless, and the checks below already handle that.
-if ! hook_is_work_tree "$PROJECT_DIR"; then
-  echo "[branch-guard] Blocked: '$PROJECT_DIR' is no git repository, so the branch this command" >&2
-  echo "[branch-guard] would act on cannot be read. Nothing was verified; this is not a pass." >&2
-  echo "[branch-guard] Run the command from the checkout it belongs to." >&2
-  exit 2
-fi
-# One branch reader, with the default on the VALUE. `git branch --show-current` exits 0 and prints
-# NOTHING on a detached HEAD, so an `|| echo …` arm here never runs — three hooks wrote one and all
-# three were dead code. THIS caller wants the empty value: the checks below key on emptiness to
-# recognise a detached HEAD, which is why the default is the caller's to name.
-CURRENT_BRANCH=$(hook_current_branch "$PROJECT_DIR" "")
-
-# A detached HEAD has no branch name, so the protected-branch checks below have nothing to compare
-# and the guard used to stop here. Branch CREATION is different: creating `feat/x` while detached at
-# `main` is precisely the wrong base this guard refuses, and stopping first made that unreachable —
-# the base check could never run in the one state where nobody notices the base.
-if [[ -z "$CURRENT_BRANCH" && "$IS_BRANCH_CREATE" != "true" ]]; then
-  exit 0
-fi
-
-# Block new branch creation when local branches have commits not yet in the INTEGRATION branch.
-# `git-branch.md` § One-Branch-At-A-Time names the comparison itself — `git branch --no-merged
-# develop` — and this compared against `main`. `main` trails `develop` between promotions, so 53 of
-# 140 local branches here were counted unmerged while already being in `develop`. Measured, and a
-# straight contradiction of the rule this check enforces.
-# This correctly handles squash-merged branches (their commits appear reachable
-# from main after squash) as long as the local branch pointer is deleted post-merge.
-if [[ "$IS_BRANCH_CREATE" == "true" && "${BRANCH_GUARD_ALLOW_OPEN_BRANCHES:-0}" != "1" ]]; then
-  # Prefer the remote-tracking integration head; fall back to local `develop` when offline.
-  INTEGRATION_REF=origin/develop
-  hook_git_in "$PROJECT_DIR" rev-parse --verify --quiet "$INTEGRATION_REF" >/dev/null 2>&1 || INTEGRATION_REF=develop
-  # A branch whose PR was SQUASH-merged keeps commits git cannot find in the integration branch, so
-  # ancestry alone calls it unmerged forever. Measured 2026-07-28: 83 branches reported, 73 of them
-  # with a MERGED PR — an 88% false-positive rate. A guard wrong seven times out of eight is one
-  # that gets overridden as a reflex, and it was: twice in one session, by me. The message under
-  # this loop already told people to delete squash-merged branches; the check never used what the
-  # message knew.
-  #
-  # Matched on NAME AND COMMIT, never name alone. A branch name gets reused: merge `feat/x`, leave the
-  # local branch, and stack new work on it, and a name-only match would wave those new commits through
-  # — silently disabling the very rule this check enforces. The delete-guard below already carries that
-  # lesson ("a merged PR earlier in this branch's history does not make deletion safe"); this path was
-  # written without it.
-  MERGED_REFS=""
-  MERGED_REFS_READ=false
-  MERGED_LIMIT=500
-  #
-  # Bounded, because this runs on every branch creation. Before this check the path was entirely
-  # local; it now makes a network call, and a SLOW response is not a failed one — without a limit a
-  # stalled connection would hang the hook indefinitely instead of taking the fallback below.
-  #
-  # The bound is hand-rolled rather than delegated to `timeout`, which is absent on a stock macOS.
-  # Branching on whether it exists would leave the promise above true on one platform and silently
-  # false on another, with the untested path being the one nobody runs — the shape of defect this
-  # directory has spent the week removing. One path, everywhere.
-  GH_TIMEOUT=10
-  bounded_merged_refs() {
-    local out pid watcher rc
-    out=$(mktemp) || return 1
-    (gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
-      --jq '.[] | "\(.headRefName) \(.headRefOid)"' >"$out" 2>/dev/null) &
-    pid=$!
-
-    # A watchdog rather than a `kill -0` polling loop. Polling asks "is the child still alive", and a
-    # child that has exited but not yet been reaped can still answer yes — on a shell where it does,
-    # every successful query would burn the whole deadline and then be thrown away as a timeout, so
-    # the feature would always fall back and every branch creation would cost ten seconds. Measured
-    # here at 1.2s with the polling version, so it did not reproduce on this bash; `wait` removes the
-    # question rather than leaving it to the platform, and returns the instant the query finishes.
-    # stdout detached deliberately. This function runs inside a command substitution, and a command
-    # substitution does not return until EVERY process holding the write end of its pipe is gone —
-    # so a watchdog inheriting that pipe kept it open for the full deadline even after the query had
-    # answered and the watchdog itself was killed, because the `sleep` it spawned still held the fd.
-    # Measured: the success path took 10.2s that way, worse than the polling it replaced.
-    (
-      sleep "$GH_TIMEOUT"
-      kill -TERM "$pid" 2>/dev/null || true
-    ) >/dev/null 2>&1 &
-    watcher=$!
-
-    if wait "$pid"; then rc=0; else rc=1; fi
-    kill -TERM "$watcher" 2>/dev/null || true
-    wait "$watcher" 2>/dev/null || true
-
-    if [[ "$rc" -eq 0 ]]; then
-      cat "$out"
+      if [[ "$rc" -eq 0 ]]; then
+        cat "$out"
+        rm -f "$out"
+        return 0
+      fi
       rm -f "$out"
-      return 0
-    fi
-    rm -f "$out"
-    return 1
-  }
+      return 1
+    }
 
-  if command -v gh >/dev/null 2>&1; then
-    if MERGED_REFS=$(bounded_merged_refs); then
-      MERGED_REFS_READ=true
-    fi
-  fi
-
-  # A full page may mean the list was truncated, so older merged branches would be missing and the
-  # check would over-report again — without the notice that explains why. Say it rather than let the
-  # list quietly grow back.
-  MERGED_TRUNCATED=false
-  if [[ "$MERGED_REFS_READ" == "true" ]] &&
-    [[ "$(printf '%s\n' "$MERGED_REFS" | grep -c .)" -ge "$MERGED_LIMIT" ]]; then
-    MERGED_TRUNCATED=true
-  fi
-
-  UNMERGED_BRANCHES=()
-  SKIP_PATTERNS="^(main|master|develop|gh-pages)$"
-  while IFS= read -r candidate; do
-    candidate="${candidate#  }"   # strip leading spaces
-    candidate="${candidate#\* }"  # strip current-branch marker
-    candidate="${candidate#+ }"   # strip the worktree marker, which otherwise yielded a bogus name
-    [[ "$candidate" =~ $SKIP_PATTERNS ]] && continue
-    [[ -z "$candidate" ]] && continue
-    ahead=$(hook_git_in "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
-    [[ "$ahead" -gt 0 ]] || continue
-    # A merged PR settles it — for the COMMIT that was merged, not for the name.
-    if [[ "$MERGED_REFS_READ" == "true" ]]; then
-      candidate_sha=$(hook_git_in "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
-      if [[ -n "$candidate_sha" ]] &&
-        printf '%s\n' "$MERGED_REFS" | grep -Fxq -- "$candidate $candidate_sha"; then
-        continue
+    if command -v gh >/dev/null 2>&1; then
+      if MERGED_REFS=$(bounded_merged_refs); then
+        MERGED_REFS_READ=true
       fi
     fi
-    UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
-  done < <(hook_git_in "$PROJECT_DIR" branch 2>/dev/null)
 
-  if [[ "${#UNMERGED_BRANCHES[@]}" -gt 0 ]]; then
-    echo "[branch-guard] Blocked: local branches with unmerged commits detected." >&2
-    echo "[branch-guard] Merge or delete them before creating a new branch:" >&2
-    for b in "${UNMERGED_BRANCHES[@]}"; do
-      echo "  - $b" >&2
-    done
-    echo "[branch-guard] After squash-merge via PR, delete the local branch: git branch -D <name>" >&2
-    if [[ "$MERGED_REFS_READ" != "true" ]]; then
-      echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
-      echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2
-    elif [[ "$MERGED_TRUNCATED" == "true" ]]; then
-      echo "[branch-guard] NOTE: the merged-PR list came back full ($MERGED_LIMIT), so older merged" >&2
-      echo "[branch-guard] branches may be missing from it and listed here as unmerged." >&2
-    fi
-    echo "[branch-guard] To override: set BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1" >&2
-    exit 2
-  fi
-fi
-
-# Enforce feature branch naming convention <type>/<desc> (git-branch.md).
-# Long-lived branches are exempt; override with BRANCH_GUARD_ALLOW_BADNAME=1.
-# Branch creation. TWO independent checks live here — the base a branch is cut from, and the name
-# it is given — each with its OWN override. They were one block gated by the NAME override, so
-# `BRANCH_GUARD_ALLOW_BADNAME=1` silently switched the base check off too and reopened the
-# promotion-ancestry hole it exists to close. Two checks, two overrides; neither excuses the other.
-if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
-  # Read the branch name out of the checkout/switch invocation itself. The previous expression
-  # ran a greedy `.*` over the WHOLE command and captured whatever followed the LAST
-  # -b/-B/-c/-C, so `git checkout -b feat/x && git -C /other status` yielded /other and
-  # refused a correctly named branch. Adding -C to that alternation made a long-standing
-  # weakness reachable.
-  # Read the name from the ORIGINAL, positioned by a match in the masked text — the same rule the
-  # `-C` target and the delete name follow. Pulling it straight out of the masked string returned
-  # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
-  NEW_BRANCH=$(hook_match_extract "$COMMAND" \
-    '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+' || true)
-  # --- the base the branch is cut from (INFRA-067) ---------------------------------------------
-  #
-  # `git-branch.md` is mandatory about this: feature branches are created from a freshly-fetched
-  # `origin/develop`, never from `main` and never from another feature branch. Nothing checked it at
-  # creation time — this guard read the NAME and the unmerged-branch list, and never the base. Two
-  # audits measured `grep -c origin/develop` over this file at 0.
-  #
-  # It cost a promotion: a branch cut from a promotion branch dragged main's merge commits into the
-  # PR range and broke the promotion-ancestry check. Branch creation is also the one guarded action
-  # with no git-native backstop — husky covers commits on protected branches, rulesets cover pushes
-  # to main, nothing covers `checkout -b`.
-  #
-  # `hotfix/*` and `release/*` are exempt: the rule lets them PR to `main` and does not prescribe
-  # develop as their base. Feature branches are what it prescribes, and what this checks.
-  if [[ -n "$NEW_BRANCH" && "${BRANCH_GUARD_ALLOW_BASE:-0}" != "1" ]] &&
-    ! [[ "$NEW_BRANCH" =~ ^(hotfix|release)/ ]]; then
-    # The start point, when the command names one: the token after the branch name. A `&&`, a `;` or
-    # another flag is not a start point — those mean the command simply ended.
-    # Flags may sit between the new branch name and the start point: `git checkout -b feat/x --track
-    # origin/main` puts `--track` where the start point was being read, so the check compared HEAD
-    # instead and passed while the branch came from `origin/main` — the exact creation this exists to
-    # refuse, waved through by one common flag.
-    START_POINT=$(hook_match_extract "$COMMAND" \
-      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+[^ \t\n]+[ \t]+(-[^ \t\n]+[ \t]+)*' || true)
-    # A start point is a git ref, and the token holding it may be glued to what follows.
-    #
-    # Blanking the whole token whenever it contained an operator was worse than the bug it replaced:
-    # `git checkout -b feat/x main;` reads as one token `main;`, git cuts from `main`, and blanking
-    # it fell back to HEAD — so a base of `main` passed whenever HEAD happened to be develop. A
-    # fail-OPEN, where the version before it at least failed to resolve and refused.
-    #
-    # So the token is TRUNCATED at the first operator rather than discarded, and a redirection is
-    # recognised by its shape — `2>&1`, `>/dev/null` — instead of by containing an operator at all.
-    # `git checkout -b feat/x 2>&1 | head` is an ordinary creation and must not be refused; that one
-    # was measured, blocking the creation of the branch this check was fixed on.
-    # A redirection, in either direction, with or without a file-descriptor number: `2>&1`,
-    # `>/dev/null`, `3<file`, `<in`. Those are not start points at all.
-    #
-    # The descriptor and the operator must be ADJACENT. Written as the glob `[0-9]*'>'*` this read
-    # "a digit, then anything, then `>`" — so `2fa-base>/tmp/out.log` matched, and a real ref whose
-    # name begins with a digit was blanked and fell back to HEAD. The same fail-open this whole arm
-    # exists to prevent, reintroduced for every start point starting with a number. So the leading
-    # run of digits is stripped and the NEXT character decides.
-    START_POINT_AFTER_FD="${START_POINT#"${START_POINT%%[!0-9]*}"}"
-    case "$START_POINT_AFTER_FD" in '>'* | '<'*) START_POINT="" ;; esac
-
-    case "$START_POINT" in
-      -* | '') START_POINT="" ;;
-      *) START_POINT="${START_POINT%%[\<\>\|\&\;]*}" ;;
-    esac
-
-    # The SESSION's repository, not `PROJECT_DIR`. `PROJECT_DIR` prefers a `git -C <path>` found
-    # anywhere in the command, and in a compound command that `-C` usually belongs to some other
-    # invocation — `git checkout -b feat/x && git -C <other> status` would have this check judge
-    # <other>, which is not where the branch lands. Measured: that shape blocked a legitimate
-    # creation. Stated limit: `git -C <other> checkout -b` is judged against the session repository
-    # rather than <other>; branches are created where the session is, and erring that way
-    # over-permits a rare form instead of refusing a common one.
-    # The `session` mode is exactly that rule, named: hook `cwd` > project dir, `git -C` ignored.
-    BASE_DIR=$(hook_effective_repo session "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
-
-    WANTED=origin/develop
-    hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
-    WANTED_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
-    BASE_REF="${START_POINT:-HEAD}"
-    BASE_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
-    # `branch --show-current` exits 0 with empty output on a detached HEAD, so `|| echo HEAD` never
-    # fired and the refusal named nothing. The default belongs on the VALUE, not on the exit code —
-    # which is what hook_current_branch does, for every caller, once.
-    BASE_NAME="${START_POINT:-$(hook_current_branch "$BASE_DIR" HEAD)}"
-
-    if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then
-      echo "[branch-guard] Blocked: cannot resolve the base for '$NEW_BRANCH'." >&2
-      echo "[branch-guard]   wanted: $WANTED   found: ${BASE_NAME:-<unresolved>}" >&2
-      echo "[branch-guard] Fetch first (git fetch origin), or override: BRANCH_GUARD_ALLOW_BASE=1" >&2
-      exit 2
+    # A full page may mean the list was truncated, so older merged branches would be missing and the
+    # check would over-report again — without the notice that explains why. Say it rather than let the
+    # list quietly grow back.
+    MERGED_TRUNCATED=false
+    if [[ "$MERGED_REFS_READ" == "true" ]] &&
+      [[ "$(printf '%s\n' "$MERGED_REFS" | grep -c .)" -ge "$MERGED_LIMIT" ]]; then
+      MERGED_TRUNCATED=true
     fi
 
-    if [[ "$BASE_SHA" != "$WANTED_SHA" ]]; then
-      echo "[branch-guard] Blocked: '$NEW_BRANCH' would be cut from the wrong base." >&2
-      echo "[branch-guard]   found:  $BASE_NAME ($(printf '%.9s' "$BASE_SHA"))" >&2
-      echo "[branch-guard]   wanted: $WANTED ($(printf '%.9s' "$WANTED_SHA"))" >&2
-      echo "[branch-guard] git-branch.md: feature branches are cut from a freshly-fetched origin/develop." >&2
-      echo "[branch-guard] Do: git fetch origin && git checkout -b $NEW_BRANCH origin/develop" >&2
-      echo "[branch-guard] Deliberate exception: BRANCH_GUARD_ALLOW_BASE=1" >&2
+    UNMERGED_BRANCHES=()
+    SKIP_PATTERNS="^(main|master|develop|gh-pages)$"
+    while IFS= read -r candidate; do
+      candidate="${candidate#  }"   # strip leading spaces
+      candidate="${candidate#\* }"  # strip current-branch marker
+      candidate="${candidate#+ }"   # strip the worktree marker, which otherwise yielded a bogus name
+      [[ "$candidate" =~ $SKIP_PATTERNS ]] && continue
+      [[ -z "$candidate" ]] && continue
+      ahead=$(hook_git_in "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
+      [[ "$ahead" -gt 0 ]] || continue
+      # A merged PR settles it — for the COMMIT that was merged, not for the name.
+      if [[ "$MERGED_REFS_READ" == "true" ]]; then
+        candidate_sha=$(hook_git_in "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
+        if [[ -n "$candidate_sha" ]] &&
+          printf '%s\n' "$MERGED_REFS" | grep -Fxq -- "$candidate $candidate_sha"; then
+          continue
+        fi
+      fi
+      UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
+    done < <(hook_git_in "$PROJECT_DIR" branch 2>/dev/null)
+
+    if [[ "${#UNMERGED_BRANCHES[@]}" -gt 0 ]]; then
+      echo "[branch-guard] Blocked: local branches with unmerged commits detected." >&2
+      echo "[branch-guard] Merge or delete them before creating a new branch:" >&2
+      for b in "${UNMERGED_BRANCHES[@]}"; do
+        echo "  - $b" >&2
+      done
+      echo "[branch-guard] After squash-merge via PR, delete the local branch: git branch -D <name>" >&2
+      if [[ "$MERGED_REFS_READ" != "true" ]]; then
+        echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
+        echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2
+      elif [[ "$MERGED_TRUNCATED" == "true" ]]; then
+        echo "[branch-guard] NOTE: the merged-PR list came back full ($MERGED_LIMIT), so older merged" >&2
+        echo "[branch-guard] branches may be missing from it and listed here as unmerged." >&2
+      fi
+      echo "[branch-guard] To override: set BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1" >&2
       exit 2
     fi
   fi
 
-  BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
-  EXEMPT_RE='^(main|master|develop|gh-pages)$'
-  if [[ -n "$NEW_BRANCH" && "${BRANCH_GUARD_ALLOW_BADNAME:-0}" != "1" ]] &&
-    ! [[ "$NEW_BRANCH" =~ $EXEMPT_RE ]] && ! [[ "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then
-    echo "[branch-guard] Blocked: branch name '$NEW_BRANCH' does not match <type>/<desc>." >&2
-    echo "[branch-guard] Expected e.g. feat/x-y, fix/z, chore/w" >&2
-    echo "[branch-guard] (types: feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)." >&2
-    echo "[branch-guard] Override: BRANCH_GUARD_ALLOW_BADNAME=1" >&2
-    exit 2
-  fi
-fi
+  # Enforce feature branch naming convention <type>/<desc> (git-branch.md).
+  # Long-lived branches are exempt; override with BRANCH_GUARD_ALLOW_BADNAME=1.
+  # Branch creation. TWO independent checks live here — the base a branch is cut from, and the name
+  # it is given — each with its OWN override. They were one block gated by the NAME override, so
+  # `BRANCH_GUARD_ALLOW_BADNAME=1` silently switched the base check off too and reopened the
+  # promotion-ancestry hole it exists to close. Two checks, two overrides; neither excuses the other.
+  if [[ "$IS_BRANCH_CREATE" == "true" ]]; then
+    # Read the branch name out of the checkout/switch invocation itself. The previous expression
+    # ran a greedy `.*` over the WHOLE command and captured whatever followed the LAST
+    # -b/-B/-c/-C, so `git checkout -b feat/x && git -C /other status` yielded /other and
+    # refused a correctly named branch. Adding -C to that alternation made a long-standing
+    # weakness reachable.
+    # Read the name from the ORIGINAL, positioned by a match in the masked text — the same rule the
+    # `-C` target and the delete name follow. Pulling it straight out of the masked string returned
+    # the \001 fill for `git checkout -b "feat/x"` and refused a correctly named branch.
+    NEW_BRANCH=$(hook_match_extract "$COMMAND" \
+      '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+' \
+        "$STMT_START" "$STMT_LEN" || true)
+    # --- the base the branch is cut from (INFRA-067) ---------------------------------------------
+    #
+    # `git-branch.md` is mandatory about this: feature branches are created from a freshly-fetched
+    # `origin/develop`, never from `main` and never from another feature branch. Nothing checked it at
+    # creation time — this guard read the NAME and the unmerged-branch list, and never the base. Two
+    # audits measured `grep -c origin/develop` over this file at 0.
+    #
+    # It cost a promotion: a branch cut from a promotion branch dragged main's merge commits into the
+    # PR range and broke the promotion-ancestry check. Branch creation is also the one guarded action
+    # with no git-native backstop — husky covers commits on protected branches, rulesets cover pushes
+    # to main, nothing covers `checkout -b`.
+    #
+    # `hotfix/*` and `release/*` are exempt: the rule lets them PR to `main` and does not prescribe
+    # develop as their base. Feature branches are what it prescribes, and what this checks.
+    if [[ -n "$NEW_BRANCH" ]] && ! stmt_override BRANCH_GUARD_ALLOW_BASE &&
+      ! [[ "$NEW_BRANCH" =~ ^(hotfix|release)/ ]]; then
+      # The start point, when the command names one: the token after the branch name. A `&&`, a `;` or
+      # another flag is not a start point — those mean the command simply ended.
+      # Flags may sit between the new branch name and the start point: `git checkout -b feat/x --track
+      # origin/main` puts `--track` where the start point was being read, so the check compared HEAD
+      # instead and passed while the branch came from `origin/main` — the exact creation this exists to
+      # refuse, waved through by one common flag.
+      START_POINT=$(hook_match_extract "$COMMAND" \
+        '(^|[ \t;&|({\n"\047`])git[ \t]+((-C|-c)[ \t]+[^ \t\n]+[ \t]+|-[^ \t\n]+[ \t]+)*(checkout|switch)[ \t]+(-[^ \t\n]+[ \t]+)*-[bBcC][ \t]+[^ \t\n]+[ \t]+(-[^ \t\n]+[ \t]+)*' \
+          "$STMT_START" "$STMT_LEN" || true)
+      # A start point is a git ref, and the token holding it may be glued to what follows.
+      #
+      # Blanking the whole token whenever it contained an operator was worse than the bug it replaced:
+      # `git checkout -b feat/x main;` reads as one token `main;`, git cuts from `main`, and blanking
+      # it fell back to HEAD — so a base of `main` passed whenever HEAD happened to be develop. A
+      # fail-OPEN, where the version before it at least failed to resolve and refused.
+      #
+      # So the token is TRUNCATED at the first operator rather than discarded, and a redirection is
+      # recognised by its shape — `2>&1`, `>/dev/null` — instead of by containing an operator at all.
+      # `git checkout -b feat/x 2>&1 | head` is an ordinary creation and must not be refused; that one
+      # was measured, blocking the creation of the branch this check was fixed on.
+      # A redirection, in either direction, with or without a file-descriptor number: `2>&1`,
+      # `>/dev/null`, `3<file`, `<in`. Those are not start points at all.
+      #
+      # The descriptor and the operator must be ADJACENT. Written as the glob `[0-9]*'>'*` this read
+      # "a digit, then anything, then `>`" — so `2fa-base>/tmp/out.log` matched, and a real ref whose
+      # name begins with a digit was blanked and fell back to HEAD. The same fail-open this whole arm
+      # exists to prevent, reintroduced for every start point starting with a number. So the leading
+      # run of digits is stripped and the NEXT character decides.
+      START_POINT_AFTER_FD="${START_POINT#"${START_POINT%%[!0-9]*}"}"
+      case "$START_POINT_AFTER_FD" in '>'* | '<'*) START_POINT="" ;; esac
 
-# Block commit on all protected branches
-# Exception: allow merge commits (when .git/MERGE_HEAD exists — completing a git merge)
-if [[ "$IS_COMMIT" == "true" ]]; then
-  MERGE_IN_PROGRESS=false
-  [[ -f "$PROJECT_DIR/.git/MERGE_HEAD" ]] && MERGE_IN_PROGRESS=true
-  if [[ "$MERGE_IN_PROGRESS" == "false" ]]; then
-    for branch in main master develop; do
+      case "$START_POINT" in
+        -* | '') START_POINT="" ;;
+        *) START_POINT="${START_POINT%%[\<\>\|\&\;]*}" ;;
+      esac
+
+      # The SESSION's repository, not `PROJECT_DIR`. `PROJECT_DIR` prefers a `git -C <path>` found
+      # anywhere in the command, and in a compound command that `-C` usually belongs to some other
+      # invocation — `git checkout -b feat/x && git -C <other> status` would have this check judge
+      # <other>, which is not where the branch lands. Measured: that shape blocked a legitimate
+      # creation. Stated limit: `git -C <other> checkout -b` is judged against the session repository
+      # rather than <other>; branches are created where the session is, and erring that way
+      # over-permits a rare form instead of refusing a common one.
+      # The `session` mode is exactly that rule, named: hook `cwd` > project dir, `git -C` ignored.
+      BASE_DIR=$(hook_effective_repo session "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
+
+      WANTED=origin/develop
+      hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" >/dev/null 2>&1 || WANTED=develop
+      WANTED_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$WANTED" 2>/dev/null || echo "")
+      BASE_REF="${START_POINT:-HEAD}"
+      BASE_SHA=$(hook_git_in "$BASE_DIR" rev-parse --verify --quiet "$BASE_REF" 2>/dev/null || echo "")
+      # `branch --show-current` exits 0 with empty output on a detached HEAD, so `|| echo HEAD` never
+      # fired and the refusal named nothing. The default belongs on the VALUE, not on the exit code —
+      # which is what hook_current_branch does, for every caller, once.
+      BASE_NAME="${START_POINT:-$(hook_current_branch "$BASE_DIR" HEAD)}"
+
+      if [[ -z "$WANTED_SHA" || -z "$BASE_SHA" ]]; then
+        echo "[branch-guard] Blocked: cannot resolve the base for '$NEW_BRANCH'." >&2
+        echo "[branch-guard]   wanted: $WANTED   found: ${BASE_NAME:-<unresolved>}" >&2
+        echo "[branch-guard] Fetch first (git fetch origin), or override: BRANCH_GUARD_ALLOW_BASE=1" >&2
+        exit 2
+      fi
+
+      if [[ "$BASE_SHA" != "$WANTED_SHA" ]]; then
+        echo "[branch-guard] Blocked: '$NEW_BRANCH' would be cut from the wrong base." >&2
+        echo "[branch-guard]   found:  $BASE_NAME ($(printf '%.9s' "$BASE_SHA"))" >&2
+        echo "[branch-guard]   wanted: $WANTED ($(printf '%.9s' "$WANTED_SHA"))" >&2
+        echo "[branch-guard] git-branch.md: feature branches are cut from a freshly-fetched origin/develop." >&2
+        echo "[branch-guard] Do: git fetch origin && git checkout -b $NEW_BRANCH origin/develop" >&2
+        echo "[branch-guard] Deliberate exception: BRANCH_GUARD_ALLOW_BASE=1" >&2
+        exit 2
+      fi
+    fi
+
+    BRANCH_NAME_RE='^(feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)/[a-z0-9][a-z0-9._/-]*$'
+    EXEMPT_RE='^(main|master|develop|gh-pages)$'
+    if [[ -n "$NEW_BRANCH" ]] && ! stmt_override BRANCH_GUARD_ALLOW_BADNAME &&
+      ! [[ "$NEW_BRANCH" =~ $EXEMPT_RE ]] && ! [[ "$NEW_BRANCH" =~ $BRANCH_NAME_RE ]]; then
+      echo "[branch-guard] Blocked: branch name '$NEW_BRANCH' does not match <type>/<desc>." >&2
+      echo "[branch-guard] Expected e.g. feat/x-y, fix/z, chore/w" >&2
+      echo "[branch-guard] (types: feat|fix|chore|docs|refactor|test|perf|build|ci|style|revert|release|hotfix)." >&2
+      echo "[branch-guard] Override: BRANCH_GUARD_ALLOW_BADNAME=1" >&2
+      exit 2
+    fi
+  fi
+
+  # Block commit on all protected branches
+  # Exception: allow merge commits (when .git/MERGE_HEAD exists — completing a git merge)
+  if [[ "$IS_COMMIT" == "true" ]]; then
+    MERGE_IN_PROGRESS=false
+    [[ -f "$PROJECT_DIR/.git/MERGE_HEAD" ]] && MERGE_IN_PROGRESS=true
+    if [[ "$MERGE_IN_PROGRESS" == "false" ]]; then
+      for branch in main master develop; do
+        if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+          echo "[branch-guard] Blocked: cannot git commit on protected branch '${branch}'. Create a feature branch first." >&2
+          exit 2
+        fi
+      done
+    fi
+  fi
+
+  # Block push on main/master only (develop push after merge is allowed)
+  # Exception: BRANCH_GUARD_ALLOW_MAIN_MERGE=1 for explicitly user-approved release pushes
+  if [[ "$IS_PUSH" == "true" ]] && ! stmt_override BRANCH_GUARD_ALLOW_MAIN_MERGE; then
+    for branch in main master; do
       if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
-        echo "[branch-guard] Blocked: cannot git commit on protected branch '${branch}'. Create a feature branch first." >&2
+        echo "[branch-guard] Blocked: cannot git push on protected branch '${branch}'." >&2
         exit 2
       fi
     done
   fi
-fi
 
-# Block push on main/master only (develop push after merge is allowed)
-# Exception: BRANCH_GUARD_ALLOW_MAIN_MERGE=1 for explicitly user-approved release pushes
-if [[ "$IS_PUSH" == "true" && "${BRANCH_GUARD_ALLOW_MAIN_MERGE:-0}" != "1" ]]; then
-  for branch in main master; do
-    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
-      echo "[branch-guard] Blocked: cannot git push on protected branch '${branch}'." >&2
-      exit 2
-    fi
-  done
-fi
+  # Block merge into main/master (release merge requires explicit user approval via PR)
+  # Exception: BRANCH_GUARD_ALLOW_MAIN_MERGE=1 for explicitly user-approved release merges
+  if [[ "$IS_MERGE" == "true" ]] && ! stmt_override BRANCH_GUARD_ALLOW_MAIN_MERGE; then
+    for branch in main master; do
+      if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+        echo "[branch-guard] Blocked: cannot git merge into '${branch}'. Use a PR or get explicit user approval for release merges." >&2
+        exit 2
+      fi
+    done
+  fi
 
-# Block merge into main/master (release merge requires explicit user approval via PR)
-# Exception: BRANCH_GUARD_ALLOW_MAIN_MERGE=1 for explicitly user-approved release merges
-if [[ "$IS_MERGE" == "true" && "${BRANCH_GUARD_ALLOW_MAIN_MERGE:-0}" != "1" ]]; then
-  for branch in main master; do
-    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
-      echo "[branch-guard] Blocked: cannot git merge into '${branch}'. Use a PR or get explicit user approval for release merges." >&2
-      exit 2
-    fi
-  done
-fi
+done <<< "$STATEMENT_RANGES"
 
 exit 0

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -562,6 +562,47 @@ HOOK_SCAN_AWK='
     mask = ""
     for (i = 1; i <= len; i++) { mask = mask m[i] }
 
+    # ---- the STATEMENTS of this command ----
+    #
+    # A Bash tool call is a SEQUENCE of statements and each guarded action belongs to exactly one of
+    # them. `branch-guard.sh` used to answer for all of them at once — booleans over the whole
+    # command, and a single NEW_BRANCH / START_POINT / DELETE_BRANCH_NAME taken from the FIRST match
+    # anywhere, because `match()` returns the first match only. Any action then escaped judgement
+    # behind any well-formed sibling; measured, with no override token involved:
+    #   git checkout -b feat/x develop ; git checkout -b feat/y main  -> exit 0 (wrong base unjudged)
+    #   git checkout -b feat/ok ; git checkout -b BAD_NAME            -> exit 0 (bad name unjudged)
+    #
+    # The boundary is looked for in the MASK, never in the original: a `;` inside a quoted argument
+    # or a heredoc body is \001 there and cannot split a statement that is not one. A NEWLINE is a
+    # separator too — leaving it out is how the next spelling of this defect would arrive, and it is
+    # safe here for the same reason, because every mode below reads the FULL-CONTEXT mask through a
+    # window rather than re-masking a slice.
+    if (MODE == "ranges") {
+      start = 1
+      for (i = 1; i <= len; i++) {
+        c = substr(mask, i, 1)
+        if (c == ";" || c == "&" || c == "|" || c == "\n") {
+          if (i > start) { print start " " (i - start) }
+          start = i + 1
+        }
+      }
+      if (len >= start) { print start " " (len - start + 1) }
+      exit
+    }
+
+    # ---- the WINDOW ----
+    #
+    # Applied to the mask and the original TOGETHER, so the offsets stay aligned. That alignment is
+    # what lets a caller ask about ONE statement without losing the context that decided what is
+    # data: the command was masked whole, and only the READING is narrowed.
+    ws = (WSTART == "" ? 1 : WSTART + 0)
+    if (ws < 1) { ws = 1 }
+    wl = (WLEN == "" ? len - ws + 1 : WLEN + 0)
+    if (wl < 0) { wl = 0 }
+    if (ws + wl - 1 > len) { wl = len - ws + 1 }
+    s = substr(s, ws, wl)
+    mask = substr(mask, ws, wl)
+
     if (MODE == "mask") { print mask; exit }
 
     # Where an unquoted VALUE ends. Whitespace and quotes were the whole list, so a value read
@@ -605,16 +646,34 @@ HOOK_SCAN_AWK='
   }
 '
 
+# THE WINDOW, shared by every reader below (INFRA-079, #1563).
+#
+# Each of these takes an optional trailing (START, LENGTH) naming ONE statement of the command, as
+# produced by `hook_statement_ranges`. Omitted, the reader answers about the whole command, which is
+# what every pre-#1563 caller asked for. Given, it answers about that statement alone — while still
+# masking the command WHOLE, so the reading of what is data never changes because a caller narrowed
+# its question.
+#
+# The window is not a second parser and not a second reading: it is the same mask, read through a
+# smaller opening. That is deliberate. A per-statement judgement built by re-masking each slice
+# would be a THIRD reading of a command, in the file whose subject is that there must be one.
+
+# The STATEMENTS of a command, one `START LENGTH` line each, in the order they will run.
+hook_statement_ranges() {
+  printf '%s\n' "$1" | awk -v MODE=ranges -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="" -v VRE="" -v WSTART="" -v WLEN="" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
+}
+
 # Print the token that follows a match, located where quotes cannot lie. $2 is an ERE ending where
-# the value begins.
+# the value begins. $3/$4 optionally narrow the reading to one statement.
 hook_match_extract() {
-  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=extract -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="" -v WSTART="${3:-}" -v WLEN="${4:-}" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
 # Like hook_match_extract, but the value is found by $3 searched in the ORIGINAL starting at the
 # anchor $2's position in the mask. For values that legitimately live inside a quoted argument.
+# $4/$5 optionally narrow the reading to one statement.
 hook_match_extract_after() {
-  printf '%s\n' "$1" | awk -v MODE=after -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="$3" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=after -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="$2" -v VRE="$3" -v WSTART="${4:-}" -v WLEN="${5:-}" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
 # What a verb-detection matcher should read — and, since #1572, the ONLY reading of a command this
@@ -626,7 +685,7 @@ hook_match_extract_after() {
 # what lets a comment inside a substitution end at its own newline rather than at the substitution's
 # closing paren. Those passes are gone; see the note where they stood.
 hook_verb_scan() {
-  printf '%s\n' "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="" -v VRE="" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
+  printf '%s\n' "$1" | awk -v MODE=mask -v IRE="$HOOK_INTERPRETER_RE" -v SRE="$HOOK_SHELL_INTERPRETER_RE" -v ERE="" -v VRE="" -v WSTART="${2:-}" -v WLEN="${3:-}" "$HOOK_TOKENIZER_AWK$HOOK_SCAN_AWK"
 }
 
 # Token classes here exclude the newline as well as space and tab. That matters in `branch-guard.sh`,
@@ -637,7 +696,7 @@ hook_verb_scan() {
 # dressed in a test that would pass either way.
 # The directory a command will act on, read from a real `git -C` and not from a quoted mention.
 hook_git_c_path() {
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t\n]+[ \t]+)*-C[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+((-c)[ \t]+[^ \t\n]+[ \t]+)*-C[ \t]+' "${2:-}" "${3:-}"
 }
 
 # The branch a remote-delete would remove, in either spelling the guard recognises.
@@ -649,22 +708,22 @@ hook_git_c_path() {
 # on unmasked text after every other check had moved off it.
 hook_deleted_branch() {
   local verbs name
-  verbs=$(hook_verb_scan "$1")
+  verbs=$(hook_verb_scan "$1" "${2:-}" "${3:-}")
 
   if printf '%s' "$verbs" | grep -qE 'gh[[:space:]]+api[^|;&]*-X[[:space:]]+DELETE[^|;&]*'; then
     # From the `gh api` call's own position, not from the start of the string. Taking the first
     # match anywhere meant `git commit -m "note /git/refs/heads/scratch" && gh api -X DELETE
     # .../heads/develop` reported scratch, so the protected-branch and merged-PR checks never saw
     # the branch actually being deleted.
-    name=$(hook_match_extract_after "$1" '(^|[ \t;&|({\n"\047`])gh[ \t]+api([ \t]|$)' '/git/refs/heads/')
+    name=$(hook_match_extract_after "$1" '(^|[ \t;&|({\n"\047`])gh[ \t]+api([ \t]|$)' '/git/refs/heads/' "${2:-}" "${3:-}")
     [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
   fi
 
   # `git push <remote> --delete <branch>` and `git push <remote> :<branch>`.
-  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t\n]+[ \t]+(--delete[ \t]+|:)')
+  name=$(hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+[^ \t\n]+[ \t]+(--delete[ \t]+|:)' "${2:-}" "${3:-}")
   [[ -n "$name" ]] && { printf '%s' "$name"; return 0; }
 
   # `git push --delete <remote> <branch>` — git accepts the flag before the remote, and the guard
   # never did. Pre-existing rather than new, but a delete this misses is a delete it permits.
-  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t\n]+[ \t]+'
+  hook_match_extract "$1" '(^|[ \t;&|({\n"\047`])git[ \t]+push[ \t]+--delete[ \t]+[^ \t\n]+[ \t]+' "${2:-}" "${3:-}"
 }

--- a/scripts/harness/__tests__/branch-guard-judges-each-statement.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-judges-each-statement.test.mjs
@@ -1,0 +1,234 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_SRC = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * INFRA-079 (#1563) — the guard judges a command; every decision belongs to a STATEMENT.
+ *
+ * A Bash tool call is a sequence of statements and each guarded action belongs to exactly one of
+ * them. `branch-guard.sh` collapsed that sequence twice: `IS_COMMIT`/`IS_PUSH`/`IS_MERGE`/
+ * `IS_BRANCH_CREATE` were booleans over the WHOLE command, and `NEW_BRANCH`/`START_POINT`/
+ * `DELETE_BRANCH_NAME` were single values taken from the FIRST match anywhere, because
+ * `hook_match_extract` uses awk `match()`. One aggregate verdict then answered for N actions.
+ *
+ * Measured on `develop`, with a bare control refused correctly and NO override token in either:
+ *
+ *   git checkout -b feat/y main                                   -> exit 2
+ *   git checkout -b feat/x develop ; git checkout -b feat/y main  -> exit 0   (wrong base unjudged)
+ *   git checkout -b BAD_NAME                                      -> exit 2
+ *   git checkout -b feat/ok ; git checkout -b BAD_NAME            -> exit 0   (bad name unjudged)
+ *
+ * This file states the property rather than the two shapes, because the two shapes are two
+ * spellings of one defect and the next spelling is by definition not on a list:
+ *
+ *     A statement that is refused on its own is refused in any company.
+ *
+ * Every guarded command is proved refused bare, every sibling is proved permitted bare, and then the
+ * cross product of the two over three separators must still refuse. The last section proves the
+ * guard is not simply refusing everything: an override on the guarded statement itself excuses it,
+ * and an override on a SIBLING does not.
+ */
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeTemp(prefix) {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  scratch.push(dir);
+  return dir;
+}
+
+/**
+ * A repository where `main` and `origin/develop` are DIFFERENT commits, checked out on a feature
+ * branch whose HEAD is `origin/develop`.
+ *
+ * All three properties are load-bearing: without the divergence "cut from main" is not a wrong base
+ * and the check has nothing to refuse; with HEAD elsewhere a creation with no start point would be
+ * refused for its base rather than for its name; and on a protected branch an ordinary sibling
+ * commit would be refused for a reason this file is not about.
+ */
+function scratchRepo() {
+  const dir = makeTemp('bg-stmt-repo-');
+  const run = (...args) =>
+    execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+  run('init', '--quiet', '--initial-branch=develop');
+  writeFileSync(path.join(dir, 'a.txt'), 'a\n');
+  run('add', '-A');
+  run('commit', '--quiet', '-m', 'chore: one');
+  run('branch', 'main');
+  writeFileSync(path.join(dir, 'b.txt'), 'b\n');
+  run('add', '-A');
+  run('commit', '--quiet', '-m', 'chore: two');
+  run('update-ref', 'refs/remotes/origin/develop', 'develop');
+  run('checkout', '--quiet', '-b', 'feat/base');
+  run('remote', 'add', 'origin', 'https://example.invalid/scratch.git');
+  return dir;
+}
+
+/** The hooks tree, copied out of any worktree path, plus a `gh` that fails rather than reaching out. */
+function hooksSandbox() {
+  const dir = makeTemp('bg-stmt-hooks-');
+  const hooks = path.join(dir, '.claude', 'hooks');
+  mkdirSync(path.dirname(hooks), { recursive: true });
+  cpSync(HOOKS_SRC, hooks, { recursive: true });
+  const bin = path.join(dir, 'bin');
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(path.join(bin, 'gh'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+  chmodSync(path.join(bin, 'gh'), 0o755);
+  return { hook: path.join(hooks, 'branch-guard.sh'), bin };
+}
+
+let repo;
+let sandbox;
+
+beforeAll(() => {
+  repo = scratchRepo();
+  sandbox = hooksSandbox();
+});
+
+function verdict(command) {
+  const result = spawnSync('bash', [sandbox.hook], {
+    input: JSON.stringify({ tool_name: 'Bash', tool_input: { command }, cwd: repo }),
+    encoding: 'utf8',
+    cwd: repo,
+    // Only PATH, HOME and the project dir. Every BRANCH_GUARD_ALLOW_* is absent by construction, so
+    // nothing below can pass because the environment permitted it.
+    env: {
+      PATH: `${sandbox.bin}:${process.env.PATH}`,
+      HOME: process.env.HOME,
+      CLAUDE_PROJECT_DIR: repo,
+    },
+    timeout: 60_000,
+  });
+  return result.status ?? -1;
+}
+
+/** Refused on its own, and none of them carries an override token of any kind. */
+const GUARDED = [
+  ['a branch cut from the wrong base', 'git checkout -b feat/y main'],
+  ['a branch name that breaks the convention', 'git checkout -b BAD_NAME'],
+  ['a protected-branch delete', 'git push origin --delete develop'],
+];
+
+/** Permitted on its own. */
+const SIBLINGS = [
+  ['a correct creation', 'git checkout -b feat/ok develop'],
+  ['a read-only git call', 'git status'],
+  ['something that is not git at all', 'echo done'],
+];
+
+/**
+ * `;`, `&&` and a NEWLINE. The newline is the one that matters most: it is the separator the
+ * previous statement-splitting in this directory did not recognise, so a fix that closed only the
+ * `;` spelling would have shipped the next hole with it.
+ */
+const SEPARATORS = [
+  ['a semicolon', ' ; '],
+  ['an and-list', ' && '],
+  ['a newline', '\n'],
+];
+
+describe('a statement refused on its own is refused in any company (INFRA-079)', () => {
+  it('refuses every guarded statement when it is written alone', () => {
+    // The controls. Without these the cross product below is satisfied by a guard that refuses
+    // everything, and with these it cannot be.
+    const wrong = GUARDED.filter(([, command]) => verdict(command) !== 2).map(([name]) => name);
+    expect(
+      wrong,
+      'a guarded command that is not refused bare proves nothing about company',
+    ).toStrictEqual([]);
+  });
+
+  it('permits every sibling when it is written alone', () => {
+    // And these. A sibling that is itself refused would make the cross product hold for the wrong
+    // reason — the compound would be refused whatever the guard did with the guarded half.
+    const wrong = SIBLINGS.filter(([, command]) => verdict(command) !== 0).map(([name]) => name);
+    expect(
+      wrong,
+      'a sibling that is refused on its own is not a sibling, it is a second defect',
+    ).toStrictEqual([]);
+  });
+
+  for (const [sepName, sep] of SEPARATORS) {
+    it(`still refuses it behind a well-formed sibling, joined by ${sepName}`, () => {
+      const escaped = [];
+      for (const [guardedName, guarded] of GUARDED) {
+        for (const [siblingName, sibling] of SIBLINGS) {
+          // Both orders. The old reading took the FIRST match anywhere, so a guarded statement in
+          // second position escaped and one in first position did not — testing one order would
+          // have called the defect closed while half of it was live.
+          if (verdict(`${sibling}${sep}${guarded}`) !== 2) {
+            escaped.push(`${guardedName} AFTER ${siblingName}`);
+          }
+          if (verdict(`${guarded}${sep}${sibling}`) !== 2) {
+            escaped.push(`${guardedName} BEFORE ${siblingName}`);
+          }
+        }
+      }
+      expect(
+        escaped,
+        'a guarded statement went unjudged because a sibling was well-formed. The verdict was ' +
+          'about the command; every decision belongs to a statement.',
+      ).toStrictEqual([]);
+    });
+  }
+});
+
+describe('an override excuses the statement it prefixes, and only that one (INFRA-079)', () => {
+  it('excuses the guarded statement it prefixes', () => {
+    // The guard is not refusing everything: written the way git-branch.md documents, the override
+    // works, alone and beside a sibling.
+    expect(verdict('BRANCH_GUARD_ALLOW_BASE=1 git checkout -b feat/y main')).toBe(0);
+    expect(verdict('BRANCH_GUARD_ALLOW_BADNAME=1 git checkout -b BAD_NAME')).toBe(0);
+    expect(
+      verdict(
+        'git checkout -b feat/ok develop ; BRANCH_GUARD_ALLOW_BASE=1 git checkout -b feat/y main',
+      ),
+    ).toBe(0);
+    expect(
+      verdict(
+        'BRANCH_GUARD_ALLOW_BASE=1 git checkout -b feat/y main ; git checkout -b feat/ok develop',
+      ),
+    ).toBe(0);
+  });
+
+  it('does not let an override on one statement excuse another', () => {
+    // The two cases #1559 closed with a counting invariant over the whole command. They stay closed
+    // now that the subject is the statement — and they close for a reason rather than by a count.
+    expect(
+      verdict(
+        'BRANCH_GUARD_ALLOW_BASE=1 git checkout -b feat/x main ; git checkout -b feat/y main',
+      ),
+    ).toBe(2);
+    expect(
+      verdict('BRANCH_GUARD_ALLOW_BADNAME=1 git checkout -b BAD_ONE ; git checkout -b BAD_TWO'),
+    ).toBe(2);
+    expect(
+      verdict(
+        'BRANCH_GUARD_ALLOW_DELETE=1 git push origin --delete scratch-1 ; git push origin --delete develop',
+      ),
+    ).toBe(2);
+  });
+
+  it('reads an override off the command, never off text inside it', () => {
+    // The oldest spelling of this defect: a commit MESSAGE that merely names the token switched the
+    // guard off. It is data, and the override is read from the masked statement.
+    expect(
+      verdict(
+        'git commit -m "tried BRANCH_GUARD_ALLOW_DELETE=1" ; git push origin --delete develop',
+      ),
+    ).toBe(2);
+  });
+});

--- a/scripts/harness/__tests__/guards-fail-closed.test.mjs
+++ b/scripts/harness/__tests__/guards-fail-closed.test.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -121,4 +122,86 @@ describe('no hook crashes instead of deciding', () => {
       }
     });
   }
+
+  it('branch-guard refuses when the statement split itself cannot run', () => {
+    // A NEW way to be unable to look, introduced by INFRA-079 (#1563) and closed with it.
+    //
+    // Since #1563 the guard runs its judgement once per STATEMENT, over ranges `awk` computes. On a
+    // host without awk that list comes back empty — and an empty list is not "a command with nothing
+    // to judge", it is "the split did not run". Left unchecked the loop simply would not execute and
+    // the hook would exit 0.
+    //
+    // Measured against `origin/develop` on the same payload with awk hidden: the guard exited 127,
+    // which the hook protocol treats as NON-blocking, so `git push origin main` ON `main` was
+    // allowed. Same input here must be refused. This is the shape the whole file exists for — "I
+    // could not look" wearing the costume of "I looked and it was fine" — reached through the one
+    // tool the new seam depends on.
+    const bin = mkdtempSync(path.join(tmpdir(), 'guards-noawk-'));
+    const repo = mkdtempSync(path.join(tmpdir(), 'guards-noawk-repo-'));
+    try {
+      for (const tool of [
+        'bash',
+        'sh',
+        'git',
+        'grep',
+        'sed',
+        'python3',
+        'jq',
+        'cat',
+        'mktemp',
+        'rm',
+        'env',
+        'dirname',
+      ]) {
+        const resolved = spawnSync('bash', ['-c', `command -v ${tool} || true`], {
+          encoding: 'utf8',
+        }).stdout.trim();
+        if (resolved) symlinkSync(resolved, path.join(bin, tool));
+      }
+      for (const args of [
+        ['init', '--quiet', '--initial-branch=main'],
+        ['config', 'user.email', 'harness@example.test'],
+        ['config', 'user.name', 'Harness'],
+        ['commit', '--quiet', '--allow-empty', '-m', 'chore: root'],
+      ]) {
+        spawnSync('git', ['-C', repo, ...args], { encoding: 'utf8' });
+      }
+
+      // The control first: with awk present the same payload is refused for the RIGHT reason, so the
+      // case below cannot pass because the fixture was broken in some other way.
+      const payload = JSON.stringify({
+        tool_name: 'Bash',
+        cwd: repo,
+        tool_input: { command: 'git push origin main' },
+      });
+      const withAwk = spawnSync('bash', [path.join(HOOKS_DIR, 'branch-guard.sh')], {
+        input: payload,
+        encoding: 'utf8',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: repo },
+        timeout: 60_000,
+      });
+      expect(withAwk.status).toBe(2);
+      expect(`${withAwk.stderr ?? ''}`).toMatch(/protected branch/);
+
+      const withoutAwk = spawnSync(
+        path.join(bin, 'bash'),
+        [path.join(HOOKS_DIR, 'branch-guard.sh')],
+        {
+          input: payload,
+          encoding: 'utf8',
+          env: { PATH: bin, HOME: repo, CLAUDE_PROJECT_DIR: repo },
+          timeout: 60_000,
+        },
+      );
+      expect(
+        withoutAwk.status,
+        'branch-guard could not split the command into statements and did not refuse. An empty ' +
+          'statement list means the split did not run, not that there was nothing to judge:\n' +
+          `${withoutAwk.stdout ?? ''}${withoutAwk.stderr ?? ''}`,
+      ).toBe(2);
+    } finally {
+      rmSync(bin, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## The defect, measured before anything changed

A Bash tool call is a *sequence of statements* and each guarded action belongs to exactly one of
them. `branch-guard.sh` collapsed that sequence twice: the detection booleans were computed over the
**whole** command, and `NEW_BRANCH` / `START_POINT` / `DELETE_BRANCH_NAME` were single values taken
from the **first match anywhere**, because `hook_match_extract` uses awk `match()`. One aggregate
verdict then answered for N actions.

Every row is a real hook run on one scratch repository. **No row carries an override token.**

```
  exit=2 (want 2)    CONTROL  wrong base, alone
        "git checkout -b feat/y main"
        [branch-guard] Blocked: 'feat/y' would be cut from the wrong base.
  exit=0 (want 2) <<< WRONG  OPEN  wrong base behind a well-formed sibling
        "git checkout -b feat/x develop ; git checkout -b feat/y main"
  exit=2 (want 2)    CONTROL  bad name, alone
        "git checkout -b BAD_NAME"
        [branch-guard] Blocked: branch name 'BAD_NAME' does not match <type>/<desc>.
  exit=0 (want 2) <<< WRONG  OPEN  bad name behind a well-formed sibling
        "git checkout -b feat/ok ; git checkout -b BAD_NAME"
  exit=2 (want 2)    CONTROL  protected-branch delete, alone
  exit=2 (want 2)    OPEN     protected delete behind a harmless sibling delete
        [branch-guard] Blocked: cannot confirm a MERGED PR for 'scratch-1' ...
  exit=0 (want 0)    SANITY   a correct creation from develop
  exit=0 (want 0)    SANITY   two correct creations
```

The third pair is worth reading closely: it *refused*, but it named `scratch-1` — the first delete in
the command, not the protected one. A guard refusing for the wrong reason about the wrong branch is
one branch name away from refusing nothing.

After: all eight rows are correct.

## The seam

`lib/command-scan.sh` grows the aligned split the issue names — **not a second parser**:

- `hook_statement_ranges` returns the `(start, length)` of each statement, found by looking for
  separators **in the MASK**, so a `;` inside a quoted argument or a heredoc body splits nothing. A
  **newline** is a separator too; leaving it out is how the next spelling of this defect would have
  arrived, and the test pins all three.
- Every reader takes an optional trailing `(START, LENGTH)`. The window is applied to the mask and
  the original **together** — the invariant the file already relies on and states: *locate in the
  MASK, read the value from the ORIGINAL at the same offset*. The command is still masked **whole**
  and only the *reading* is narrowed, so narrowing the question cannot change what counts as data.

Re-masking each slice in isolation was considered and rejected: a heredoc body sits after a newline,
so a slice starting inside one would be read as commands — and it would have been a **third** reading
of a command, in the file whose subject is that there is one.

Probed by hand before anything depended on it — a quoted `;` does not split, a heredoc body splits
into all-`\001` slices that extract nothing, an override stays attached to its own statement,
subshells and pipes behave.

## What it lets `branch-guard.sh` do

Run its whole judgement per statement: detection, the `-C` resolution, every extraction, every check.

`override_given`'s counting invariant is **gone with the thing that needed it**. When the subject is
the statement, "every guarded statement carries its own override" is not a rule to enforce — it is
what asking each statement separately *means*. The containment note naming this item is removed
because the item is resolved.

Two things the counting invariant got wrong fall out, both measured:

- It **refused correctly-overridden work**:
  `BRANCH_GUARD_ALLOW_BASE=1 git checkout -b feat/y main ; git checkout -b feat/ok develop` exited 2,
  because the override had to prefix *every* creating statement and the second one needed no override
  at all.
- `GIT_C_PATH` was a first-match-anywhere value too, so `git -C /elsewhere status && git commit`
  judged `/elsewhere`'s branch and decided the commit — the same defect, one variable to the left.

## A new way to be blind, closed with it

The judgement now depends on `awk` producing the ranges. An empty list is **not** "a command with
nothing to judge", it is "the split did not run" — and left unchecked the loop would not execute and
the hook would exit 0. Measured against `origin/develop` with awk hidden from `PATH`:
`git push origin main` **on `main`** left the guard at exit 127, which the hook protocol treats as
non-blocking. It now exits 2. Pinned in `guards-fail-closed.test.mjs` with the awk-present control
beside it; reverse-applying just that block turns the case red.

## The test states the property, not the two shapes

The two filed cases are two spellings of one defect and the next spelling is by definition not on a
list. So:

> **A statement refused on its own is refused in any company.**

Three guarded commands proved refused bare × three siblings proved permitted bare × both orders ×
three separators (`;`, `&&`, newline), plus the override direction in both senses. Against the
unfixed guard, 4 of the 8 cases fail.

## False-positive sweep

625 real command lines taken from this tree (every fenced `git`/`gh`/`pnpm`/`npx`/`node` line in 1782
documents under `.agents/` and `docs/`, plus the root `package.json` scripts), each run through all
three Bash guards under both the baseline hooks and these:

```
0 verdict(s) moved out of 1875 runs.
NEWLY SEEN (the baseline allowed it, this refuses it): 0
NEWLY BLIND (the baseline refused it, this allows it): 0
```

Full suite green (129 files, 2154 tests); all 84 scans pass.

Closes #1563
