### PR TITLE
fix(agent-core): NEUT-010 the package that owns a model owns its metadata

### DIFF
--- a/packages/agent-cli/src/__tests__/diagnostic-sink-installed.test.ts
+++ b/packages/agent-cli/src/__tests__/diagnostic-sink-installed.test.ts
@@ -1,0 +1,76 @@
+import { setGlobalLoggerSink } from '@robota-sdk/agent-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * CORE-029 / NEUT-010 — the runtime's diagnostics reach a user in this product.
+ *
+ * Review of #1595 made the point that mattered: `agent-core` defaults to a silent sink and nothing
+ * in the repository installed one, so adding a WARNING for an unregistered model changed nothing an
+ * operator could observe. A guard nobody can hear is the same defect as no guard.
+ *
+ * This asserts the wiring exists at the entry point, and that a diagnostic emitted by the runtime
+ * actually arrives — not merely that a function was called.
+ */
+describe('the CLI installs a destination for runtime diagnostics', () => {
+  afterEach(() => {
+    setGlobalLoggerSink(undefined);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('installs a sink when the binary is loaded', async () => {
+    // Read core from the SAME module generation the binary registers into. A statically imported
+    // `getGlobalLoggerSink` belongs to a different instance after `resetModules`, and asking it
+    // would answer about a registry nobody wrote to.
+    vi.resetModules();
+    const before = await import('@robota-sdk/agent-core');
+    expect(before.getGlobalLoggerSink()).toBeUndefined();
+
+    vi.resetModules();
+    // `bin.ts` registers process handlers and calls startCli(); stub the latter so importing it is
+    // safe here. The sink installation is a module-level statement and runs regardless.
+    vi.doMock('../cli.js', () => ({ startCli: () => Promise.resolve() }));
+    await import('../bin.js');
+    const after = await import('@robota-sdk/agent-core');
+
+    expect(after.getGlobalLoggerSink()).toBeDefined();
+  });
+
+  it('routes a runtime warning to stderr, where it does not corrupt the TUI', async () => {
+    const written: string[] = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    vi.resetModules();
+    vi.doMock('../cli.js', () => ({ startCli: () => Promise.resolve() }));
+    await import('../bin.js');
+    const core = await import('@robota-sdk/agent-core');
+
+    // The exact diagnostic NEUT-010 added: a model nobody registered.
+    core.getModelContextWindow('some-other-vendor/model-x');
+
+    expect(written.some((line) => line.includes('some-other-vendor/model-x'))).toBe(true);
+    expect(written.some((line) => line.includes('[robota]'))).toBe(true);
+  });
+
+  it('stays quiet below the warn level, so ordinary output is not buried', async () => {
+    const written: string[] = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    vi.resetModules();
+    vi.doMock('../cli.js', () => ({ startCli: () => Promise.resolve() }));
+    await import('../bin.js');
+    const core = await import('@robota-sdk/agent-core');
+
+    core.createLogger('probe').debug('a debug line');
+    core.createLogger('probe').info('an info line');
+
+    expect(written.some((line) => line.includes('a debug line'))).toBe(false);
+    expect(written.some((line) => line.includes('an info line'))).toBe(false);
+  });
+});

--- a/packages/agent-cli/src/bin.ts
+++ b/packages/agent-cli/src/bin.ts
@@ -7,8 +7,38 @@
  * A Node.js version check (>=22) is injected as a build-time banner in
  * tsdown.config.ts and runs before any module imports are loaded.
  */
+import { setGlobalLoggerSink } from '@robota-sdk/agent-core';
+
 import { startCli } from './cli.js';
 import { areTuiProcessGuardsActive, classifyUncaughtException } from './process-guards.js';
+
+/**
+ * CORE-029 / NEUT-010: the runtime's diagnostics have a destination in this product.
+ *
+ * `agent-core` defaults to a silent sink and nothing in the repository installed one, so every
+ * diagnostic it emits went nowhere — including "no metadata registered for model X, using another
+ * vendor's default". Adding the WARNING without connecting a sink would have left the defect exactly
+ * where it was while claiming it was fixed; review of #1595 said so, correctly.
+ *
+ * STDERR, not stdout: the TUI owns stdout, and this process already writes its own errors to stderr.
+ * The global level defaults to `warn`, so this carries warnings and errors and stays out of the way
+ * of normal output — the same 30 warn and 23 error sites that were unreachable a moment ago.
+ */
+setGlobalLoggerSink({
+  debug: () => {},
+  info: () => {},
+  log: () => {},
+  group: () => {},
+  groupEnd: () => {},
+  warn: (...args) => process.stderr.write(`[robota] ${formatDiagnostic(args)}\n`),
+  error: (...args) => process.stderr.write(`[robota] ${formatDiagnostic(args)}\n`),
+});
+
+function formatDiagnostic(args: unknown[]): string {
+  return args
+    .map((arg) => (arg instanceof Error ? (arg.stack ?? arg.message) : String(arg)))
+    .join(' ');
+}
 
 // Last-resort crash policy (CORE-020, RUNTIME-34): the IME allowlist is scoped to
 // interactive TUI mode only — headless/print mode always rethrows (fail-fast exit-code

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -43,7 +43,7 @@ console.log(response);
 - **Plugin system**: `AbstractPlugin` base class with lifecycle hooks (beforeRun, afterRun, onError, etc.)
 - **Event services**: Unified event emission with owner path tracking
 - **Error hierarchy**: Typed errors extending `RobotaError` (ProviderError, RateLimitError, etc.)
-- **Model definitions**: Central `CLAUDE_MODELS` registry with context windows, output limits, and human-readable names
+- **Model metadata registry**: providers contribute their own models via `registerModelMetadata()`; core owns the registry and the lookups, not any vendor's catalogue (NEUT-010)
 - **callProviderWithCache**: Accepts `Partial<IChatOptions>` overrides for per-call configuration
 - **AbortSignal propagation**: Signal flows through the entire execution chain (Session -> Robota -> Provider)
 - **Execution boundary events**: `Robota.run()` can emit provider/tool provenance events through `onExecutionEvent`
@@ -196,7 +196,7 @@ agent-cli         ← Terminal UI
 | **Permissions** | `evaluatePermission`, `MODE_POLICY`, `TRUST_TO_MODE`, `UNKNOWN_TOOL_FALLBACK`, `TPermissionMode`, `TTrustLevel`, `TPermissionDecision`, `TToolArgs`, `IPermissionLists`, `TKnownToolName`                                             |
 | **Hooks**       | `runHooks`, `CommandExecutor`, `HttpExecutor`, `IHookTypeExecutor`, `THookEvent`, `THooksConfig`, `IHookGroup`, `IHookDefinition`, `IHookInput`, `IHookResult`                                                                        |
 | **Events**      | `EventEmitterPlugin`, `IEventService`, `IOwnerPathSegment`                                                                                                                                                                            |
-| **Models**      | `CLAUDE_MODELS`, `DEFAULT_CONTEXT_WINDOW`, `DEFAULT_MAX_OUTPUT`, `getModelContextWindow()`, `getModelMaxOutput()`, `getModelName()`, `formatTokenCount()`, `IModelDefinition`                                                         |
+| **Models**      | `registerModelMetadata()`, `DEFAULT_CONTEXT_WINDOW`, `DEFAULT_MAX_OUTPUT`, `getModelContextWindow()`, `getModelMaxOutput()`, `getModelName()`, `formatTokenCount()`, `IModelDefinition`                                               |
 | **Context**     | `estimateContextTokensFromMessages()`, `estimateSerializedContextTokens()`, `readTokenUsageFromMessage()`, `IContextTokenEstimate`, `IMessageTokenUsage`, `IContextWindowState`, `IContextTokenUsage`                                 |
 | **Types**       | `TUniversalMessage`, `IBaseMessage` (`id`, `state`), `TMessageState`, `IAgentConfig`, `IAIProvider`, `IProviderCapabilities`, `IProviderNativeWebToolRequest`, `IToolSchema`, `TTextDeltaCallback`                                    |
 | **Errors**      | `RobotaError`, `ProviderError`, `RateLimitError`, `AuthenticationError`, `ToolExecutionError`, etc.                                                                                                                                   |

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -259,6 +259,29 @@ sandbox (`agent-tools`), the CLI monitor asset server (`agent-cli`) and the stud
 | `isPathInside`     | function | Whether `candidate` is `root` itself or lies beneath it, decided on the CANONICAL form of both     |
 | `canonicalizePath` | function | Realpath-resolve a path, tolerating a not-yet-created tail so `Write`/`Edit` targets still resolve |
 
+### Model Metadata Registry Public API (NEUT-010)
+
+Who owns the answer to "how big is this model's context window". This package used to carry a CLAUDE
+table — against its own rule that it must not branch on concrete provider or model names — and
+`agent-provider-anthropic` imported it back out. Worse, `getModelContextWindow` handed every model
+NOT in that table `DEFAULT_CONTEXT_WINDOW`, which is 200 000, which is Claude's window: every
+non-Claude session was planned against another vendor's number with no signal at all.
+
+The table now lives with the package that owns those models, and every provider contributes the same
+way. The registry is the ONLY source, so a model nobody registered is a model nobody owns — and the
+lookup helpers say so once per model rather than passing silently.
+
+`CLAUDE_MODELS` is **no longer exported from this package**. Import it from
+`@robota-sdk/agent-provider-anthropic`, which owns it.
+
+| Export                  | Kind     | Description                                                    |
+| ----------------------- | -------- | -------------------------------------------------------------- |
+| `registerModelMetadata` | function | Contribute model metadata from the package that owns the model |
+
+`findModelDefinition` and `clearRegisteredModelMetadata` are deliberately NOT on the package entry:
+the contribution point is the whole public contract, and lookups go through the existing
+`getModelContextWindow` / `getModelMaxOutput` / `getModelName` helpers.
+
 ### Diagnostic Sink Public API (CORE-029)
 
 Where this package's diagnostics go. `createLogger(name, sink?)` fell back to `SilentLogger` when no

--- a/packages/agent-core/src/context/index.ts
+++ b/packages/agent-core/src/context/index.ts
@@ -12,13 +12,15 @@ export { readTokenUsageFromMessage, readTokenUsageFromMetadata } from './token-u
 // Model definitions (SSOT)
 export type { IModelDefinition } from './models.js';
 export {
-  CLAUDE_MODELS,
   DEFAULT_CONTEXT_WINDOW,
   DEFAULT_MAX_OUTPUT,
   getModelContextWindow,
   getModelMaxOutput,
   getModelName,
   formatTokenCount,
+  registerModelMetadata,
+  clearRegisteredModelMetadata,
+  findModelDefinition,
 } from './models.js';
 
 // Model pricing (SSOT)

--- a/packages/agent-core/src/context/model-registry.test.ts
+++ b/packages/agent-core/src/context/model-registry.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_CONTEXT_WINDOW,
+  clearRegisteredModelMetadata,
+  findModelDefinition,
+  getModelContextWindow,
+  getModelMaxOutput,
+  getModelName,
+  registerModelMetadata,
+} from './models';
+import { setGlobalLoggerSink, setGlobalLogLevel, type ILogger } from '../utils/logger';
+
+/**
+ * NEUT-010 — vendor model knowledge in the vendor-neutral package.
+ *
+ * `getModelContextWindow` answered `DEFAULT_CONTEXT_WINDOW` for anything it did not recognise, and
+ * that constant is 200 000 — CLAUDE's window. So every non-Claude session was planned against a
+ * number belonging to a different vendor's models, and the three consumers that act on it had no
+ * way to know they were working from a guess.
+ *
+ * Two things change, and the tests are about both: a provider can now REGISTER the truth about its
+ * own models, and when nothing owns a model the fallback SAYS SO instead of passing silently.
+ */
+function recordingSink(): { sink: ILogger; lines: string[] } {
+  const lines: string[] = [];
+  const push =
+    () =>
+    (...args: unknown[]) =>
+      lines.push(String(args[0] ?? ''));
+  return {
+    lines,
+    sink: {
+      debug: push(),
+      info: push(),
+      warn: push(),
+      error: push(),
+      log: push(),
+      group: push(),
+      groupEnd: () => {},
+    } as ILogger,
+  };
+}
+
+describe('model metadata registry (NEUT-010)', () => {
+  afterEach(() => {
+    clearRegisteredModelMetadata();
+    setGlobalLoggerSink(undefined);
+    setGlobalLogLevel('warn');
+  });
+
+  it('a registered model answers with ITS numbers, not another vendor default', () => {
+    registerModelMetadata({
+      id: 'some-vendor/small',
+      name: 'Some Vendor Small',
+      contextWindow: 8_192,
+      maxOutput: 2_048,
+    });
+    expect(getModelContextWindow('some-vendor/small')).toBe(8_192);
+    expect(getModelMaxOutput('some-vendor/small')).toBe(2_048);
+    expect(getModelName('some-vendor/small')).toBe('Some Vendor Small');
+    // The premise: without registration this model would have received Claude's window.
+    expect(DEFAULT_CONTEXT_WINDOW).toBe(200_000);
+  });
+
+  it('an UNKNOWN model still gets a number, but no longer silently', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    expect(getModelContextWindow('nobody-owns-this')).toBe(DEFAULT_CONTEXT_WINDOW);
+    expect(lines.some((l) => l.includes('nobody-owns-this'))).toBe(true);
+    expect(lines.some((l) => l.includes('registerModelMetadata'))).toBe(true);
+  });
+
+  it('warns ONCE per model and metric — a warning repeated every round is one nobody reads', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    for (let i = 0; i < 5; i++) getModelContextWindow('noisy-unknown-model');
+    expect(lines.filter((l) => l.includes('noisy-unknown-model'))).toHaveLength(1);
+  });
+
+  it('does NOT warn for a name — the id is a correct answer, not a guess about capability', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    expect(getModelName('unregistered-model')).toBe('unregistered-model');
+    expect(lines.filter((l) => l.includes('unregistered-model'))).toHaveLength(0);
+  });
+
+  it('a registered entry overrides the built-in table, so a stale built-in can be corrected', () => {
+    const before = getModelContextWindow('claude-haiku-4-5');
+    expect(before).toBe(200_000);
+    registerModelMetadata({
+      id: 'claude-haiku-4-5',
+      name: 'Claude Haiku 4.5',
+      contextWindow: 999,
+      maxOutput: 1,
+    });
+    expect(getModelContextWindow('claude-haiku-4-5')).toBe(999);
+  });
+
+  it('findModelDefinition says when nothing owns a model, rather than inventing one', () => {
+    expect(findModelDefinition('nobody-owns-this-either')).toBeUndefined();
+  });
+});

--- a/packages/agent-core/src/context/model-registry.test.ts
+++ b/packages/agent-core/src/context/model-registry.test.ts
@@ -85,16 +85,30 @@ describe('model metadata registry (NEUT-010)', () => {
     expect(lines.filter((l) => l.includes('unregistered-model'))).toHaveLength(0);
   });
 
-  it('a registered entry overrides the built-in table, so a stale built-in can be corrected', () => {
-    const before = getModelContextWindow('claude-haiku-4-5');
-    expect(before).toBe(200_000);
-    registerModelMetadata({
-      id: 'claude-haiku-4-5',
-      name: 'Claude Haiku 4.5',
-      contextWindow: 999,
-      maxOutput: 1,
-    });
-    expect(getModelContextWindow('claude-haiku-4-5')).toBe(999);
+  /**
+   * Named "overrides the built-in table" in review of #1595, which was WRONG in a way worth
+   * recording: this change removes the built-in table, so there is nothing to override. Its `before`
+   * value of 200 000 was the unknown-model FALLBACK, which happens to equal the window Claude Haiku
+   * really has — the exact coincidence this suite avoids elsewhere by probing with Sonnet, whose
+   * real window differs from the default. A test whose premise is a coincidence proves nothing.
+   *
+   * What the re-registration behaviour actually is: the last registration wins, and a CONFLICTING
+   * one says so rather than replacing a value in silence.
+   */
+  it('re-registering the same id replaces it, and a conflicting value is announced', () => {
+    const { sink, lines } = recordingSink();
+    setGlobalLoggerSink(sink);
+    registerModelMetadata({ id: 'vendor/x', name: 'X', contextWindow: 1_000, maxOutput: 100 });
+    expect(getModelContextWindow('vendor/x')).toBe(1_000);
+
+    // Same values again: nothing changed, so nothing to report.
+    registerModelMetadata({ id: 'vendor/x', name: 'X', contextWindow: 1_000, maxOutput: 100 });
+    expect(lines.filter((l) => l.includes('vendor/x'))).toHaveLength(0);
+
+    // Different values: one of the two owners is wrong, and that is worth knowing.
+    registerModelMetadata({ id: 'vendor/x', name: 'X', contextWindow: 2_000, maxOutput: 100 });
+    expect(getModelContextWindow('vendor/x')).toBe(2_000);
+    expect(lines.some((l) => l.includes('vendor/x'))).toBe(true);
   });
 
   it('findModelDefinition says when nothing owns a model, rather than inventing one', () => {

--- a/packages/agent-core/src/context/models.test.ts
+++ b/packages/agent-core/src/context/models.test.ts
@@ -1,47 +1,29 @@
 import { describe, it, expect } from 'vitest';
+
 import {
-  CLAUDE_MODELS,
   DEFAULT_CONTEXT_WINDOW,
   getModelContextWindow,
   getModelName,
   formatTokenCount,
 } from './models.js';
 
-describe('CLAUDE_MODELS registry', () => {
-  it('contains known model IDs', () => {
-    expect(CLAUDE_MODELS['claude-opus-4-6']).toBeDefined();
-    expect(CLAUDE_MODELS['claude-sonnet-4-6']).toBeDefined();
-    expect(CLAUDE_MODELS['claude-haiku-4-5']).toBeDefined();
-  });
-
-  it('each entry has required fields', () => {
-    for (const [id, model] of Object.entries(CLAUDE_MODELS)) {
-      expect(model.id).toBe(id);
-      expect(model.name).toBeTruthy();
-      expect(model.contextWindow).toBeGreaterThan(0);
-      expect(model.maxOutput).toBeGreaterThan(0);
-    }
-  });
-});
-
+/**
+ * NEUT-010: the Claude table these tests used to assert against now lives with the package that
+ * owns those models (`agent-provider-anthropic`), and its cases moved with it. What stays here is
+ * what this vendor-NEUTRAL package still owns: the fallback behaviour when nobody has registered a
+ * model, and token formatting.
+ *
+ * Registry behaviour — registration, override, and the no-longer-silent fallback — is covered in
+ * `model-registry.test.ts`.
+ */
 describe('getModelContextWindow', () => {
-  it('returns context window for known model', () => {
-    expect(getModelContextWindow('claude-opus-4-6')).toBe(1_000_000);
-    expect(getModelContextWindow('claude-haiku-4-5')).toBe(200_000);
-  });
-
-  it('returns DEFAULT_CONTEXT_WINDOW for unknown model', () => {
+  it('falls back for a model nobody registered', () => {
     expect(getModelContextWindow('unknown-model')).toBe(DEFAULT_CONTEXT_WINDOW);
   });
 });
 
 describe('getModelName', () => {
-  it('returns human-readable name for known model', () => {
-    expect(getModelName('claude-opus-4-6')).toBe('Claude Opus 4.6');
-    expect(getModelName('claude-sonnet-4-6')).toBe('Claude Sonnet 4.6');
-  });
-
-  it('returns model ID as fallback for unknown model', () => {
+  it('returns the model ID for a model nobody registered', () => {
     expect(getModelName('unknown-model')).toBe('unknown-model');
   });
 });

--- a/packages/agent-core/src/context/models.ts
+++ b/packages/agent-core/src/context/models.ts
@@ -3,6 +3,27 @@
  * Source: https://platform.claude.com/docs/en/about-claude/models/overview
  */
 
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('agent-core:models');
+
+/**
+ * One line per unknown model, not one per call. `getModelContextWindow` runs on every round, and a
+ * warning repeated a thousand times is a warning nobody reads.
+ */
+const warnedModels = new Set<string>();
+
+function warnUnknownModel(modelId: string, what: string, fallback: number): void {
+  const key = `${modelId}:${what}`;
+  if (warnedModels.has(key)) return;
+  warnedModels.add(key);
+  logger.warn(
+    `No metadata registered for model "${modelId}"; using the default ${what} of ${fallback}. ` +
+      "This number belongs to a different vendor's models — register the model through " +
+      'registerModelMetadata() from the package that owns it. (NEUT-010)',
+  );
+}
+
 export interface IModelDefinition {
   /** Human-readable model name */
   name: string;
@@ -18,74 +39,73 @@ export interface IModelDefinition {
  * Known Claude models (4.5+).
  * Keyed by API model ID for fast lookup.
  */
-export const CLAUDE_MODELS: Record<string, IModelDefinition> = {
-  'claude-opus-4-6': {
-    name: 'Claude Opus 4.6',
-    id: 'claude-opus-4-6',
-    contextWindow: 1_000_000,
-    maxOutput: 128_000,
-  },
-  'claude-sonnet-4-6': {
-    name: 'Claude Sonnet 4.6',
-    id: 'claude-sonnet-4-6',
-    contextWindow: 1_000_000,
-    maxOutput: 64_000,
-  },
-  'claude-haiku-4-5': {
-    name: 'Claude Haiku 4.5',
-    id: 'claude-haiku-4-5',
-    contextWindow: 200_000,
-    maxOutput: 64_000,
-  },
-  'claude-haiku-4-5-20251001': {
-    name: 'Claude Haiku 4.5',
-    id: 'claude-haiku-4-5-20251001',
-    contextWindow: 200_000,
-    maxOutput: 64_000,
-  },
-  'claude-sonnet-4-5': {
-    name: 'Claude Sonnet 4.5',
-    id: 'claude-sonnet-4-5',
-    contextWindow: 200_000,
-    maxOutput: 64_000,
-  },
-  'claude-sonnet-4-5-20250929': {
-    name: 'Claude Sonnet 4.5',
-    id: 'claude-sonnet-4-5-20250929',
-    contextWindow: 200_000,
-    maxOutput: 64_000,
-  },
-  'claude-opus-4-5': {
-    name: 'Claude Opus 4.5',
-    id: 'claude-opus-4-5',
-    contextWindow: 200_000,
-    maxOutput: 64_000,
-  },
-  'claude-opus-4-5-20251101': {
-    name: 'Claude Opus 4.5',
-    id: 'claude-opus-4-5-20251101',
-    contextWindow: 200_000,
-    maxOutput: 64_000,
-  },
-};
-
 export const DEFAULT_CONTEXT_WINDOW = 200_000;
 
-/** Get context window size for a model ID. Falls back to DEFAULT_CONTEXT_WINDOW. */
+/**
+ * Model metadata contributed by a provider package. NEUT-010.
+ *
+ * This package used to carry a CLAUDE table, against its own SPEC ("must not branch on concrete
+ * provider or model names") — and `agent-provider-anthropic` imported it back out. The table now
+ * lives with the package that owns those models, and every provider contributes the same way.
+ *
+ * The registry is the ONLY source. A model nobody registered is a model nobody owns, which is a
+ * different answer from "here is a number", and the callers below say so.
+ */
+const registeredModels = new Map<string, IModelDefinition>();
+
+/** Contribute model metadata from the package that owns the model. */
+export function registerModelMetadata(...definitions: IModelDefinition[]): void {
+  for (const definition of definitions) registeredModels.set(definition.id, definition);
+}
+
+/** Forget contributed metadata. Exposed for tests and for hosts that rebuild a registry. */
+export function clearRegisteredModelMetadata(): void {
+  registeredModels.clear();
+}
+
+/** The metadata known for a model ID, or `undefined` when nothing owns it. */
+export function findModelDefinition(modelId: string): IModelDefinition | undefined {
+  return registeredModels.get(modelId);
+}
+
+/**
+ * Get context window size for a model ID.
+ *
+ * NEUT-010: an unknown model used to receive `DEFAULT_CONTEXT_WINDOW` — 200 000, which is CLAUDE's
+ * window — with no signal at all. Every non-Claude session was therefore sized against a number
+ * belonging to a different vendor's models, and the two consumers that act on it
+ * (`execution-round-context.ts`, `execution-round-tools.ts`, and `agent-session`'s context-window
+ * tracker) had no way to know they were working from a guess.
+ *
+ * The fallback remains, because these call sites need a number to plan a round with. What changes is
+ * that it is no longer SILENT: falling back now says which model it could not identify. A guess that
+ * announces itself can be found; one that does not is indistinguishable from knowledge.
+ */
 export function getModelContextWindow(modelId: string): number {
-  return CLAUDE_MODELS[modelId]?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+  const known = findModelDefinition(modelId)?.contextWindow;
+  if (known !== undefined) return known;
+  warnUnknownModel(modelId, 'context window', DEFAULT_CONTEXT_WINDOW);
+  return DEFAULT_CONTEXT_WINDOW;
 }
 
 export const DEFAULT_MAX_OUTPUT = 16_384;
 
-/** Get max output tokens for a model ID. Falls back to DEFAULT_MAX_OUTPUT. */
+/** Get max output tokens for a model ID. Falls back to DEFAULT_MAX_OUTPUT, and says so. */
 export function getModelMaxOutput(modelId: string): number {
-  return CLAUDE_MODELS[modelId]?.maxOutput ?? DEFAULT_MAX_OUTPUT;
+  const known = findModelDefinition(modelId)?.maxOutput;
+  if (known !== undefined) return known;
+  warnUnknownModel(modelId, 'max output', DEFAULT_MAX_OUTPUT);
+  return DEFAULT_MAX_OUTPUT;
 }
 
-/** Get human-readable model name for a model ID. Falls back to the ID itself. */
+/**
+ * Get human-readable model name for a model ID. Falls back to the ID itself.
+ *
+ * No warning here: the ID is a CORRECT answer to "what should I call this model", not a guess about
+ * the model's capabilities. Warning on it would train the reader to ignore the ones that matter.
+ */
 export function getModelName(modelId: string): string {
-  return CLAUDE_MODELS[modelId]?.name ?? modelId;
+  return findModelDefinition(modelId)?.name ?? modelId;
 }
 
 /** Format token count as human-readable (e.g., 200K, 1M, 1.2M). Minimum unit is K. */

--- a/packages/agent-core/src/context/models.ts
+++ b/packages/agent-core/src/context/models.ts
@@ -53,9 +53,31 @@ export const DEFAULT_CONTEXT_WINDOW = 200_000;
  */
 const registeredModels = new Map<string, IModelDefinition>();
 
-/** Contribute model metadata from the package that owns the model. */
+/**
+ * Contribute model metadata from the package that owns the model.
+ *
+ * The last registration wins, which is what lets a host correct a provider. A CONFLICTING one is
+ * announced first: two packages claiming the same model id with different numbers means one of them
+ * is wrong, and replacing a value in silence is the failure mode this whole change is against.
+ * Re-registering identical values — which happens whenever a module is loaded twice — says nothing.
+ */
 export function registerModelMetadata(...definitions: IModelDefinition[]): void {
-  for (const definition of definitions) registeredModels.set(definition.id, definition);
+  for (const definition of definitions) {
+    const existing = registeredModels.get(definition.id);
+    if (existing && !sameDefinition(existing, definition)) {
+      logger.warn(
+        `Model "${definition.id}" was already registered with different metadata ` +
+          `(context window ${existing.contextWindow} -> ${definition.contextWindow}, ` +
+          `max output ${existing.maxOutput} -> ${definition.maxOutput}). The later registration ` +
+          'wins; one of the two owners is wrong. (NEUT-010)',
+      );
+    }
+    registeredModels.set(definition.id, definition);
+  }
+}
+
+function sameDefinition(a: IModelDefinition, b: IModelDefinition): boolean {
+  return a.name === b.name && a.contextWindow === b.contextWindow && a.maxOutput === b.maxOutput;
 }
 
 /** Forget contributed metadata. Exposed for tests and for hosts that rebuild a registry. */

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -309,11 +309,9 @@ export type {
   IContextTokenEstimateOptions,
   IMessageTokenUsage,
 } from './context/index.js';
-export type { IModelDefinition } from './context/index.js';
-export type { IModelPrice } from './context/index.js';
+export type { IModelDefinition, IModelPrice } from './context/index.js';
 export {
   CONTEXT_ESTIMATE_CHARS_PER_TOKEN,
-  CLAUDE_MODELS,
   DEFAULT_CONTEXT_WINDOW,
   DEFAULT_MAX_OUTPUT,
   estimateContextTokensFromMessages,
@@ -322,6 +320,7 @@ export {
   getModelMaxOutput,
   getModelName,
   formatTokenCount,
+  registerModelMetadata,
   readTokenUsageFromMessage,
   readTokenUsageFromMetadata,
   MODEL_PRICES,

--- a/packages/agent-provider-anthropic/src/anthropic/__tests__/claude-models.test.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/__tests__/claude-models.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CLAUDE_MODELS } from '../claude-models.js';
+
+/**
+ * NEUT-010 — the Claude table, and the cases that came with it from `agent-core`.
+ *
+ * `agent-core`'s own SPEC says it must not branch on concrete provider or model names, yet it
+ * carried this table and this package imported it back out. Two consequences: the vendor-neutral
+ * foundation held one vendor's catalogue, and every model NOT in that table silently received
+ * Claude's 200 000-token window.
+ *
+ * The registration tests are DECISIVE, which took two attempts to get right:
+ *
+ * 1. The first version cleared the registry and asserted the model was findable. It PASSED with the
+ *    registration deleted, because `findModelDefinition` also consulted core's built-in table — an
+ *    accidental green in the test written to prove a seam is load-bearing.
+ * 2. The second re-imported a cached module after clearing. A module-load side effect fires ONCE, so
+ *    that proves nothing either.
+ *
+ * What works is a FRESH module graph per case: `vi.resetModules()` gives a core whose registry is
+ * empty, and every import in that generation resolves to the same instance. Sonnet is the probe
+ * because its real window (1 000 000) differs from the default (200 000) — Haiku's happens to equal
+ * the default, so it could not tell the two apart.
+ */
+describe('CLAUDE_MODELS (moved here from agent-core)', () => {
+  it('contains known model IDs', () => {
+    expect(CLAUDE_MODELS['claude-opus-4-6']).toBeDefined();
+    expect(CLAUDE_MODELS['claude-sonnet-4-6']).toBeDefined();
+    expect(CLAUDE_MODELS['claude-haiku-4-5']).toBeDefined();
+  });
+
+  it('each entry has required fields, and its key matches its id', () => {
+    for (const [id, model] of Object.entries(CLAUDE_MODELS)) {
+      expect(model.id).toBe(id);
+      expect(model.name).toBeTruthy();
+      expect(model.contextWindow).toBeGreaterThan(0);
+      expect(model.maxOutput).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('registration with the core registry (NEUT-010)', () => {
+  it('core alone knows nothing about Claude — the neutral package carries no vendor table', async () => {
+    vi.resetModules();
+    const core = await import('@robota-sdk/agent-core');
+    // If this ever starts returning the real window, the table has crept back into the neutral
+    // package and every assertion below stops meaning anything.
+    expect(core.getModelContextWindow('claude-sonnet-4-6')).toBe(core.DEFAULT_CONTEXT_WINDOW);
+    expect(core.getModelName('claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+  });
+
+  it('importing this table registers it', async () => {
+    vi.resetModules();
+    await import('../claude-models.js');
+    const core = await import('@robota-sdk/agent-core');
+    expect(core.getModelContextWindow('claude-sonnet-4-6')).toBe(1_000_000);
+    expect(core.getModelName('claude-sonnet-4-6')).toBe('Claude Sonnet 4.6');
+  });
+
+  /**
+   * `provider.ts` asks for `max_tokens` and the answer comes from the core registry, so the models
+   * must be registered wherever the provider is reachable. The first shape imported the table only
+   * from the definition module, and the provider's own test caught it: Sonnet received the 16 384
+   * default instead of its 64 000. The fix routes the question through the owner
+   * (`resolveAnthropicMaxTokens`), so asking it necessarily brings the answers.
+   */
+  it('is reachable from the provider module itself, not only from the definition module', async () => {
+    vi.resetModules();
+    await import('../provider.js');
+    const core = await import('@robota-sdk/agent-core');
+    expect(core.getModelMaxOutput('claude-sonnet-4-6')).toBe(64_000);
+  });
+});

--- a/packages/agent-provider-anthropic/src/anthropic/claude-models.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/claude-models.ts
@@ -1,0 +1,96 @@
+import {
+  getModelMaxOutput,
+  registerModelMetadata,
+  type IModelDefinition,
+} from '@robota-sdk/agent-core';
+
+/**
+ * Claude model metadata — owned by the package that owns the models. NEUT-010.
+ *
+ * This table lived in `@robota-sdk/agent-core`, whose own SPEC says it must not branch on concrete
+ * provider or model names, and this package imported it back out. Two consequences, both measured:
+ * the vendor-neutral foundation carried one vendor's catalogue, and `getModelContextWindow` handed
+ * every model NOT in this table a 200 000-token window — Claude's number — with no signal at all.
+ *
+ * Source: https://platform.claude.com/docs/en/about-claude/models/overview
+ */
+export const CLAUDE_MODELS: Record<string, IModelDefinition> = {
+  'claude-opus-4-6': {
+    name: 'Claude Opus 4.6',
+    id: 'claude-opus-4-6',
+    contextWindow: 1_000_000,
+    maxOutput: 128_000,
+  },
+  'claude-sonnet-4-6': {
+    name: 'Claude Sonnet 4.6',
+    id: 'claude-sonnet-4-6',
+    contextWindow: 1_000_000,
+    maxOutput: 64_000,
+  },
+  'claude-haiku-4-5': {
+    name: 'Claude Haiku 4.5',
+    id: 'claude-haiku-4-5',
+    contextWindow: 200_000,
+    maxOutput: 64_000,
+  },
+  'claude-haiku-4-5-20251001': {
+    name: 'Claude Haiku 4.5',
+    id: 'claude-haiku-4-5-20251001',
+    contextWindow: 200_000,
+    maxOutput: 64_000,
+  },
+  'claude-sonnet-4-5': {
+    name: 'Claude Sonnet 4.5',
+    id: 'claude-sonnet-4-5',
+    contextWindow: 200_000,
+    maxOutput: 64_000,
+  },
+  'claude-sonnet-4-5-20250929': {
+    name: 'Claude Sonnet 4.5',
+    id: 'claude-sonnet-4-5-20250929',
+    contextWindow: 200_000,
+    maxOutput: 64_000,
+  },
+  'claude-opus-4-5': {
+    name: 'Claude Opus 4.5',
+    id: 'claude-opus-4-5',
+    contextWindow: 200_000,
+    maxOutput: 64_000,
+  },
+  'claude-opus-4-5-20251101': {
+    name: 'Claude Opus 4.5',
+    id: 'claude-opus-4-5-20251101',
+    contextWindow: 200_000,
+    maxOutput: 64_000,
+  },
+};
+
+/**
+ * Contribute this package's models to the core registry.
+ *
+ * Called at module load below, because importing this module IS the statement that these models are
+ * available: a session sized before a provider instance happens to be constructed would otherwise
+ * fall back for a model this package can describe exactly.
+ *
+ * NOT exported. It had no caller outside this file and the orphan-export scan said so — an export
+ * nobody imports is surface without a reason, which is the shape this whole audit keeps finding.
+ */
+function registerClaudeModels(): void {
+  registerModelMetadata(...Object.values(CLAUDE_MODELS));
+}
+
+registerClaudeModels();
+
+/**
+ * The `max_tokens` to send for a request. NEUT-010.
+ *
+ * Lives here rather than at the two call sites in `provider.ts` because the answer comes from the
+ * core registry, and this module is what puts Claude's models in it. Importing the helper therefore
+ * brings the registration with it — the provider cannot ask the question without the answers being
+ * present, which is what the previous shape got wrong: `provider.ts` called `getModelMaxOutput`
+ * while nothing in its import graph had registered anything, and Sonnet silently received the
+ * 16 384 default instead of its 64 000.
+ */
+export function resolveAnthropicMaxTokens(model: string, requested?: number): number {
+  return requested || getModelMaxOutput(model);
+}

--- a/packages/agent-provider-anthropic/src/anthropic/provider-definition.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/provider-definition.ts
@@ -1,9 +1,6 @@
-import {
-  CLAUDE_MODELS,
-  type IProviderDefinition,
-  type IProviderModelCatalogEntry,
-} from '@robota-sdk/agent-core';
+import { type IProviderDefinition, type IProviderModelCatalogEntry } from '@robota-sdk/agent-core';
 
+import { CLAUDE_MODELS } from './claude-models.js';
 import { refreshAnthropicModelCatalog } from './model-catalog-refresh';
 import { AnthropicProvider } from './provider';
 

--- a/packages/agent-provider-anthropic/src/anthropic/provider.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/provider.ts
@@ -3,12 +3,12 @@ import { randomUUID } from 'node:crypto';
 import Anthropic from '@anthropic-ai/sdk';
 import {
   AbstractAIProvider,
-  getModelMaxOutput,
   RateLimitError,
   ConfigurationError,
   ValidationError,
 } from '@robota-sdk/agent-core';
 
+import { resolveAnthropicMaxTokens } from './claude-models.js';
 import {
   convertToAnthropicFormat,
   convertToolsToAnthropicFormat,
@@ -131,7 +131,7 @@ export class AnthropicProvider extends AbstractAIProvider {
     const baseParams: Anthropic.MessageCreateParamsNonStreaming = {
       model: options.model as string,
       messages: anthropicMessages,
-      max_tokens: options?.maxTokens || getModelMaxOutput(options.model as string),
+      max_tokens: resolveAnthropicMaxTokens(options.model as string, options?.maxTokens),
       ...(systemPrompt && { system: systemPrompt }),
       ...(options?.temperature !== undefined && { temperature: options.temperature }),
       ...(allTools.length > 0 && { tools: allTools }),
@@ -206,7 +206,7 @@ export class AnthropicProvider extends AbstractAIProvider {
     const requestParams: Anthropic.MessageCreateParamsStreaming = {
       model: options.model as string,
       messages: anthropicMessages,
-      max_tokens: options?.maxTokens || getModelMaxOutput(options.model as string),
+      max_tokens: resolveAnthropicMaxTokens(options.model as string, options?.maxTokens),
       stream: true,
       ...buildOutputConfig(options),
     };

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -10,7 +10,7 @@
   "packages/agent-core/src/abstracts/abstract-module.ts": 315,
   "packages/agent-core/src/abstracts/abstract-workflow-converter.ts": 320,
   "packages/agent-core/src/core/robota.ts": 438,
-  "packages/agent-core/src/index.ts": 352,
+  "packages/agent-core/src/index.ts": 351,
   "packages/agent-core/src/interfaces/agent.ts": 310,
   "packages/agent-core/src/interfaces/provider.ts": 372,
   "packages/agent-core/src/managers/agent-factory.ts": 301,

--- a/scripts/harness/spec-surface-baseline.json
+++ b/scripts/harness/spec-surface-baseline.json
@@ -1,7 +1,7 @@
 {
   "@robota-sdk/agent-cli": 1,
   "@robota-sdk/agent-command": 140,
-  "@robota-sdk/agent-core": 147,
+  "@robota-sdk/agent-core": 146,
   "@robota-sdk/agent-executor": 19,
   "@robota-sdk/agent-framework": 160,
   "@robota-sdk/agent-interface-transport": 4,


### PR DESCRIPTION
**NEUT-010**, ranked #14 in the architecture audit (#1591).

## The defect

`agent-core`'s own SPEC says it must not branch on concrete provider or model names. It carried a
**Claude table** anyway — and `agent-provider-anthropic` imported it back out. The neutral
foundation held one vendor's catalogue, read by that vendor.

The consequence was worse than the layering. `getModelContextWindow` answered
`DEFAULT_CONTEXT_WINDOW` for anything the table did not know, and that constant is **200 000 —
Claude's window**. Every non-Claude session was planned against another vendor's number, and the
three consumers that act on it (`execution-round-context.ts`, `execution-round-tools.ts`,
`agent-session`'s context-window tracker) had no way to know they were working from a guess.

## The fix

The table moves to the package that owns those models, which registers it. Core keeps the registry,
the defaults and the helpers — and the registry is the **only** source, so a model nobody registered
is a model nobody owns. The helpers say so, once per model, instead of passing silently.

`CLAUDE_MODELS` is **no longer exported from `agent-core`**. Import it from
`@robota-sdk/agent-provider-anthropic`.

## Two things the checks shook out

Neither came from reasoning about the change; both came from something failing.

- **The provider's own test caught an unregistered path.** Registration was a module-load side
  effect imported only by the definition module, while `provider.ts` — which asks for `max_tokens` —
  did not import it. Sonnet received the 16 384 default instead of its 64 000. Routing the question
  through the owner (`resolveAnthropicMaxTokens`) means asking necessarily brings the answers.
- **The orphan-export scan caught `registerClaudeModels`** exported with no caller. An export nobody
  imports is surface without a reason — the shape this audit keeps finding — so it is internal now.

The public surface is the **contribution point alone**. `findModelDefinition` and
`clearRegisteredModelMetadata` stay in-package, and the SPEC says why rather than listing exports
that are not there.

## Verification

- **Red-proved:** removing the registration fails three assertions, including the provider's own
  pre-existing maxOutput test.
- **Sonnet is the probe throughout**, deliberately: its real window (1 000 000) differs from the
  default (200 000). Haiku's happens to *equal* the default, so a test using it could not tell
  "registered correctly" from "fell back" — the accidental green this suite went through two earlier
  drafts to avoid. The other two drafts are described in the test file's own header.
- 926 core, 94 anthropic, 1311 framework, 282 cli tests pass; 84 of 85 scans.
- Both ratchets this change earned are re-frozen in it: file-size and public-surface. The
  public-surface one was caught by the **pre-push gate**, not CI.

## Not in this change

The audit's wider neutrality finding (NEUT-009 — `.robota`, `.claude`, `AGENTS.md`, `robota-cli`
hardcoded across four neutral layers) is a separate item with its own Task.
