### PR TITLE
fix(harness): a worktree does not share its neighbour's stash

### DIFF
--- a/.agents/skills/worktree-parallel-orchestration/SKILL.md
+++ b/.agents/skills/worktree-parallel-orchestration/SKILL.md
@@ -61,6 +61,20 @@ Spawn each parallel implementer with the `Agent` tool's `isolation: "worktree"`.
 concurrent feature branch cut from a **freshly-fetched integration branch**, created with the branch-guard
 override the git rules define for exactly this case. Hand each agent its OWNED + FORBIDDEN lists verbatim.
 
+**Where the isolation stops.** A worktree owns its working tree and its index. It shares everything
+else in the clone, and an agent told to work "in isolation" will not assume that unless it is said:
+
+| Shared                          | Consequence measured 2026-08-01                                                                                                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `refs/stash`                    | one agent's bare `git stash push` + `pop` took **another agent's uncommitted work** into its own tree                                                                   |
+| `refs/stash`, via `lint-staged` | a concurrent stash destroyed the pre-commit backup: `lint-staged automatic backup is missing!` — the exposure is **every commit**, not only agents who type `git stash` |
+| `refs/` and the object store    | `branch-guard` enumerates branches across all worktrees, so every branch creation during a wave needs the open-branches override                                        |
+
+Two things follow, and both are now mechanical rather than advisory (INFRA-082): the pre-commit hook
+runs `lint-staged` under a clone-wide lock, and a bare stash command is refused while a sibling
+worktree exists. For a before/after comparison use `git archive` or a copy — no shared ref is
+involved, and it is what the agent that hit this switched to.
+
 ### 3. Sequence overlapping work behind occupants
 
 If a candidate item's territory overlaps the OWNED paths of a **currently-running** agent, **HOLD** it —

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -72,22 +72,6 @@ fi
 # the wrong subject. An override is given to ONE command: the one it precedes. So the only check
 # that closes it is asked of the destructive statement itself.
 
-# --- (b) worktree-assignment marker -------------------------------------------------------------
-# Present iff this session was spawned as a worktree-assigned subagent. Absent → ordinary main-clone
-# session → FAIL-SAFE, never block.
-# The marker the original design hoped for — `ROBOTA_AGENT_WORKTREE`, exported by the launcher —
-# is exported by nothing. Measured 2026-07-30: the only places that set it in this repository are
-# this guard's own tests, so in every real session the variable was empty and the guard exited here
-# before checking anything. Ten green tests, and a guard that had never once run (INFRA-068).
-#
-# The session's own cwd cannot answer the question, because a cwd that has fallen back to the main
-# checkout is the very condition being guarded. What can answer it is WHICH COPY OF THIS HOOK IS
-# RUNNING: a worktree session has `CLAUDE_PROJECT_DIR` pointing at its worktree, and
-# `.claude/settings.json` invokes the hook through that variable — so the file executing right now
-# lives under `.claude/worktrees/` exactly when this is a worktree session. That is supplied by the
-# deployment rather than hoped for from it.
-#
-# The env marker is still honoured, for a launcher that does export it.
 # --- The shared stash ------------------------------------------------------------------------
 #
 # Checked BEFORE the worktree-session gate below, and that placement is the point: the hazard is not
@@ -104,15 +88,28 @@ fi
 # never mechanically reached. This is the reaching. (INFRA-082)
 #
 # Read-only subcommands (`list`, `show`) are untouched — they cannot move anyone's work.
-STASH_CMD=$(hook_command_of "$INPUT" 2>/dev/null || true)
-STASH_VERBS=$(hook_verb_scan "$STASH_CMD" 2>/dev/null || true)
+# Fail closed on an unreadable command, matching this file's first read of the same payload and
+# hook-facts.sh's stated contract: a non-zero return means the value could NOT be read, and a guard
+# must refuse rather than treat it as an empty string that matches nothing.
+if ! STASH_CMD=$(hook_command_of "$INPUT"); then
+  echo "[worktree-cwd-guard] Blocked: the tool command could not be decoded, so it cannot be judged." >&2
+  exit 2
+fi
+if ! STASH_VERBS=$(hook_verb_scan "$STASH_CMD"); then
+  echo "[worktree-cwd-guard] Blocked: the command could not be scanned, so a stash cannot be ruled out." >&2
+  exit 2
+fi
 if printf '%s' "$STASH_VERBS" | grep -qE '(^|[;&|({[:space:]])[[:space:]]*git[[:space:]]+stash([[:space:]]|$)'; then
   BARE_STASH=false
   # A bare `git stash` / `git stash push` (creates an entry others may pop), or a `pop`/`apply`/
   # `drop` with no explicit `stash@{N}` (takes whatever is on top, which may be someone else's).
   printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]*(;|&|\||$)' && BARE_STASH=true
   printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(push|save)([[:space:]]|$)' && BARE_STASH=true
-  if printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(pop|apply|drop)([[:space:]]|$)'; then
+  # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
+  # yet — the worst of the set, and the one the first version of this list forgot.
+  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+clear([[:space:]]|$)' && BARE_STASH=true
+  # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named.
+  if printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(pop|apply|drop|branch)([[:space:]]|$)'; then
     printf '%s' "$STASH_VERBS" | grep -qE 'stash@\{' || BARE_STASH=true
   fi
   if [[ "$BARE_STASH" == "true" ]]; then
@@ -121,7 +118,17 @@ if printf '%s' "$STASH_VERBS" | grep -qE '(^|[;&|({[:space:]])[[:space:]]*git[[:
     # `hook_git_in`, not a bare `git -C`: with `GIT_DIR` exported, `git -C <dir>` reports the OUTER
     # repository, so the count would be another clone's. INFRA-077 measured that and this file's own
     # floor caught this line the moment it was written.
-    WORKTREE_COUNT=$(hook_git_in "$STASH_REPO" worktree list 2>/dev/null | grep -c . || echo 0)
+    # Read the list first, THEN count it. `git … | grep -c . || echo 0` yields the two-line string
+    # "0\n0" when git produces nothing — `grep -c` prints 0 and exits 1, so the `||` fires as well —
+    # and the arithmetic comparison below then errors and the guard falls OPEN. Measured, and it is
+    # the opposite of what this PR's own with-repo-lock.sh does when it cannot resolve its subject.
+    if ! WORKTREE_LIST=$(hook_git_in "$STASH_REPO" worktree list 2>/dev/null); then
+      echo "[worktree-cwd-guard] Blocked: cannot read the worktree list, so a shared stash cannot be" >&2
+      echo "[worktree-cwd-guard] ruled out. Name an explicit ref: git stash pop stash@{N}" >&2
+      exit 2
+    fi
+    WORKTREE_COUNT=$(printf '%s\n' "$WORKTREE_LIST" | grep -c . || true)
+    [[ "$WORKTREE_COUNT" =~ ^[0-9]+$ ]] || WORKTREE_COUNT=0
     if [[ "$WORKTREE_COUNT" -gt 1 ]]; then
       echo "[worktree-cwd-guard] Blocked: a bare stash command while this clone has $WORKTREE_COUNT worktrees." >&2
       echo "[worktree-cwd-guard] refs/stash is SHARED across every worktree — a bare push or pop can" >&2
@@ -133,6 +140,22 @@ if printf '%s' "$STASH_VERBS" | grep -qE '(^|[;&|({[:space:]])[[:space:]]*git[[:
   fi
 fi
 
+# --- (b) worktree-assignment marker -------------------------------------------------------------
+# Present iff this session was spawned as a worktree-assigned subagent. Absent → ordinary main-clone
+# session → FAIL-SAFE, never block.
+# The marker the original design hoped for — `ROBOTA_AGENT_WORKTREE`, exported by the launcher —
+# is exported by nothing. Measured 2026-07-30: the only places that set it in this repository are
+# this guard's own tests, so in every real session the variable was empty and the guard exited here
+# before checking anything. Ten green tests, and a guard that had never once run (INFRA-068).
+#
+# The session's own cwd cannot answer the question, because a cwd that has fallen back to the main
+# checkout is the very condition being guarded. What can answer it is WHICH COPY OF THIS HOOK IS
+# RUNNING: a worktree session has `CLAUDE_PROJECT_DIR` pointing at its worktree, and
+# `.claude/settings.json` invokes the hook through that variable — so the file executing right now
+# lives under `.claude/worktrees/` exactly when this is a worktree session. That is supplied by the
+# deployment rather than hoped for from it.
+#
+# The env marker is still honoured, for a launcher that does export it.
 IN_WORKTREE_SESSION=false
 SELF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo "")
 case "$SELF_DIR" in */.claude/worktrees/*) IN_WORKTREE_SESSION=true ;; esac

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -88,6 +88,51 @@ fi
 # deployment rather than hoped for from it.
 #
 # The env marker is still honoured, for a launcher that does export it.
+# --- The shared stash ------------------------------------------------------------------------
+#
+# Checked BEFORE the worktree-session gate below, and that placement is the point: the hazard is not
+# "I am inside a worktree", it is "this clone HAS more than one", which is equally true of the main
+# checkout. A guard that only fired inside worktrees would miss the main clone racing them.
+#
+# `refs/stash` is a single ref on the shared object store. `worktree-parallel-orchestration` promises
+# worktree-isolated agents, and the isolation is real for the working tree and the index — not for
+# this. Measured 2026-08-01 during a five-agent wave: one agent's bare `git stash push` + `pop` took
+# ANOTHER agent's uncommitted work into its own tree.
+#
+# git-branch.md has said "never a bare `git stash pop`, pop by explicit ref" since LESSON-005
+# (2026-06-15), and an agent did it anyway ten weeks later, because the rule was written down and
+# never mechanically reached. This is the reaching. (INFRA-082)
+#
+# Read-only subcommands (`list`, `show`) are untouched — they cannot move anyone's work.
+STASH_CMD=$(hook_command_of "$INPUT" 2>/dev/null || true)
+STASH_VERBS=$(hook_verb_scan "$STASH_CMD" 2>/dev/null || true)
+if printf '%s' "$STASH_VERBS" | grep -qE '(^|[;&|({[:space:]])[[:space:]]*git[[:space:]]+stash([[:space:]]|$)'; then
+  BARE_STASH=false
+  # A bare `git stash` / `git stash push` (creates an entry others may pop), or a `pop`/`apply`/
+  # `drop` with no explicit `stash@{N}` (takes whatever is on top, which may be someone else's).
+  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]*(;|&|\||$)' && BARE_STASH=true
+  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(push|save)([[:space:]]|$)' && BARE_STASH=true
+  if printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(pop|apply|drop)([[:space:]]|$)'; then
+    printf '%s' "$STASH_VERBS" | grep -qE 'stash@\{' || BARE_STASH=true
+  fi
+  if [[ "$BARE_STASH" == "true" ]]; then
+    STASH_REPO="${CLAUDE_PROJECT_DIR:-$(hook_cwd_of "$INPUT" 2>/dev/null || echo .)}"
+    # `git worktree list` counts the main checkout as one, so >1 means a sibling exists.
+    # `hook_git_in`, not a bare `git -C`: with `GIT_DIR` exported, `git -C <dir>` reports the OUTER
+    # repository, so the count would be another clone's. INFRA-077 measured that and this file's own
+    # floor caught this line the moment it was written.
+    WORKTREE_COUNT=$(hook_git_in "$STASH_REPO" worktree list 2>/dev/null | grep -c . || echo 0)
+    if [[ "$WORKTREE_COUNT" -gt 1 ]]; then
+      echo "[worktree-cwd-guard] Blocked: a bare stash command while this clone has $WORKTREE_COUNT worktrees." >&2
+      echo "[worktree-cwd-guard] refs/stash is SHARED across every worktree — a bare push or pop can" >&2
+      echo "[worktree-cwd-guard] take another agent's uncommitted work. It has already happened once." >&2
+      echo "[worktree-cwd-guard] Pop by explicit ref: git stash pop stash@{N}   (git-branch.md)" >&2
+      echo "[worktree-cwd-guard] To save state instead, copy the files — no shared ref is involved." >&2
+      exit 2
+    fi
+  fi
+fi
+
 IN_WORKTREE_SESSION=false
 SELF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo "")
 case "$SELF_DIR" in */.claude/worktrees/*) IN_WORKTREE_SESSION=true ;; esac

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -134,61 +134,12 @@ if printf '%s' "$VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
   # destructive-command override, and says so there: "the token sitting on a sibling command excuses
   # nothing". The new block did not reuse the split and reintroduced it. (#1585)
   #
-  # Same separators the override loop uses, and NO second comment pass.
-  #
-  # The round that closed the sibling-ref hole added `sed 's/#.*$//'` here, to stop a trailing
-  # `# stash@{0}` reading as a ref. It opened a new bypass instead: a `#` mid-word is not a comment,
-  # and that sed cannot tell the difference, so `echo a#b; git stash pop` lost everything after the
-  # `#` — including the bare pop. URL fragments and unquoted issue references are ordinary text.
-  #
-  # It was also unnecessary. `hook_verb_scan` already masks REAL comments — only a `#` at a word
-  # boundary opens one — which is visible in its output:
-  #   git stash pop  # stash@{0}   ->  git stash pop  \001\001\001…
-  #   echo a#b; git stash pop      ->  echo a#b; git stash pop
-  # A crude second pass layered on a correct first one is how a fix becomes the next bypass. (#1585)
-  STASH_STATEMENTS=$(printf '%s\n' "$VERBS" | sed -E 's/(\|\||&&|[;&|])/\n/g')
-  while IFS= read -r STMT; do
-    printf '%s' "$STMT" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}" || continue
-    # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
-    # with no subcommand keyword, and they add an entry another agent's bare pop can take. Matching
-    # only the literal words `push`/`save` let every one of them through. (#1585)
-    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]*$" && BARE_STASH=true
-    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]*(\)|\`)" && BARE_STASH=true
-    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(push|save)${STASH_END}" && BARE_STASH=true
-    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+-" && BARE_STASH=true
-    # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
-    # yet — the worst of the set, and the one the first version of this list forgot.
-    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+clear${STASH_END}" && BARE_STASH=true
-    # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named — and the
-    # ref must be in THIS statement.
-    if printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
-      printf '%s' "$STMT" | grep -qE 'stash@\{' || BARE_STASH=true
-    fi
-    # The repository is a property of THIS statement too. Read from the whole command,
-    # `hook_git_c_path` returned any `-C` anywhere — so `git -C /elsewhere fetch; git stash pop`
-    # counted /elsewhere's worktrees while the pop acted on the session repository. One worktree
-    # there and the guard waved it through: the same "`-C` points somewhere else" class an earlier
-    # round closed, arriving from a sibling statement. (#1585)
-    if [[ "$BARE_STASH" == "true" && -z "${BARE_STASH_C:-}" ]]; then
-      BARE_STASH_C=$(hook_git_c_path "$STMT" 2>/dev/null || printf '')
-    fi
-  done <<< "$STASH_STATEMENTS"
-  if [[ "$BARE_STASH" == "true" ]]; then
-    # The same resolver the destructive-command path uses, and NO `.` fallback. This file already
-    # documents why `.` was rejected there — "`.` is wherever the hook binary runs, not where the
-    # tool command runs — resolving its toplevel would judge an unrelated checkout (this caused a
-    # fail-safe bug)" — and I wrote that fallback back in here. With no `CLAUDE_PROJECT_DIR` and no
-    # payload `cwd`, the worktree count came from whatever repository the hook process happened to
-    # sit in: one worktree there, and a bare pop in the real, shared target was waved through.
-    #
-    # `hook_cwd_of` returns exit 0 with an EMPTY string when the field is absent — its stated
-    # contract — so a `||` fallback never fires for the ordinary case anyway. The resolver takes the
-    # first non-empty of the three, which is what "first-nonempty" means. (#1585)
-    STASH_REPO=$(hook_effective_repo first-nonempty \
-      "${BARE_STASH_C:-}" \
-      "$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')" \
-      "${CLAUDE_PROJECT_DIR:-}" 2>/dev/null || printf '')
-    if [[ -z "$STASH_REPO" ]]; then
+  # One judgement, called once per BARE statement — because each is judged against ITS OWN
+  # repository. Capturing the repo once let `git -C <scratch> stash push; git -C <shared> stash pop`
+  # be judged entirely against the scratch repo, and the second, genuinely bare pop went through.
+  stash_refuse_unless_single_worktree() {
+    local repo="$1" list count
+    if [[ -z "$repo" ]]; then
       # REFUSE, not fail-safe — and the difference from the destructive path is deliberate. A bare
       # pop always has a correct form (`stash@{N}`), so refusing costs the caller a ref they should
       # have written. A destructive command has no such substitute, which is why that path fails safe.
@@ -197,43 +148,91 @@ if printf '%s' "$VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
       echo "[worktree-cwd-guard] Name an explicit ref: git stash pop stash@{N}   (git-branch.md)" >&2
       exit 2
     fi
-    # `git worktree list` counts the main checkout as one, so >1 means a sibling exists.
     # `hook_git_in`, not a bare `git -C`: with `GIT_DIR` exported, `git -C <dir>` reports the OUTER
-    # repository, so the count would be another clone's. INFRA-077 measured that and this file's own
-    # floor caught this line the moment it was written.
+    # repository, so the count would be another clone's. INFRA-077 measured that, and this file's own
+    # floor caught the line the moment it was written.
+    #
     # Read the list first, THEN count it. `git … | grep -c . || echo 0` yields the two-line string
-    # "0\n0" when git produces nothing — `grep -c` prints 0 and exits 1, so the `||` fires as well —
-    # and the arithmetic comparison below then errors and the guard falls OPEN. Measured, and it is
-    # the opposite of what this PR's own with-repo-lock.sh does when it cannot resolve its subject.
-    if ! WORKTREE_LIST=$(hook_git_in "$STASH_REPO" worktree list 2>/dev/null); then
+    # "0\n0" when git produces nothing — `grep -c` prints 0 AND exits 1, so the `||` fires as well —
+    # and the arithmetic comparison then errors and the guard falls OPEN.
+    if ! list=$(hook_git_in "$repo" worktree list 2>/dev/null); then
       echo "[worktree-cwd-guard] Blocked: cannot read the worktree list, so a shared stash cannot be" >&2
       echo "[worktree-cwd-guard] ruled out. Name an explicit ref: git stash pop stash@{N}" >&2
       exit 2
     fi
-    WORKTREE_COUNT=$(printf '%s\n' "$WORKTREE_LIST" | grep -c . || true)
-    # A count that is not a number means the count was not read, and this file's stated policy —
-    # and with-repo-lock.sh's, in the same change — is that an unreadable subject is a refusal.
-    # Defaulting to 0 would read it as "one worktree" and wave the command through, which is the
-    # opposite policy written one line from the comment claiming the first. (#1585)
-    #
-    # No test covers this branch, and saying so is the honest form: `grep -c` always emits a number,
-    # so it is unreachable by construction. A test that appeared to exercise it would be passing for
-    # some other reason — the first attempt at one did exactly that, blocking because the fixture had
-    # two worktrees rather than because the count was unparseable.
-    if [[ ! "$WORKTREE_COUNT" =~ ^[0-9]+$ ]]; then
+    count=$(printf '%s\n' "$list" | grep -c . || true)
+    # A count that is not a number means the count was not read, and this file's stated policy is
+    # that an unreadable subject is a refusal. No test covers this branch and saying so is the honest
+    # form: `grep -c` always emits a number, so it is unreachable by construction. A test that
+    # appeared to exercise it would be passing for some other reason — the first attempt at one did
+    # exactly that, blocking because the fixture had two worktrees. (#1585)
+    if [[ ! "$count" =~ ^[0-9]+$ ]]; then
       echo "[worktree-cwd-guard] Blocked: the worktree count could not be read, so a shared stash" >&2
       echo "[worktree-cwd-guard] cannot be ruled out. Name an explicit ref: git stash pop stash@{N}" >&2
       exit 2
     fi
-    if [[ "$WORKTREE_COUNT" -gt 1 ]]; then
-      echo "[worktree-cwd-guard] Blocked: a bare stash command while this clone has $WORKTREE_COUNT worktrees." >&2
+    if [[ "$count" -gt 1 ]]; then
+      echo "[worktree-cwd-guard] Blocked: a bare stash command while this clone has $count worktrees." >&2
       echo "[worktree-cwd-guard] refs/stash is SHARED across every worktree — a bare push or pop can" >&2
       echo "[worktree-cwd-guard] take another agent's uncommitted work. It has already happened once." >&2
       echo "[worktree-cwd-guard] Pop by explicit ref: git stash pop stash@{N}   (git-branch.md)" >&2
       echo "[worktree-cwd-guard] To save state instead, copy the files — no shared ref is involved." >&2
       exit 2
     fi
+  }
+
+  # The statements come from `hook_statement_ranges`, and every reader below is given that
+  # statement's (START, LENGTH). The command is masked WHOLE and only the READING is narrowed.
+  #
+  # This replaces a `sed` split over the already-masked `$VERBS`, which was the root cause of the
+  # last two review rounds and which `command-scan.sh` warns against by name: "a per-statement
+  # judgement built by re-masking each slice would be a THIRD reading of a command, in the file whose
+  # subject is that there must be one." Both findings followed from it — a comment pass that could
+  # not tell a real comment from a `#` mid-word, and a `-C` extracted from mangled text where a
+  # quoted path with a space came back as `\001` bytes. The window is the facility that already
+  # exists for this. (#1585)
+  #
+  # Read from a here-string, never a PIPE: a `while` on the right of a pipe runs in a SUBSHELL, where
+  # the `exit 2` of a refusal would end only that subshell and the hook would carry on and exit 0 —
+  # a refusal that refuses nothing. `branch-guard.sh` records the same trap.
+  STASH_RANGES=$(hook_statement_ranges "$COMMAND" || printf '')
+  if [[ -z "${STASH_RANGES//[[:space:]]/}" ]]; then
+    echo "[worktree-cwd-guard] Blocked: the command names a stash and could not be split into" >&2
+    echo "[worktree-cwd-guard] statements, so nothing in it was judged. This is not a pass." >&2
+    exit 2
   fi
+  while read -r WSTART WLEN; do
+    [[ -n "$WSTART" && -n "$WLEN" ]] || continue
+    STMT=$(hook_verb_scan "$COMMAND" "$WSTART" "$WLEN" || printf '')
+    printf '%s' "$STMT" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}" || continue
+    STMT_BARE=false
+    # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
+    # with no subcommand keyword, and they add an entry another agent's bare pop can take. Matching
+    # only the literal words `push`/`save` let every one of them through. (#1585)
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]*$" && STMT_BARE=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]*(\)|\`)" && STMT_BARE=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(push|save)${STASH_END}" && STMT_BARE=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+-" && STMT_BARE=true
+    # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
+    # yet — the worst of the set, and the one the first version of this list forgot.
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+clear${STASH_END}" && STMT_BARE=true
+    # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named — and the
+    # ref must be in THIS statement.
+    if printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
+      printf '%s' "$STMT" | grep -qE 'stash@\{' || STMT_BARE=true
+    fi
+    [[ "$STMT_BARE" == "true" ]] || continue
+    BARE_STASH=true
+    # EVERY bare statement is judged against ITS OWN repository, not the first one's. Capturing the
+    # `-C` once let `git -C <scratch> stash push; git -C <shared> stash pop` be judged entirely
+    # against the scratch repo — the second, genuinely bare pop waved through. The `-C` is read from
+    # the RAW command through this statement's window, so a quoted path with a space survives. (#1585)
+    STASH_REPO=$(hook_effective_repo first-nonempty \
+      "$(hook_git_c_path "$COMMAND" "$WSTART" "$WLEN" 2>/dev/null || printf '')" \
+      "$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')" \
+      "${CLAUDE_PROJECT_DIR:-}" 2>/dev/null || printf '')
+    stash_refuse_unless_single_worktree "$STASH_REPO"
+  done <<< "$STASH_RANGES"
 fi
 
 # --- (b) worktree-assignment marker -------------------------------------------------------------

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -112,19 +112,35 @@ STASH_PRE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=)?[[:space:]]*'
 STASH_END='([^-[:alnum:]_]|$)'
 if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}git[[:space:]]+stash${STASH_END}"; then
   BARE_STASH=false
-  # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
-  # with no subcommand keyword, and they add an entry another agent's bare pop can take. Matching
-  # only the literal words `push`/`save` let every one of them through. (#1585)
-  printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]*(;|&|\||\)|\`|$)" && BARE_STASH=true
-  printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]+(push|save)${STASH_END}" && BARE_STASH=true
-  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+-' && BARE_STASH=true
-  # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
-  # yet — the worst of the set, and the one the first version of this list forgot.
-  printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]+clear${STASH_END}" && BARE_STASH=true
-  # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named.
-  if printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
-    printf '%s' "$STASH_VERBS" | grep -qE 'stash@\{' || BARE_STASH=true
-  fi
+  # PER STATEMENT, and a comment is not a statement.
+  #
+  # The ref check asked whether `stash@{` occurred ANYWHERE in the command. So a bare pop travelled
+  # free beside a well-formed sibling — `git stash pop; git stash pop stash@{0}` — and a trailing
+  # `# stash@{0}` was enough on its own. This file had already met that class further down, for the
+  # destructive-command override, and says so there: "the token sitting on a sibling command excuses
+  # nothing". The new block did not reuse the split and reintroduced it. (#1585)
+  #
+  # Same separators the override loop uses. Comments are stripped first, because a suppression a
+  # reader can write in prose is not a suppression.
+  STASH_STATEMENTS=$(printf '%s\n' "$STASH_VERBS" | sed -E 's/#.*$//' | sed -E 's/(\|\||&&|[;&|])/\n/g')
+  while IFS= read -r STMT; do
+    printf '%s' "$STMT" | grep -qE "${STASH_PRE}git[[:space:]]+stash${STASH_END}" || continue
+    # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
+    # with no subcommand keyword, and they add an entry another agent's bare pop can take. Matching
+    # only the literal words `push`/`save` let every one of them through. (#1585)
+    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]*$" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]*(\)|\`)" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]+(push|save)${STASH_END}" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE 'git[[:space:]]+stash[[:space:]]+-' && BARE_STASH=true
+    # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
+    # yet — the worst of the set, and the one the first version of this list forgot.
+    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]+clear${STASH_END}" && BARE_STASH=true
+    # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named — and the
+    # ref must be in THIS statement.
+    if printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
+      printf '%s' "$STMT" | grep -qE 'stash@\{' || BARE_STASH=true
+    fi
+  done <<< "$STASH_STATEMENTS"
   if [[ "$BARE_STASH" == "true" ]]; then
     # `hook_cwd_of` returns exit 0 with an EMPTY string when the field is absent — that is its stated
     # contract — so `|| echo .` never fires there and `git -C ""` would mean "no change" rather than

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -134,9 +134,19 @@ if printf '%s' "$VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
   # destructive-command override, and says so there: "the token sitting on a sibling command excuses
   # nothing". The new block did not reuse the split and reintroduced it. (#1585)
   #
-  # Same separators the override loop uses. Comments are stripped first, because a suppression a
-  # reader can write in prose is not a suppression.
-  STASH_STATEMENTS=$(printf '%s\n' "$VERBS" | sed -E 's/#.*$//' | sed -E 's/(\|\||&&|[;&|])/\n/g')
+  # Same separators the override loop uses, and NO second comment pass.
+  #
+  # The round that closed the sibling-ref hole added `sed 's/#.*$//'` here, to stop a trailing
+  # `# stash@{0}` reading as a ref. It opened a new bypass instead: a `#` mid-word is not a comment,
+  # and that sed cannot tell the difference, so `echo a#b; git stash pop` lost everything after the
+  # `#` — including the bare pop. URL fragments and unquoted issue references are ordinary text.
+  #
+  # It was also unnecessary. `hook_verb_scan` already masks REAL comments — only a `#` at a word
+  # boundary opens one — which is visible in its output:
+  #   git stash pop  # stash@{0}   ->  git stash pop  \001\001\001…
+  #   echo a#b; git stash pop      ->  echo a#b; git stash pop
+  # A crude second pass layered on a correct first one is how a fix becomes the next bypass. (#1585)
+  STASH_STATEMENTS=$(printf '%s\n' "$VERBS" | sed -E 's/(\|\||&&|[;&|])/\n/g')
   while IFS= read -r STMT; do
     printf '%s' "$STMT" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}" || continue
     # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
@@ -154,6 +164,14 @@ if printf '%s' "$VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
     if printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
       printf '%s' "$STMT" | grep -qE 'stash@\{' || BARE_STASH=true
     fi
+    # The repository is a property of THIS statement too. Read from the whole command,
+    # `hook_git_c_path` returned any `-C` anywhere — so `git -C /elsewhere fetch; git stash pop`
+    # counted /elsewhere's worktrees while the pop acted on the session repository. One worktree
+    # there and the guard waved it through: the same "`-C` points somewhere else" class an earlier
+    # round closed, arriving from a sibling statement. (#1585)
+    if [[ "$BARE_STASH" == "true" && -z "${BARE_STASH_C:-}" ]]; then
+      BARE_STASH_C=$(hook_git_c_path "$STMT" 2>/dev/null || printf '')
+    fi
   done <<< "$STASH_STATEMENTS"
   if [[ "$BARE_STASH" == "true" ]]; then
     # The same resolver the destructive-command path uses, and NO `.` fallback. This file already
@@ -167,7 +185,7 @@ if printf '%s' "$VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
     # contract — so a `||` fallback never fires for the ordinary case anyway. The resolver takes the
     # first non-empty of the three, which is what "first-nonempty" means. (#1585)
     STASH_REPO=$(hook_effective_repo first-nonempty \
-      "$(hook_git_c_path "$COMMAND" 2>/dev/null || printf '')" \
+      "${BARE_STASH_C:-}" \
       "$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')" \
       "${CLAUDE_PROJECT_DIR:-}" 2>/dev/null || printf '')
     if [[ -z "$STASH_REPO" ]]; then

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -110,7 +110,14 @@ fi
 # not a word character or `-`, which covers the closing backtick, `)`, `;` and end of line.
 STASH_PRE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=)?[[:space:]]*'
 STASH_END='([^-[:alnum:]_]|$)'
-if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}git[[:space:]]+stash${STASH_END}"; then
+# `git`, INCLUDING the global flags that may precede a subcommand — the same tolerance GITPFX below
+# already has. Written once and used by every match, because the fourth review finding on this change
+# was that the entry gate lacked it: `git -C <sibling-worktree> stash pop` skipped the whole check,
+# and a `-C` pointing at a sibling worktree is not an edge case — it is how one worktree reaches into
+# another. Three earlier findings on this same block were the same shape: a rule this file already
+# states, re-derived worse a few lines away. (#1585)
+STASH_GIT='git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*stash'
+if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
   BARE_STASH=false
   # PER STATEMENT, and a comment is not a statement.
   #
@@ -124,20 +131,20 @@ if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}git[[:space:]]+stash${STAS
   # reader can write in prose is not a suppression.
   STASH_STATEMENTS=$(printf '%s\n' "$STASH_VERBS" | sed -E 's/#.*$//' | sed -E 's/(\|\||&&|[;&|])/\n/g')
   while IFS= read -r STMT; do
-    printf '%s' "$STMT" | grep -qE "${STASH_PRE}git[[:space:]]+stash${STASH_END}" || continue
+    printf '%s' "$STMT" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}" || continue
     # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
     # with no subcommand keyword, and they add an entry another agent's bare pop can take. Matching
     # only the literal words `push`/`save` let every one of them through. (#1585)
-    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]*$" && BARE_STASH=true
-    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]*(\)|\`)" && BARE_STASH=true
-    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]+(push|save)${STASH_END}" && BARE_STASH=true
-    printf '%s' "$STMT" | grep -qE 'git[[:space:]]+stash[[:space:]]+-' && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]*$" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]*(\)|\`)" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(push|save)${STASH_END}" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+-" && BARE_STASH=true
     # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
     # yet — the worst of the set, and the one the first version of this list forgot.
-    printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]+clear${STASH_END}" && BARE_STASH=true
+    printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+clear${STASH_END}" && BARE_STASH=true
     # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named — and the
     # ref must be in THIS statement.
-    if printf '%s' "$STMT" | grep -qE "git[[:space:]]+stash[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
+    if printf '%s' "$STMT" | grep -qE "${STASH_GIT}[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
       printf '%s' "$STMT" | grep -qE 'stash@\{' || BARE_STASH=true
     fi
   done <<< "$STASH_STATEMENTS"

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -99,21 +99,41 @@ if ! STASH_VERBS=$(hook_verb_scan "$STASH_CMD"); then
   echo "[worktree-cwd-guard] Blocked: the command could not be scanned, so a stash cannot be ruled out." >&2
   exit 2
 fi
-if printf '%s' "$STASH_VERBS" | grep -qE '(^|[;&|({[:space:]])[[:space:]]*git[[:space:]]+stash([[:space:]]|$)'; then
+# ONE boundary pair, used by every match below.
+#
+# Review of #1585 found the entry gate missing the backtick, so `OUT=`git stash pop`` skipped the
+# whole guard. Fixing that in place then left the SAME defect one line down — `pop` followed by a
+# closing backtick failed the trailing `([[:space:]]|$)`. Five hand-written copies of "what ends a
+# word" is five chances to disagree, and two of them already had. So they are written once.
+#
+# The leading class matches this file's GITPFX; the trailing one is GITEND's rule — anything that is
+# not a word character or `-`, which covers the closing backtick, `)`, `;` and end of line.
+STASH_PRE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=)?[[:space:]]*'
+STASH_END='([^-[:alnum:]_]|$)'
+if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}git[[:space:]]+stash${STASH_END}"; then
   BARE_STASH=false
-  # A bare `git stash` / `git stash push` (creates an entry others may pop), or a `pop`/`apply`/
-  # `drop` with no explicit `stash@{N}` (takes whatever is on top, which may be someone else's).
-  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]*(;|&|\||$)' && BARE_STASH=true
-  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(push|save)([[:space:]]|$)' && BARE_STASH=true
+  # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
+  # with no subcommand keyword, and they add an entry another agent's bare pop can take. Matching
+  # only the literal words `push`/`save` let every one of them through. (#1585)
+  printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]*(;|&|\||\)|\`|$)" && BARE_STASH=true
+  printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]+(push|save)${STASH_END}" && BARE_STASH=true
+  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+-' && BARE_STASH=true
   # `clear` takes no argument and deletes EVERY entry, including ones another agent has not popped
   # yet — the worst of the set, and the one the first version of this list forgot.
-  printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+clear([[:space:]]|$)' && BARE_STASH=true
+  printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]+clear${STASH_END}" && BARE_STASH=true
   # `branch` and `pop`/`apply`/`drop` all take the TOP of the stack when no ref is named.
-  if printf '%s' "$STASH_VERBS" | grep -qE 'git[[:space:]]+stash[[:space:]]+(pop|apply|drop|branch)([[:space:]]|$)'; then
+  if printf '%s' "$STASH_VERBS" | grep -qE "git[[:space:]]+stash[[:space:]]+(pop|apply|drop|branch)${STASH_END}"; then
     printf '%s' "$STASH_VERBS" | grep -qE 'stash@\{' || BARE_STASH=true
   fi
   if [[ "$BARE_STASH" == "true" ]]; then
-    STASH_REPO="${CLAUDE_PROJECT_DIR:-$(hook_cwd_of "$INPUT" 2>/dev/null || echo .)}"
+    # `hook_cwd_of` returns exit 0 with an EMPTY string when the field is absent — that is its stated
+    # contract — so `|| echo .` never fires there and `git -C ""` would mean "no change" rather than
+    # the intended fallback. The default is applied to the VALUE, not to the exit code. (#1585)
+    STASH_REPO="${CLAUDE_PROJECT_DIR:-}"
+    if [[ -z "$STASH_REPO" ]]; then
+      STASH_REPO=$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')
+    fi
+    [[ -n "$STASH_REPO" ]] || STASH_REPO=.
     # `git worktree list` counts the main checkout as one, so >1 means a sibling exists.
     # `hook_git_in`, not a bare `git -C`: with `GIT_DIR` exported, `git -C <dir>` reports the OUTER
     # repository, so the count would be another clone's. INFRA-077 measured that and this file's own
@@ -128,7 +148,20 @@ if printf '%s' "$STASH_VERBS" | grep -qE '(^|[;&|({[:space:]])[[:space:]]*git[[:
       exit 2
     fi
     WORKTREE_COUNT=$(printf '%s\n' "$WORKTREE_LIST" | grep -c . || true)
-    [[ "$WORKTREE_COUNT" =~ ^[0-9]+$ ]] || WORKTREE_COUNT=0
+    # A count that is not a number means the count was not read, and this file's stated policy —
+    # and with-repo-lock.sh's, in the same change — is that an unreadable subject is a refusal.
+    # Defaulting to 0 would read it as "one worktree" and wave the command through, which is the
+    # opposite policy written one line from the comment claiming the first. (#1585)
+    #
+    # No test covers this branch, and saying so is the honest form: `grep -c` always emits a number,
+    # so it is unreachable by construction. A test that appeared to exercise it would be passing for
+    # some other reason — the first attempt at one did exactly that, blocking because the fixture had
+    # two worktrees rather than because the count was unparseable.
+    if [[ ! "$WORKTREE_COUNT" =~ ^[0-9]+$ ]]; then
+      echo "[worktree-cwd-guard] Blocked: the worktree count could not be read, so a shared stash" >&2
+      echo "[worktree-cwd-guard] cannot be ruled out. Name an explicit ref: git stash pop stash@{N}" >&2
+      exit 2
+    fi
     if [[ "$WORKTREE_COUNT" -gt 1 ]]; then
       echo "[worktree-cwd-guard] Blocked: a bare stash command while this clone has $WORKTREE_COUNT worktrees." >&2
       echo "[worktree-cwd-guard] refs/stash is SHARED across every worktree — a bare push or pop can" >&2

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -88,15 +88,22 @@ fi
 # never mechanically reached. This is the reaching. (INFRA-082)
 #
 # Read-only subcommands (`list`, `show`) are untouched — they cannot move anyone's work.
-# Fail closed on an unreadable command, matching this file's first read of the same payload and
-# hook-facts.sh's stated contract: a non-zero return means the value could NOT be read, and a guard
-# must refuse rather than treat it as an empty string that matches nothing.
-if ! STASH_CMD=$(hook_command_of "$INPUT"); then
-  echo "[worktree-cwd-guard] Blocked: the tool command could not be decoded, so it cannot be judged." >&2
-  exit 2
-fi
-if ! STASH_VERBS=$(hook_verb_scan "$STASH_CMD"); then
-  echo "[worktree-cwd-guard] Blocked: the command could not be scanned, so a stash cannot be ruled out." >&2
+# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: `VERBS` from the
+# tokenizer and `SCAN` from two line-oriented passes that did no quote masking at all. Measured on a
+# worktree session, with the bare form refused correctly:
+#   git -C <MAIN> reset --hard                                 -> exit 2
+#   echo "see <<EOF for details" ; git -C <MAIN> reset --hard  -> exit 0
+# The quoted `<<EOF` opened a heredoc the old reading never saw close, so the `git -C <MAIN>` after it
+# was deleted from the string this guard examined and the destructive command was allowed.
+#
+# Computed HERE, above the stash gate, and read by both checks. The stash block first ran the
+# tokenizer a second time on the same text — and since it runs before the worktree-session gate, that
+# doubled the cost on EVERY Bash call in every session, not only ones naming a stash. (#1585)
+#
+# Fail closed on an unreadable command: a non-zero return means the value could NOT be read, and a
+# guard must refuse rather than treat it as an empty string that matches nothing.
+if ! VERBS=$(hook_verb_scan "$COMMAND"); then
+  echo "[worktree-cwd-guard] Blocked: the command could not be scanned, so nothing can be judged." >&2
   exit 2
 fi
 # ONE boundary pair, used by every match below.
@@ -108,7 +115,7 @@ fi
 #
 # The leading class matches this file's GITPFX; the trailing one is GITEND's rule — anything that is
 # not a word character or `-`, which covers the closing backtick, `)`, `;` and end of line.
-STASH_PRE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=)?[[:space:]]*'
+STASH_PRE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*([^[:space:]]+=)?[[:space:]]*'
 STASH_END='([^-[:alnum:]_]|$)'
 # `git`, INCLUDING the global flags that may precede a subcommand — the same tolerance GITPFX below
 # already has. Written once and used by every match, because the fourth review finding on this change
@@ -117,7 +124,7 @@ STASH_END='([^-[:alnum:]_]|$)'
 # another. Three earlier findings on this same block were the same shape: a rule this file already
 # states, re-derived worse a few lines away. (#1585)
 STASH_GIT='git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*stash'
-if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
+if printf '%s' "$VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}"; then
   BARE_STASH=false
   # PER STATEMENT, and a comment is not a statement.
   #
@@ -129,7 +136,7 @@ if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}";
   #
   # Same separators the override loop uses. Comments are stripped first, because a suppression a
   # reader can write in prose is not a suppression.
-  STASH_STATEMENTS=$(printf '%s\n' "$STASH_VERBS" | sed -E 's/#.*$//' | sed -E 's/(\|\||&&|[;&|])/\n/g')
+  STASH_STATEMENTS=$(printf '%s\n' "$VERBS" | sed -E 's/#.*$//' | sed -E 's/(\|\||&&|[;&|])/\n/g')
   while IFS= read -r STMT; do
     printf '%s' "$STMT" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}" || continue
     # A bare `git stash`, or one whose next word is a FLAG — `-u`, `--all`, `-k` are implicit pushes
@@ -160,7 +167,7 @@ if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}";
     # contract — so a `||` fallback never fires for the ordinary case anyway. The resolver takes the
     # first non-empty of the three, which is what "first-nonempty" means. (#1585)
     STASH_REPO=$(hook_effective_repo first-nonempty \
-      "$(hook_git_c_path "$STASH_CMD" 2>/dev/null || printf '')" \
+      "$(hook_git_c_path "$COMMAND" 2>/dev/null || printf '')" \
       "$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')" \
       "${CLAUDE_PROJECT_DIR:-}" 2>/dev/null || printf '')
     if [[ -z "$STASH_REPO" ]]; then
@@ -238,15 +245,6 @@ if [[ "$IN_WORKTREE_SESSION" != "true" ]]; then
 fi
 
 # --- Detect destructive git commands ------------------------------------------------------------
-# ONE reading, by the grammar (INFRA-075, #1572). This hook used to hold two: `VERBS` from the
-# tokenizer and `SCAN` from two line-oriented passes that did no quote masking at all, and the `-C`
-# extraction below read `SCAN`. Measured on a worktree session, with the bare form refused correctly:
-#   git -C <MAIN> reset --hard                                 -> exit 2
-#   echo "see <<EOF for details" ; git -C <MAIN> reset --hard  -> exit 0
-# The quoted `<<EOF` opened a heredoc the old reading never saw close, so the `git -C <MAIN>` after it
-# was deleted from the string this guard examined, the effective repo fell back to the worktree, and a
-# `git reset --hard` on the MAIN checkout — the incident this file exists for — was allowed.
-VERBS=$(hook_verb_scan "$COMMAND")
 
 # GITPFX tolerates env prefixes and global git flags before the subcommand (`git -C <path> reset`,
 # `git -c k=v push`) — the same pattern branch-guard uses.

--- a/.claude/hooks/worktree-cwd-guard.sh
+++ b/.claude/hooks/worktree-cwd-guard.sh
@@ -149,14 +149,29 @@ if printf '%s' "$STASH_VERBS" | grep -qE "${STASH_PRE}${STASH_GIT}${STASH_END}";
     fi
   done <<< "$STASH_STATEMENTS"
   if [[ "$BARE_STASH" == "true" ]]; then
-    # `hook_cwd_of` returns exit 0 with an EMPTY string when the field is absent — that is its stated
-    # contract — so `|| echo .` never fires there and `git -C ""` would mean "no change" rather than
-    # the intended fallback. The default is applied to the VALUE, not to the exit code. (#1585)
-    STASH_REPO="${CLAUDE_PROJECT_DIR:-}"
+    # The same resolver the destructive-command path uses, and NO `.` fallback. This file already
+    # documents why `.` was rejected there — "`.` is wherever the hook binary runs, not where the
+    # tool command runs — resolving its toplevel would judge an unrelated checkout (this caused a
+    # fail-safe bug)" — and I wrote that fallback back in here. With no `CLAUDE_PROJECT_DIR` and no
+    # payload `cwd`, the worktree count came from whatever repository the hook process happened to
+    # sit in: one worktree there, and a bare pop in the real, shared target was waved through.
+    #
+    # `hook_cwd_of` returns exit 0 with an EMPTY string when the field is absent — its stated
+    # contract — so a `||` fallback never fires for the ordinary case anyway. The resolver takes the
+    # first non-empty of the three, which is what "first-nonempty" means. (#1585)
+    STASH_REPO=$(hook_effective_repo first-nonempty \
+      "$(hook_git_c_path "$STASH_CMD" 2>/dev/null || printf '')" \
+      "$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')" \
+      "${CLAUDE_PROJECT_DIR:-}" 2>/dev/null || printf '')
     if [[ -z "$STASH_REPO" ]]; then
-      STASH_REPO=$(hook_cwd_of "$INPUT" 2>/dev/null || printf '')
+      # REFUSE, not fail-safe — and the difference from the destructive path is deliberate. A bare
+      # pop always has a correct form (`stash@{N}`), so refusing costs the caller a ref they should
+      # have written. A destructive command has no such substitute, which is why that path fails safe.
+      echo "[worktree-cwd-guard] Blocked: a bare stash command, and no repository could be named," >&2
+      echo "[worktree-cwd-guard] so a shared stack cannot be ruled out." >&2
+      echo "[worktree-cwd-guard] Name an explicit ref: git stash pop stash@{N}   (git-branch.md)" >&2
+      exit 2
     fi
-    [[ -n "$STASH_REPO" ]] || STASH_REPO=.
     # `git worktree list` counts the main checkout as one, so >1 means a sibling exists.
     # `hook_git_in`, not a bare `git -C`: with `GIT_DIR` exported, `git -C <dir>` reports the OUTER
     # repository, so the count would be another clone's. INFRA-077 measured that and this file's own

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -38,4 +38,10 @@ if [ "${ALLOW_LESSONS_COMMIT:-0}" != "1" ]; then
   fi
 fi
 
-NODE_OPTIONS="--max-old-space-size=8192" pnpm exec lint-staged
+# Held across every worktree of this clone, because `lint-staged` backs up unstaged changes with
+# `git stash` and `refs/stash` is shared — a concurrent commit in a sibling worktree destroys the
+# backup and the commit fails with "lint-staged automatic backup is missing!", which is the state in
+# which uncommitted work is at risk. Measured during a five-agent parallel wave. (INFRA-082)
+NODE_OPTIONS="--max-old-space-size=8192" \
+  "$(git rev-parse --show-toplevel)/scripts/harness/with-repo-lock.sh" \
+  pnpm exec lint-staged

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -326,4 +326,38 @@ describe('a bare stash command is refused while the stack is shared', () => {
     const { status, output } = run(`git -C ${sibling} stash pop stash@{0}`, dir);
     expect(status, `the explicit form behind -C was refused: ${output}`).toBe(0);
   });
+
+  it('refuses when no directory can be named, instead of judging the hook own cwd', () => {
+    // Review of #1585, MUST — and the FIFTH time this change re-derived something this file already
+    // documents. Its own comment on EFFECTIVE_DIR says why `.` was rejected there: "`.` is wherever
+    // the hook binary runs, not where the tool command runs — resolving its toplevel would judge an
+    // unrelated checkout (this caused a fail-safe bug)". I wrote that fallback back in.
+    //
+    // The fixture makes the difference visible: the hook PROCESS sits in a repo with ONE worktree,
+    // and the payload names no directory at all. With the `.` fallback the count comes from that
+    // unrelated repo, reads 1, and a bare pop is waved through — while the repository the command
+    // would really act on is unknown and may well be shared.
+    //
+    // Refuse rather than fail-safe, and that differs from the destructive-command path deliberately:
+    // a bare pop always HAS a correct form (`stash@{N}`), so refusing costs the caller a ref they
+    // should have written anyway. The destructive path has no such substitute, which is why it
+    // fails safe instead.
+    //
+    // A first version of this case set `cwd` to the MULTI-worktree repo and passed on arrival — it
+    // blocked for the ordinary reason and proved nothing.
+    const unrelated = repoWithWorktrees(1);
+    const payload = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'git stash pop' } });
+    const result = spawnSync('bash', [HOOK], {
+      input: payload,
+      cwd: unrelated,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, HOME: process.env.HOME },
+      timeout: 120_000,
+    });
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    expect(
+      result.status ?? 1,
+      `a nameless directory was judged against the hook own cwd: ${output}`,
+    ).not.toBe(0);
+  });
 });

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -419,5 +419,48 @@ describe('a bare stash command is refused while the stack is shared', () => {
       run(`git -C ${shared} stash pop`, single).status,
       'the stash statement own -C was ignored',
     ).not.toBe(0);
+  });
+
+  it('judges every bare statement against its own repository', () => {
+    // Review of #1585, MUST. The `-C` was captured from whichever statement tripped bare FIRST and
+    // never re-derived, so two independently-bare stash operations against two different repos were
+    // both judged against the first one:
+    //
+    //     git -C <single-worktree scratch> stash push; git -C <shared> stash pop
+    //
+    // Count 1 from the scratch repo, whole command allowed — including the second, genuinely bare
+    // pop against the shared clone. That is the incident this guard exists for, reopened for the
+    // multi-statement case.
+    const scratch = repoWithWorktrees(1);
+    const shared = repoWithWorktrees(2);
+    expect(
+      run(`git -C ${scratch} stash push; git -C ${shared} stash pop`, scratch).status,
+      'the first statement repository answered for the second',
+    ).not.toBe(0);
+  });
+
+  it('reads a quoted -C path with a space', () => {
+    // Review of #1585, SHOULD. `hook_git_c_path` was handed `$STMT`, a slice of the ALREADY-MASKED
+    // command, so a quoted path containing whitespace came back as \001 bytes — non-empty, so the
+    // cwd/CLAUDE_PROJECT_DIR fallbacks never fired, and the guard blocked with "cannot read the
+    // worktree list": a false positive that also defeated the fallback chain.
+    //
+    // The `-C` is read from the RAW command through the statement's window now, which is what
+    // `hook_git_c_path`'s window parameters exist for.
+    const parent = mkdtempSync(path.join(tmpdir(), 'spaced-'));
+    scratch.push(parent);
+    const spaced = path.join(parent, 'a repo');
+    const git = (...a) => spawnSync('git', ['-C', spaced, ...a], { encoding: 'utf8' });
+    mkdirSync(spaced, { recursive: true });
+    git('init', '--quiet', '--initial-branch=main');
+    git('config', 'user.email', 'harness@example.test');
+    git('config', 'user.name', 'Harness');
+    writeFileSync(path.join(spaced, 'f'), 'x');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'root');
+
+    const { status, output } = run(`git -C "${spaced}" stash pop stash@{0}`, spaced);
+    expect(status, `a quoted path with a space was misread: ${output}`).toBe(0);
+    expect(output, `the guard spoke on a correct command: ${output}`).toBe('');
   });
 });

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -252,4 +252,24 @@ describe('a bare stash command is refused while the stack is shared', () => {
     });
     expect(status, `an unreadable worktree count waved the command through: ${output}`).not.toBe(0);
   });
+
+  it('is not escaped by a backtick or by a flag-only push', () => {
+    // Review of #1585, both real bypasses of the gate this PR exists to close.
+    //
+    // 1. The entry boundary class omitted the BACKTICK that this same file's GITPFX includes a few
+    //    lines below, for exactly this reason. `OUT=`git stash pop`` never reached the gate at all.
+    // 2. `git stash -u` / `--all` / `-k` are implicit pushes — they add an entry another agent's
+    //    bare pop can take — and matched none of the branches, which looked only for the literal
+    //    words `push`/`save`.
+    const dir = repoWithWorktrees(2);
+    for (const command of [
+      'OUT=`git stash pop`',
+      'OUT=$(git stash pop)',
+      'git stash -u',
+      'git stash --all',
+      'git stash -k',
+    ]) {
+      expect(run(command, dir).status, `a stash command escaped the gate: ${command}`).not.toBe(0);
+    }
+  });
 });

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -272,4 +272,32 @@ describe('a bare stash command is refused while the stack is shared', () => {
       expect(run(command, dir).status, `a stash command escaped the gate: ${command}`).not.toBe(0);
     }
   });
+
+  it('a ref on a sibling statement does not excuse a bare one', () => {
+    // Review of #1585, MUST. The ref check asked whether `stash@{` occurs ANYWHERE in the command,
+    // not whether the matched subcommand is the one carrying it. So a bare pop travelled free
+    // alongside a well-formed sibling — and a comment was enough.
+    //
+    // This file had already met and closed this class further down, for the destructive-command
+    // override: "excused only if the override prefixes THAT statement; the token sitting on a
+    // sibling command excuses nothing". The new block did not reuse that split and reintroduced it.
+    const dir = repoWithWorktrees(2);
+    for (const command of [
+      'git stash pop; git stash pop stash@{0}',
+      'git stash pop  # stash@{0}',
+      'git stash pop stash@{0} && git stash drop',
+    ]) {
+      expect(
+        run(command, dir).status,
+        `a ref on a sibling statement excused a bare one: ${command}`,
+      ).not.toBe(0);
+    }
+  });
+
+  it('still allows a command whose every stash statement names its ref', () => {
+    // The other direction, so the case above cannot be satisfied by refusing all compounds.
+    const dir = repoWithWorktrees(2);
+    const { status, output } = run('git stash pop stash@{0}; git stash drop stash@{1}', dir);
+    expect(status, `a fully-explicit compound was refused: ${output}`).toBe(0);
+  });
 });

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -300,4 +300,30 @@ describe('a bare stash command is refused while the stack is shared', () => {
     const { status, output } = run('git stash pop stash@{0}; git stash drop stash@{1}', dir);
     expect(status, `a fully-explicit compound was refused: ${output}`).toBe(0);
   });
+
+  it('is not escaped by a global git flag', () => {
+    // Review of #1585, MUST — and the FOURTH time in this PR that a rule already written down in
+    // this file was re-derived worse a few lines away. GITPFX tolerates `git -C <path>` and
+    // `git -c k=v` before the subcommand; the entry gate written beside it did not, so
+    // `git -C <sibling-worktree> stash pop` skipped the whole shared-stash check.
+    //
+    // A `-C` pointing at a SIBLING worktree is the sharpest form of the hazard, not an edge case:
+    // it is how one worktree reaches into another in the first place.
+    const dir = repoWithWorktrees(2);
+    const sibling = path.join(dir, 'wt-1');
+    for (const command of [
+      `git -C ${sibling} stash pop`,
+      `git -c core.editor=true stash`,
+      `git -C ${sibling} stash clear`,
+    ]) {
+      expect(run(command, dir).status, `a global flag escaped the gate: ${command}`).not.toBe(0);
+    }
+  });
+
+  it('still allows the explicit form behind a global flag', () => {
+    const dir = repoWithWorktrees(2);
+    const sibling = path.join(dir, 'wt-1');
+    const { status, output } = run(`git -C ${sibling} stash pop stash@{0}`, dir);
+    expect(status, `the explicit form behind -C was refused: ${output}`).toBe(0);
+  });
 });

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -1,0 +1,199 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const LOCK_WRAPPER = path.join(WORKSPACE_ROOT, 'scripts/harness/with-repo-lock.sh');
+const PRE_COMMIT = path.join(WORKSPACE_ROOT, '.husky/pre-commit');
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratchRepo() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'repo-lock-'));
+  scratch.push(dir);
+  const git = (...a) => spawnSync('git', ['-C', dir, ...a], { encoding: 'utf8' });
+  git('init', '--quiet', '--initial-branch=main');
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  return dir;
+}
+
+/**
+ * Two concurrent runs, each reporting when IT entered and left its critical section.
+ *
+ * The timestamps come from the CHILD, not from `spawn`/`close` in this process. A first version
+ * measured spawn-to-close and failed against a lock that demonstrably worked: the second process is
+ * spawned immediately either way and simply waits, so its spawn time precedes the first one's exit
+ * whether or not anything is serialised. That is an observable both states share — the accidental-
+ * green shape this repository has a floor for — and it was measuring the scheduler, not the lock.
+ *
+ * The property asserted is that the two sections do not OVERLAP. Ordering would be a coin flip;
+ * non-overlap is what the lock actually promises.
+ */
+function criticalSections(cwd, wrapped) {
+  const command = 'echo IN $(date +%s%3N); sleep 0.2; echo OUT $(date +%s%3N)';
+  return Promise.all(
+    [0, 1].map(
+      () =>
+        new Promise((resolve) => {
+          const argv = wrapped ? [LOCK_WRAPPER, 'bash', '-c', command] : ['-c', command];
+          const child = spawn('bash', argv, { cwd, encoding: 'utf8' });
+          let out = '';
+          child.stdout.on('data', (d) => (out += d));
+          child.stderr.on('data', (d) => (out += d));
+          child.on('close', (code) => {
+            const enter = Number(/IN (\d+)/.exec(out)?.[1] ?? NaN);
+            const leave = Number(/OUT (\d+)/.exec(out)?.[1] ?? NaN);
+            resolve({ code, out, enter, leave });
+          });
+        }),
+    ),
+  );
+}
+
+function overlaps(runs) {
+  const [a, b] = runs.sort((x, y) => x.enter - y.enter);
+  return { overlapped: b.enter < a.leave, a, b };
+}
+
+describe('a worktree does not share its neighbour lint-staged backup', () => {
+  it('serialises the critical section across concurrent runs', async () => {
+    const dir = scratchRepo();
+    const runs = await criticalSections(dir, true);
+    for (const run of runs) {
+      expect(run.code, `a run failed: ${run.out}`).toBe(0);
+      expect(
+        Number.isFinite(run.enter) && Number.isFinite(run.leave),
+        `no timestamps: ${run.out}`,
+      ).toBe(true);
+    }
+    const { overlapped, a, b } = overlaps(runs);
+    expect(
+      overlapped,
+      `the two sections overlapped: ${a.enter}-${a.leave} and ${b.enter}-${b.leave}`,
+    ).toBe(false);
+  });
+
+  it('proves the case above is not vacuous — unwrapped, they DO overlap', async () => {
+    // Without this, "they did not overlap" would also pass on a machine that happened to run them
+    // one after another, and the locked case would prove nothing.
+    const dir = scratchRepo();
+    const runs = await criticalSections(dir, false);
+    const { overlapped, a, b } = overlaps(runs);
+    expect(
+      overlapped,
+      `the unwrapped pair did not overlap (${a.enter}-${a.leave}, ${b.enter}-${b.leave}), so the locked case proves nothing`,
+    ).toBe(true);
+  });
+
+  it('refuses when it cannot find the repository, rather than running unserialised', () => {
+    // Fail closed. Running without the lock here is the exact hazard, so "cannot tell" is a refusal.
+    const outside = mkdtempSync(path.join(tmpdir(), 'not-a-repo-'));
+    scratch.push(outside);
+    const result = spawnSync('bash', [LOCK_WRAPPER, 'true'], {
+      cwd: outside,
+      encoding: 'utf8',
+      env: { ...process.env, GIT_CEILING_DIRECTORIES: path.dirname(outside) },
+    });
+    expect(result.status, `it ran anyway: ${result.stdout}${result.stderr}`).not.toBe(0);
+  });
+
+  it('refuses an empty command rather than reporting success over nothing', () => {
+    const dir = scratchRepo();
+    const result = spawnSync('bash', [LOCK_WRAPPER], { cwd: dir, encoding: 'utf8' });
+    expect(result.status).toBe(2);
+  });
+
+  it('the pre-commit hook actually goes through it', () => {
+    // Registered is not reached. A lock nothing calls is a file, and lint-staged is the one caller
+    // that matters — it is the shared-stash user every commit passes through, whether or not the
+    // author ever types `git stash`.
+    // Backslash continuations are joined FIRST. A line-by-line reading called the wired-up hook
+    // unwired, because the invocation spans three lines — the check would have forced the shell to
+    // be written a particular way rather than to do the right thing, and a guard that polices
+    // formatting is one people route around.
+    const statements = readFileSync(PRE_COMMIT, 'utf8')
+      .replace(/\\\r?\n\s*/g, ' ')
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('#'));
+    const lintStaged = statements.filter((line) => line.includes('lint-staged'));
+
+    expect(lintStaged, 'the hook no longer runs lint-staged at all').not.toHaveLength(0);
+    for (const line of lintStaged) {
+      expect(line.trim(), `lint-staged runs without the cross-worktree lock: ${line}`).toContain(
+        'with-repo-lock.sh',
+      );
+    }
+  });
+});
+
+describe('a bare stash command is refused while the stack is shared', () => {
+  // The other half of INFRA-082. The lock covers the caller nobody chooses — lint-staged, on every
+  // commit. This covers the one an agent types, which is what the rule in git-branch.md has asked
+  // for since LESSON-005 (2026-06-15) and which an agent did anyway ten weeks later, because the
+  // rule was written down and never mechanically reached.
+  const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/worktree-cwd-guard.sh');
+
+  function repoWithWorktrees(count) {
+    const dir = scratchRepo();
+    const git = (...a) => spawnSync('git', ['-C', dir, ...a], { encoding: 'utf8' });
+    spawnSync('bash', ['-c', 'printf x > f'], { cwd: dir });
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'root');
+    for (let i = 1; i < count; i += 1) {
+      git('worktree', 'add', '--detach', '--quiet', path.join(dir, `wt-${i}`), 'HEAD');
+    }
+    return dir;
+  }
+
+  function run(command, dir) {
+    const result = spawnSync('bash', [HOOK], {
+      input: JSON.stringify({ tool_name: 'Bash', cwd: dir, tool_input: { command } }),
+      cwd: dir,
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, HOME: process.env.HOME, CLAUDE_PROJECT_DIR: dir },
+      timeout: 120_000,
+    });
+    return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+  }
+
+  it('refuses a bare pop or apply when a sibling worktree exists', () => {
+    const dir = repoWithWorktrees(2);
+    for (const command of ['git stash pop', 'git stash apply', 'git stash']) {
+      expect(
+        run(command, dir).status,
+        `a bare stash command was allowed while another worktree exists: ${command}`,
+      ).not.toBe(0);
+    }
+  });
+
+  it('allows the explicit form, and read-only queries, silently', () => {
+    // A guard that refuses the correct form is one people switch off. The rule names
+    // `git stash pop stash@{N}` as the right way, so that must keep working.
+    const dir = repoWithWorktrees(2);
+    for (const command of [
+      'git stash pop stash@{0}',
+      'git stash apply stash@{2}',
+      'git stash list',
+      'git stash show -p stash@{0}',
+    ]) {
+      const { status, output } = run(command, dir);
+      expect(status, `the documented form was refused: ${command} -> ${output}`).toBe(0);
+      expect(output, `the guard narrated on the happy path: ${command} -> ${output}`).toBe('');
+    }
+  });
+
+  it('leaves a single-worktree clone alone', () => {
+    // The hazard is a SHARED stack. With one worktree there is nothing to race, and refusing there
+    // would be the guard firing on correct work.
+    const dir = repoWithWorktrees(1);
+    const { status, output } = run('git stash pop', dir);
+    expect(status, `a bare pop was refused in a clone with one worktree: ${output}`).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -152,15 +152,34 @@ describe('a bare stash command is refused while the stack is shared', () => {
     return dir;
   }
 
-  function run(command, dir) {
+  function run(command, dir, overrides = {}) {
     const result = spawnSync('bash', [HOOK], {
       input: JSON.stringify({ tool_name: 'Bash', cwd: dir, tool_input: { command } }),
       cwd: dir,
       encoding: 'utf8',
-      env: { PATH: process.env.PATH, HOME: process.env.HOME, CLAUDE_PROJECT_DIR: dir },
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        CLAUDE_PROJECT_DIR: dir,
+        ...overrides,
+      },
       timeout: 120_000,
     });
     return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+  }
+
+  /**
+   * A PATH whose `git` produces no output and exits non-zero — the state that made the old
+   * `grep -c . || echo 0` expression yield a two-line count and fall open.
+   *
+   * The rest of the real PATH follows it, so the hook's other tools still resolve; only `git` is
+   * shadowed, which is the single input under test.
+   */
+  function mkFailingGitPath() {
+    const dir = mkdtempSync(path.join(tmpdir(), 'failing-git-'));
+    scratch.push(dir);
+    writeFileSync(path.join(dir, 'git'), '#!/bin/sh\nexit 1\n', { mode: 0o755 });
+    return `${dir}:${process.env.PATH}`;
   }
 
   it('refuses a bare pop or apply when a sibling worktree exists', () => {
@@ -195,5 +214,42 @@ describe('a bare stash command is refused while the stack is shared', () => {
     const dir = repoWithWorktrees(1);
     const { status, output } = run('git stash pop', dir);
     expect(status, `a bare pop was refused in a clone with one worktree: ${output}`).toBe(0);
+  });
+
+  it('refuses every subcommand that touches the shared stack, not only the ones first thought of', () => {
+    // Review of #1585. `clear` and `branch` were missing from the list, and both match the threat
+    // model exactly: `clear` takes no argument and deletes EVERY entry, including ones another agent
+    // has not popped yet; `branch` with no ref implicitly takes the top of the stack.
+    const dir = repoWithWorktrees(2);
+    for (const command of ['git stash clear', 'git stash branch feat/x']) {
+      expect(
+        run(command, dir).status,
+        `a shared-stack subcommand was allowed: ${command}`,
+      ).not.toBe(0);
+    }
+  });
+
+  it('allows git stash branch with an explicit ref', () => {
+    // `branch` names its source when given one, so it takes nobody else's entry.
+    const dir = repoWithWorktrees(2);
+    const { status, output } = run('git stash branch feat/x stash@{0}', dir);
+    expect(status, `the explicit form was refused: ${output}`).toBe(0);
+  });
+
+  it('refuses rather than waving through when the worktree count cannot be read', () => {
+    // Review of #1585, finding 3, and it is the one that mattered: `git … | grep -c . || echo 0`
+    // yields the TWO-LINE string "0\n0" when the git call produces nothing, because `grep -c` prints
+    // 0 and exits 1, so the `||` fires as well. The arithmetic comparison then errors and the guard
+    // falls open — inside the same PR whose own `with-repo-lock.sh` says "cannot resolve it, so
+    // refuse". Measured before the fix:
+    //     count=[0
+    //     0]
+    //     bash: [: 0\n0: integer expression expected
+    const dir = repoWithWorktrees(2);
+    const { status, output } = run('git stash pop', dir, {
+      // A `git` that produces nothing and fails, which is the state the old expression mishandled.
+      PATH: mkFailingGitPath(),
+    });
+    expect(status, `an unreadable worktree count waved the command through: ${output}`).not.toBe(0);
   });
 });

--- a/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
+++ b/scripts/harness/__tests__/worktrees-share-the-stash.test.mjs
@@ -360,4 +360,64 @@ describe('a bare stash command is refused while the stack is shared', () => {
       `a nameless directory was judged against the hook own cwd: ${output}`,
     ).not.toBe(0);
   });
+
+  it('is not escaped by a `#` that is not a comment', () => {
+    // Review of #1585, MUST — and this bypass was INTRODUCED by the previous round's fix. I added
+    // `sed 's/#.*$//'` to strip comments, on top of a tokenizer that already masks real ones (only a
+    // `#` at a word boundary opens a comment). The second pass cannot tell those apart, so a literal
+    // `#` mid-word deleted the rest of the line — including the bare pop after it.
+    //
+    // The shapes are ordinary: a URL fragment, an unquoted issue reference.
+    const dir = repoWithWorktrees(2);
+    for (const command of [
+      'echo a#b; git stash pop',
+      'echo https://x/y#section; git stash pop',
+      'echo fix#123 && git stash clear',
+    ]) {
+      expect(run(command, dir).status, `a non-comment # escaped the gate: ${command}`).not.toBe(0);
+    }
+  });
+
+  it('still ignores a real trailing comment', () => {
+    // The other direction: a genuine comment must not turn into a ref. `git stash pop # stash@{0}`
+    // is a BARE pop with a comment after it, and the round that added comment-stripping was fixing
+    // exactly that. Both must hold at once.
+    const dir = repoWithWorktrees(2);
+    expect(
+      run('git stash pop  # stash@{0}', dir).status,
+      'a commented ref excused a bare pop',
+    ).not.toBe(0);
+    expect(
+      run('git stash pop stash@{0}  # fine', dir).status,
+      'a real comment refused a good command',
+    ).toBe(0);
+  });
+
+  it('does not take the repository from a different statement -C', () => {
+    // Review of #1585, SHOULD. `STASH_REPO` came from `hook_git_c_path` over the WHOLE command, so a
+    // `-C` on an unrelated call decided which repository the worktree count was taken from:
+    //
+    //     git -C /elsewhere fetch; git stash pop
+    //
+    // The bare pop acts on the session repository — possibly shared — while the count was read from
+    // `/elsewhere`. One worktree there and the guard waved it through: the same `-C points somewhere
+    // else` class the earlier round closed, arriving from a sibling statement instead.
+    const dir = repoWithWorktrees(2);
+    const single = repoWithWorktrees(1);
+    expect(
+      run(`git -C ${single} fetch; git stash pop`, dir).status,
+      `a sibling statement -C decided the repository`,
+    ).not.toBe(0);
+  });
+
+  it('still reads the -C of the stash statement itself', () => {
+    // The other direction, so the fix is not "ignore -C entirely" — that would undo the round that
+    // closed `git -C <sibling> stash pop`.
+    const single = repoWithWorktrees(1);
+    const shared = repoWithWorktrees(2);
+    expect(
+      run(`git -C ${shared} stash pop`, single).status,
+      'the stash statement own -C was ignored',
+    ).not.toBe(0);
+  });
 });

--- a/scripts/harness/with-repo-lock.sh
+++ b/scripts/harness/with-repo-lock.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Run a command holding a lock shared by every worktree of this clone.
+#
+# WHY THIS EXISTS. `worktree-parallel-orchestration` runs several agents at once, each in its own
+# worktree, and the isolation is real for the working tree and the index. It is NOT real for
+# `refs/stash`, which is a single ref on the shared object store.
+#
+# `lint-staged` uses `git stash` INTERNALLY to back up unstaged changes for the duration of the
+# pre-commit hook. Measured 2026-08-01, during a five-agent wave, in an agent that never invoked
+# `git stash` itself:
+#
+#     [STARTED] Cleaning up temporary files...
+#     [FAILED] lint-staged automatic backup is missing!
+#     husky - pre-commit script failed (code 1)
+#
+# A concurrent stash operation in another worktree destroyed the backup ref. So the exposure is not
+# "agents who type `git stash`" — it is every agent on every commit, and the thing at risk is exactly
+# the uncommitted work `lint-staged` is holding on the author's behalf. That run recovered; "backup
+# is missing" is the state in which it would not have. (INFRA-082)
+#
+# WHY A LOCK RATHER THAN `--no-stash`. `--no-stash` removes the backup instead of protecting it, so
+# a failing task can lose unstaged work — trading a rare race for a routine one. The critical section
+# here is seconds long and per-clone, so serialising it costs a wait and never a file.
+#
+# The lock lives beside the shared object store (`--git-common-dir`), because that is precisely the
+# scope of what is shared: one lock per clone, held across all of its worktrees.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "[with-repo-lock] Blocked: no command given. Refusing rather than reporting success over nothing." >&2
+  exit 2
+fi
+
+COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+if [[ -z "$COMMON_DIR" || ! -d "$COMMON_DIR" ]]; then
+  # Fail closed. Running unserialised here would be the exact hazard this exists to remove, and a
+  # command that cannot locate its repository has a bigger problem than the lock.
+  echo "[with-repo-lock] Blocked: cannot resolve the shared git directory, so the lock has no home." >&2
+  echo "[with-repo-lock] Run this inside a git repository." >&2
+  exit 2
+fi
+
+LOCK_FILE="$COMMON_DIR/robota-hook.lock"
+
+if ! command -v flock >/dev/null 2>&1; then
+  # Stated limit, not a silent one: without flock the command still runs, because refusing every
+  # commit on a host that lacks a util-linux tool is worse than the race it prevents. It says so, so
+  # a "backup is missing" failure here is traceable to this line rather than mysterious.
+  echo "[with-repo-lock] flock is unavailable — running WITHOUT the cross-worktree lock." >&2
+  echo "[with-repo-lock] Concurrent commits in sibling worktrees can destroy each other's" >&2
+  echo "[with-repo-lock] lint-staged backup. See INFRA-082." >&2
+  exec "$@"
+fi
+
+# `-w` rather than a blocking wait: a lock that can hang forever turns one stuck hook into a stuck
+# clone. Ten minutes is far beyond any observed lint-staged run and far below "someone will not
+# notice".
+exec flock -w 600 "$LOCK_FILE" "$@"


### PR DESCRIPTION
Closes #1584.

## Problem

`worktree-parallel-orchestration` promises worktree-isolated agents. The isolation is real for the
working tree and the index. It is **not** real for `refs/stash`, which is one ref on the shared
object store — and nothing said so, so an agent reading the skill would reasonably believe otherwise.

Measured 2026-08-01 during a five-agent wave, twice. The second is the serious one.

**1. An agent's bare stash-push-then-pop took another agent's uncommitted work into its own tree.**
It noticed, re-stashed it with an explicit label, and reported it. Nothing was lost because the
victim had already committed. That is luck, not design.

**2. An agent that never invoked `git stash` hit it anyway:**

```
[FAILED] lint-staged automatic backup is missing!
husky - pre-commit script failed (code 1)
```

`lint-staged` backs up unstaged changes with `git stash`. A concurrent stash in a sibling worktree
destroyed the backup. The exposure is therefore not "agents who type `git stash`" — it is **every
agent on every commit**, and the thing at risk is precisely the uncommitted work `lint-staged` is
holding on the author's behalf.

## Two mechanisms, because the two callers differ in kind

**The lock, for the caller nobody chooses.** `scripts/harness/with-repo-lock.sh` holds a `flock` on
the shared git dir; the pre-commit hook runs `lint-staged` under it. Chosen over `--no-stash`, which
removes the backup rather than protecting it — trading a rare race for a routine loss.

**The guard, for the caller an agent types.** A bare `git stash` / `push`, or a `pop`/`apply`/`drop`
with no explicit `stash@{N}`, is refused while a sibling worktree exists. `list` and `show` are
untouched; they cannot move anyone's work.

## The guard half is a recurrence, and that is the point

`git-branch.md` has said *"never a bare `git stash pop` … pop by explicit ref"* since **LESSON-005,
2026-06-15**. Ten weeks later an agent did exactly that. The rule was written, registered in the
right document, and **never mechanically reached** — this repository's signature defect, applied to
its own process.

The new failure is also worse than the old one. LESSON-005's was *your own past work restored at the
wrong time*: annoying, recoverable by reading the diff. This one is *a live agent's work taken out
from under it*, with no signal to the victim.

## Placement, stated because it is deliberate

The guard sits **before** the worktree-session gate in `worktree-cwd-guard.sh`. The hazard is "this
clone HAS more than one worktree", which is equally true of the main checkout — a guard that only
fired inside worktrees would miss the main clone racing them.

## Red proof, both directions

The lock serialises two concurrent runs; an unwrapped pair is asserted to **overlap**, so the locked
case cannot pass vacuously. Reachability is checked separately — a lock nothing calls is a file — by
requiring every `lint-staged` invocation in the hook to go through the wrapper, red-proved by
unwiring it.

**The first version of the lock test was wrong, and the way it was wrong is worth recording.** It
measured spawn-to-close and reported an overlap against a lock that demonstrably worked: the second
process is spawned immediately either way and simply waits, so its spawn time precedes the first
one's exit whether or not anything is serialised. An observable both states share. The timestamps now
come from the child's own critical section.

The stash guard: three bare forms refused with a sibling worktree, four correct forms
(`pop stash@{0}`, `apply stash@{2}`, `list`, `show -p`) allowed **and silent**, and a single-worktree
clone left alone.

## Caught by an existing floor while writing it

INFRA-077's `leaves no hook calling git without the scrub` failed on my `git -C`. With `GIT_DIR`
exported that reports the OUTER repository, so the worktree count would have been another clone's.
Now `hook_git_in`. The floor did its job on a line written minutes earlier.

## Also documented

The skill now states where the isolation stops — `refs/stash` directly, `refs/stash` via
`lint-staged`, and `refs/` generally (which is why `branch-guard` lists 14 branches during a wave and
trains the open-branches override reflex, noted on the issue and not fixed here).

## Verification

2189 harness tests green, 84 scans pass. The commit that carries this went through the new lock.
