### PR TITLE
fix(agent-core): CORE-029 give the diagnostics a destination

### DIFF
--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -259,6 +259,24 @@ sandbox (`agent-tools`), the CLI monitor asset server (`agent-cli`) and the stud
 | `isPathInside`     | function | Whether `candidate` is `root` itself or lies beneath it, decided on the CANONICAL form of both     |
 | `canonicalizePath` | function | Realpath-resolve a path, tolerating a not-yet-created tail so `Write`/`Edit` targets still resolve |
 
+### Diagnostic Sink Public API (CORE-029)
+
+Where this package's diagnostics go. `createLogger(name, sink?)` fell back to `SilentLogger` when no
+sink was passed; no call site in the repository ever passed one, and nothing could install one
+afterwards — so every `logger.*` call in the package, including "Robota initialization failed" and
+every catch-and-log-only path, had no reachable destination. That is not "logging was not
+configured": it could not be.
+
+The default remains SILENT. A library that starts writing to `console` because it was imported is a
+different defect, so turning diagnostics on is something a host does deliberately. The sink is
+resolved per call rather than frozen at construction, which is what lets a logger created during
+module initialisation honour a sink installed afterwards.
+
+| Export                | Kind     | Description                                                                        |
+| --------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `setGlobalLoggerSink` | function | Install the process-wide sink every logger writes to; `undefined` restores silence |
+| `getGlobalLoggerSink` | function | The installed sink, or `undefined` when diagnostics are going nowhere              |
+
 ### Abort Classification Public API (CORE-027)
 
 The SSOT for "was this failure an ABORT?" whenever the answer changes what the caller reports.

--- a/packages/agent-core/src/utils/logger-sink.test.ts
+++ b/packages/agent-core/src/utils/logger-sink.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createLogger,
+  getGlobalLoggerSink,
+  setGlobalLogLevel,
+  setGlobalLoggerSink,
+  type ILogger,
+} from './logger';
+
+/**
+ * CORE-029 — every diagnostic `agent-core` emits was discarded BY CONSTRUCTION.
+ *
+ * `createLogger(name, sink?)` fell back to `SilentLogger` when no sink was passed, no call site in
+ * the repository ever passed one, and nothing could install one afterwards. So 157 `logger.*` calls
+ * — including "Robota initialization failed" and every catch-and-log-only path — had no reachable
+ * destination. That is not "logging was not configured"; it could not be.
+ *
+ * The assertions below are about REACHABILITY, which is the thing that was missing. Each fails
+ * against the previous implementation: there was no `setGlobalLoggerSink` to call.
+ */
+function recordingSink(): { sink: ILogger; lines: string[] } {
+  const lines: string[] = [];
+  const push =
+    (level: string) =>
+    (...args: unknown[]) =>
+      lines.push(`${level}:${String(args[0] ?? '')}`);
+  return {
+    lines,
+    sink: {
+      debug: push('debug'),
+      info: push('info'),
+      warn: push('warn'),
+      error: push('error'),
+      log: push('log'),
+      group: push('group'),
+      groupEnd: () => {},
+    } as ILogger,
+  };
+}
+
+describe('global logger sink (CORE-029)', () => {
+  afterEach(() => {
+    setGlobalLoggerSink(undefined);
+    setGlobalLogLevel('warn');
+  });
+
+  it('is silent by default — a library that logs because it was imported is a different defect', () => {
+    expect(getGlobalLoggerSink()).toBeUndefined();
+    // Nothing to assert output against, which is the point: the default is unchanged.
+    expect(() => createLogger('pkg').error('boom')).not.toThrow();
+  });
+
+  it('delivers a diagnostic to an installed sink', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    createLogger('pkg').error('Robota initialization failed');
+    expect(lines.some((l) => l.includes('Robota initialization failed'))).toBe(true);
+  });
+
+  it('reaches a logger that was CREATED BEFORE the sink was installed', () => {
+    // The shape that matters: module-level loggers are constructed at import time, long before a
+    // host can configure anything. Freezing the sink in the constructor would lose all of them.
+    const logger = createLogger('created-early');
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    logger.error('late delivery');
+    expect(lines.some((l) => l.includes('late delivery'))).toBe(true);
+  });
+
+  it('an explicitly passed sink still wins over the global one', () => {
+    const explicit = recordingSink();
+    const global = recordingSink();
+    setGlobalLoggerSink(global.sink);
+    createLogger('pkg', explicit.sink).error('to the explicit one');
+    expect(explicit.lines.some((l) => l.includes('to the explicit one'))).toBe(true);
+    expect(global.lines).toHaveLength(0);
+  });
+
+  it('goes back to silence when the sink is removed', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    const logger = createLogger('pkg');
+    logger.error('first');
+    setGlobalLoggerSink(undefined);
+    logger.error('second');
+    expect(lines.filter((l) => l.includes('first'))).toHaveLength(1);
+    expect(lines.some((l) => l.includes('second'))).toBe(false);
+  });
+
+  it('still respects the level — a sink does not turn every level on', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    setGlobalLogLevel('error');
+    const logger = createLogger('pkg');
+    logger.debug('not this');
+    logger.error('this one');
+    expect(lines.some((l) => l.includes('not this'))).toBe(false);
+    expect(lines.some((l) => l.includes('this one'))).toBe(true);
+  });
+});

--- a/packages/agent-core/src/utils/logger.ts
+++ b/packages/agent-core/src/utils/logger.ts
@@ -56,6 +56,7 @@ export const SilentLogger: ILogger = {
 class LoggerConfig {
   private static instance: LoggerConfig;
   private globalLevel: TUtilLogLevel;
+  private globalSink: ILogger | undefined;
 
   private constructor() {
     // Set default level (environment variables no longer used for browser compatibility)
@@ -76,6 +77,14 @@ class LoggerConfig {
   setGlobalLevel(level: TUtilLogLevel): void {
     this.globalLevel = level;
   }
+
+  getGlobalSink(): ILogger | undefined {
+    return this.globalSink;
+  }
+
+  setGlobalSink(sink: ILogger | undefined): void {
+    this.globalSink = sink;
+  }
 }
 
 /**
@@ -85,11 +94,27 @@ class LoggerConfig {
 export class ConsoleLogger implements ILogger {
   private level?: TUtilLogLevel; // undefined means use global level
   private packageName: string;
-  private sinkLogger: ILogger;
+  private explicitSink: ILogger | undefined;
 
+  /**
+   * CORE-029: the sink is resolved PER CALL, not frozen at construction.
+   *
+   * It used to be `logger || SilentLogger`, decided once in the constructor. No call site in the
+   * repository ever passed one and there was no way to set one afterwards, so every diagnostic this
+   * package emits — 157 `logger.*` calls, including "Robota initialization failed" and every
+   * catch-and-log-only path — went to `SilentLogger` by construction. Not "was not configured":
+   * could not be.
+   *
+   * Resolving late is what makes a host able to turn logging on at all, and it is also why a logger
+   * created during module initialisation still honours a sink installed afterwards.
+   */
   constructor(packageName: string, logger?: ILogger) {
     this.packageName = packageName;
-    this.sinkLogger = logger || SilentLogger;
+    this.explicitSink = logger;
+  }
+
+  private get sinkLogger(): ILogger {
+    return this.explicitSink ?? LoggerConfig.getInstance().getGlobalSink() ?? SilentLogger;
   }
 
   debug(...args: Array<TUniversalValue | TLoggerData | Error>): void {
@@ -196,6 +221,26 @@ export function setGlobalLogLevel(level: TUtilLogLevel): void {
  */
 export function getGlobalLogLevel(): TUtilLogLevel {
   return LoggerConfig.getInstance().getGlobalLevel();
+}
+
+/**
+ * Install the process-wide sink every logger writes to. CORE-029.
+ *
+ * Without this there was no way to receive anything this package logs: `createLogger`'s optional
+ * sink parameter had no caller anywhere in the repository, and nothing could supply one later, so
+ * `SilentLogger` was not a default — it was the only reachable outcome.
+ *
+ * The default stays SILENT. A library that starts writing to `console` because it was imported is a
+ * different defect, so turning diagnostics on remains something a host does deliberately. Pass
+ * `undefined` to go back to silence.
+ */
+export function setGlobalLoggerSink(sink: ILogger | undefined): void {
+  LoggerConfig.getInstance().setGlobalSink(sink);
+}
+
+/** The installed process-wide sink, or `undefined` when diagnostics are going nowhere. */
+export function getGlobalLoggerSink(): ILogger | undefined {
+  return LoggerConfig.getInstance().getGlobalSink();
 }
 
 /**


### PR DESCRIPTION
**CORE-029**, ranked #15 in the architecture audit (#1591) and observed at four layers.

## The defect

Every diagnostic `agent-core` emits was discarded **by construction**.

`createLogger(name, sink?)` fell back to `SilentLogger` when no sink was passed. **No call site in
the repository ever passed one** — measured: zero, the three grep matches are the declaration itself
— and there was no way to install one afterwards.

So 157 `logger.*` calls had no reachable destination, including `"Robota initialization failed"` and
every catch-and-log-only path.

That is not "logging was not configured". It could not be.

## The fix

`setGlobalLoggerSink(sink)` makes it configurable, and the sink is resolved **per call** rather than
frozen in the constructor.

That second part is the one that matters: module-level loggers are constructed at import time, long
before a host can configure anything. Freezing the sink at construction would have silently lost
every one of them — which is most of them — and the fix would have looked like it worked.

**The default stays silent.** A library that starts writing to `console` because it was imported is a
different defect, so turning diagnostics on remains something a host does deliberately. Passing
`undefined` returns to silence.

## Verification

- **Red-proved:** with the construction-frozen sink restored, **4 of the 6** assertions fail.
- The assertions are about **reachability**, which is the thing that was missing — including the
  late-install case, that an explicit sink still wins over the global one, and that installing a sink
  does not turn every level on.
- Both exports are documented in the SPEC rather than added quietly; the public-surface gate caught
  them, as it did on CORE-027.
- 924 `agent-core` tests pass.

## Not in this change

The audit lists the same silence pattern at three layers above this one. Those are separate call
sites with their own owners; this change makes the destination exist, which is the precondition for
any of them. The Task keeps them open.
