### PR TITLE
fix(agent-core): CORE-030 an unevaluable deny is not an allow

### DIFF
--- a/.agents/tasks/CORE-030-permission-policy-is-a-hardcoded-tool-name-matrix.md
+++ b/.agents/tasks/CORE-030-permission-policy-is-a-hardcoded-tool-name-matrix.md
@@ -12,9 +12,25 @@ depends_on: []
 
 ## Problem
 
-A `MyTool(secrets/**)` **deny** pattern never matches, and evaluation falls through to
-`UNKNOWN_TOOL_FALLBACK = 'approve'` in `default` and `acceptEdits` modes. A tool the table does not
-know about is therefore **unprotectable and defaults to approve** — silently.
+A `MyTool(secrets/**)` **deny** pattern never matches for a tool the argument table does not know,
+so evaluation walks on past the deny list.
+
+**Severity correction, measured while implementing (#1596).** The audit said this "falls through to
+`UNKNOWN_TOOL_FALLBACK = 'approve'`" and read that as fail-open. It is not: in this vocabulary
+`'approve'` means PROMPT THE USER and `'auto'` is the decision that proceeds silently
+(`permissions/types.ts:29-34`). A deny with no allow beside it already ended at a prompt.
+
+The real fail-open needs an allow entry as well, and it is genuine — measured against the pre-fix
+code:
+
+```
+deny: ['MyTool(secrets/**)']                     -> approve   (prompt; already fine)
+deny: ['MyTool(secrets/**)'], allow: ['MyTool']  -> auto      (silently approved)
+deny: ['Shell(rm*)'],        allow: ['Shell']    -> deny      (known tool; correct)
+```
+
+Denying a narrow case while allowing the tool broadly is the ordinary way to write these lists, so
+for any tool the foundation does not know, the narrow deny simply vanished.
 
 Risk classification is owned by a hardcoded name table in the zero-dependency foundation, two layers
 below the tools it names, instead of being declared by each tool. The two owners can drift silently,
@@ -55,7 +71,7 @@ know about is unprotectable and defaults to approve._
 **FOUNDATIONAL.** The synthesis's reasoning: the table lives in the zero-dependency foundation and is
 keyed on a closed union of product tool names, so no layer above — and no third-party tool author —
 can register a tool's risk classification. The `default: return undefined` in `permission-gate.ts`
-plus `UNKNOWN_TOOL_FALLBACK = 'approve'` makes the failure mode fail-open.
+makes an unevaluable deny lose to a broader allow — see the severity correction above.
 
 Severity HIGH, security-relevant and silent. The synthesis also cross-lists it under theme T3 (a
 trust boundary that is documentation rather than code) and theme T9 (`TKnownToolName`/`MODE_POLICY`

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -259,6 +259,23 @@ sandbox (`agent-tools`), the CLI monitor asset server (`agent-cli`) and the stud
 | `isPathInside`     | function | Whether `candidate` is `root` itself or lies beneath it, decided on the CANONICAL form of both     |
 | `canonicalizePath` | function | Realpath-resolve a path, tolerating a not-yet-created tail so `Write`/`Edit` targets still resolve |
 
+### Permission Argument Registry Public API (CORE-030)
+
+Which argument a tool's permission patterns are scoped to. The gate resolved this from a hardcoded
+table of PRODUCT tool names in the vendor-neutral foundation, so an argument-scoped deny for a tool
+it had never heard of could never match — and a `false` from a DENY list reads as "not denied", so
+the deny lost to any broader allow beside it and the invocation was auto-approved.
+
+A tool's owner declares its key. A deny that cannot be evaluated now prompts (or denies in `plan`
+mode) instead of continuing to the allow list.
+
+| Export                    | Kind     | Description                                                          |
+| ------------------------- | -------- | -------------------------------------------------------------------- |
+| `registerToolArgumentKey` | function | Declare which argument this tool's permission patterns are scoped to |
+
+`clearRegisteredToolArgumentKeys` stays in-package: it exists for tests and for a host rebuilding a
+registry, not as part of the contract.
+
 ### Model Metadata Registry Public API (NEUT-010)
 
 Who owns the answer to "how big is this model's context window". This package used to carry a CLAUDE
@@ -363,7 +380,7 @@ renderer is attached; a tool treats absence as "no human available" (never a sil
 
 | Export                      | Kind     | Description                                                                                                                                               |
 | --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `evaluatePermission`        | function | 3-step deterministic policy: deny list, allow list, mode                                                                                                  |
+| `evaluatePermission`        | function | 4-step deterministic policy: deny list, UNEVALUABLE deny, allow list, mode                                                                                |
 | `resolvePermissionByPolicy` | function | CORE-025: resolve a background/subagent `TBackgroundPermissionPolicy` (+ task/parent allow-deny) to `allow`/`deny`/`prompt`, pre-empting the session mode |
 | `MODE_POLICY`               | const    | Permission mode to tool decision matrix                                                                                                                   |
 | `TRUST_TO_MODE`             | const    | Maps TTrustLevel to TPermissionMode                                                                                                                       |
@@ -680,13 +697,14 @@ Events are bound to their owner via `bindWithOwnerPath()`.
 
 ## Permission System
 
-The permission module (`src/permissions/`) provides a deterministic, three-step policy evaluation for tool calls. It is consumed by the session layer to gate tool execution before delegating to the actual tool.
+The permission module (`src/permissions/`) provides a deterministic, four-step policy evaluation for tool calls. It is consumed by the session layer to gate tool execution before delegating to the actual tool.
 
 ### Evaluation Algorithm (`evaluatePermission`)
 
 1. **Deny list match** -- If any deny pattern matches the tool invocation, return `'deny'`.
-2. **Allow list match** -- If any allow pattern matches, return `'auto'` (proceed without prompting).
-3. **Mode policy lookup** -- Look up the tool in `MODE_POLICY[mode]`. If found, return the mapped decision. Otherwise, return `UNKNOWN_TOOL_FALLBACK[mode]`.
+2. **Deny list unevaluable** (CORE-030) -- If a deny pattern is scoped to an ARGUMENT and no owner has declared which argument this tool's patterns are about, the deny cannot be evaluated. Return `'approve'` (prompt), or `'deny'` in `plan` mode. Previously this read as "not denied" and the evaluation continued to step 3, where a broader allow could silently auto-approve it. A tool's owner declares its key with `registerToolArgumentKey(toolName, argumentKey)`; the built-in tools are pre-declared.
+3. **Allow list match** -- If any allow pattern matches, return `'auto'` (proceed without prompting).
+4. **Mode policy lookup** -- Look up the tool in `MODE_POLICY[mode]`. If found, return the mapped decision. Otherwise, return `UNKNOWN_TOOL_FALLBACK[mode]`.
 
 ### Permission Modes
 

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -283,20 +283,19 @@ export type {
 export { ExecutionProxy, createExecutionProxy, withEventEmission } from './utils/execution-proxy';
 
 // Permissions
-export type {
-  TPermissionMode,
-  TTrustLevel,
-  TPermissionDecision,
-  TBackgroundPermissionPolicy,
-  TToolArgs,
-  IPermissionLists,
-  TPermissionPolicyDecision,
-  IPermissionPolicyContext,
-  TKnownToolName,
-} from './permissions/index.js';
 export {
+  type TPermissionMode,
+  type TTrustLevel,
+  type TPermissionDecision,
+  type TBackgroundPermissionPolicy,
+  type TToolArgs,
+  type IPermissionLists,
+  type TPermissionPolicyDecision,
+  type IPermissionPolicyContext,
+  type TKnownToolName,
   TRUST_TO_MODE,
   evaluatePermission,
+  registerToolArgumentKey,
   resolvePermissionByPolicy,
   MODE_POLICY,
   UNKNOWN_TOOL_FALLBACK,

--- a/packages/agent-core/src/permissions/__tests__/unknown-tool-deny.test.ts
+++ b/packages/agent-core/src/permissions/__tests__/unknown-tool-deny.test.ts
@@ -5,6 +5,7 @@ import {
   evaluatePermission,
   registerToolArgumentKey,
 } from '../permission-gate.js';
+import { resolvePermissionByPolicy } from '../permission-policy.js';
 
 /**
  * CORE-030 — a deny the gate could not EVALUATE was overridden by a broader allow.
@@ -129,5 +130,68 @@ describe('an unevaluable deny is not overridden by a broader allow (CORE-030)', 
         deny: ['Shell(rm*)'],
       }),
     ).toBe('deny');
+  });
+});
+
+/**
+ * The SIBLING gate, found in review of #1596. `resolvePermissionByPolicy` had the same defect and
+ * was untouched by the first pass — a missed call site, not a deferred one.
+ *
+ * It is worse here. This is the gate for BACKGROUND and SUBAGENT calls
+ * (`agent-session/src/permission-enforcer.ts:219`), it exists to be MORE restrictive than the
+ * session mode, and it has no prompt at its allow step: an unevaluable deny beside a broader allow
+ * resolved to `'allow'` outright.
+ *
+ * It denies rather than prompting, because a detached task has no human attached by definition —
+ * the same reasoning the allow step already applies with "unmatched → deny (never prompt)".
+ */
+describe('the background/subagent gate has the same rule (CORE-030)', () => {
+  afterEach(() => clearRegisteredToolArgumentKeys());
+
+  const context = { taskDeny: ['MyTool(secrets/**)'], taskAllow: ['MyTool'] };
+
+  it('THE DEFECT: an unevaluable deny no longer resolves to allow', () => {
+    // Previously `'allow'` — the deny could not match, and the allowlist decided.
+    expect(
+      resolvePermissionByPolicy('preapproved', 'MyTool', { path: 'secrets/key.pem' }, context),
+    ).toBe('deny');
+  });
+
+  it('the same on the inherited path', () => {
+    expect(
+      resolvePermissionByPolicy(
+        'inherit-allowlist',
+        'MyTool',
+        { path: 'secrets/key.pem' },
+        {
+          parentDeny: ['MyTool(secrets/**)'],
+          parentAllow: ['MyTool'],
+        },
+      ),
+    ).toBe('deny');
+  });
+
+  it('ALLOWS once the owner declares the key and the argument does not match the deny', () => {
+    registerToolArgumentKey('MyTool', 'path');
+    expect(
+      resolvePermissionByPolicy('preapproved', 'MyTool', { path: 'public/readme.md' }, context),
+    ).toBe('allow');
+    expect(
+      resolvePermissionByPolicy('preapproved', 'MyTool', { path: 'secrets/key.pem' }, context),
+    ).toBe('deny');
+  });
+
+  it('leaves a known tool alone', () => {
+    expect(
+      resolvePermissionByPolicy(
+        'preapproved',
+        'Shell',
+        { command: 'ls' },
+        {
+          taskDeny: ['Shell(rm*)'],
+          taskAllow: ['Shell'],
+        },
+      ),
+    ).toBe('allow');
   });
 });

--- a/packages/agent-core/src/permissions/__tests__/unknown-tool-deny.test.ts
+++ b/packages/agent-core/src/permissions/__tests__/unknown-tool-deny.test.ts
@@ -80,6 +80,22 @@ describe('an unevaluable deny is not overridden by a broader allow (CORE-030)', 
     ).toBe('auto');
   });
 
+  /**
+   * The distinction review of #1596 caught: the first version folded these two into one condition,
+   * so a REGISTERED tool invoked without its declared argument was treated as unevaluable — which
+   * contradicted the comment beside it and the test below it.
+   *
+   * A key nobody declared is unevaluable. A declared key that this invocation simply does not carry
+   * is a real NON-match: the pattern is about `path`, there is no path, so there is nothing to deny.
+   */
+  it('a DECLARED key absent from the invocation is a real non-match, not an unevaluable one', () => {
+    registerToolArgumentKey('MyTool', 'path');
+    // No `path` in the args at all. The deny cannot apply, so the allow list decides.
+    expect(evaluatePermission('MyTool', { other: 'x' }, 'default', narrowDenyBroadAllow)).toBe(
+      'auto',
+    );
+  });
+
   it('leaves an unknown tool with no argument-scoped deny alone', () => {
     expect(
       evaluatePermission('MyTool', { path: 'x' }, 'default', {

--- a/packages/agent-core/src/permissions/__tests__/unknown-tool-deny.test.ts
+++ b/packages/agent-core/src/permissions/__tests__/unknown-tool-deny.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearRegisteredToolArgumentKeys,
+  evaluatePermission,
+  registerToolArgumentKey,
+} from '../permission-gate.js';
+
+/**
+ * CORE-030 — a deny the gate could not EVALUATE was overridden by a broader allow.
+ *
+ * `primaryArg` is a hardcoded switch over PRODUCT tool names in the vendor-neutral foundation. For a
+ * tool it has never heard of it returns `undefined`, `matchesPattern` answers `false`, and `false`
+ * from a DENY list means "not denied" — so evaluation walked on to the allow list.
+ *
+ * **The audit's severity claim was overstated, and measuring it is what showed that.** It said the
+ * unevaluable deny "falls through to `UNKNOWN_TOOL_FALLBACK = 'approve'`", read as fail-open. But in
+ * this vocabulary `'approve'` means PROMPT THE USER; `'auto'` is the one that proceeds silently. So
+ * a deny with no allow beside it already ended at a prompt.
+ *
+ * The real fail-open needs both entries, and it is genuine. Measured against the previous code:
+ *
+ *   deny: ['MyTool(secrets/**)']                     -> approve   (prompt — already fine)
+ *   deny: ['MyTool(secrets/**)'], allow: ['MyTool']  -> auto      (silently approved)
+ *   deny: ['Shell(rm*)'],        allow: ['Shell']    -> deny      (known tool, correct)
+ *
+ * An operator who denies a narrow case and allows the tool broadly is the ordinary way to write
+ * these lists, and for any tool the foundation does not know the narrow deny simply vanished.
+ */
+describe('an unevaluable deny is not overridden by a broader allow (CORE-030)', () => {
+  afterEach(() => clearRegisteredToolArgumentKeys());
+
+  const narrowDenyBroadAllow = { deny: ['MyTool(secrets/**)'], allow: ['MyTool'] };
+
+  it('THE DEFECT: a narrow deny plus a broad allow no longer auto-approves', () => {
+    // Previously `'auto'` — proceed with no prompt at all.
+    expect(
+      evaluatePermission('MyTool', { path: 'secrets/key.pem' }, 'default', narrowDenyBroadAllow),
+    ).toBe('approve');
+  });
+
+  it('the same in acceptEdits', () => {
+    expect(
+      evaluatePermission(
+        'MyTool',
+        { path: 'secrets/key.pem' },
+        'acceptEdits',
+        narrowDenyBroadAllow,
+      ),
+    ).toBe('approve');
+  });
+
+  it('and in bypassPermissions, where the allow list would otherwise be moot', () => {
+    // `bypassPermissions` auto-approves everything, but an unevaluable DENY is still a deny the
+    // operator wrote; it prompts rather than proceeding.
+    expect(
+      evaluatePermission(
+        'MyTool',
+        { path: 'secrets/key.pem' },
+        'bypassPermissions',
+        narrowDenyBroadAllow,
+      ),
+    ).toBe('approve');
+  });
+
+  it('plan mode denies outright, matching its own fallback', () => {
+    expect(
+      evaluatePermission('MyTool', { path: 'secrets/key.pem' }, 'plan', narrowDenyBroadAllow),
+    ).toBe('deny');
+  });
+
+  it('DENIES once the tool owner declares which argument the pattern is about', () => {
+    registerToolArgumentKey('MyTool', 'path');
+    expect(
+      evaluatePermission('MyTool', { path: 'secrets/key.pem' }, 'default', narrowDenyBroadAllow),
+    ).toBe('deny');
+    // …and a non-matching argument goes back to the allow list, as it should.
+    expect(
+      evaluatePermission('MyTool', { path: 'public/readme.md' }, 'default', narrowDenyBroadAllow),
+    ).toBe('auto');
+  });
+
+  it('leaves an unknown tool with no argument-scoped deny alone', () => {
+    expect(
+      evaluatePermission('MyTool', { path: 'x' }, 'default', {
+        deny: ['OtherTool(x)'],
+        allow: ['MyTool'],
+      }),
+    ).toBe('auto');
+  });
+
+  it('still denies a whole-tool deny for an unknown tool', () => {
+    expect(
+      evaluatePermission('MyTool', { path: 'x' }, 'default', {
+        deny: ['MyTool'],
+        allow: ['MyTool'],
+      }),
+    ).toBe('deny');
+  });
+
+  it('does not disturb the built-in tools, whose argument key is already known', () => {
+    const lists = { deny: ['Shell(rm*)'], allow: ['Shell'] };
+    expect(evaluatePermission('Shell', { command: 'rm -rf /tmp/x' }, 'default', lists)).toBe(
+      'deny',
+    );
+    expect(evaluatePermission('Shell', { command: 'ls' }, 'default', lists)).toBe('auto');
+  });
+
+  it('a registered key wins over the built-in switch, so an owner can correct it', () => {
+    registerToolArgumentKey('Shell', 'script');
+    expect(
+      evaluatePermission('Shell', { script: 'rm -rf /', command: 'ls' }, 'default', {
+        deny: ['Shell(rm*)'],
+      }),
+    ).toBe('deny');
+  });
+});

--- a/packages/agent-core/src/permissions/index.ts
+++ b/packages/agent-core/src/permissions/index.ts
@@ -6,7 +6,11 @@ export type {
   TBackgroundPermissionPolicy,
 } from './types.js';
 export { TRUST_TO_MODE } from './types.js';
-export { evaluatePermission } from './permission-gate.js';
+export {
+  evaluatePermission,
+  registerToolArgumentKey,
+  clearRegisteredToolArgumentKeys,
+} from './permission-gate.js';
 export type { TToolArgs, IPermissionLists } from './permission-gate.js';
 export { resolvePermissionByPolicy } from './permission-policy.js';
 export type { TPermissionPolicyDecision, IPermissionPolicyContext } from './permission-policy.js';

--- a/packages/agent-core/src/permissions/permission-gate.ts
+++ b/packages/agent-core/src/permissions/permission-gate.ts
@@ -1,10 +1,11 @@
 /**
  * Permission gate — evaluates whether a tool call is auto-approved, needs user approval, or denied.
  *
- * Three-step deterministic policy (in order of precedence):
+ * Deterministic policy, in order of precedence:
  * 1. Deny list match → deny
- * 2. Allow list match → auto
- * 3. Mode policy lookup
+ * 2. Deny list UNEVALUABLE (CORE-030) → approve (prompt), or deny in plan mode
+ * 3. Allow list match → auto
+ * 4. Mode policy lookup
  *
  * Pattern syntax (same as Claude Code):
  * - `Bash(pnpm *)` — Bash tool whose command starts with "pnpm "
@@ -63,28 +64,18 @@ function parsePattern(pattern: string): { toolName: string; argPattern: string |
   return { toolName, argPattern };
 }
 
-/**
- * Return the "primary" argument value for a tool to match against argument patterns.
- * The matching argument depends on the tool:
- *   Shell/Bash → args.command
- *   Read → args.filePath
- *   Write → args.filePath
- *   Edit → args.filePath
- *   Glob → args.pattern
- *   Grep → args.pattern
- */
+/** Argument keys contributed by the packages that own the tools. See `BUILT_IN_ARGUMENT_KEYS`. */
 const registeredArgumentKeys = new Map<string, string>();
 
 /**
  * Declare which argument a tool's permission patterns are scoped to. CORE-030.
  *
- * The switch below is a hardcoded list of PRODUCT tool names in the vendor-neutral foundation, and
- * a tool it has never heard of had no way onto it. That is not merely a layering complaint: an
- * argument-scoped deny for such a tool could never match, and evaluation fell through to
- * `UNKNOWN_TOOL_FALLBACK`, which is `'approve'` in `default` and `acceptEdits`. A deny that silently
- * becomes an approve is the worst direction for this particular failure.
+ * `BUILT_IN_ARGUMENT_KEYS` below is a hardcoded list of PRODUCT tool names in the vendor-neutral
+ * foundation, and a tool it has never heard of had no way onto it. That is not merely a layering
+ * complaint: an argument-scoped deny for such a tool could never match, so the deny lost to any
+ * broader allow beside it and the invocation was auto-approved.
  *
- * A tool's owner registers its key; the built-in switch remains until those tools do the same.
+ * A tool's owner registers its key; the built-in table remains until those tools do the same.
  */
 export function registerToolArgumentKey(toolName: string, argumentKey: string): void {
   registeredArgumentKeys.set(toolName, argumentKey);
@@ -95,32 +86,33 @@ export function clearRegisteredToolArgumentKeys(): void {
   registeredArgumentKeys.clear();
 }
 
-/** Whether the argument a pattern would be matched against is knowable for this tool at all. */
-function hasKnownArgumentKey(toolName: string): boolean {
-  if (registeredArgumentKeys.has(toolName)) return true;
-  return ['Shell', 'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'].includes(toolName);
+/**
+ * The built-in argument keys, as DATA rather than as a switch.
+ *
+ * It was a `switch` plus a second hardcoded list of the same names in `hasKnownArgumentKey` — a
+ * third copy of a tool-name table, in the change whose own Task calls that pattern out. One table,
+ * and both questions ("which key" and "is it knowable") are derived from it. (#1596 review)
+ */
+const BUILT_IN_ARGUMENT_KEYS: Readonly<Record<string, string>> = {
+  Shell: 'command',
+  Bash: 'command',
+  Read: 'filePath',
+  Write: 'filePath',
+  Edit: 'filePath',
+  Glob: 'pattern',
+  Grep: 'pattern',
+};
+
+/** Which argument a pattern is matched against, or `undefined` when nobody has said. */
+function argumentKeyFor(toolName: string): string | undefined {
+  return registeredArgumentKeys.get(toolName) ?? BUILT_IN_ARGUMENT_KEYS[toolName];
 }
 
 function primaryArg(toolName: string, args: TToolArgs): string | undefined {
-  const registeredKey = registeredArgumentKeys.get(toolName);
-  if (registeredKey !== undefined) {
-    const value = args[registeredKey];
-    return typeof value === 'string' ? value : undefined;
-  }
-  switch (toolName) {
-    case 'Shell':
-    case 'Bash':
-      return typeof args['command'] === 'string' ? args['command'] : undefined;
-    case 'Read':
-    case 'Write':
-    case 'Edit':
-      return typeof args['filePath'] === 'string' ? args['filePath'] : undefined;
-    case 'Glob':
-    case 'Grep':
-      return typeof args['pattern'] === 'string' ? args['pattern'] : undefined;
-    default:
-      return undefined;
-  }
+  const key = argumentKeyFor(toolName);
+  if (key === undefined) return undefined;
+  const value = args[key];
+  return typeof value === 'string' ? value : undefined;
 }
 
 /**
@@ -139,20 +131,24 @@ export function matchesAnyPattern(
  * Whether an argument-scoped pattern for this tool cannot be evaluated at all. CORE-030.
  *
  * `matchesPattern` answers `false` when the argument is unknowable, and `false` from a DENY list
- * means "not denied" — so `MyTool(secrets/**)` silently permitted every invocation of a tool the
- * foundation had never heard of. "I cannot tell" is not "no".
+ * means "not denied" — so `MyTool(secrets/**)` lost to a broader `allow: ['MyTool']` and the
+ * invocation was auto-approved. "I cannot tell" is not "no".
  */
 function hasUnevaluableArgumentPattern(
   toolName: string,
-  args: TToolArgs,
+  _args: TToolArgs,
   patterns: readonly string[],
 ): boolean {
   return patterns.some((pattern) => {
     const parsed = parsePattern(pattern);
     if (parsed.toolName !== toolName || parsed.argPattern === undefined) return false;
-    // Knowable in principle but absent from THIS invocation is a real non-match; unknowable at all
-    // is the case that must not read as one.
-    return !hasKnownArgumentKey(toolName) || primaryArg(toolName, args) === undefined;
+    // ONLY "nobody knows which argument this pattern is about". A tool whose key IS known but which
+    // was invoked without that argument is a real NON-match — the pattern is about `path`, there is
+    // no path, so there is nothing to deny — and it goes back to the allow list.
+    //
+    // The first version also treated that case as unevaluable, which contradicted its own comment
+    // and the test beside it. Review of #1596 caught the two conditions collapsing into one.
+    return argumentKeyFor(toolName) === undefined;
   });
 }
 

--- a/packages/agent-core/src/permissions/permission-gate.ts
+++ b/packages/agent-core/src/permissions/permission-gate.ts
@@ -73,7 +73,40 @@ function parsePattern(pattern: string): { toolName: string; argPattern: string |
  *   Glob → args.pattern
  *   Grep → args.pattern
  */
+const registeredArgumentKeys = new Map<string, string>();
+
+/**
+ * Declare which argument a tool's permission patterns are scoped to. CORE-030.
+ *
+ * The switch below is a hardcoded list of PRODUCT tool names in the vendor-neutral foundation, and
+ * a tool it has never heard of had no way onto it. That is not merely a layering complaint: an
+ * argument-scoped deny for such a tool could never match, and evaluation fell through to
+ * `UNKNOWN_TOOL_FALLBACK`, which is `'approve'` in `default` and `acceptEdits`. A deny that silently
+ * becomes an approve is the worst direction for this particular failure.
+ *
+ * A tool's owner registers its key; the built-in switch remains until those tools do the same.
+ */
+export function registerToolArgumentKey(toolName: string, argumentKey: string): void {
+  registeredArgumentKeys.set(toolName, argumentKey);
+}
+
+/** Forget registered argument keys. For tests and for hosts that rebuild a registry. */
+export function clearRegisteredToolArgumentKeys(): void {
+  registeredArgumentKeys.clear();
+}
+
+/** Whether the argument a pattern would be matched against is knowable for this tool at all. */
+function hasKnownArgumentKey(toolName: string): boolean {
+  if (registeredArgumentKeys.has(toolName)) return true;
+  return ['Shell', 'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'].includes(toolName);
+}
+
 function primaryArg(toolName: string, args: TToolArgs): string | undefined {
+  const registeredKey = registeredArgumentKeys.get(toolName);
+  if (registeredKey !== undefined) {
+    const value = args[registeredKey];
+    return typeof value === 'string' ? value : undefined;
+  }
   switch (toolName) {
     case 'Shell':
     case 'Bash':
@@ -100,6 +133,27 @@ export function matchesAnyPattern(
   patterns: readonly string[],
 ): boolean {
   return patterns.some((pattern) => matchesPattern(toolName, args, pattern));
+}
+
+/**
+ * Whether an argument-scoped pattern for this tool cannot be evaluated at all. CORE-030.
+ *
+ * `matchesPattern` answers `false` when the argument is unknowable, and `false` from a DENY list
+ * means "not denied" — so `MyTool(secrets/**)` silently permitted every invocation of a tool the
+ * foundation had never heard of. "I cannot tell" is not "no".
+ */
+function hasUnevaluableArgumentPattern(
+  toolName: string,
+  args: TToolArgs,
+  patterns: readonly string[],
+): boolean {
+  return patterns.some((pattern) => {
+    const parsed = parsePattern(pattern);
+    if (parsed.toolName !== toolName || parsed.argPattern === undefined) return false;
+    // Knowable in principle but absent from THIS invocation is a real non-match; unknowable at all
+    // is the case that must not read as one.
+    return !hasKnownArgumentKey(toolName) || primaryArg(toolName, args) === undefined;
+  });
 }
 
 /**
@@ -145,6 +199,18 @@ export function evaluatePermission(
   // Step 1: deny list — if any deny pattern matches, block immediately
   if (matchesAnyPattern(toolName, toolArgs, deny)) {
     return 'deny';
+  }
+
+  // CORE-030: a deny the gate could not EVALUATE is not a deny that did not match. When the
+  // argument a pattern is scoped to is unknowable for this tool, the previous code answered "not
+  // denied" and — in `default` and `acceptEdits` — went on to AUTO-approve. The operator wrote a
+  // deny and got an approval.
+  //
+  // `'approve'` in this vocabulary means "ask the user", which is the right answer here: refusing
+  // outright would break a legitimate invocation the pattern was never about, and auto-approving is
+  // what this exists to stop. `plan` mode still denies, matching its fallback.
+  if (hasUnevaluableArgumentPattern(toolName, toolArgs, deny)) {
+    return mode === 'plan' ? 'deny' : 'approve';
   }
 
   // Step 2: allow list — if any allow pattern matches, auto-approve

--- a/packages/agent-core/src/permissions/permission-gate.ts
+++ b/packages/agent-core/src/permissions/permission-gate.ts
@@ -134,7 +134,7 @@ export function matchesAnyPattern(
  * means "not denied" — so `MyTool(secrets/**)` lost to a broader `allow: ['MyTool']` and the
  * invocation was auto-approved. "I cannot tell" is not "no".
  */
-function hasUnevaluableArgumentPattern(
+export function hasUnevaluableArgumentPattern(
   toolName: string,
   _args: TToolArgs,
   patterns: readonly string[],

--- a/packages/agent-core/src/permissions/permission-policy.ts
+++ b/packages/agent-core/src/permissions/permission-policy.ts
@@ -15,7 +15,7 @@
  *      unmatched → deny (never prompt) — the detached-safe locked-down semantics.
  */
 
-import { matchesAnyPattern } from './permission-gate.js';
+import { hasUnevaluableArgumentPattern, matchesAnyPattern } from './permission-gate.js';
 
 import type { TToolArgs } from './permission-gate.js';
 import type { TBackgroundPermissionPolicy } from './types.js';
@@ -49,6 +49,21 @@ export function resolvePermissionByPolicy(
   if (
     matchesAnyPattern(toolName, toolArgs, taskDeny) ||
     matchesAnyPattern(toolName, toolArgs, parentDeny)
+  ) {
+    return 'deny';
+  }
+
+  // CORE-030: and a deny this gate could not EVALUATE is not one that did not match. Same defect as
+  // `evaluatePermission`'s, found in review of #1596 — but WORSE here, because this path has no
+  // prompt at step 4: an unevaluable `MyTool(secrets/**)` beside `allow: ['MyTool']` resolved to
+  // `'allow'`, and this is the gate for BACKGROUND and SUBAGENT calls, which exists to be more
+  // restrictive than the session mode, not less.
+  //
+  // It denies rather than prompting: a detached task has no human attached by definition, which is
+  // the same reasoning step 4 already applies with "unmatched → deny (never prompt)".
+  if (
+    hasUnevaluableArgumentPattern(toolName, toolArgs, taskDeny) ||
+    hasUnevaluableArgumentPattern(toolName, toolArgs, parentDeny)
   ) {
     return 'deny';
   }

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -10,7 +10,7 @@
   "packages/agent-core/src/abstracts/abstract-module.ts": 315,
   "packages/agent-core/src/abstracts/abstract-workflow-converter.ts": 320,
   "packages/agent-core/src/core/robota.ts": 438,
-  "packages/agent-core/src/index.ts": 351,
+  "packages/agent-core/src/index.ts": 350,
   "packages/agent-core/src/interfaces/agent.ts": 310,
   "packages/agent-core/src/interfaces/provider.ts": 372,
   "packages/agent-core/src/managers/agent-factory.ts": 301,


### PR DESCRIPTION
**CORE-030**, ranked #16 in the architecture audit (#1591).

## The defect

The permission gate resolves a pattern's argument through a **hardcoded switch over product tool
names**, in the vendor-neutral foundation. For a tool it has never heard of it returns `undefined`,
`matchesPattern` answers `false`, and `false` from a **deny** list means "not denied" — so evaluation
walked on to the allow list.

## The audit overstated the severity, and measuring it is what showed that

The audit said the unevaluable deny "falls through to `UNKNOWN_TOOL_FALLBACK = 'approve'`", read as
fail-open. In this vocabulary `'approve'` means **prompt the user**; `'auto'` is the decision that
proceeds silently (`permissions/types.ts:29-34`). A deny with no allow beside it already ended at a
prompt.

The real fail-open needs both entries, and it is genuine. Measured against the previous code:

```
deny: ['MyTool(secrets/**)']                     ->  approve   (prompt; already fine)
deny: ['MyTool(secrets/**)'], allow: ['MyTool']  ->  auto      (silently approved)
deny: ['Shell(rm*)'],        allow: ['Shell']    ->  deny      (known tool; correct)
```

Denying a narrow case while allowing the tool broadly is the ordinary way to write these lists, so
for any tool the foundation does not know, the narrow deny simply **vanished**.

The Task carries the correction rather than the original claim — the record is what the next person
acts on.

## The fix

- A tool's owner can declare which argument its patterns are scoped to
  (`registerToolArgumentKey`), instead of the foundation guessing from a name list two layers below
  the tools it names.
- A deny the gate could not **evaluate** no longer reads as one that did not match. It prompts, or
  denies in `plan` mode. **"I cannot tell" is not "no."**

## Verification, and an accidental green worth naming

**Red-proved at the second attempt.** The first version of these tests asserted `'approve'` for a
deny-only list and **passed with the fix removed** — `'approve'` was already the answer. That green
came from believing the audit's severity instead of measuring it, in the change written to fix a
silent-wrong-answer.

The assertions now name the case that actually changes: removing the branch fails **4 of the 9**.
935 `agent-core` tests pass.

## Not in this change

The wider half of CORE-030 — `TKnownToolName` and `MODE_POLICY` enumerating product tool names in
the zero-dependency foundation at all — is a contract relocation like NEUT-010's, and stays open in
the Task. This change adds the seam that makes it possible and closes the security consequence.
