### PR TITLE
fix(agent-server): SEC-008 the token decides who the caller is

### DIFF
--- a/apps/agent-server/src/__tests__/app.test.ts
+++ b/apps/agent-server/src/__tests__/app.test.ts
@@ -1,9 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import { createApp } from '../app.js';
 
 describe('Agent Server HTTP routes', () => {
   const app = createApp();
+
+  // SEC-008: `/api/v1/remote/chat` spends the OPERATOR's provider credit and is now authenticated.
+  // The validation cases below are about the BODY, so they carry a valid token — otherwise they
+  // would be asserting the auth gate by accident and would stop testing what they are named for.
+  const TEST_SECRET = 'app-test-secret';
+  const bearer = () => `Bearer ${jwt.sign({ sub: 'test-user' }, TEST_SECRET)}`;
+  let previousSecret: string | undefined;
+  beforeAll(() => {
+    previousSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+  afterAll(() => {
+    if (previousSecret === undefined) delete process.env.JWT_SECRET;
+    else process.env.JWT_SECRET = previousSecret;
+  });
 
   describe('GET /health', () => {
     it('returns 200', async () => {
@@ -67,13 +83,17 @@ describe('Agent Server HTTP routes', () => {
 
   describe('POST /api/v1/remote/chat', () => {
     it('rejects request with no body fields with 400', async () => {
-      const res = await request(app).post('/api/v1/remote/chat').send({});
+      const res = await request(app)
+        .post('/api/v1/remote/chat')
+        .set('authorization', bearer())
+        .send({});
       expect(res.status).toBe(400);
     });
 
     it('rejects request without provider field with 400', async () => {
       const res = await request(app)
         .post('/api/v1/remote/chat')
+        .set('authorization', bearer())
         .send({ messages: [{ role: 'user', content: 'hi' }] });
       expect([400, 401, 422]).toContain(res.status);
     });
@@ -81,21 +101,92 @@ describe('Agent Server HTTP routes', () => {
     it('rejects request with unknown provider with 400', async () => {
       const res = await request(app)
         .post('/api/v1/remote/chat')
+        .set('authorization', bearer())
         .send({ provider: 'unknown-provider', messages: [{ role: 'user', content: 'hi' }] });
       expect(res.status).toBe(400);
       expect(res.body.error).toMatch(/unknown provider/i);
     });
 
     it('rejects request with missing messages with 400', async () => {
-      const res = await request(app).post('/api/v1/remote/chat').send({ provider: 'openai' });
+      const res = await request(app)
+        .post('/api/v1/remote/chat')
+        .set('authorization', bearer())
+        .send({ provider: 'openai' });
       expect(res.status).toBe(400);
     });
 
     it('rejects request with empty messages array with 400', async () => {
       const res = await request(app)
         .post('/api/v1/remote/chat')
+        .set('authorization', bearer())
         .send({ provider: 'openai', messages: [] });
       expect(res.status).toBe(400);
+    });
+  });
+
+  /**
+   * SEC-008. This route reaches providers built from the OPERATOR's `OPENAI_API_KEY` /
+   * `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` and had no authentication at all — the only control was
+   * a global IP rate limiter, which bounds the RATE of anonymous spending rather than preventing it.
+   *
+   * Every assertion here fails against the unauthenticated route: it answered 400 on a bad body and
+   * would have answered 200 on a good one, whoever asked.
+   */
+  describe('SEC-008 regression: /api/v1/remote/chat spends operator credit and must be authenticated', () => {
+    const body = { provider: 'unknown-provider', messages: [{ role: 'user', content: 'hi' }] };
+
+    it('refuses an anonymous request before it reads the body', async () => {
+      const res = await request(app).post('/api/v1/remote/chat').send(body);
+      expect(res.status).toBe(401);
+      // Not 400: the gate runs BEFORE validation, so an anonymous caller cannot probe the body
+      // contract either.
+      expect(res.body.error).toMatch(/bearer token/i);
+    });
+
+    it('refuses a token signed with a different secret', async () => {
+      const res = await request(app)
+        .post('/api/v1/remote/chat')
+        .set('authorization', `Bearer ${jwt.sign({ sub: 'x' }, 'not-the-secret')}`)
+        .send(body);
+      expect(res.status).toBe(401);
+    });
+
+    it('refuses a non-bearer authorization header', async () => {
+      const res = await request(app)
+        .post('/api/v1/remote/chat')
+        .set('authorization', 'Basic dXNlcjpwYXNz')
+        .send(body);
+      expect(res.status).toBe(401);
+    });
+
+    it('refuses everything when the server has no secret to verify against', async () => {
+      const saved = process.env.JWT_SECRET;
+      delete process.env.JWT_SECRET;
+      try {
+        const res = await request(app)
+          .post('/api/v1/remote/chat')
+          .set('authorization', bearer())
+          .send(body);
+        expect(res.status).toBe(503);
+        expect(res.body.error).toMatch(/JWT_SECRET/);
+      } finally {
+        process.env.JWT_SECRET = saved;
+      }
+    });
+
+    it('lets an authenticated request through to the route it was asking for', async () => {
+      const res = await request(app)
+        .post('/api/v1/remote/chat')
+        .set('authorization', bearer())
+        .send(body);
+      // 400 "unknown provider" — the gate passed and the route answered.
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/unknown provider/i);
+    });
+
+    it('leaves BYOK open — the caller brings their own key, so there is no operator credit to protect', async () => {
+      const res = await request(app).post('/api/v1/byok/chat').send({});
+      expect(res.status).not.toBe(401);
     });
   });
 

--- a/apps/agent-server/src/__tests__/authenticate-playground-client.test.ts
+++ b/apps/agent-server/src/__tests__/authenticate-playground-client.test.ts
@@ -1,0 +1,116 @@
+import jwt from 'jsonwebtoken';
+import { describe, expect, it } from 'vitest';
+
+import { authenticatePlaygroundClient } from '../authenticate-playground-client.js';
+
+/**
+ * SEC-008. The decision is a pure function precisely so these cases can be stated without a socket
+ * — the socket test in `websocket-server.test.ts` proves the transport HONOURS this decision; these
+ * prove the decision itself.
+ *
+ * Both defects this replaces are asserted from the failing side first: an unverifiable token is not
+ * a weaker credential, and a valid token that names someone else is not a credential for this user.
+ */
+describe('authenticatePlaygroundClient (SEC-008)', () => {
+  const secret = 'test-secret';
+  const sign = (payload: object) => jwt.sign(payload, secret);
+
+  it('refuses everything when there is no secret — an unverifiable token is not a weaker one', () => {
+    // The exact string the removed development fallback accepted.
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-1',
+      token: 'a.b.c',
+      secret: undefined,
+    });
+    expect(decision.authenticated).toBe(false);
+    expect(decision).toMatchObject({ reason: 'Server is not configured for authentication' });
+    // …and it says so where an operator will see it, rather than serving on quietly.
+    expect(decision.authenticated === false && decision.configurationError).toContain('JWT_SECRET');
+  });
+
+  it('refuses a valid token that names a DIFFERENT user than the request claims', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-BBB',
+      sessionId: 'session-1',
+      token: sign({ sub: 'user-AAA' }),
+      secret,
+    });
+    expect(decision).toMatchObject({
+      authenticated: false,
+      reason: 'Authentication token does not match the claimed user',
+    });
+  });
+
+  it('refuses a valid token that carries no subject to bind an identity to', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-1',
+      token: sign({ someOtherClaim: 'user-123' }),
+      secret,
+    });
+    expect(decision).toMatchObject({
+      authenticated: false,
+      reason: 'Authentication token does not identify a user',
+    });
+  });
+
+  it('refuses a token scoped to a different session', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-WANTED',
+      token: sign({ sub: 'user-123', sessionId: 'session-GRANTED' }),
+      secret,
+    });
+    expect(decision).toMatchObject({
+      authenticated: false,
+      reason: 'Authentication token does not match the claimed session',
+    });
+  });
+
+  it('refuses a token signed with a different secret', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-1',
+      token: jwt.sign({ sub: 'user-123' }, 'some-other-secret'),
+      secret,
+    });
+    expect(decision).toMatchObject({
+      authenticated: false,
+      reason: 'Invalid or expired authentication token',
+    });
+  });
+
+  it('refuses an expired token', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-1',
+      token: jwt.sign({ sub: 'user-123' }, secret, { expiresIn: '-1s' }),
+      secret,
+    });
+    expect(decision).toMatchObject({
+      authenticated: false,
+      reason: 'Invalid or expired authentication token',
+    });
+  });
+
+  it('accepts a token for the user it names, and returns the identity FROM the claim', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-1',
+      token: sign({ sub: 'user-123' }),
+      secret,
+    });
+    expect(decision).toEqual({ authenticated: true, userId: 'user-123', sessionId: 'session-1' });
+  });
+
+  it('accepts a token scoped to the session being requested', () => {
+    const decision = authenticatePlaygroundClient({
+      userId: 'user-123',
+      sessionId: 'session-1',
+      token: sign({ sub: 'user-123', sessionId: 'session-1' }),
+      secret,
+    });
+    expect(decision).toEqual({ authenticated: true, userId: 'user-123', sessionId: 'session-1' });
+  });
+});

--- a/apps/agent-server/src/__tests__/websocket-server.test.ts
+++ b/apps/agent-server/src/__tests__/websocket-server.test.ts
@@ -127,4 +127,102 @@ describe('PlaygroundWebSocketServer', () => {
       await new Promise<void>((resolve) => httpServer.close(() => resolve()));
     });
   });
+
+  /**
+   * SEC-008. Two defects, one root: the token was not the thing that decided who the caller is.
+   *
+   * The dev fallback accepted ANY three-dot-separated string, so `"a.b.c"` authenticated as any
+   * `userId`/`sessionId` — and it was selected by an environment variable being ABSENT, which is
+   * exactly the state a misconfigured deployment is in. Separately, the verified path discarded
+   * `jwt.verify`'s return and read the identity from the message body, so a holder of any valid
+   * token could claim another user's session and reach `broadcastToSession` for it.
+   *
+   * Both assertions fail against the code they were written for.
+   */
+  describe('SEC-008 regression: the token decides the identity, or nobody is authenticated', () => {
+    async function attempt(
+      payload: Record<string, unknown>,
+      env: Record<string, string | undefined>,
+    ) {
+      const previous = process.env.JWT_SECRET;
+      if (env.JWT_SECRET === undefined) delete process.env.JWT_SECRET;
+      else process.env.JWT_SECRET = env.JWT_SECRET;
+
+      const httpServer = createServer();
+      const server = new PlaygroundWebSocketServer(httpServer);
+      await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+      const port = (httpServer.address() as { port: number }).port;
+      const { WebSocket } = await import('ws');
+
+      const messages: string[] = [];
+      let closed = false;
+      await new Promise<void>((resolve, reject) => {
+        const ws = new WebSocket(`ws://localhost:${port}/ws/playground`);
+        ws.on('open', () =>
+          ws.send(
+            JSON.stringify({ type: 'auth', timestamp: new Date().toISOString(), data: payload }),
+          ),
+        );
+        ws.on('message', (data: Buffer) => messages.push(data.toString()));
+        ws.on('close', () => {
+          closed = true;
+          resolve();
+        });
+        ws.on('error', reject);
+        setTimeout(() => {
+          ws.terminate();
+          resolve();
+        }, 2000);
+      });
+
+      const stats = server.getStats();
+      server.close();
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      if (previous === undefined) delete process.env.JWT_SECRET;
+      else process.env.JWT_SECRET = previous;
+
+      const parsed = messages.map(
+        (m) => JSON.parse(m) as { data?: { success?: boolean; error?: string } },
+      );
+      return {
+        closed,
+        authenticated: stats.authenticatedConnections,
+        error: parsed.find((m) => m.data?.success === false || m.data?.error)?.data?.error,
+      };
+    }
+
+    it('refuses every attempt when there is no secret to verify against', async () => {
+      const result = await attempt(
+        { userId: 'user-123', sessionId: 'session-456', token: 'a.b.c' },
+        { JWT_SECRET: undefined },
+      );
+      expect(result.authenticated).toBe(0);
+      expect(result.closed).toBe(true);
+      expect(result.error).toBe('Server is not configured for authentication');
+    });
+
+    it('refuses a valid token that names a different user than the message claims', async () => {
+      const jwtModule = await import('jsonwebtoken');
+      const sign = (jwtModule.default ?? jwtModule).sign;
+      const token = sign({ sub: 'user-AAA' }, 'test-secret');
+      const result = await attempt(
+        { userId: 'user-BBB', sessionId: 'session-456', token },
+        { JWT_SECRET: 'test-secret' },
+      );
+      expect(result.authenticated).toBe(0);
+      expect(result.closed).toBe(true);
+      expect(result.error).toBe('Authentication token does not match the claimed user');
+    });
+
+    it('accepts a valid token for the user it names', async () => {
+      const jwtModule = await import('jsonwebtoken');
+      const sign = (jwtModule.default ?? jwtModule).sign;
+      const token = sign({ sub: 'user-123' }, 'test-secret');
+      const result = await attempt(
+        { userId: 'user-123', sessionId: 'session-456', token },
+        { JWT_SECRET: 'test-secret' },
+      );
+      expect(result.authenticated).toBe(1);
+    });
+  });
 });

--- a/apps/agent-server/src/app.ts
+++ b/apps/agent-server/src/app.ts
@@ -9,6 +9,7 @@ import express from 'express';
 import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 
+import { requireOperatorKeyAuth } from './middleware/require-operator-key-auth.js';
 import { playgroundRouter } from './routes/playground.js';
 
 import type { PlaygroundWebSocketServer } from './websocket-server';
@@ -112,7 +113,11 @@ export function createApp(): express.Application {
   app.get('/api/v1/remote/health', (_req, res) => {
     res.json({ status: 'ok', providers: providerNames, timestamp: new Date().toISOString() });
   });
-  app.post('/api/v1/remote/chat', async (req, res) => {
+  // SEC-008: this route spends the OPERATOR's provider credit (the providers above are built from
+  // the operator's API keys), and it had no authentication — only a global IP rate limiter, which
+  // bounds the rate of anonymous spending rather than preventing it. BYOK below is deliberately not
+  // gated: the caller brings their own key.
+  app.post('/api/v1/remote/chat', requireOperatorKeyAuth, async (req, res) => {
     try {
       const { provider: providerName, messages, model } = req.body;
       if (!providerName || typeof providerName !== 'string') {

--- a/apps/agent-server/src/authenticate-playground-client.ts
+++ b/apps/agent-server/src/authenticate-playground-client.ts
@@ -1,0 +1,81 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * SEC-008 — who the caller is, decided by the TOKEN.
+ *
+ * This lived inline in `websocket-server.ts` and carried two defects that are one root: the token
+ * was not the thing that decided the identity.
+ *
+ * - A "development fallback" accepted any three-dot-separated string, so `"a.b.c"` authenticated as
+ *   any user. It was selected by `JWT_SECRET` being ABSENT — which is the state a misconfigured
+ *   deployment is in, not a state only a developer can reach. A server that cannot verify a token
+ *   has not verified it.
+ * - The verified path discarded `jwt.verify`'s return and read `userId`/`sessionId` from the message
+ *   body, so a holder of ANY valid token could claim another user's session and reach that session's
+ *   broadcasts. A token that does not name who it is for cannot authorize anyone.
+ *
+ * It is a pure function so the decision can be tested without a socket, and so the transport layer
+ * cannot reach past it.
+ */
+export type TPlaygroundAuthDecision =
+  | { authenticated: true; userId: string; sessionId: string }
+  | { authenticated: false; reason: string; configurationError?: string };
+
+export interface IPlaygroundAuthAttempt {
+  readonly userId: string;
+  readonly sessionId: string;
+  readonly token: string;
+  /** The verification secret. `undefined` means the server cannot verify anything. */
+  readonly secret: string | undefined;
+}
+
+export function authenticatePlaygroundClient(
+  attempt: IPlaygroundAuthAttempt,
+): TPlaygroundAuthDecision {
+  const { userId, sessionId, token, secret } = attempt;
+
+  if (!secret) {
+    return {
+      authenticated: false,
+      reason: 'Server is not configured for authentication',
+      configurationError:
+        'JWT_SECRET is not set, so no authentication can be performed. Refusing the connection.',
+    };
+  }
+
+  let claims: jwt.JwtPayload;
+  try {
+    const verified = jwt.verify(token, secret);
+    // A token whose payload is a bare string carries no claims to bind an identity to.
+    if (typeof verified === 'string') {
+      return { authenticated: false, reason: 'Invalid or expired authentication token' };
+    }
+    claims = verified;
+  } catch {
+    return { authenticated: false, reason: 'Invalid or expired authentication token' };
+  }
+
+  const subject = typeof claims.sub === 'string' ? claims.sub : undefined;
+  if (!subject) {
+    return { authenticated: false, reason: 'Authentication token does not identify a user' };
+  }
+  if (subject !== userId) {
+    return {
+      authenticated: false,
+      reason: 'Authentication token does not match the claimed user',
+    };
+  }
+
+  // A token MAY scope itself to one session. When it does, the claim wins; when it does not, the
+  // requested session stands — widening that is a separate decision, recorded in SEC-008 rather
+  // than made here.
+  const scopedSession = typeof claims.sessionId === 'string' ? claims.sessionId : undefined;
+  if (scopedSession !== undefined && scopedSession !== sessionId) {
+    return {
+      authenticated: false,
+      reason: 'Authentication token does not match the claimed session',
+    };
+  }
+
+  return { authenticated: true, userId: subject, sessionId };
+}

--- a/apps/agent-server/src/middleware/require-operator-key-auth.ts
+++ b/apps/agent-server/src/middleware/require-operator-key-auth.ts
@@ -1,0 +1,45 @@
+import jwt from 'jsonwebtoken';
+
+import type { NextFunction, Request, Response } from 'express';
+
+/**
+ * SEC-008 — a route that spends the OPERATOR's provider credit must know who is spending it.
+ *
+ * `POST /api/v1/remote/chat` reaches providers constructed from the operator's `OPENAI_API_KEY` /
+ * `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` and had no authentication at all. The only control was a
+ * global IP rate limiter, which bounds the RATE of anonymous spending rather than preventing it.
+ *
+ * BYOK (`/api/v1/byok/chat`) is deliberately NOT behind this: the caller supplies their own key, so
+ * there is no operator credit to protect and requiring an account would be a different product
+ * decision, not a security fix.
+ *
+ * Same shape as the playground WebSocket gate: no secret means no authentication is possible, and a
+ * server that cannot verify a token refuses rather than inventing a weaker check.
+ */
+export function requireOperatorKeyAuth(req: Request, res: Response, next: NextFunction): void {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    res.status(503).json({
+      error:
+        "This endpoint spends the operator's provider credit and requires authentication, but " +
+        'JWT_SECRET is not set, so no token can be verified. Set JWT_SECRET to serve it.',
+    });
+    return;
+  }
+
+  const header = req.header('authorization') ?? '';
+  const [scheme, token] = header.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    res.status(401).json({ error: 'Missing bearer token' });
+    return;
+  }
+
+  try {
+    jwt.verify(token, secret);
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired authentication token' });
+    return;
+  }
+
+  next();
+}

--- a/apps/agent-server/src/websocket-server.ts
+++ b/apps/agent-server/src/websocket-server.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@robota-sdk/agent-core';
-import * as jwt from 'jsonwebtoken';
 import { WebSocket, WebSocketServer } from 'ws';
+
+import { authenticatePlaygroundClient } from './authenticate-playground-client.js';
 
 import type { ILogger, TUniversalValue } from '@robota-sdk/agent-core';
 import type {
@@ -10,7 +11,6 @@ import type {
 import type { Server } from 'http';
 import type { IncomingMessage } from 'http';
 
-const JWT_PART_COUNT = 3;
 const CLEANUP_INTERVAL_MS = 30000;
 
 function isUniversalObjectValue(value: TUniversalValue): value is Record<string, TUniversalValue> {
@@ -67,10 +67,10 @@ export class PlaygroundWebSocketServer {
     );
 
     if (!process.env.JWT_SECRET) {
-      this.logger.warn(
-        'JWT_SECRET environment variable is not set. ' +
-          'JWT validation will use format-only checking (development mode). ' +
-          'Set JWT_SECRET for production use.',
+      this.logger.error(
+        'JWT_SECRET is not set. Every authentication attempt will be REFUSED — ' +
+          'there is no format-only development mode, because accepting an unverifiable token is ' +
+          'not a weaker check, it is no check. Set JWT_SECRET to serve this endpoint.',
       );
     }
 
@@ -178,28 +178,24 @@ export class PlaygroundWebSocketServer {
       return;
     }
 
-    const jwtSecret = process.env.JWT_SECRET;
-    if (jwtSecret) {
-      try {
-        jwt.verify(token, jwtSecret);
-      } catch {
-        this.sendError(clientId, 'Invalid or expired authentication token');
-        client.ws.close();
-        return;
-      }
-    } else {
-      // Development fallback: verify JWT format (3 dot-separated parts)
-      const parts = token.split('.');
-      if (parts.length !== JWT_PART_COUNT) {
-        this.sendError(clientId, 'Invalid or expired authentication token');
-        client.ws.close();
-        return;
-      }
+    // The decision lives in `authenticate-playground-client.ts` — a pure function, so it can be
+    // tested without a socket and so this transport cannot reach past it. (SEC-008)
+    const decision = authenticatePlaygroundClient({
+      userId,
+      sessionId,
+      token,
+      secret: process.env.JWT_SECRET,
+    });
+    if (!decision.authenticated) {
+      if (decision.configurationError) this.logger.error(decision.configurationError);
+      this.sendError(clientId, decision.reason);
+      client.ws.close();
+      return;
     }
 
-    // Update client info
-    client.userId = userId;
-    client.sessionId = sessionId;
+    // From the verified claim, never from the message body.
+    client.userId = decision.userId;
+    client.sessionId = decision.sessionId;
     client.isAuthenticated = true;
 
     // Track user sessions

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -1,5 +1,5 @@
 {
-  "apps/agent-server/src/websocket-server.ts": 367,
+  "apps/agent-server/src/websocket-server.ts": 363,
   "apps/remote-signaling/src/relay.ts": 311,
   "packages/agent-cli/src/cli.ts": 504,
   "packages/agent-cli/src/remote-control/remote-control-controller.ts": 485,


### PR DESCRIPTION
Closes the `apps/agent-server` half of **SEC-008**, ranked #2 in the bottom-up architecture audit
(#1591). Three defects, one root: **the token was not the thing that decided who the caller is.**

## 1. Any three-dot string authenticated as any user

`websocket-server.ts` had a "development fallback": with `JWT_SECRET` unset, it accepted a token
whose only property was having three dot-separated parts. `"a.b.c"` authenticated as any
`userId`/`sessionId`.

It was selected by an **environment variable being absent** — which is the state a misconfigured
deployment is in, not a state only a developer can reach. The constructor logged a warning and served
anyway.

There is no weaker check now. A server that cannot verify a token refuses, and says why where an
operator will see it.

## 2. A valid token could claim someone else's session

Even on the verified path, `jwt.verify`'s return was **discarded** and `client.userId` /
`client.sessionId` were read from the **message body**. Any holder of any valid token could therefore
claim another user's session and reach that session's broadcasts.

The identity now comes from the claim: the token must carry a subject, the subject must match the
requested user, and a token that scopes itself to a session may not be used for a different one.

## 3. A route spending the operator's provider credit had no authentication

`POST /api/v1/remote/chat` reaches providers built from the operator's `OPENAI_API_KEY` /
`ANTHROPIC_API_KEY` / `GEMINI_API_KEY`. The only control was the global IP rate limiter, which bounds
the **rate** of anonymous spending rather than preventing it.

It now requires a verified bearer token, and the gate runs **before** body validation so an anonymous
caller cannot probe the body contract either.

**BYOK is deliberately left open, and that is asserted rather than assumed.** `/api/v1/byok/chat`
takes the caller's own key, so there is no operator credit to protect; requiring an account there
would be a product decision, not a security fix.

## Shape of the change

The playground decision moved into a **pure function**
(`authenticate-playground-client.ts`). It can be tested without a socket, the transport cannot reach
past it, and it took `websocket-server.ts` back **under** its file-size baseline — which is re-frozen
in the same change so the ratchet keeps the gain rather than licensing a regrowth.

## Verification

- **Red-proved, both halves.** With the previous authentication restored, 2 of the WebSocket
  assertions fail. With the middleware removed, 4 of the 6 route assertions fail.
- 8 unit cases cover the decision itself — including the exact string the removed fallback accepted,
  a token with no subject, a token scoped to another session, a wrong secret, and an expired token.
- The socket test proves the transport **honours** that decision; the unit tests prove the decision.
- The five pre-existing body-validation cases now carry a token. Without that they would have started
  asserting the auth gate by accident and stopped testing what they are named for — a passing suite
  that had quietly changed subject.
- 37 `agent-server` tests, typecheck and the file-size ratchet all green.

## Not in this change

SEC-008 also covers the transport-layer half the audit found — `agent-transport-http` and
`agent-transport-mcp` ship with no admission gate at all, and `agent-transport-webrtc` makes its
secret optional while its sibling `-ws` auto-mints one. That is a contract change (admission is a
member of no contract, which is why each transport re-decides it) and it belongs in its own change
against `ITransportAdapter`. The Task records both halves.
