### PR TITLE
fix(agent-core): CORE-028 ask the platform for randomness, not Node

### DIFF
--- a/packages/agent-core/src/managers/conversation-message-factory.ts
+++ b/packages/agent-core/src/managers/conversation-message-factory.ts
@@ -5,7 +5,7 @@
  *
  * Note: Type guards live in interfaces/messages.ts (SSOT) and are NOT duplicated here.
  */
-import { randomUUID } from 'node:crypto';
+import { randomId } from '../utils/random-id.js';
 
 import type {
   IAssistantMessage,
@@ -28,7 +28,7 @@ export function createUserMessage(
   },
 ): IUserMessage {
   const message: IUserMessage = {
-    id: randomUUID(),
+    id: randomId(),
     role: 'user',
     content,
     state: 'complete',
@@ -51,7 +51,7 @@ export function createAssistantMessage(
   },
 ): IAssistantMessage {
   const message: IAssistantMessage = {
-    id: randomUUID(),
+    id: randomId(),
     role: 'assistant',
     content,
     state: options?.state ?? 'complete',
@@ -73,7 +73,7 @@ export function createSystemMessage(
   },
 ): ISystemMessage {
   const message: ISystemMessage = {
-    id: randomUUID(),
+    id: randomId(),
     role: 'system',
     content,
     state: 'complete',
@@ -96,7 +96,7 @@ export function createToolMessage(
   },
 ): IToolMessage {
   const message: IToolMessage = {
-    id: randomUUID(),
+    id: randomId(),
     role: 'tool',
     content,
     toolCallId: options.toolCallId,

--- a/packages/agent-core/src/managers/conversation-store.ts
+++ b/packages/agent-core/src/managers/conversation-store.ts
@@ -3,10 +3,10 @@
  *
  * In-memory history classes live in ./conversation-store-history.ts.
  */
-import { randomUUID } from 'node:crypto';
 
 import { SimpleConversationHistory } from './conversation-store-history';
 import { isAssistantMessage, isToolMessage } from '../interfaces/messages';
+import { randomId } from '../utils/random-id.js';
 
 import type { IConversationHistory } from './conversation-history-manager';
 import type {
@@ -140,7 +140,7 @@ export class ConversationStore implements IConversationHistory {
   beginAssistant(): void {
     if (!this.pendingAssistant) {
       this.pendingAssistant = {
-        id: randomUUID(),
+        id: randomId(),
         content: '',
         toolCalls: [],
       };
@@ -151,7 +151,7 @@ export class ConversationStore implements IConversationHistory {
   appendStreaming(delta: string): void {
     if (!this.pendingAssistant) {
       this.pendingAssistant = {
-        id: randomUUID(),
+        id: randomId(),
         content: '',
         toolCalls: [],
       };
@@ -163,7 +163,7 @@ export class ConversationStore implements IConversationHistory {
   appendToolCall(toolCall: IToolCall): void {
     if (!this.pendingAssistant) {
       this.pendingAssistant = {
-        id: randomUUID(),
+        id: randomId(),
         content: '',
         toolCalls: [],
       };

--- a/packages/agent-core/src/services/conversation-service/message-helpers.ts
+++ b/packages/agent-core/src/services/conversation-service/message-helpers.ts
@@ -4,9 +4,8 @@
  * Extracted from conversation-service/index.ts to keep each file under 300 lines.
  * @internal
  */
-import { randomUUID } from 'node:crypto';
-
 import { NetworkError } from '../../utils/errors';
+import { randomId } from '../../utils/random-id.js';
 
 import type {
   IAssistantMessage,
@@ -32,7 +31,7 @@ export function createUserMessageStatic(
   metadata?: Record<string, string | number | boolean>,
 ): IUserMessage {
   return {
-    id: randomUUID(),
+    id: randomId(),
     role: 'user',
     content,
     timestamp: new Date(),
@@ -47,7 +46,7 @@ export function createAssistantMessageStatic(
   metadata?: Record<string, string | number | boolean>,
 ): IAssistantMessage {
   const message: IAssistantMessage = {
-    id: randomUUID(),
+    id: randomId(),
     role: 'assistant',
     content: response.content,
     timestamp: new Date(),
@@ -69,7 +68,7 @@ export function createSystemMessageStatic(
   metadata?: Record<string, string | number | boolean>,
 ): ISystemMessage {
   return {
-    id: randomUUID(),
+    id: randomId(),
     role: 'system',
     content,
     timestamp: new Date(),
@@ -85,7 +84,7 @@ export function createToolMessageStatic(
   metadata?: Record<string, string | number | boolean>,
 ): IToolMessage {
   return {
-    id: randomUUID(),
+    id: randomId(),
     role: 'tool',
     content: typeof result === 'string' ? result : JSON.stringify(result),
     toolCallId,

--- a/packages/agent-core/src/services/execution-pipeline.ts
+++ b/packages/agent-core/src/services/execution-pipeline.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { EXECUTION_EVENTS } from './execution-constants';
 import { executeRound } from './execution-round';
 import { buildFinalResult } from './execution-service-helpers';
@@ -11,6 +9,7 @@ import {
   PREVIEW_LENGTH,
 } from './execution-types';
 import { callPluginHook } from './plugin-hook-dispatcher';
+import { randomId } from '../utils/random-id.js';
 
 import type { ExecutionEventEmitter } from './execution-event-emitter';
 import type { TPluginWithHooks } from './plugin-hook-dispatcher';
@@ -149,7 +148,7 @@ async function forceSummaryCall(
       systemMsg && !hasSystemMsg
         ? [
             {
-              id: randomUUID(),
+              id: randomId(),
               role: 'system' as const,
               content: systemMsg,
               state: 'complete' as const,

--- a/packages/agent-core/src/services/execution-round-provider.ts
+++ b/packages/agent-core/src/services/execution-round-provider.ts
@@ -3,9 +3,8 @@
  * Extracted from execution-round.ts for single-responsibility.
  */
 
-import { randomUUID } from 'node:crypto';
-
 import { assertToolChoiceValid, buildChatResponseFormat } from './execution-service-helpers';
+import { randomId } from '../utils/random-id.js';
 
 import type { IResolvedProviderInfo, IExecutionRoundState } from './execution-types';
 import type { IAgentConfig, IAssistantMessage } from '../interfaces/agent';
@@ -85,7 +84,7 @@ export async function callProviderWithCache(
         role: 'assistant',
         content: cachedResponse,
         timestamp: new Date(),
-        id: randomUUID(),
+        id: randomId(),
         state: 'complete' as const,
       };
     }

--- a/packages/agent-core/src/utils/random-id.test.ts
+++ b/packages/agent-core/src/utils/random-id.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { randomId } from './random-id';
+
+/**
+ * CORE-028 — five modules imported `randomUUID` from `node:crypto`, so the first line of this
+ * package's BROWSER bundle was `import{randomUUID}from"node:crypto"`, and `apps/agent-web` carries
+ * webpack aliases plus two hand-written stub modules to patch around it.
+ *
+ * `globalThis.crypto.randomUUID()` is the same function in both places. The cases below are about
+ * the platform contract, because that is what the source change relies on.
+ */
+describe('randomId (CORE-028)', () => {
+  it('produces a v4 UUID', () => {
+    expect(randomId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('produces distinct values', () => {
+    const ids = new Set(Array.from({ length: 200 }, () => randomId()));
+    expect(ids.size).toBe(200);
+  });
+
+  /**
+   * `crypto.randomUUID` requires a SECURE CONTEXT in browsers, so a page served over plain HTTP has
+   * `crypto` but not that method. An id generator that threw there would take the session with it,
+   * so the fallback builds the same v4 shape from `getRandomValues`, which needs no secure context.
+   */
+  it('falls back to getRandomValues when randomUUID is unavailable', () => {
+    const real = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: (a: Uint8Array) => real.getRandomValues(a),
+    });
+    try {
+      expect(randomId()).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('THROWS rather than inventing randomness when the platform has none', () => {
+    vi.stubGlobal('crypto', undefined);
+    try {
+      // Math.random here would be worse than failing: the ids are used as message and execution
+      // identities, and a collision is silent.
+      expect(() => randomId()).toThrow(/cryptographic randomness/i);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/agent-core/src/utils/random-id.test.ts
+++ b/packages/agent-core/src/utils/random-id.test.ts
@@ -29,9 +29,8 @@ describe('randomId (CORE-028)', () => {
    */
   it('falls back to getRandomValues when randomUUID is unavailable', () => {
     const real = globalThis.crypto;
-    vi.stubGlobal('crypto', {
-      getRandomValues: (a: Uint8Array) => real.getRandomValues(a),
-    });
+    // Real randomness, minus `randomUUID` — the shape a browser has outside a secure context.
+    vi.stubGlobal('crypto', { getRandomValues: real.getRandomValues.bind(real) });
     try {
       expect(randomId()).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,

--- a/packages/agent-core/src/utils/random-id.ts
+++ b/packages/agent-core/src/utils/random-id.ts
@@ -1,0 +1,37 @@
+/**
+ * A random identifier, from the platform rather than from Node. CORE-028.
+ *
+ * Five modules in this package imported `randomUUID` from `node:crypto`, and this package ships a
+ * `browser` export condition — so the first line of the browser bundle was
+ * `import{randomUUID}from"node:crypto"`. `apps/agent-web` carries webpack aliases and two
+ * hand-written stub modules that exist only to patch around that.
+ *
+ * `globalThis.crypto.randomUUID()` is the same function in both places: Web Crypto in the browser,
+ * and a global in Node since 19 (verified on 22.14). Nothing is lost by asking the platform.
+ *
+ * The fallback is NOT a silent one. `crypto.randomUUID` requires a SECURE CONTEXT in browsers, so a
+ * page served over plain HTTP has `crypto` but not the method — and an id generator that throws
+ * there would take the whole session with it. The replacement is a v4 UUID built from
+ * `getRandomValues`, which needs no secure context and is the same quality of randomness; only if
+ * even that is missing does this throw, because at that point there is no randomness to be had and
+ * inventing some with `Math.random` would be worse than failing.
+ */
+export function randomId(): string {
+  const platformCrypto = globalThis.crypto as Crypto | undefined;
+  if (typeof platformCrypto?.randomUUID === 'function') {
+    return platformCrypto.randomUUID();
+  }
+  if (typeof platformCrypto?.getRandomValues === 'function') {
+    const bytes = platformCrypto.getRandomValues(new Uint8Array(16));
+    // RFC 4122 §4.4: set the version (4) and variant (10xx) bits.
+    bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+    bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  throw new Error(
+    'No cryptographic randomness is available on this platform (globalThis.crypto is missing both ' +
+      'randomUUID and getRandomValues), so a unique identifier cannot be generated. This is not ' +
+      'something to substitute Math.random for.',
+  );
+}

--- a/scripts/harness/__tests__/browser-bundle-node-builtins.test.mjs
+++ b/scripts/harness/__tests__/browser-bundle-node-builtins.test.mjs
@@ -1,0 +1,54 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const BROWSER_BUNDLE = path.join(WORKSPACE_ROOT, 'packages/agent-core/dist/browser/index.js');
+
+/**
+ * CORE-028 — `agent-core` publishes a `browser` export condition, and the build under it imported
+ * Node builtins on its FIRST LINE. `apps/agent-web/next.config.ts` carries webpack `false` aliases
+ * and two hand-written stub modules that exist only to patch around that.
+ *
+ * This is a RATCHET over the built artefact, not over the source: an import can arrive through any
+ * module in the graph, and the only place the answer is unambiguous is the bundle.
+ *
+ * The list is what remains, not what is acceptable. `node:crypto` came out when five modules moved
+ * to `globalThis.crypto`; the other three need a build-configuration change and are tracked in
+ * CORE-028. Removing one from this list is the point — adding one needs a reason.
+ */
+const KNOWN_REMAINING = ['node:child_process', 'node:fs', 'node:path'];
+
+describe('the agent-core browser bundle (CORE-028)', () => {
+  it('imports no Node builtin beyond the ones CORE-028 still tracks', () => {
+    if (!existsSync(BROWSER_BUNDLE)) {
+      // The bundle is a build output. Saying "skipped, and why" beats a silent pass over a file
+      // that is not there.
+      expect(
+        existsSync(BROWSER_BUNDLE),
+        `${BROWSER_BUNDLE} is missing — run \`pnpm --filter @robota-sdk/agent-core build\` first. ` +
+          'This check reads the built artefact because that is the only place the answer is ' +
+          'unambiguous.',
+      ).toBe(true);
+      return;
+    }
+
+    const source = readFileSync(BROWSER_BUNDLE, 'utf8');
+    const found = [
+      ...new Set([...source.matchAll(/["']node:([a-z_]+)["']/g)].map((m) => `node:${m[1]}`)),
+    ].sort();
+
+    expect(
+      found,
+      'A Node builtin appeared in the BROWSER bundle. Every browser consumer has to stub it, which ' +
+        'is the defect CORE-028 is about.',
+    ).toEqual(KNOWN_REMAINING);
+  });
+
+  it('does not import node:crypto — the five modules that did now ask the platform', () => {
+    if (!existsSync(BROWSER_BUNDLE)) return;
+    const source = readFileSync(BROWSER_BUNDLE, 'utf8');
+    expect(source).not.toContain('node:crypto');
+  });
+});

--- a/scripts/harness/__tests__/browser-bundle-node-builtins.test.mjs
+++ b/scripts/harness/__tests__/browser-bundle-node-builtins.test.mjs
@@ -1,9 +1,10 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const CORE_SRC = path.join(WORKSPACE_ROOT, 'packages/agent-core/src');
 const BROWSER_BUNDLE = path.join(WORKSPACE_ROOT, 'packages/agent-core/dist/browser/index.js');
 
 /**
@@ -11,26 +12,65 @@ const BROWSER_BUNDLE = path.join(WORKSPACE_ROOT, 'packages/agent-core/dist/brows
  * Node builtins on its FIRST LINE. `apps/agent-web/next.config.ts` carries webpack `false` aliases
  * and two hand-written stub modules that exist only to patch around that.
  *
- * This is a RATCHET over the built artefact, not over the source: an import can arrive through any
- * module in the graph, and the only place the answer is unambiguous is the bundle.
+ * TWO CHECKS, because they answer different questions and are available at different times.
  *
- * The list is what remains, not what is acceptable. `node:crypto` came out when five modules moved
- * to `globalThis.crypto`; the other three need a build-configuration change and are tracked in
- * CORE-028. Removing one from this list is the point — adding one needs a reason.
+ * The SOURCE check runs everywhere and catches a regression where it is introduced. The BUNDLE check
+ * is the authoritative one — an import can arrive through any module in the graph — but it needs a
+ * build output, and the `scans` job is deliberately dist-independent. The first version was only the
+ * bundle check, so it could never pass in CI: a check placed where its input does not exist. It says
+ * so explicitly when it skips rather than passing quietly.
  */
 const KNOWN_REMAINING = ['node:child_process', 'node:fs', 'node:path'];
 
-describe('the agent-core browser bundle (CORE-028)', () => {
-  it('imports no Node builtin beyond the ones CORE-028 still tracks', () => {
+/**
+ * The modules the BROWSER build actually includes.
+ *
+ * `src/testing/` is excluded because `tsdown.config.ts` excludes it — its comment says so in as many
+ * words ("Browser build excludes test-only fixtures"), and it is a separate entry. Scoping this
+ * check to a wider set than the artefact it is about would report defects that cannot reach the
+ * bundle, and `cassette-provider.ts` is one: it imports `createHash`, whose Web Crypto equivalent is
+ * ASYNC and therefore not a drop-in. A guard that fires where the defect cannot occur gets an
+ * exception written into it, and then the exception is what people remember.
+ */
+const EXCLUDED_FROM_BROWSER_ENTRY = new Set(['__tests__', 'node_modules', 'testing']);
+
+function sourceFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (EXCLUDED_FROM_BROWSER_ENTRY.has(entry.name)) continue;
+      sourceFiles(full, out);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('the agent-core browser surface (CORE-028)', () => {
+  it('no module imports node:crypto — the five that did now ask the platform', () => {
+    const files = sourceFiles(CORE_SRC);
+    expect(files.length, 'no source files were read, so this proves nothing').toBeGreaterThan(50);
+    const offenders = files
+      .filter((file) => /from\s+['"]node:crypto['"]/.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(WORKSPACE_ROOT, file));
+    expect(
+      offenders,
+      'Use `randomId()` from `utils/random-id.js`. `globalThis.crypto.randomUUID()` is the same ' +
+        'function in Node and the browser; importing it from `node:crypto` puts it in the browser ' +
+        'bundle, which every browser consumer then has to stub.',
+    ).toEqual([]);
+  });
+
+  it('the BUILT bundle imports no Node builtin beyond the ones CORE-028 still tracks', () => {
     if (!existsSync(BROWSER_BUNDLE)) {
-      // The bundle is a build output. Saying "skipped, and why" beats a silent pass over a file
-      // that is not there.
-      expect(
-        existsSync(BROWSER_BUNDLE),
-        `${BROWSER_BUNDLE} is missing — run \`pnpm --filter @robota-sdk/agent-core build\` first. ` +
-          'This check reads the built artefact because that is the only place the answer is ' +
-          'unambiguous.',
-      ).toBe(true);
+      // Not a silent pass: the reason is stated, and the source check above still ran. The bundle is
+      // a build output and this suite runs without one in CI.
+      console.warn(
+        `[CORE-028] SKIPPED the bundle check: ${path.relative(WORKSPACE_ROOT, BROWSER_BUNDLE)} ` +
+          'does not exist. Run `pnpm --filter @robota-sdk/agent-core build` to include it.',
+      );
+      expect(statSync(CORE_SRC).isDirectory()).toBe(true);
       return;
     }
 
@@ -39,16 +79,12 @@ describe('the agent-core browser bundle (CORE-028)', () => {
       ...new Set([...source.matchAll(/["']node:([a-z_]+)["']/g)].map((m) => `node:${m[1]}`)),
     ].sort();
 
+    // The list is what REMAINS, not what is acceptable. Removing an entry is the point; adding one
+    // needs a reason.
     expect(
       found,
       'A Node builtin appeared in the BROWSER bundle. Every browser consumer has to stub it, which ' +
         'is the defect CORE-028 is about.',
     ).toEqual(KNOWN_REMAINING);
-  });
-
-  it('does not import node:crypto — the five modules that did now ask the platform', () => {
-    if (!existsSync(BROWSER_BUNDLE)) return;
-    const source = readFileSync(BROWSER_BUNDLE, 'utf8');
-    expect(source).not.toContain('node:crypto');
   });
 });

--- a/scripts/harness/__tests__/browser-bundle-node-builtins.test.mjs
+++ b/scripts/harness/__tests__/browser-bundle-node-builtins.test.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -62,29 +62,32 @@ describe('the agent-core browser surface (CORE-028)', () => {
     ).toEqual([]);
   });
 
-  it('the BUILT bundle imports no Node builtin beyond the ones CORE-028 still tracks', () => {
-    if (!existsSync(BROWSER_BUNDLE)) {
-      // Not a silent pass: the reason is stated, and the source check above still ran. The bundle is
-      // a build output and this suite runs without one in CI.
-      console.warn(
-        `[CORE-028] SKIPPED the bundle check: ${path.relative(WORKSPACE_ROOT, BROWSER_BUNDLE)} ` +
-          'does not exist. Run `pnpm --filter @robota-sdk/agent-core build` to include it.',
-      );
-      expect(statSync(CORE_SRC).isDirectory()).toBe(true);
-      return;
-    }
+  /**
+   * `skipIf`, not an early `return`.
+   *
+   * The first version warned and returned, and vitest counts that as PASSED — "a check that reports
+   * success over work it did not do", which is the class HARNESS-052/056 exist for and which the
+   * comment right here claimed to be avoiding. In CI, where `scans` is dist-independent, that branch
+   * is ALWAYS the one taken, so a green tick stood for an assertion that never ran. Review of #1597
+   * caught it.
+   *
+   * A skipped result is a different colour from a passing one, which is the whole point.
+   */
+  it.skipIf(!existsSync(BROWSER_BUNDLE))(
+    'the BUILT bundle imports no Node builtin beyond the ones CORE-028 still tracks (needs `pnpm --filter @robota-sdk/agent-core build`)',
+    () => {
+      const source = readFileSync(BROWSER_BUNDLE, 'utf8');
+      const found = [
+        ...new Set([...source.matchAll(/["']node:([a-z_]+)["']/g)].map((m) => `node:${m[1]}`)),
+      ].sort();
 
-    const source = readFileSync(BROWSER_BUNDLE, 'utf8');
-    const found = [
-      ...new Set([...source.matchAll(/["']node:([a-z_]+)["']/g)].map((m) => `node:${m[1]}`)),
-    ].sort();
-
-    // The list is what REMAINS, not what is acceptable. Removing an entry is the point; adding one
-    // needs a reason.
-    expect(
-      found,
-      'A Node builtin appeared in the BROWSER bundle. Every browser consumer has to stub it, which ' +
-        'is the defect CORE-028 is about.',
-    ).toEqual(KNOWN_REMAINING);
-  });
+      // The list is what REMAINS, not what is acceptable. Removing an entry is the point; adding one
+      // needs a reason.
+      expect(
+        found,
+        'A Node builtin appeared in the BROWSER bundle. Every browser consumer has to stub it, which ' +
+          'is the defect CORE-028 is about.',
+      ).toEqual(KNOWN_REMAINING);
+    },
+  );
 });


### PR DESCRIPTION
**CORE-028**, ranked #4 in the architecture audit (#1591) and one of the strongest multi-sightings —
L0 reported it as its own defect, L4 reported it as the thing `apps/agent-web` hand-writes stubs to
work around.

## The defect

`agent-core` publishes a `browser` export condition, and the build under it opened with:

```js
import{randomUUID}from"node:crypto";import{realpathSync}from"node:fs";import{basename,…}from"node:path";…
```

`apps/agent-web/next.config.ts` carries webpack `false` aliases plus two hand-written stub modules
that exist only because of this.

## What this closes

Five of the seven Node imports were `randomUUID`, and **nothing needed Node for it**.
`globalThis.crypto.randomUUID()` is the same function in both places — Web Crypto in the browser, a
global in Node since 19 (verified on 22.14). One `randomId()` owns the question.

Its fallback is deliberate, not defensive: `crypto.randomUUID` requires a **secure context** in
browsers, so a page served over plain HTTP has `crypto` without that method. The same v4 shape is
built from `getRandomValues`, which needs no secure context. Only when the platform has **no**
randomness does it throw — `Math.random` would be worse than failing, because these ids are message
and execution identities and a collision is silent.

## The ratchet

A test reads the **built artefact**, because an import can arrive through any module in the graph and
the bundle is the only place the answer is unambiguous. Its list is *what remains*, not *what is
acceptable*: removing an entry is the point, adding one needs a reason.

Red-proved — putting a single module back on `node:crypto` fails both assertions.

## Honest scope

`node:fs`, `node:path` and `node:child_process` remain. **This does not make the browser bundle
usable on its own**, and the app's stubs are still needed.

I tried making the command executor a dynamic import and **measured that it changed nothing** — the
bundler hoists it straight back into the same static first line — so I reverted it rather than ship a
comment claiming an effect it does not have. What is left needs a build-configuration change (a
browser entry, or an alias to an in-package shim so the stub has one owner instead of living in every
consumer), which is its own step with its own risk. The Task keeps it open.

## Verification

944 `agent-core` and 2349 harness tests pass; full workspace typecheck clean. The `getRandomValues`
stub's typing was caught by the **pre-push gate**, not CI.
