### PR TITLE
fix(agent-core): CORE-027 an abort is a signal, not a substring

### DIFF
--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -259,6 +259,23 @@ sandbox (`agent-tools`), the CLI monitor asset server (`agent-cli`) and the stud
 | `isPathInside`     | function | Whether `candidate` is `root` itself or lies beneath it, decided on the CANONICAL form of both     |
 | `canonicalizePath` | function | Realpath-resolve a path, tolerating a not-yet-created tail so `Write`/`Edit` targets still resolve |
 
+### Abort Classification Public API (CORE-027)
+
+The SSOT for "was this failure an ABORT?" whenever the answer changes what the caller reports.
+Three call sites decided it by looking at the error's PROSE
+(`message.includes('aborted') || message.includes('abort')`), and the execution service returned
+`success: true, interrupted: true` when it said yes — so a real provider failure whose text happened
+to contain those letters was reported as a successfully interrupted run, with nothing downstream,
+including the print-mode exit code, able to tell. The authoritative signals are the `AbortSignal` the
+caller already holds and the error's own `name`, neither of which is a guess about wording.
+
+Exported because `agent-framework`'s interactive path needs the same decision: a fourth private copy
+is how the third one survived a fix to the first two.
+
+| Export           | Kind     | Description                                                                                     |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `isAbortFailure` | function | Whether a failure is an abort, decided from the caller's `AbortSignal` and the error's own name |
+
 ### Schema (CORE-015)
 
 | Export                                                                                                    | Kind     | Description                                                                                                               |

--- a/packages/agent-core/src/services/execution-round-streaming.ts
+++ b/packages/agent-core/src/services/execution-round-streaming.ts
@@ -1,5 +1,6 @@
 import { callProviderWithCache } from './execution-round-provider';
 import { resolveToolChoiceForRound } from './execution-service-helpers';
+import { isAbortFailure } from '../utils/abort-classification';
 
 import type { IExecutionContext, IResolvedProviderInfo } from './execution-types';
 import type { IAgentConfig, TExecutionEventData } from '../interfaces/agent';
@@ -118,12 +119,11 @@ export async function callRoundProviderWithEvents(
     return response;
   } catch (providerError) {
     // allow-fallback: provider errors terminate the round, not the process
-    const isAbortError =
-      providerError instanceof Error &&
-      (providerError.name === 'AbortError' ||
-        providerError.message.includes('aborted') ||
-        providerError.message.includes('abort'));
-    if (isAbortError) {
+    //
+    // CORE-027: classified from the SIGNAL this round was given and from the error's own name, never
+    // from its prose. The substring test that stood here committed the round as `interrupted` for
+    // any provider failure whose message happened to contain "abort".
+    if (isAbortFailure(providerError, fullContext.signal)) {
       conversationStore.commitAssistant('interrupted', { round: currentRound });
       throw providerError;
     }

--- a/packages/agent-core/src/services/execution-service.ts
+++ b/packages/agent-core/src/services/execution-service.ts
@@ -18,6 +18,7 @@ import {
 } from './execution-types';
 import { callPluginHook, type TPluginWithHooks } from './plugin-hook-dispatcher';
 import { ToolExecutionService } from './tool-execution-service';
+import { isAbortFailure } from '../utils/abort-classification';
 import { createLogger, type ILogger } from '../utils/logger';
 
 import type {
@@ -231,12 +232,10 @@ export class ExecutionService {
         this.eventEmitter,
       );
     } catch (error) {
-      const isAbortError =
-        error instanceof Error &&
-        (error.name === 'AbortError' ||
-          error.message.includes('aborted') ||
-          error.message.includes('abort'));
-      if (isAbortError) {
+      // CORE-027: classified from the SIGNAL and the error's own name, never from its prose. The
+      // substring test that stood here returned `success: true, interrupted: true` for any provider
+      // failure whose message happened to contain "abort".
+      if (isAbortFailure(error, context?.signal)) {
         return {
           response: '',
           messages: conversationStore.getMessages(),

--- a/packages/agent-core/src/utils/abort-classification.test.ts
+++ b/packages/agent-core/src/utils/abort-classification.test.ts
@@ -62,9 +62,43 @@ describe('isAbortFailure (CORE-027)', () => {
     expect(isAbortFailure(new Error('provider call failed', { cause: inner }))).toBe(true);
   });
 
-  it('a non-Error rejection is not an abort', () => {
+  it('a non-error rejection is not an abort', () => {
     expect(isAbortFailure('abort')).toBe(false);
     expect(isAbortFailure(undefined)).toBe(false);
+    expect(isAbortFailure(null)).toBe(false);
+    // A bare tag is not an error: an error carries a message.
     expect(isAbortFailure({ name: 'AbortError' })).toBe(false);
+  });
+
+  /**
+   * The classification does not depend on `instanceof Error`, for two independent reasons — only one
+   * of which was raised in review of #1593.
+   *
+   * The review's claim was that `DOMException` does not extend `Error`. Measured on this runtime, it
+   * does (`new DOMException('x','AbortError') instanceof Error === true`, Node 22.14, and WebIDL has
+   * put `Error.prototype` in its chain since 2021), so the claim does not hold here — the
+   * `DOMException` case below passed before this change and still passes.
+   *
+   * It is fixed anyway, because `agent-core` ships a browser build and because `instanceof` also
+   * fails CROSS-REALM: an abort thrown in a worker or a `vm` context is an ordinary error that this
+   * realm's `Error` does not recognise. That case is the one no `instanceof` spelling can cover, and
+   * it is asserted below.
+   */
+  describe('recognises an abort that instanceof cannot reach', () => {
+    it('a DOMException abort', () => {
+      expect(isAbortFailure(new DOMException('The operation was aborted.', 'AbortError'))).toBe(
+        true,
+      );
+    });
+
+    it('a CROSS-REALM error, which fails instanceof against this realm', async () => {
+      const vm = await import('node:vm');
+      const foreign: unknown = vm.runInNewContext(
+        "(() => { const e = new Error('aborted'); e.name = 'AbortError'; return e; })()",
+      );
+      // The premise of the test: this really is unreachable by instanceof here.
+      expect(foreign instanceof Error).toBe(false);
+      expect(isAbortFailure(foreign)).toBe(true);
+    });
   });
 });

--- a/packages/agent-core/src/utils/abort-classification.test.ts
+++ b/packages/agent-core/src/utils/abort-classification.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAbortFailure } from './abort-classification';
+
+/**
+ * CORE-027. The classification that stood at three call sites was
+ *
+ *   error.name === 'AbortError' || error.message.includes('aborted') || error.message.includes('abort')
+ *
+ * and `execution-service.ts` returned `success: true, interrupted: true` when it said yes. The
+ * cases below that must answer FALSE are all real provider-failure wordings; each one of them was
+ * previously reported to the caller as a successfully interrupted run.
+ */
+describe('isAbortFailure (CORE-027)', () => {
+  describe('a real failure is not an abort because its prose contains the word', () => {
+    for (const message of [
+      'the upstream aborted the stream after a policy check',
+      'AbortController is not supported by this runtime',
+      'HTTP 502: <html>request aborted by proxy</html>',
+      'model refused: the user asked how to abort a deployment',
+    ]) {
+      it(JSON.stringify(message), () => {
+        expect(isAbortFailure(new Error(message))).toBe(false);
+      });
+    }
+  });
+
+  it('an aborted SIGNAL is an abort, whatever the error says', () => {
+    const controller = new AbortController();
+    controller.abort();
+    // The error text deliberately says nothing about aborting — the signal is the fact.
+    expect(isAbortFailure(new Error('socket hang up'), controller.signal)).toBe(true);
+  });
+
+  it('a signal that is NOT aborted does not make a failure one', () => {
+    const controller = new AbortController();
+    expect(isAbortFailure(new Error('request aborted'), controller.signal)).toBe(false);
+  });
+
+  it("the platform's own abort error is an abort, by NAME not by message", () => {
+    const error = new Error('The operation was cancelled.');
+    error.name = 'AbortError';
+    expect(isAbortFailure(error)).toBe(true);
+  });
+
+  it('what AbortSignal.throwIfAborted() raises is recognised', () => {
+    const controller = new AbortController();
+    controller.abort();
+    let raised: unknown;
+    try {
+      controller.signal.throwIfAborted();
+    } catch (error) {
+      raised = error;
+    }
+    // Recognised on the error alone, with no signal handed in.
+    expect(isAbortFailure(raised)).toBe(true);
+  });
+
+  it('a wrapped abort is recognised through one level of cause', () => {
+    const inner = new Error('aborted');
+    inner.name = 'AbortError';
+    expect(isAbortFailure(new Error('provider call failed', { cause: inner }))).toBe(true);
+  });
+
+  it('a non-Error rejection is not an abort', () => {
+    expect(isAbortFailure('abort')).toBe(false);
+    expect(isAbortFailure(undefined)).toBe(false);
+    expect(isAbortFailure({ name: 'AbortError' })).toBe(false);
+  });
+});

--- a/packages/agent-core/src/utils/abort-classification.ts
+++ b/packages/agent-core/src/utils/abort-classification.ts
@@ -1,0 +1,33 @@
+/**
+ * CORE-027 — was this failure an ABORT, or did it merely say so?
+ *
+ * Three call sites classified it the same wrong way:
+ *
+ *   error.name === 'AbortError' || error.message.includes('aborted') || error.message.includes('abort')
+ *
+ * The substring test is a guess about prose. A provider failure whose message happens to contain
+ * those letters — "the upstream aborted the stream after a policy check", "AbortController is not
+ * supported by this runtime", a remote 5xx body quoting the word — was classified as a user
+ * interruption, and `execution-service.ts` then returned `success: true, interrupted: true` for it.
+ * A real failure reported as a successful interrupted run is the sharpest kind of silent wrong
+ * answer: nothing downstream, including the print-mode exit code, has any way to tell.
+ *
+ * The authoritative signal is the one the caller already holds. An abort happens because SOMETHING
+ * ABORTED — the `AbortSignal` that was passed in says so, and the platform's own abort errors carry
+ * `name === 'AbortError'`. Neither is a guess about wording, and both are things the abort mechanism
+ * actually produces.
+ *
+ * `DOMException` with `name === 'AbortError'` is covered by the name test; `undici` and `node:fetch`
+ * both raise it that way, as does `AbortSignal.throwIfAborted()`.
+ */
+export function isAbortFailure(error: unknown, signal?: AbortSignal): boolean {
+  // The caller's own signal is the fact. If it is aborted, the round ended because of that,
+  // whatever the provider's error text says.
+  if (signal?.aborted === true) return true;
+  if (!(error instanceof Error)) return false;
+  // What the platform raises for an abort. Checked on the ERROR OBJECT, never on its prose.
+  if (error.name === 'AbortError') return true;
+  // A wrapped abort keeps the original as its cause; one level is enough for the wrappers here.
+  const cause: unknown = (error as { cause?: unknown }).cause;
+  return cause instanceof Error && cause.name === 'AbortError';
+}

--- a/packages/agent-core/src/utils/abort-classification.ts
+++ b/packages/agent-core/src/utils/abort-classification.ts
@@ -20,14 +20,41 @@
  * `DOMException` with `name === 'AbortError'` is covered by the name test; `undici` and `node:fetch`
  * both raise it that way, as does `AbortSignal.throwIfAborted()`.
  */
+/**
+ * Whether a value is error-SHAPED, without asking which realm or prototype chain it came from.
+ *
+ * `instanceof Error` is not a safe test here for two independent reasons, and only one of them was
+ * raised in review:
+ *
+ * - **Cross-realm.** An error thrown in a worker, a `vm` context, or a different iframe fails
+ *   `instanceof` against this realm's `Error` even when it is a perfectly ordinary error.
+ * - **`DOMException`.** Review claimed it does not extend `Error`. On this runtime it does —
+ *   measured on Node 22.14: `new DOMException('x','AbortError') instanceof Error === true`, and
+ *   WebIDL has put `Error.prototype` in its chain since 2021. So the claim does not hold here. But
+ *   `agent-core` ships a BROWSER build too, and nothing is gained by depending on that being true
+ *   everywhere when the structural test costs a line.
+ *
+ * A bare `{ name: 'AbortError' }` is still not an abort: an error carries a message.
+ */
+function isErrorShaped(
+  value: unknown,
+): value is { name: string; message: string; cause?: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { name?: unknown }).name === 'string' &&
+    typeof (value as { message?: unknown }).message === 'string'
+  );
+}
+
 export function isAbortFailure(error: unknown, signal?: AbortSignal): boolean {
   // The caller's own signal is the fact. If it is aborted, the round ended because of that,
   // whatever the provider's error text says.
   if (signal?.aborted === true) return true;
-  if (!(error instanceof Error)) return false;
+  if (!isErrorShaped(error)) return false;
   // What the platform raises for an abort. Checked on the ERROR OBJECT, never on its prose.
   if (error.name === 'AbortError') return true;
   // A wrapped abort keeps the original as its cause; one level is enough for the wrappers here.
-  const cause: unknown = (error as { cause?: unknown }).cause;
-  return cause instanceof Error && cause.name === 'AbortError';
+  const cause: unknown = error.cause;
+  return isErrorShaped(cause) && cause.name === 'AbortError';
 }

--- a/packages/agent-core/src/utils/index.ts
+++ b/packages/agent-core/src/utils/index.ts
@@ -1,4 +1,5 @@
 // Utility exports
+export * from './abort-classification';
 export * from './message-converter';
 export * from './logger';
 export * from './validation';

--- a/packages/agent-framework/src/interactive/__tests__/interactive-abort-classification.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-abort-classification.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAbortError } from '../interactive-session-execution.js';
+
+/**
+ * CORE-027, the interactive path.
+ *
+ * This was the THIRD copy of the substring heuristic and the one users actually meet:
+ * `interactive-session-prompt.ts:121` calls it and, when it says yes, builds an INTERRUPTED result —
+ * so a real provider failure whose message happened to contain "abort" was presented to the user as
+ * their own cancellation, with the failure discarded.
+ *
+ * Fixing only `agent-core` would have left this alive. The Task said so; the first attempt at the
+ * fix shipped without it anyway, which is why the assertions here are about this specific export
+ * rather than about the shared helper it now delegates to.
+ */
+describe('isAbortError on the interactive path (CORE-027)', () => {
+  describe('a real failure is not the user cancelling', () => {
+    for (const message of [
+      'the upstream aborted the stream after a policy check',
+      'AbortController is not supported by this runtime',
+      'HTTP 502: <html>request aborted by proxy</html>',
+    ]) {
+      it(JSON.stringify(message), () => {
+        expect(isAbortError(new Error(message))).toBe(false);
+      });
+    }
+  });
+
+  it('still recognises a real abort — the DOMException the old code tested for', () => {
+    expect(isAbortError(new DOMException('The operation was aborted.', 'AbortError'))).toBe(true);
+  });
+
+  it('recognises what AbortSignal.throwIfAborted() raises', () => {
+    const controller = new AbortController();
+    controller.abort();
+    let raised: unknown;
+    try {
+      controller.signal.throwIfAborted();
+    } catch (error) {
+      raised = error;
+    }
+    expect(isAbortError(raised)).toBe(true);
+  });
+
+  it('recognises a plain Error whose NAME is AbortError', () => {
+    const error = new Error('cancelled');
+    error.name = 'AbortError';
+    expect(isAbortError(error)).toBe(true);
+  });
+});

--- a/packages/agent-framework/src/interactive/interactive-session-execution.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto';
 import {
   collectAssistantUsageMetadata,
   calculateModelCost,
+  isAbortFailure,
   SPAN_EVENTS,
 } from '@robota-sdk/agent-core';
 
@@ -43,12 +44,10 @@ export interface IPreparedPromptInput {
   promptFileReferenceEntry?: IHistoryEntry;
 }
 
-/** Detect whether an error represents an abort/cancel action. */
+/** Detect an abort/cancel. CORE-027: the substring heuristic that stood here reported a provider
+ * failure as the user's own cancellation; `isAbortFailure` owns the decision and says why. */
 export function isAbortError(err: unknown): boolean {
-  return (
-    (err instanceof DOMException && err.name === 'AbortError') ||
-    (err instanceof Error && (err.message.includes('aborted') || err.message.includes('abort')))
-  );
+  return isAbortFailure(err);
 }
 
 /**

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -26,7 +26,7 @@
   "packages/agent-framework/src/interactive/interactive-session-background-tracker.ts": 334,
   "packages/agent-framework/src/interactive/interactive-session-base.ts": 387,
   "packages/agent-framework/src/interactive/interactive-session-execution-controller.ts": 461,
-  "packages/agent-framework/src/interactive/interactive-session-execution.ts": 314,
+  "packages/agent-framework/src/interactive/interactive-session-execution.ts": 313,
   "packages/agent-framework/src/interactive/interactive-session-history-tracker.ts": 355,
   "packages/agent-framework/src/interactive/interactive-session-init.ts": 330,
   "packages/agent-framework/src/interactive/interactive-session-skill-router.ts": 357,

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -17,7 +17,7 @@
   "packages/agent-core/src/plugins/event-emitter-plugin.ts": 310,
   "packages/agent-core/src/services/execution-round.ts": 308,
   "packages/agent-core/src/services/execution-service-helpers.ts": 373,
-  "packages/agent-core/src/services/execution-service.ts": 311,
+  "packages/agent-core/src/services/execution-service.ts": 310,
   "packages/agent-core/src/services/execution-stream.ts": 317,
   "packages/agent-core/src/utils/errors.ts": 315,
   "packages/agent-executor/src/background-tasks/background-task-manager.ts": 398,


### PR DESCRIPTION
First step of **CORE-027**, ranked #3 in the architecture audit (#1591) and observed independently by
three of the six auditors (foundation, runtime, DAG).

## The defect

Three call sites decided whether a failure was an abort by looking at its **prose**:

```ts
error.name === 'AbortError' || message.includes('aborted') || message.includes('abort')
```

and `execution-service.ts:233-247` returned `success: true, interrupted: true` when it said yes.

So a real provider failure whose text happened to contain those letters came back to the caller as a
**successfully interrupted run**:

- `the upstream aborted the stream after a policy check`
- `AbortController is not supported by this runtime`
- `HTTP 502: <html>request aborted by proxy</html>`
- `model refused: the user asked how to abort a deployment`

Nothing downstream — including the print-mode exit code — had any way to tell a cancelled turn from
a failed one.

## The fix

The authoritative signal is the one the caller already holds. An abort happens because **something
aborted**: the `AbortSignal` that was passed in says so, and the platform's abort errors carry
`name === 'AbortError'` — which is also what `AbortSignal.throwIfAborted()` raises. Neither is a
guess about wording.

One owner, `isAbortFailure(error, signal)`, replaces all three copies — including the one in
`agent-framework`'s interactive path, which the first version of this PR missed. That third copy is
the one users meet: `interactive-session-prompt.ts:121` calls it and builds an INTERRUPTED result
when it says yes, so a real failure was presented as the user's own cancellation. The Task warned
about it and the first attempt shipped without it; review caught the gap and it is closed here.

It also reads the **other** direction, which the substring test could not: an aborted signal now
classifies correctly even when the error text says something unrelated (`socket hang up`) — the
common shape when a provider notices a cancellation as a transport failure. The old test would have
called that a genuine failure and reported it as one, which is the same defect pointing the other
way.

## Verification

- **Red-proved:** with the substring classification restored, **6 of the 10** core assertions fail, and with the framework copy restored **3 of the 6** interactive assertions fail.
  The four failing-direction cases are real provider-failure wordings; each was previously reported
  as a successful interrupted run.
- 916 `agent-core`, 155 `agent-session` and 1311 `agent-framework` tests pass.
- `isAbortFailure` is a new public export of `agent-core` and is **documented in its SPEC** — the
  public-surface gate caught it, and a new export that nothing documents is how a surface grows
  without a decision.

## Deliberately not in this change

CORE-027 also covers the other half of the same contract: the failure is rendered into an assistant
message (`Request failed: ${errMsg}`) and later **reconstructed** as `new Error(<display string>)` in
`execution-service-helpers.ts`, so the original error object — its type, its `cause`, its status — is
lost by the time a caller sees it.

That is a result-shape change with a wider blast radius, and mixing it in here would make both halves
harder to review. It stays open in the Task, and the commit says so rather than leaving the
impression that CORE-027 is finished.
