### PR TITLE
fix(tools,session)!: the execution root is a required contract field (ARCH-010 P1)

### DIFF
--- a/.agents/tasks/ARCH-010-execution-root-carried-by-no-contract.md
+++ b/.agents/tasks/ARCH-010-execution-root-carried-by-no-contract.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-010: the execution root (`cwd`) is carried by no execution contract, so every layer falls back to `process.cwd()` and the containment guard is disarmed by default'
-status: todo
+status: in-progress
 created: 2026-08-02
 priority: critical
 urgency: now
@@ -124,3 +124,77 @@ to read.
 - **Cleanup:** none — the scenario writes nothing.
 - **Evidence (fill in after implementation):** transcript excerpt showing the refusal and the root it
   was measured against.
+
+## Progress
+
+### P1 — the root is a required field, and the guard fails closed (2 of 3 phases; ~67%)
+
+**The guard.** `packages/agent-tools/src/builtins/path-guard.ts` — `isWithinCwd(path, undefined)`
+returned `true`, so with no root everything was inside it. It now returns `false`, and
+`checkPathWithinCwd` returns a refusal naming the real fault ("no containment root is configured …
+this is an assembly bug, not a path problem") rather than an ordinary out-of-root message. Inverting
+this FIRST is what the Direction's risk note asks for: making the field required without it would
+leave any not-yet-migrated site silently unprotected.
+
+Measured, not inferred: before the change, a `Read` built with no root returned
+`[File: /etc/hostname (1 lines)]\n1\tserver`. That is `pack-coding`'s doc comment, reproduced.
+
+**The contracts.** `cwd` is now REQUIRED on `ISandboxToolOptions`, `IContainedBuiltinToolOptions`
+(and therefore `ISandboxBuiltinToolOptions`/`IShellToolOptions`/`IGrepToolOptions`),
+`ICreateDefaultToolsOptions`, `ISessionOptions`, and `ISubagentOptions`. The `= {}` default parameter
+is gone from every builtin factory — that default was the mechanism by which "forgot the root" was
+legal. `Session` no longer reads `process.cwd()` in its constructor, and `getCwd()` exposes the root
+so a fork or subagent asks the session rather than re-deriving one that can disagree.
+
+**The call sites the type system then named**, each fixed with the root that was already in scope:
+`child-process-subagent-worker.ts` (`payload.request.cwd` — the spawn contract had carried it all
+along), `in-process-subagent-runner.ts` (`job.request.worktreePath ?? job.request.cwd`, so a
+worktree-isolated subagent runs in its worktree), `create-session.ts` (the same `cwd` it had already
+bound the tools, hooks and skill source to), `create-subagent-session.ts`, `interactive-session-fork.ts`
+(`parentSession.getCwd()` — a fork continues the same conversation in the same place).
+
+**Seven context-free singletons removed** — `readTool`, `writeTool`, `editTool`, `globTool`,
+`grepTool`, `shellTool`, `bashTool`. A module-level instance is bound at import time and can carry no
+root, so post-inversion they could only refuse; they had no in-repo consumer, and every assembly
+already built per-session tools. Keeping them would have meant shipping seven exports that always
+fail — the same declared-but-unreachable shape the audit is about. SPEC and README updated.
+
+**A control test that depended on the defect.** `enumeration-containment.test.ts`'s CONTROL pair
+proved the escape was real by running Glob/Grep with NO root — which worked only because the guard
+was fail-open, so closing it turned the control red. Grep's control now uses a WIDER root; Glob's
+uses a `..` traversal instead of the symlink, because a contained Glob sets
+`followSymbolicLinks: false` and so cannot observe a symlink escape under any root. A control that
+depends on a defect elsewhere stops being a control the moment that defect is fixed.
+
+**Required is enforced at RUNTIME too, not only by the type.** `Session`'s constructor refuses a
+missing, empty or non-string `cwd` with an error naming what the value FEEDS. This is not belt-and-
+braces: this package's tsconfig EXCLUDES `*.test.ts` and a JavaScript consumer is not type-checked at
+all, so the field would otherwise simply be `undefined` and the session would report a root it does
+not have. The error says what consumes the root so a caller can judge whether `process.cwd()` is
+actually right, rather than pasting it in reflexively — which is the ambient read this removes.
+
+**Red-proof (8 cases, all on named assertions, no timeouts).** Restoring the two defects — the
+fail-open guard and the constructor's `?? process.cwd()`:
+
+```
+× a session must be told where it runs > REFUSES to construct with no execution root
+  → expected [Function] to throw an error
+× … > refuses an empty string / a non-string / names what the value is FOR   (3 more, same shape)
+× checkPathWithinCwd > REFUSES when cwd is not set          → expected undefined to be defined
+× containment is fail-closed > isWithinCwd REFUSES …        → expected true to be false
+× containment is fail-closed > checkPathWithinCwd returns a refusal …
+× containment is fail-closed > a Read built with no root REFUSES an absolute path …
+```
+
+### Remaining — P2, the DAG half
+
+`INodeExecutionContext` still carries no workspace root, and `dag-nodes/skill/src/index.ts:96` still
+takes its root from the LLM-authorable `.dag.json` (`config.cwd ?? process.cwd()`) without calling
+`resolveContainmentRoot`.
+
+A finding that changes the shape of that work, recorded here rather than acted on blind: the
+synthesis names `IWorkspaceLayout` (`dag-core/src/types/workspace-layout.ts`) as the existing unused
+seam, but its `root` is a path RELATIVE to the project dir (`.workflows`) and it describes where
+workflow DEFINITIONS live — it is not an absolute execution root and cannot be threaded in as one
+without changing what it means. `INodeExecutionContext` also has 57 consumers, so adding a required
+member there is its own migration. P2 needs a design pass, not a mechanical edit.

--- a/.changeset/arch-010-execution-root-required.md
+++ b/.changeset/arch-010-execution-root-required.md
@@ -1,0 +1,48 @@
+---
+'@robota-sdk/agent-tools': major
+'@robota-sdk/agent-session': major
+'@robota-sdk/agent-framework': major
+'@robota-sdk/agent-subagent-runner': major
+---
+
+**BREAKING — ARCH-010: the execution root is a required contract field, and the containment guard now fails closed.**
+
+The file-tool containment guard was fail-open: with no root configured it answered "allowed". A tool
+built with no `cwd` therefore had no boundary — measured, a `Read` constructed that way returned the
+contents of `/etc/hostname` — and the child-process subagent worker called `createDefaultTools()` with
+no argument at all, so subagents got exactly that. Three independent auditors found three different
+symptoms of this one missing field.
+
+**Removed — seven context-free tool singletons.** `readTool`, `writeTool`, `editTool`, `globTool`,
+`grepTool`, `shellTool`, `bashTool` are gone from `@robota-sdk/agent-tools`. A module-level instance is
+bound at import time and can carry no containment root, so after the guard was inverted they could only
+refuse everything.
+
+Migrate to the factory of the same name, passing the directory the tool is allowed to work in:
+
+```ts
+// before
+import { readTool, globTool } from '@robota-sdk/agent-tools';
+const tools = [readTool, globTool];
+
+// after
+import { createReadTool, createGlobTool } from '@robota-sdk/agent-tools';
+const cwd = process.cwd(); // or the workspace this agent is scoped to
+const tools = [createReadTool({ cwd }), createGlobTool({ cwd })];
+```
+
+`webFetchTool`, `webSearchTool` and `askUserQuestionTool` are unchanged — they touch no filesystem, so
+there is no root to contain them by.
+
+**`cwd` is now REQUIRED** on `ISandboxToolOptions`, `IContainedBuiltinToolOptions` (and everything
+extending them), `ICreateDefaultToolsOptions`, `ISessionOptions` and `ISubagentOptions`. The `= {}`
+default parameter was removed from every builtin factory — that default was the mechanism by which
+"forgot the root" was legal. `new Session({...})` without `cwd` no longer compiles, and also throws at
+construction, because a required field is only required to a TypeScript caller.
+
+**`Session` no longer reads `process.cwd()`.** It uses the root it was given, and `getCwd()` exposes it
+so a fork or subagent asks the session instead of re-deriving a root that can disagree with it.
+
+**Behavioural change even for callers that already passed a root**: a tool that somehow reaches the
+guard with no root now REFUSES with an explicit error ("no containment root is configured … this is an
+assembly bug, not a path problem") instead of allowing the access.

--- a/content/examples/tool-calling.md
+++ b/content/examples/tool-calling.md
@@ -92,15 +92,30 @@ const response = await agent.run('Find all .ts files in src/ and show me the sma
 
 ```typescript
 import { Robota, type IAIProvider } from '@robota-sdk/agent-core';
-import { bashTool, readTool, globTool, grepTool } from '@robota-sdk/agent-tools';
+import {
+  createBashTool,
+  createReadTool,
+  createGlobTool,
+  createGrepTool,
+} from '@robota-sdk/agent-tools';
 
 declare const provider: IAIProvider;
+
+// Every file tool is built against an explicit containment root (ARCH-010). There are no ready-made
+// tool instances: one bound at import time could carry no root, and a file tool with no root has no
+// boundary. Pass the directory the agent is meant to work in.
+const workspaceRoot = process.cwd();
 
 const agent = new Robota({
   name: 'DevAgent',
   aiProviders: [provider],
   defaultModel: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-  tools: [bashTool, readTool, globTool, grepTool],
+  tools: [
+    createBashTool({ cwd: workspaceRoot }),
+    createReadTool({ cwd: workspaceRoot }),
+    createGlobTool({ cwd: workspaceRoot }),
+    createGrepTool({ cwd: workspaceRoot }),
+  ],
 });
 
 const response = await agent.run('Find all TODO comments in the project');

--- a/content/examples/tool-calling.md
+++ b/content/examples/tool-calling.md
@@ -153,10 +153,12 @@ const agent = new Robota({
   aiProviders: [provider],
   defaultModel: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
   tools: [
-    createBashTool({ sandboxClient }),
-    createReadTool({ sandboxClient }),
-    createWriteTool({ sandboxClient }),
-    createEditTool({ sandboxClient }),
+    // `cwd` is required even with a sandbox client (ARCH-010): it is the root inside the sandbox,
+    // and it still contains any tool that falls through to the host filesystem.
+    createBashTool({ sandboxClient, cwd: '/workspace' }),
+    createReadTool({ sandboxClient, cwd: '/workspace' }),
+    createWriteTool({ sandboxClient, cwd: '/workspace' }),
+    createEditTool({ sandboxClient, cwd: '/workspace' }),
   ],
 });
 ```

--- a/content/guide/building-agents.md
+++ b/content/guide/building-agents.md
@@ -243,17 +243,19 @@ const response = await agent.run(
 
 ### Built-in CLI Tools
 
-`@robota-sdk/agent-tools` ships ready-to-use tools for file system operations and web access:
+`@robota-sdk/agent-tools` ships tools for file system operations and web access. Every filesystem
+tool is a factory taking the directory it is allowed to work in — `createReadTool({ cwd })` — because
+a file tool with no containment root has no boundary:
 
 | Tool                  | Description                                             |
 | --------------------- | ------------------------------------------------------- |
-| `shellTool`           | Execute host shell commands (OS-aware: bash/PowerShell) |
-| `bashTool`            | Alias of `shellTool` (model-familiar name)              |
-| `readTool`            | Read file contents with line numbers                    |
-| `writeTool`           | Write content to a file                                 |
-| `editTool`            | Replace a string in a file                              |
-| `globTool`            | Find files by glob pattern                              |
-| `grepTool`            | Search file contents with regex                         |
+| `createShellTool`     | Execute host shell commands (OS-aware: bash/PowerShell) |
+| `createBashTool`      | Alias of `Shell` (model-familiar name)                  |
+| `createReadTool`      | Read file contents with line numbers                    |
+| `createWriteTool`     | Write content to a file                                 |
+| `createEditTool`      | Replace a string in a file                              |
+| `createGlobTool`      | Find files by glob pattern                              |
+| `createGrepTool`      | Search file contents with regex                         |
 | `webFetchTool`        | Fetch URL content (HTML-to-text)                        |
 | `webSearchTool`       | Web search via Brave Search API                         |
 | `askUserQuestionTool` | Ask the user a question and wait for their answer       |

--- a/packages/agent-cli/src/__tests__/robota-assembly-equivalence.test.ts
+++ b/packages/agent-cli/src/__tests__/robota-assembly-equivalence.test.ts
@@ -333,7 +333,12 @@ describe('ARCH-005 S2 — the assembled robota runtime matches the pre-change ba
   });
 
   it('leaves the tool set and identity defaults untouched', () => {
-    expect(createDefaultTools().map((t) => t.getName())).toEqual(BASELINE_DEFAULT_TOOL_NAMES);
+    // ARCH-010 — `createDefaultTools` now requires the root. This case reads tool NAMES only and never
+    // executes a tool, so the root is inert; it is the same `/tmp/equivalence` the session cases above
+    // use, rather than a real workspace the assertion has no business pointing at.
+    expect(createDefaultTools({ cwd: '/tmp/equivalence' }).map((t) => t.getName())).toEqual(
+      BASELINE_DEFAULT_TOOL_NAMES,
+    );
     expect(DEFAULT_AGENT_NAME).toBe(BASELINE_DEFAULT_AGENT_NAME);
   });
 

--- a/packages/agent-executor/docs/SPEC.md
+++ b/packages/agent-executor/docs/SPEC.md
@@ -134,7 +134,7 @@ Hook event types and hook execution are owned by `agent-core`.
 
 ## Public API Surface
 
-### Background Tasks
+### Public API: Background Tasks
 
 | Export                                  | Kind     | Description                                          |
 | --------------------------------------- | -------- | ---------------------------------------------------- |
@@ -148,7 +148,7 @@ Hook event types and hook execution are owned by `agent-core`.
 | `createBackgroundTaskLogPage`           | function | Cursor-based log pagination helper                   |
 | `DEFAULT_BACKGROUND_TASK_LOG_PAGE_SIZE` | constant | Default page size (200 lines) for log pagination     |
 
-### Background Task Runners (Concrete — default implementations)
+### Public API: Background Task Runners (Concrete — default implementations)
 
 The following are concrete `IBackgroundTaskRunner` implementations provided by this package.
 They depend on Node.js `child_process`. CLI and SDK shells use them as default runners;
@@ -171,13 +171,14 @@ wiring croner's own `.pause()`/`.resume()` on the handle (`IBackgroundTaskHandle
 in place (same task id + `schedule`). No new scheduler is introduced — this is a thin lifecycle extension over
 the existing runner. (Persistence of `paused` across restart is the FLOW-003 re-arm path — a later slice.)
 
-### Subagents
+### Public API: Subagents
 
-| Export                         | Kind     | Description                                                     |
-| ------------------------------ | -------- | --------------------------------------------------------------- |
-| `SubagentManager`              | class    | Subagent facade over `BackgroundTaskManager`                    |
-| `WorktreeSubagentRunner`       | class    | Decorates an `ISubagentRunner` with worktree isolation behavior |
-| `createWorktreeSubagentRunner` | function | Factory for `WorktreeSubagentRunner`                            |
+| Export                         | Kind     | Description                                                                                                                                                                                |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SubagentManager`              | class    | Subagent facade over `BackgroundTaskManager`                                                                                                                                               |
+| `WorktreeSubagentRunner`       | class    | Decorates an `ISubagentRunner` with worktree isolation behavior                                                                                                                            |
+| `createWorktreeSubagentRunner` | function | Factory for `WorktreeSubagentRunner`                                                                                                                                                       |
+| `subagentExecutionRoot`        | function | ARCH-010: the single answer to which directory a spawned subagent runs in — `worktreePath ?? cwd`, never the process directory. Both runners read it rather than each writing the rule out |
 
 **Note on the concrete worktree adapter (ARCH-FIX-024 — DONE)**: The concrete
 `GitWorktreeIsolationAdapter` (calls `execFileSync`, performs Git operations) has been moved out of
@@ -189,7 +190,7 @@ and scheduled task runners; that usage is documented above and is unrelated to w
 
 The package entrypoint exports these symbols explicitly from `src/index.ts`. SDK compatibility barrels may re-export the same symbols, but they must not redefine the contracts.
 
-### Provider Factory
+### Public API: Provider Factory
 
 Functions in `src/providers/` resolve serializable provider config or profiles into live `IAIProvider` instances. They depend only on `@robota-sdk/agent-core` provider definitions and are provider-package-agnostic.
 

--- a/packages/agent-executor/src/index.ts
+++ b/packages/agent-executor/src/index.ts
@@ -36,6 +36,8 @@ export {
   SubagentManager,
   WorktreeSubagentRunner,
   createWorktreeSubagentRunner,
+  // ARCH-010: the single answer to "which directory does this subagent run in".
+  subagentExecutionRoot,
 } from './subagents/index.js';
 export type {
   IPreparedSubagentWorktree,

--- a/packages/agent-executor/src/subagents/__tests__/execution-root.test.ts
+++ b/packages/agent-executor/src/subagents/__tests__/execution-root.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { subagentExecutionRoot } from '../execution-root.js';
+
+import type { ISubagentSpawnRequest } from '../types.js';
+
+/**
+ * ARCH-010 — which directory a spawned subagent actually runs in.
+ *
+ * This is where the audit's measured breach was: neither runner read `request.cwd`, so both children
+ * fell back to `process.cwd()` — the parent's directory — and their file tools, built with no
+ * containment root, had no boundary at all. A subagent `Read` of `/etc/hostname` returned the file.
+ *
+ * The type now FORCES a root at both call sites, but a type cannot force the RIGHT one: a regression
+ * to `process.cwd()` here would compile and every existing test would stay green. That is what these
+ * cases are for, and why the rule lives in one function rather than being written out at each runner.
+ */
+function request(overrides: Partial<ISubagentSpawnRequest>): ISubagentSpawnRequest {
+  return {
+    type: 'general-purpose',
+    label: 'test',
+    parentSessionId: 'parent',
+    mode: 'sync',
+    depth: 1,
+    cwd: '/parent/checkout',
+    prompt: 'do the thing',
+    ...overrides,
+  } as ISubagentSpawnRequest;
+}
+
+describe('subagentExecutionRoot (ARCH-010)', () => {
+  it('uses the request cwd — never the process directory', () => {
+    // The defect in one line: both runners produced the parent's directory here.
+    expect(subagentExecutionRoot(request({ cwd: '/some/workspace' }))).toBe('/some/workspace');
+    expect(subagentExecutionRoot(request({ cwd: '/some/workspace' }))).not.toBe(process.cwd());
+  });
+
+  it('prefers the WORKTREE when the job is worktree-isolated', () => {
+    // Isolating a subagent into a worktree and then running it in the parent's checkout would defeat
+    // the isolation entirely — the worktree is the point.
+    const root = subagentExecutionRoot(
+      request({ cwd: '/parent/checkout', worktreePath: '/tmp/wt/job-1' }),
+    );
+    expect(root).toBe('/tmp/wt/job-1');
+  });
+
+  it('falls back to cwd when there is no worktree — not to anything ambient', () => {
+    expect(subagentExecutionRoot(request({ worktreePath: undefined }))).toBe('/parent/checkout');
+  });
+});

--- a/packages/agent-executor/src/subagents/execution-root.ts
+++ b/packages/agent-executor/src/subagents/execution-root.ts
@@ -1,0 +1,21 @@
+import type { ISubagentSpawnRequest } from './types.js';
+
+/**
+ * The directory a spawned subagent actually runs in. ARCH-010.
+ *
+ * `ISubagentSpawnRequest.cwd` has always been REQUIRED, but neither runner read it: the in-process
+ * one had no session option to pass it to, and the child-process worker called `createDefaultTools()`
+ * with no argument at all. Both children therefore fell back to `process.cwd()` — the PARENT's
+ * directory — and their file tools, with no containment root, had no boundary. That is the breach the
+ * audit measured: a subagent `Read` of `/etc/hostname` returned the file.
+ *
+ * A worktree-isolated job runs in its WORKTREE. Isolating a subagent into a worktree and then running
+ * it in the parent's checkout would defeat the isolation entirely, so the worktree wins when present.
+ *
+ * One implementation rather than the same expression at each runner, because two copies of a rule
+ * about which root a subagent runs in can disagree — and a subagent running in a root nobody intended
+ * is exactly the defect this closes.
+ */
+export function subagentExecutionRoot(request: ISubagentSpawnRequest): string {
+  return request.worktreePath ?? request.cwd;
+}

--- a/packages/agent-executor/src/subagents/index.ts
+++ b/packages/agent-executor/src/subagents/index.ts
@@ -1,3 +1,4 @@
+export { subagentExecutionRoot } from './execution-root.js';
 export { SubagentManager } from './subagent-manager.js';
 export {
   WorktreeSubagentRunner,

--- a/packages/agent-framework/README.md
+++ b/packages/agent-framework/README.md
@@ -337,20 +337,38 @@ one-shot calls.
 `@robota-sdk/agent-framework` assembles built-in tools for SDK sessions, but direct tool usage imports
 from the owner package:
 
+Each file tool is a FACTORY that requires the containment root it operates in (ARCH-010) — there is
+no ready-made instance, because one bound at import time can carry no root, and a file tool without a
+root has no boundary:
+
 ```typescript
 import {
-  shellTool,
-  bashTool,
-  editTool,
-  globTool,
-  grepTool,
-  readTool,
+  createShellTool,
+  createBashTool,
+  createEditTool,
+  createGlobTool,
+  createGrepTool,
+  createReadTool,
+  createWriteTool,
   webFetchTool,
   webSearchTool,
-  writeTool,
   askUserQuestionTool,
 } from '@robota-sdk/agent-tools';
+
+const cwd = process.cwd();
+const fileTools = [
+  createShellTool({ cwd }),
+  createBashTool({ cwd }),
+  createEditTool({ cwd }),
+  createGlobTool({ cwd }),
+  createGrepTool({ cwd }),
+  createReadTool({ cwd }),
+  createWriteTool({ cwd }),
+];
 ```
+
+`webFetchTool`, `webSearchTool` and `askUserQuestionTool` remain instances: they touch no filesystem,
+so there is no root for them to be contained by.
 
 ### Sandbox Execution
 

--- a/packages/agent-framework/docs/PUBLIC-SURFACE.md
+++ b/packages/agent-framework/docs/PUBLIC-SURFACE.md
@@ -30,7 +30,7 @@ Use owner packages for general-purpose APIs:
 
 ```typescript
 import { getMessagesForAPI, type IHistoryEntry } from '@robota-sdk/agent-core';
-import { readTool, webSearchTool } from '@robota-sdk/agent-tools';
+import { createReadTool, webSearchTool } from '@robota-sdk/agent-tools';
 import { Session } from '@robota-sdk/agent-session';
 ```
 

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -46,7 +46,7 @@ This package does NOT own: provider implementations, generic session run loop, t
 
 - `agent-core`: provider interface (`IAIProvider`), engine (`Robota`), history helpers, permissions enforcement (`evaluatePermission`), hook runner (`runHooks`), generic message utilities
 - `agent-session`: `Session` class, `SessionStore`, `PermissionEnforcer`, `ContextWindowTracker`, `CompactionOrchestrator`, terminal output (`ITerminalOutput`)
-- `agent-tools`: built-in tools (`shellTool`/`bashTool`, `readTool`, `writeTool`, etc.), tool creation infrastructure, sandbox client (`ISandboxClient`), `IToolInvocationResult`
+- `agent-tools`: built-in tool FACTORIES (`createShellTool`/`createBashTool`, `createReadTool`, `createWriteTool`, etc. — each takes the required containment root, ARCH-010), tool creation infrastructure, sandbox client (`ISandboxClient`), `IToolInvocationResult`
 - `agent-executor`: `BackgroundTaskManager`, `SubagentManager`, `WorktreeSubagentRunner`, lifecycle state machine
 - `agent-provider-*`: provider implementations
 - React/Ink components (belong in `agent-cli`)
@@ -1860,17 +1860,23 @@ import {
 `@robota-sdk/agent-framework` assembles built-in tools internally for SDK sessions. Direct tool usage
 imports from `@robota-sdk/agent-tools`:
 
+Each file tool is a FACTORY taking the containment root it operates in (ARCH-010); there is no
+ready-made instance, because one bound at import time can carry no root:
+
 ```typescript
 import {
-  bashTool,
-  editTool,
-  globTool,
-  grepTool,
-  readTool,
+  createBashTool,
+  createEditTool,
+  createGlobTool,
+  createGrepTool,
+  createReadTool,
+  createWriteTool,
   webFetchTool,
   webSearchTool,
-  writeTool,
 } from '@robota-sdk/agent-tools';
+
+const cwd = process.cwd();
+const tools = [createBashTool({ cwd }), createReadTool({ cwd }), createWriteTool({ cwd })];
 ```
 
 ### Permissions — Direct Usage

--- a/packages/agent-framework/src/__tests__/bash-tool.test.ts
+++ b/packages/agent-framework/src/__tests__/bash-tool.test.ts
@@ -2,11 +2,19 @@
  * Tests for BashTool
  */
 
-import { bashTool } from '@robota-sdk/agent-tools';
+import { createBashTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect } from 'vitest';
 
 import type { TToolParameters } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-010 — the context-free `bashTool` singleton is gone and `cwd` is required. For the shell family
+ * `cwd` is the DEFAULT WORKING DIRECTORY and deliberately not a containment boundary, so the host process
+ * directory is what these cases already ran in; it is now said out loud. No case here reads or writes a
+ * file — the two that care about a directory pass `workingDirectory` explicitly.
+ */
+const bashTool = createBashTool({ cwd: process.cwd() });
 
 async function run(params: TToolParameters): Promise<IToolInvocationResult> {
   const rawResult = await bashTool.execute(params);

--- a/packages/agent-framework/src/__tests__/create-session-default-tools.test.ts
+++ b/packages/agent-framework/src/__tests__/create-session-default-tools.test.ts
@@ -143,7 +143,13 @@ describe('ARCH-006 — additionalTools dedupe by tool name', () => {
       additionalTools: [namedTool('AcmeTicketLookup', 'new')],
     });
 
-    expect(names).toEqual([...createDefaultTools().map((t) => t.getName()), 'AcmeTicketLookup']);
+    // ARCH-010 — `createDefaultTools` now requires the root. `process.cwd()` is the root the assembled
+    // session under test uses (`createSession` resolves `options.cwd ?? process.cwd()`), so the two
+    // sides of this comparison are built the same way; only tool NAMES are read from either.
+    expect(names).toEqual([
+      ...createDefaultTools({ cwd: process.cwd() }).map((t) => t.getName()),
+      'AcmeTicketLookup',
+    ]);
   });
 });
 
@@ -183,6 +189,7 @@ describe('ARCH-006 — the injectable/suppressible default tool tier', () => {
     const { createDefaultTools } = await import('../assembly/create-tools.js');
     const { names } = await assembleToolNames();
 
-    expect(names).toEqual(createDefaultTools().map((t) => t.getName()));
+    // Same mirroring as above: the session resolves its root to `process.cwd()` when none is supplied.
+    expect(names).toEqual(createDefaultTools({ cwd: process.cwd() }).map((t) => t.getName()));
   });
 });

--- a/packages/agent-framework/src/__tests__/create-subagent-session.test.ts
+++ b/packages/agent-framework/src/__tests__/create-subagent-session.test.ts
@@ -44,6 +44,13 @@ function makeTool(name: string): IToolWithEventService {
   } as unknown as IToolWithEventService;
 }
 
+/**
+ * ARCH-010 made `ISubagentOptions.cwd` required — a subagent's execution root is passed in rather than
+ * derived. `Session` is mocked here and every tool is a `makeTool` double, so this root arms no path
+ * guard; it is the host process directory, which is what the assembly resolved on its own before.
+ */
+const SUBAGENT_ROOT = process.cwd();
+
 function makeTerminal(): ITerminalOutput {
   return {
     write: vi.fn(),
@@ -99,6 +106,7 @@ describe('createSubagentSession', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     expect(mockSessionConstructor).toHaveBeenCalledTimes(1);
@@ -119,6 +127,7 @@ describe('createSubagentSession', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -143,6 +152,7 @@ describe('createSubagentSession', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -163,6 +173,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -179,6 +190,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       roleModels: {
         planner: [
           { provider: 'anthropic', model: 'claude-opus-4-5' },
@@ -199,6 +211,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       roleModels: { planner: [{ provider: 'anthropic', model: 'claude-opus-4-5' }] },
     });
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -214,6 +227,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       roleModels: { planner: [{ provider: 'anthropic', model: 'claude-opus-4-5' }] },
     });
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -231,6 +245,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider, // name: 'anthropic'
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       roleModels: {
         planner: [
           { provider: 'openai', model: 'o3' }, // primary — foreign provider, skipped in v1
@@ -251,6 +266,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider, // name: 'anthropic'
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       roleModels: { planner: [{ provider: 'openai', model: 'o3' }] }, // no anthropic entry
     });
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -267,6 +283,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -283,6 +300,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -299,6 +317,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -317,6 +336,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -336,6 +356,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -357,6 +378,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       isForkWorker: true,
     });
 
@@ -375,6 +397,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -392,6 +415,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       permissionHandler: handler,
     });
 
@@ -411,6 +435,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       onTextDelta,
       onToolExecution,
     });
@@ -431,6 +456,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -452,6 +478,7 @@ describe('createSubagentSession', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -474,6 +501,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -493,6 +521,7 @@ describe('createSubagentSession', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -510,6 +539,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -532,6 +562,7 @@ describe('createSubagentSession', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -552,6 +583,7 @@ describe('createSubagentSession', () => {
       parentTools: [],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -569,6 +601,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
       // isForkWorker not specified
     });
 
@@ -589,6 +622,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -605,6 +639,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -623,6 +658,7 @@ describe('createSubagentSession', () => {
       parentTools: [makeTool('Read')],
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;

--- a/packages/agent-framework/src/__tests__/edit-tool.test.ts
+++ b/packages/agent-framework/src/__tests__/edit-tool.test.ts
@@ -6,11 +6,18 @@ import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { editTool } from '@robota-sdk/agent-tools';
+import { createEditTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import type { TToolParameters } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-010 — the context-free `editTool` singleton is gone and the containment root is a required
+ * constructor argument, so the tool is built against the tmpdir fixture below. That fixture is the only
+ * directory these cases edit; a wider root would let this suite rewrite files outside its own fixture.
+ */
+let editTool: ReturnType<typeof createEditTool>;
 
 async function run(params: TToolParameters): Promise<IToolInvocationResult> {
   const rawResult = await editTool.execute(params);
@@ -21,6 +28,7 @@ let tmpDir: string;
 
 beforeAll(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'edit-tool-test-'));
+  editTool = createEditTool({ cwd: tmpDir });
 });
 
 afterAll(async () => {

--- a/packages/agent-framework/src/__tests__/glob-tool.test.ts
+++ b/packages/agent-framework/src/__tests__/glob-tool.test.ts
@@ -6,11 +6,19 @@ import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { globTool } from '@robota-sdk/agent-tools';
+import { createGlobTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import type { TToolParameters } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-010 — the context-free `globTool` singleton is gone and the containment root is a required
+ * constructor argument, so the tool is built against the tmpdir fixture below. The root is what a
+ * pathless glob enumerates, so it has to be the fixture: pointed at the repo, the counts and exclusion
+ * assertions here would be about the source tree rather than the files this suite created.
+ */
+let globTool: ReturnType<typeof createGlobTool>;
 
 async function run(params: TToolParameters): Promise<IToolInvocationResult> {
   const rawResult = await globTool.execute(params);
@@ -43,6 +51,8 @@ beforeAll(async () => {
   await writeFile(join(tmpDir, 'node_modules', 'excluded.ts'), 'excluded');
   await mkdir(join(tmpDir, '.git'));
   await writeFile(join(tmpDir, '.git', 'excluded.ts'), 'excluded');
+
+  globTool = createGlobTool({ cwd: tmpDir });
 });
 
 afterAll(async () => {
@@ -88,7 +98,8 @@ describe('GlobTool', () => {
   });
 
   it('uses cwd as default path when path is not provided', async () => {
-    // Just verify it doesn't crash — actual results depend on the test cwd
+    // Just verify it doesn't crash — ARCH-010 made the root explicit, so the default path is now this
+    // suite's fixture rather than whatever directory vitest happened to start in.
     const result = await run({ pattern: '*.json' });
     expect(result.success).toBe(true);
   });

--- a/packages/agent-framework/src/__tests__/grep-tool.test.ts
+++ b/packages/agent-framework/src/__tests__/grep-tool.test.ts
@@ -6,11 +6,19 @@ import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { grepTool } from '@robota-sdk/agent-tools';
+import { createGrepTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import type { TToolParameters } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-010 — the context-free `grepTool` singleton is gone and the containment root is a required
+ * constructor argument, so the tool is built against the tmpdir fixture below. The root bounds the
+ * search, so it has to be the fixture: pointed at the repo, these cases would be grepping the source
+ * tree instead of the four files this suite writes.
+ */
+let grepTool: ReturnType<typeof createGrepTool>;
 
 async function run(params: TToolParameters): Promise<IToolInvocationResult> {
   const rawResult = await grepTool.execute(params);
@@ -37,6 +45,8 @@ beforeAll(async () => {
   await writeFile(join(tmpDir, 'sub', 'gamma.ts'), 'hello world\nfoo bar\n');
   await mkdir(join(tmpDir, 'node_modules'));
   await writeFile(join(tmpDir, 'node_modules', 'excluded.ts'), 'hello inside node_modules\n');
+
+  grepTool = createGrepTool({ cwd: tmpDir });
 });
 
 afterAll(async () => {

--- a/packages/agent-framework/src/__tests__/hook-wiring.test.ts
+++ b/packages/agent-framework/src/__tests__/hook-wiring.test.ts
@@ -119,6 +119,14 @@ function createMockProvider() {
   } as never;
 }
 
+/**
+ * ARCH-010 made `ISessionOptions.cwd` required — `Session` no longer reads `process.cwd()` itself. Every
+ * session here is built with `tools: []`, so this root arms no tool guard; it is the session's execution
+ * root, which reaches the hook and permission context these cases assert on, and the host process
+ * directory is what the constructor used to derive on its own.
+ */
+const SESSION_ROOT = process.cwd();
+
 describe('Hook wiring in session', () => {
   beforeEach(() => {
     runHooksCalls.length = 0;
@@ -130,6 +138,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 
@@ -145,6 +154,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 
@@ -164,6 +174,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 
@@ -183,6 +194,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 
@@ -203,6 +215,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 
@@ -223,6 +236,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 
@@ -243,6 +257,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
       hookTypeExecutors: [mockExecutor],
     });
@@ -262,6 +277,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       // No hooks config
     });
 
@@ -280,6 +296,7 @@ describe('Hook wiring in session', () => {
       provider: createMockProvider(),
       systemMessage: 'test',
       terminal: MOCK_TERMINAL,
+      cwd: SESSION_ROOT,
       hooks: SAMPLE_HOOKS,
     });
 

--- a/packages/agent-framework/src/__tests__/read-tool.test.ts
+++ b/packages/agent-framework/src/__tests__/read-tool.test.ts
@@ -6,11 +6,18 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { readTool } from '@robota-sdk/agent-tools';
+import { createReadTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import type { TToolParameters } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-010 — the context-free `readTool` singleton is gone and the containment root is a required
+ * constructor argument, so the tool is built against the tmpdir fixture below. That fixture is the only
+ * directory these cases read; binding the tool to `process.cwd()` would widen the root to the whole repo.
+ */
+let readTool: ReturnType<typeof createReadTool>;
 
 async function run(params: TToolParameters): Promise<IToolInvocationResult> {
   const rawResult = await readTool.execute(params);
@@ -21,6 +28,7 @@ let tmpDir: string;
 
 beforeAll(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'read-tool-test-'));
+  readTool = createReadTool({ cwd: tmpDir });
 });
 
 afterAll(async () => {

--- a/packages/agent-framework/src/__tests__/subagent-integration.test.ts
+++ b/packages/agent-framework/src/__tests__/subagent-integration.test.ts
@@ -74,6 +74,14 @@ function makeTerminal(): ITerminalOutput {
   } as unknown as ITerminalOutput;
 }
 
+/**
+ * ARCH-010 made `ISubagentOptions.cwd` required — a subagent's execution root is passed in rather than
+ * derived. `Session` is mocked here and every tool is a `makeTool` double, so this root arms no path
+ * guard; it is the host process directory, which is what the assembly resolved on its own before. The
+ * `tmpDir` fixtures further down belong to the loader/logger cases, which take their root explicitly.
+ */
+const SUBAGENT_ROOT = process.cwd();
+
 function makeParentConfig(overrides?: Partial<IResolvedConfig>): IResolvedConfig {
   return {
     defaultTrustLevel: 'moderate',
@@ -132,6 +140,7 @@ describe('Subagent integration', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal,
+      cwd: SUBAGENT_ROOT,
     });
 
     expect(mockSessionConstructor).toHaveBeenCalledTimes(1);
@@ -162,6 +171,7 @@ describe('Subagent integration', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -200,6 +210,7 @@ describe('Subagent integration', () => {
       parentTools: tools,
       provider: mockProvider,
       terminal: makeTerminal(),
+      cwd: SUBAGENT_ROOT,
     });
 
     const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;
@@ -228,6 +239,7 @@ describe('Subagent integration', () => {
         parentTools: tools,
         provider: mockProvider,
         terminal: makeTerminal(),
+        cwd: SUBAGENT_ROOT,
       });
 
       const passedOptions = mockSessionConstructor.mock.calls[0][0] as Record<string, unknown>;

--- a/packages/agent-framework/src/__tests__/write-tool.test.ts
+++ b/packages/agent-framework/src/__tests__/write-tool.test.ts
@@ -6,11 +6,18 @@ import { mkdtemp, readFile, mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { writeTool } from '@robota-sdk/agent-tools';
+import { createWriteTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import type { TToolParameters } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-010 — the context-free `writeTool` singleton is gone and the containment root is a required
+ * constructor argument, so the tool is built against the tmpdir fixture below. That fixture is the only
+ * directory these cases write to; a wider root would let this suite create files outside its own fixture.
+ */
+let writeTool: ReturnType<typeof createWriteTool>;
 
 async function run(params: TToolParameters): Promise<IToolInvocationResult> {
   const rawResult = await writeTool.execute(params);
@@ -21,6 +28,7 @@ let tmpDir: string;
 
 beforeAll(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'write-tool-test-'));
+  writeTool = createWriteTool({ cwd: tmpDir });
 });
 
 afterAll(async () => {

--- a/packages/agent-framework/src/assembly/__tests__/create-tools.test.ts
+++ b/packages/agent-framework/src/assembly/__tests__/create-tools.test.ts
@@ -5,9 +5,16 @@ import { createDefaultTools, DEFAULT_TOOL_DESCRIPTIONS } from '../create-tools';
 
 import type { IRetrievalAdapter, IComputerDriver } from '@robota-sdk/agent-tools';
 
+/**
+ * ARCH-010 made `cwd` a required field of `ICreateDefaultToolsOptions`. The cases that assert the tool
+ * LIST never execute a tool and so never reach a path guard; this root is named once, here, so that
+ * inertness is visible rather than implied. The containment cases below choose their own roots.
+ */
+const ASSEMBLY_ROOT = '/tmp/create-tools-assembly-root';
+
 describe('createDefaultTools', () => {
   it('assembles all default local tools and describes web tools as local tools', () => {
-    expect(createDefaultTools().map((tool) => tool.getName())).toEqual([
+    expect(createDefaultTools({ cwd: ASSEMBLY_ROOT }).map((tool) => tool.getName())).toEqual([
       'Shell',
       'Bash',
       'Read',
@@ -29,7 +36,9 @@ describe('createDefaultTools', () => {
   it('accepts a sandbox client while preserving the default tool list', () => {
     const sandboxClient = new InMemorySandboxClient();
 
-    expect(createDefaultTools({ sandboxClient }).map((tool) => tool.getName())).toEqual([
+    expect(
+      createDefaultTools({ sandboxClient, cwd: ASSEMBLY_ROOT }).map((tool) => tool.getName()),
+    ).toEqual([
       'Shell',
       'Bash',
       'Read',
@@ -50,13 +59,16 @@ describe('createDefaultTools', () => {
   // `cwd` nobody passes.
   it('SEC-007: Glob and Grep are bound to the assembly cwd, not context-free singletons', async () => {
     const contained = createDefaultTools({ cwd: '/tmp/sec007-assembly-scope' });
-    const unbound = createDefaultTools();
+    // ARCH-010 — this used to be `createDefaultTools()` with no root at all, which is no longer
+    // constructible. A SECOND root serves the same purpose and states it better: one shared singleton
+    // could not carry two different roots either way.
+    const otherRoot = createDefaultTools({ cwd: '/tmp/sec007-other-scope' });
 
     for (const name of ['Glob', 'Grep']) {
       const tool = contained.find((candidate) => candidate.getName() === name);
       expect(tool, `${name} must be part of the default set`).toBeDefined();
       // A fresh instance per call — a shared singleton could not carry two different roots.
-      expect(tool).not.toBe(unbound.find((candidate) => candidate.getName() === name));
+      expect(tool).not.toBe(otherRoot.find((candidate) => candidate.getName() === name));
 
       const parameters = { pattern: name === 'Grep' ? 'root' : '*', path: '/etc' };
       const outcome = await tool!.execute(
@@ -79,21 +91,23 @@ describe('createDefaultTools', () => {
   // SELFHOST-003 TC-03: the retrieval adapter is threaded through assembly and the tool is
   // adapter-gated — absent with no adapter, present (and only then) when an adapter is supplied.
   it('TC-03: CodebaseRetrieval joins the default set only when a retrieval adapter is supplied', () => {
-    expect(createDefaultTools().map((tool) => tool.getName())).not.toContain('CodebaseRetrieval');
+    expect(createDefaultTools({ cwd: ASSEMBLY_ROOT }).map((tool) => tool.getName())).not.toContain(
+      'CodebaseRetrieval',
+    );
 
     const retrievalAdapter: IRetrievalAdapter = {
       retrieve: async () => ({ symbols: [], totalTokens: 0 }),
     };
-    expect(createDefaultTools({ retrievalAdapter }).map((tool) => tool.getName())).toContain(
-      'CodebaseRetrieval',
-    );
+    expect(
+      createDefaultTools({ retrievalAdapter, cwd: ASSEMBLY_ROOT }).map((tool) => tool.getName()),
+    ).toContain('CodebaseRetrieval');
   });
 
   // SELFHOST-010 TC-04: the computer driver is threaded through assembly and the ComputerView/Computer
   // tools are adapter-gated — ABSENT with no driver (no host fallback), present only when a driver is
   // supplied.
   it('TC-04: ComputerView/Computer join the default set only when a computer driver is supplied', () => {
-    const withoutDriver = createDefaultTools().map((tool) => tool.getName());
+    const withoutDriver = createDefaultTools({ cwd: ASSEMBLY_ROOT }).map((tool) => tool.getName());
     expect(withoutDriver).not.toContain('ComputerView');
     expect(withoutDriver).not.toContain('Computer');
 
@@ -101,7 +115,9 @@ describe('createDefaultTools', () => {
       screenshot: async () => ({ data: 'x', mediaType: 'image/png' }),
       act: async () => ({ screenshot: { data: 'x', mediaType: 'image/png' } }),
     };
-    const withDriver = createDefaultTools({ computerDriver }).map((tool) => tool.getName());
+    const withDriver = createDefaultTools({ computerDriver, cwd: ASSEMBLY_ROOT }).map((tool) =>
+      tool.getName(),
+    );
     expect(withDriver).toContain('ComputerView');
     expect(withDriver).toContain('Computer');
   });

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -240,6 +240,10 @@ export function createSession(options: ICreateSessionOptions): ICreateSessionRes
     provider,
     systemMessage: finalSystemMessage,
     terminal: options.terminal,
+    // ARCH-010: the same root the tools, hooks and skill source were bound to above. It used to be
+    // computed here and then re-derived inside `Session` from `process.cwd()`, so the two could
+    // disagree the moment a caller supplied `options.cwd`.
+    cwd,
     permissions: mergedPermissions,
     hooks: resolvedHooks,
     permissionMode: options.permissionMode,

--- a/packages/agent-framework/src/assembly/create-subagent-session.ts
+++ b/packages/agent-framework/src/assembly/create-subagent-session.ts
@@ -59,6 +59,15 @@ export interface ISubagentOptions {
   roleModels?: TRoleModelMap;
   /** Terminal output interface. */
   terminal: ITerminalOutput;
+  /**
+   * The subagent's execution root. REQUIRED — ARCH-010.
+   *
+   * The spawn contract has always declared it required (`ISubagentSpawnRequest.cwd: string`), but
+   * this assembly had no field for it, so the runner could not pass it on and the child session fell
+   * back to whatever `process.cwd()` happened to be — the parent's directory, not the subagent's
+   * workspace. A worktree-isolated subagent was the case that made that visibly wrong.
+   */
+  cwd: string;
   /** Stable session ID for transcript files. */
   sessionId?: string;
   /** Optional logger for subagent transcripts. */
@@ -186,6 +195,7 @@ export function createSubagentSession(options: ISubagentOptions): Session {
     provider,
     systemMessage,
     terminal,
+    cwd: options.cwd,
     ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
     ...(options.sessionLogger !== undefined ? { sessionLogger: options.sessionLogger } : {}),
     model,

--- a/packages/agent-framework/src/assembly/create-tools.ts
+++ b/packages/agent-framework/src/assembly/create-tools.ts
@@ -40,7 +40,15 @@ export const DEFAULT_TOOL_DESCRIPTIONS = [
  */
 export interface ICreateDefaultToolsOptions {
   sandboxClient?: ISandboxClient;
-  cwd?: string;
+  /**
+   * The execution root every file tool is contained by. REQUIRED — ARCH-010.
+   *
+   * It was optional, and `child-process-subagent-worker.ts` called this factory with no argument at
+   * all: `cwd` was `undefined`, the path guard was fail-open, and the subagent's `Read` returned
+   * `/etc/hostname`. Requiring it means a construction site that forgets does not compile, which is
+   * the only way a containment root stays a contract rather than a convention.
+   */
+  cwd: string;
   /** SELFHOST-003: when present, adds the adapter-gated `CodebaseRetrieval` tool (absent otherwise). */
   retrievalAdapter?: IRetrievalAdapter;
   /**
@@ -51,9 +59,7 @@ export interface ICreateDefaultToolsOptions {
   computerDriver?: IComputerDriver;
 }
 
-export function createDefaultTools(
-  options: ICreateDefaultToolsOptions = {},
-): IToolWithEventService[] {
+export function createDefaultTools(options: ICreateDefaultToolsOptions): IToolWithEventService[] {
   return [
     createShellTool(options) as IToolWithEventService,
     createBashTool(options) as IToolWithEventService,

--- a/packages/agent-framework/src/checkpoints/__tests__/edit-checkpoint-tools.test.ts
+++ b/packages/agent-framework/src/checkpoints/__tests__/edit-checkpoint-tools.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, rmSync, readFileSync, mkdtempSync } from 'node:f
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { writeTool } from '@robota-sdk/agent-tools';
+import { createWriteTool } from '@robota-sdk/agent-tools';
 import { describe, expect, it, afterEach, vi } from 'vitest';
 
 import { wrapEditCheckpointTools } from '../edit-checkpoint-tools.js';
@@ -31,7 +31,9 @@ describe('wrapEditCheckpointTools', () => {
         expect(existsSync(filePath)).toBe(false);
       }),
     };
-    const [tool] = wrapEditCheckpointTools([writeTool], recorder);
+    // ARCH-010 — the context-free `writeTool` singleton is gone and the root is a required constructor
+    // argument. It is the per-case project directory, which is exactly where `filePath` lives.
+    const [tool] = wrapEditCheckpointTools([createWriteTool({ cwd })], recorder);
 
     await tool?.execute(
       { filePath, content: 'written' },

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-skill-command.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-skill-command.test.ts
@@ -26,8 +26,15 @@ vi.mock('../../assembly/create-subagent-session.js', () => ({
   createSubagentSession: mocks.createSubagentSession,
 }));
 
-function makeParentSession() {
+/**
+ * ARCH-010 — a `Session` now carries its execution root and exposes it as `getCwd()`; a fork reads the
+ * PARENT's root instead of re-deriving one, so this double has to answer. It reports the same directory
+ * the `InteractiveSession` under test is given (each case's own tmpdir), which is what a real parent
+ * session in that position would hold. The default is only for the case that constructs no `cwd` at all.
+ */
+function makeParentSession(cwd: string = process.cwd()) {
   return {
+    getCwd: vi.fn().mockReturnValue(cwd),
     run: vi.fn().mockResolvedValue('parent response'),
     abort: vi.fn(),
     getHistory: vi.fn().mockReturnValue([]),
@@ -106,7 +113,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('submits non-fork skills into the parent session', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-user-skill-common-api-'));
     createTempSkill(cwd);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     const session = new InteractiveSession({ session: parentSession as never, cwd });
     const skillActivation = vi.fn();
     session.on('skill_activation', skillActivation);
@@ -149,7 +156,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('activates model-invocable skills through the SDK path without submitting a user turn', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-model-skill-'));
     createTempSkill(cwd);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     const session = new InteractiveSession({ session: parentSession as never, cwd });
 
     const result = await session.executeSkillCommandByName('audit', 'src/index.ts', {
@@ -177,7 +184,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('executes named user skills through the SDK path', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-user-skill-'));
     createTempSkill(cwd);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     const session = new InteractiveSession({ session: parentSession as never, cwd });
 
     const result = await session.executeSkillCommandByName('audit', 'src/index.ts', {
@@ -216,7 +223,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('does not route natural-language skill directives outside the command tool path', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-natural-language-skill-'));
     createTempSkill(cwd);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     const session = new InteractiveSession({ session: parentSession as never, cwd });
 
     await session.submit('Use the audit skill to inspect src/index.ts.');
@@ -231,7 +238,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('does not record skill activation for prompt-only skill references', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-prompt-only-skill-'));
     createTempSkill(cwd);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     const session = new InteractiveSession({ session: parentSession as never, cwd });
 
     await session.submit('The audit skill exists in this repository.');
@@ -244,7 +251,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('persists skill activation events in the session record', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-persisted-skill-'));
     createTempSkill(cwd);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     let savedRecord: IInteractiveSessionRecord | undefined;
     const sessionStore: IInteractiveSessionStore = {
       save: (record) => {
@@ -273,7 +280,7 @@ describe('InteractiveSession skill activation common API', () => {
   it('runs context: fork skills through an isolated subagent session', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'robota-fork-skill-common-api-'));
     createTempSkill(cwd, 'audit', ['context: fork', 'agent: Explore', 'allowed-tools: Read']);
-    const parentSession = makeParentSession();
+    const parentSession = makeParentSession(cwd);
     const session = new InteractiveSession({ session: parentSession as never, cwd });
     const exploreAgent: IAgentDefinition = {
       name: 'Explore',

--- a/packages/agent-framework/src/interactive/interactive-session-fork.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-fork.ts
@@ -51,6 +51,9 @@ export async function runSkillInFork(
     parentTools: deps.tools,
     provider: deps.provider,
     terminal: deps.terminal,
+    // ARCH-010: a fork continues the SAME conversation in the same place, so it inherits the parent
+    // session's root rather than re-deriving one.
+    cwd: parentSession.getCwd(),
     isForkWorker: true,
     permissionMode: deps.permissionMode,
     permissionHandler: deps.permissionHandler,

--- a/packages/agent-framework/src/subagents/in-process-subagent-runner.ts
+++ b/packages/agent-framework/src/subagents/in-process-subagent-runner.ts
@@ -138,6 +138,11 @@ export function createInProcessSubagentRunner(deps: IInProcessSubagentRunnerDeps
         parentTools: deps.tools,
         provider: deps.provider,
         terminal: deps.terminal,
+        // ARCH-010: the spawn request has always declared `cwd` required; there was simply no option
+        // to pass it to, so the child session read `process.cwd()` — the PARENT's directory. A
+        // worktree-isolated job runs in its worktree, which is the whole point of the isolation, so
+        // that root wins when present.
+        cwd: job.request.worktreePath ?? job.request.cwd,
         permissionMode: deps.permissionMode,
         // CORE-025: carry the task's permission policy + its own tool lists so the child session gates tool
         // calls by policy BEFORE the inherited session mode (deny/preapproved bind even under bypass).

--- a/packages/agent-framework/src/subagents/in-process-subagent-runner.ts
+++ b/packages/agent-framework/src/subagents/in-process-subagent-runner.ts
@@ -1,4 +1,5 @@
 import { sumHistoryUsage } from '@robota-sdk/agent-core';
+import { subagentExecutionRoot } from '@robota-sdk/agent-executor';
 
 import { getBuiltInAgent } from '../agents/built-in-agents.js';
 import { createSubagentSession } from '../assembly/create-subagent-session.js';
@@ -139,10 +140,8 @@ export function createInProcessSubagentRunner(deps: IInProcessSubagentRunnerDeps
         provider: deps.provider,
         terminal: deps.terminal,
         // ARCH-010: the spawn request has always declared `cwd` required; there was simply no option
-        // to pass it to, so the child session read `process.cwd()` — the PARENT's directory. A
-        // worktree-isolated job runs in its worktree, which is the whole point of the isolation, so
-        // that root wins when present.
-        cwd: job.request.worktreePath ?? job.request.cwd,
+        // to pass it to, so the child session read `process.cwd()` — the PARENT's directory.
+        cwd: subagentExecutionRoot(job.request),
         permissionMode: deps.permissionMode,
         // CORE-025: carry the task's permission policy + its own tool lists so the child session gates tool
         // calls by policy BEFORE the inherited session mode (deny/preapproved bind even under bypass).

--- a/packages/agent-session/README.md
+++ b/packages/agent-session/README.md
@@ -23,6 +23,10 @@ const session = new Session({
   provider,
   systemMessage: 'You are a helpful assistant.',
   terminal,
+  // ARCH-010: required. The session's execution root feeds every hook input, CLAUDE_PROJECT_DIR, the
+  // permission root and the persisted record — it is not read from the process any more, so a
+  // subagent runs in its own workspace rather than its parent's.
+  cwd: process.cwd(),
   permissions: { allow: ['Read(*)'], deny: [] },
   autoCompactThreshold: 0.75,
 });

--- a/packages/agent-session/docs/SPEC.md
+++ b/packages/agent-session/docs/SPEC.md
@@ -189,6 +189,7 @@ the agent runtime was built at assembly. The default is `true`.
 | `getPermissionMode`           | `() => TPermissionMode`                                                                                                 | Returns the active permission mode.                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `setPermissionMode`           | `(mode: TPermissionMode) => void`                                                                                       | Changes the permission mode for future tool calls.                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `getSessionId`                | `() => string`                                                                                                          | Returns the stable session identifier.                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `getCwd`                      | `() => string`                                                                                                          | ARCH-010: the session's execution root, as supplied to `ISessionOptions.cwd`. Readable so a fork or subagent derived from this session asks it rather than re-deriving from `process.cwd()`.                                                                                                                                                                                                                                                            |
 | `getMessageCount`             | `() => number`                                                                                                          | Returns the number of completed `run()` calls.                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `clearHistory`                | `() => void`                                                                                                            | Clears the underlying Robota conversation history and resets token usage.                                                                                                                                                                                                                                                                                                                                                                               |
 | `getHistory`                  | `() => TUniversalMessage[]`                                                                                             | Returns the current conversation history as `TUniversalMessage[]` (chat entries only). Unchanged.                                                                                                                                                                                                                                                                                                                                                       |
@@ -338,6 +339,17 @@ bytes are already on disk and is safely ignored.
 ## Abort Behavior
 
 The `Session` class supports aborting an in-progress `run()` call via `AbortController`.
+
+### Execution Root (ARCH-010)
+
+`ISessionOptions.cwd` is REQUIRED. It did not exist: the constructor read `process.cwd()`, and that
+ambient value became the session's identity everywhere it matters — every hook input,
+`CLAUDE_PROJECT_DIR`, the permission enforcer's root, and the persisted record. A session could not be
+told where it ran, so a subagent ran in its parent's directory rather than its own workspace, while
+the subagent spawn contract had declared `cwd` required all along.
+
+`getCwd()` exposes it, because a fork or subagent derived from a session must be able to ask which
+root that session actually uses instead of re-deriving one that can disagree.
 
 ### Turn Identity (RUNTIME-003)
 

--- a/packages/agent-session/examples/verify-offline.ts
+++ b/packages/agent-session/examples/verify-offline.ts
@@ -44,6 +44,8 @@ const silentTerminal: ITerminalOutput = {
 
 async function main(): Promise<void> {
   const session = new Session({
+    // ARCH-010: the session's execution root is an explicit field, not an ambient process read.
+    cwd: process.cwd(),
     tools: [],
     provider: new MockAIProvider(),
     systemMessage: 'You are a test assistant.',

--- a/packages/agent-session/src/__tests__/active-preset-state.test.ts
+++ b/packages/agent-session/src/__tests__/active-preset-state.test.ts
@@ -49,6 +49,7 @@ const MOCK_TERMINAL = {
 describe('Session active preset state (PRESET-011)', () => {
   it('TC-01: initializes activePresetId from options', () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -61,6 +62,7 @@ describe('Session active preset state (PRESET-011)', () => {
 
   it("TC-02: defaults activePresetId to 'default' when not provided", () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -72,6 +74,7 @@ describe('Session active preset state (PRESET-011)', () => {
 
   it('TC-03: setActivePresetId mutates state only — no option re-application', () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',

--- a/packages/agent-session/src/__tests__/apply-model-options-cold-session.test.ts
+++ b/packages/agent-session/src/__tests__/apply-model-options-cold-session.test.ts
@@ -42,6 +42,7 @@ const MOCK_TERMINAL = {
 
 function buildColdSession(): Session {
   return new Session({
+    cwd: process.cwd(),
     tools: [],
     provider: new ColdTestProvider() as never,
     systemMessage: 'test',

--- a/packages/agent-session/src/__tests__/apply-model-options.test.ts
+++ b/packages/agent-session/src/__tests__/apply-model-options.test.ts
@@ -52,6 +52,7 @@ const MOCK_TERMINAL = {
 
 function buildSession(): Session {
   return new Session({
+    cwd: process.cwd(),
     tools: [],
     provider: MOCK_PROVIDER as never,
     systemMessage: 'test',

--- a/packages/agent-session/src/__tests__/parallel-subagents-gate.test.ts
+++ b/packages/agent-session/src/__tests__/parallel-subagents-gate.test.ts
@@ -50,6 +50,7 @@ const MOCK_TERMINAL = {
 describe('Session parallel-subagents gate (PRESET-016)', () => {
   it('TC-01: initializes parallelSubagentsEnabled from options; defaults to true', () => {
     const disabled = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -59,6 +60,7 @@ describe('Session parallel-subagents gate (PRESET-016)', () => {
     expect(disabled.getParallelSubagentsEnabled()).toBe(false);
 
     const defaulted = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -69,6 +71,7 @@ describe('Session parallel-subagents gate (PRESET-016)', () => {
 
   it('TC-02: setParallelSubagentsEnabled(false) flips the live flag', () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',

--- a/packages/agent-session/src/__tests__/selfhost-009-pretooluse-gate.test.ts
+++ b/packages/agent-session/src/__tests__/selfhost-009-pretooluse-gate.test.ts
@@ -79,9 +79,11 @@ function makeEnforcer(executor: IHookTypeExecutor): PermissionEnforcer {
 
 describe('SELFHOST-009 TC-02 — PreToolUse security gate (functional)', () => {
   it('exit-code-2 hook blocks the tool: execute is never called, denial returned', async () => {
-    const underlying = vi.fn(
-      async (): Promise<IToolResult> => ({ success: true, data: 'ran', metadata: {} }),
-    );
+    const underlying = vi.fn(async (): Promise<IToolResult> => ({
+      success: true,
+      data: 'ran',
+      metadata: {},
+    }));
     const enforcer = makeEnforcer(makeDenyExecutor('exit2'));
     const [wrapped] = enforcer.wrapTools([makeTool('Bash', underlying)]);
 
@@ -94,9 +96,11 @@ describe('SELFHOST-009 TC-02 — PreToolUse security gate (functional)', () => {
   });
 
   it('permissionDecision:"deny" hook blocks the tool the same way', async () => {
-    const underlying = vi.fn(
-      async (): Promise<IToolResult> => ({ success: true, data: 'ran', metadata: {} }),
-    );
+    const underlying = vi.fn(async (): Promise<IToolResult> => ({
+      success: true,
+      data: 'ran',
+      metadata: {},
+    }));
     const enforcer = makeEnforcer(makeDenyExecutor('json-deny'));
     const [wrapped] = enforcer.wrapTools([makeTool('Write', underlying)]);
 
@@ -108,9 +112,11 @@ describe('SELFHOST-009 TC-02 — PreToolUse security gate (functional)', () => {
   });
 
   it('a passing (exit 0) PreToolUse hook lets the tool run', async () => {
-    const underlying = vi.fn(
-      async (): Promise<IToolResult> => ({ success: true, data: 'ran', metadata: {} }),
-    );
+    const underlying = vi.fn(async (): Promise<IToolResult> => ({
+      success: true,
+      data: 'ran',
+      metadata: {},
+    }));
     const passExecutor: IHookTypeExecutor = {
       type: 'command',
       execute: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })),

--- a/packages/agent-session/src/__tests__/session-compaction.test.ts
+++ b/packages/agent-session/src/__tests__/session-compaction.test.ts
@@ -98,6 +98,7 @@ let mockProvider: ReturnType<typeof createMockProvider>;
 function createSession(opts: Record<string, unknown> = {}): Session {
   mockProvider = createMockProvider();
   return new Session({
+    cwd: process.cwd(),
     tools: MOCK_TOOLS,
     provider: mockProvider,
     systemMessage: 'test system',

--- a/packages/agent-session/src/__tests__/session-execution-root.test.ts
+++ b/packages/agent-session/src/__tests__/session-execution-root.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Session } from '../session.js';
+
+/**
+ * ARCH-010 — the session's execution root is a required field, and required is enforced at RUNTIME.
+ *
+ * `Session` used to read `process.cwd()` in its constructor. That ambient value became the session's
+ * identity everywhere it matters — every hook input, `CLAUDE_PROJECT_DIR`, the permission enforcer's
+ * root, the persisted record — so a subagent ran in its parent's directory rather than its own
+ * workspace, while the subagent spawn contract had declared `cwd` required all along.
+ *
+ * Making it a required TypeScript field is necessary and not sufficient. This package's tsconfig
+ * EXCLUDES `*.test.ts`, and a JavaScript consumer is not type-checked at all — so without a runtime
+ * check the field would simply be `undefined`, and the session would report a root it does not have
+ * while everything downstream quietly used nothing. That is the silent shape the whole task is about.
+ */
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn().mockResolvedValue(''),
+  select: vi.fn().mockResolvedValue(0),
+  spinner: vi.fn().mockReturnValue({ stop: vi.fn(), update: vi.fn() }),
+};
+
+const PROVIDER = {
+  name: 'test-provider',
+  version: '1.0.0',
+  chat: vi.fn(),
+  supportsTools: () => true,
+  validateConfig: () => true,
+};
+
+/** The shape a JS consumer or an untypechecked test actually passes. */
+function construct(cwd: unknown): () => Session {
+  return () =>
+    new Session({
+      tools: [] as never,
+      provider: PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL,
+      cwd,
+    } as never);
+}
+
+describe('a session must be told where it runs (ARCH-010)', () => {
+  it('REFUSES to construct with no execution root', () => {
+    expect(construct(undefined)).toThrow(/requires `cwd`/i);
+  });
+
+  it('refuses an empty string — a root of "" is not a root', () => {
+    expect(construct('')).toThrow(/requires `cwd`/i);
+  });
+
+  it('refuses a non-string, which is what a JS caller passing the wrong thing supplies', () => {
+    expect(construct(123)).toThrow(/requires `cwd`/i);
+  });
+
+  it('names what the value is FOR, so the caller can tell whether process.cwd() is right', () => {
+    // An error that only says "cwd is required" gets `process.cwd()` pasted in reflexively, which is
+    // the ambient read this change removed. Saying what consumes it makes that a decision.
+    expect(construct(undefined)).toThrow(/hook input|CLAUDE_PROJECT_DIR|permission root/i);
+  });
+
+  it('constructs, and reports the root it was given', () => {
+    const session = new Session({
+      tools: [] as never,
+      provider: PROVIDER as never,
+      systemMessage: 'test',
+      terminal: MOCK_TERMINAL,
+      cwd: '/tmp/some-workspace',
+    });
+    // `getCwd()` exists so a fork or subagent asks the session instead of re-deriving a root that
+    // can disagree with it.
+    expect(session.getCwd()).toBe('/tmp/some-workspace');
+  });
+});

--- a/packages/agent-session/src/__tests__/session-execution-root.test.ts
+++ b/packages/agent-session/src/__tests__/session-execution-root.test.ts
@@ -58,6 +58,13 @@ describe('a session must be told where it runs (ARCH-010)', () => {
     expect(construct(123)).toThrow(/requires `cwd`/i);
   });
 
+  it('refuses a RELATIVE root — the ambient read must not return through the value', () => {
+    // `./workspace` is resolved against `process.cwd()` by everything downstream, so accepting it
+    // would reintroduce exactly the ambient dependency this field replaces.
+    expect(construct('./workspace')).toThrow(/ABSOLUTE/);
+    expect(construct('workspace')).toThrow(/ABSOLUTE/);
+  });
+
   it('names what the value is FOR, so the caller can tell whether process.cwd() is right', () => {
     // An error that only says "cwd is required" gets `process.cwd()` pasted in reflexively, which is
     // the ambient read this change removed. Saying what consumes it makes that a decision.

--- a/packages/agent-session/src/__tests__/session-id-override.test.ts
+++ b/packages/agent-session/src/__tests__/session-id-override.test.ts
@@ -45,6 +45,7 @@ const MOCK_TERMINAL = {
 describe('Session sessionId override', () => {
   it('generates a unique session ID by default', () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -56,6 +57,7 @@ describe('Session sessionId override', () => {
 
   it('uses provided sessionId when specified', () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -68,6 +70,7 @@ describe('Session sessionId override', () => {
 
   it('generates a new ID when sessionId is undefined', () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',

--- a/packages/agent-session/src/__tests__/session-provider-callback-isolation.test.ts
+++ b/packages/agent-session/src/__tests__/session-provider-callback-isolation.test.ts
@@ -39,6 +39,7 @@ function createTerminal() {
 
 function createSession(provider: IAIProvider, onTextDelta: (delta: string) => void): Session {
   return new Session({
+    cwd: process.cwd(),
     tools: [],
     provider,
     systemMessage: 'test system',
@@ -80,6 +81,7 @@ describe('Session provider callback isolation', () => {
       };
     });
     const session = new Session({
+      cwd: process.cwd(),
       tools: [],
       provider,
       systemMessage: 'test system',

--- a/packages/agent-session/src/__tests__/session-shutdown-best-effort.test.ts
+++ b/packages/agent-session/src/__tests__/session-shutdown-best-effort.test.ts
@@ -39,6 +39,7 @@ describe('Session.shutdown — best-effort disposal (CORE-013)', () => {
       execute: vi.fn().mockRejectedValue(new Error('hook boom')),
     };
     const session = new Session({
+      cwd: process.cwd(),
       tools: [] as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -53,6 +54,7 @@ describe('Session.shutdown — best-effort disposal (CORE-013)', () => {
 
   it('destroys the wrapped agent — run() after shutdown rejects with [LIFECYCLE] (CORE-022)', async () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [] as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',
@@ -66,6 +68,7 @@ describe('Session.shutdown — best-effort disposal (CORE-013)', () => {
 
   it('returns the same cached promise on repeated shutdown calls', async () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: [] as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test',

--- a/packages/agent-session/src/__tests__/session-system-prompt.test.ts
+++ b/packages/agent-session/src/__tests__/session-system-prompt.test.ts
@@ -96,6 +96,7 @@ describe('Session — system prompt delivery', () => {
     const systemMessage = `Agent Instructions\n${agentsContent}\n\nAvailable tools: Bash, Read`;
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -117,6 +118,7 @@ describe('Session — system prompt delivery', () => {
     const systemMessage = `Project Notes\n${claudeContent}\n\nAvailable tools: Bash`;
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -131,6 +133,7 @@ describe('Session — system prompt delivery', () => {
     const systemMessage = 'test agents content\ntest claude content\nAvailable tools: Bash';
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -149,6 +152,7 @@ describe('Session — system prompt delivery', () => {
     const systemMessage = 'Some base system prompt with tools listed';
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -165,6 +169,7 @@ describe('Session — system prompt delivery', () => {
       'Available tools: Bash — execute shell commands, Read — read files, Grep — search';
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -181,6 +186,7 @@ describe('Session — system prompt delivery', () => {
     const systemMessage = 'Trust level: moderate\nAvailable tools: Bash';
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -193,6 +199,7 @@ describe('Session — system prompt delivery', () => {
 
   it('should pass provider timeout into Robota agent config', () => {
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test system',
@@ -206,6 +213,7 @@ describe('Session — system prompt delivery', () => {
 
   it('passes maxTurns to Robota.run as maxExecutionRounds', async () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test system',
@@ -220,6 +228,7 @@ describe('Session — system prompt delivery', () => {
 
   it('uses unlimited core execution rounds when maxTurns is omitted', async () => {
     const session = new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'test system',
@@ -236,6 +245,7 @@ describe('Session — system prompt delivery', () => {
     const logger = { log: vi.fn() };
 
     new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage,
@@ -271,6 +281,7 @@ describe('Session — system prompt delivery', () => {
     const logger = { log: vi.fn() };
 
     const session = new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'System prompt',
@@ -295,6 +306,7 @@ describe('Session — system prompt delivery', () => {
     const logger = { log: vi.fn() };
 
     const session = new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'System prompt',
@@ -323,6 +335,7 @@ describe('Session — system prompt delivery', () => {
 
     mockRunResult = 'done';
     const session = new Session({
+      cwd: process.cwd(),
       tools: MOCK_TOOLS as never,
       provider: MOCK_PROVIDER as never,
       systemMessage: 'System prompt',

--- a/packages/agent-session/src/__tests__/session-turn-reentrancy.test.ts
+++ b/packages/agent-session/src/__tests__/session-turn-reentrancy.test.ts
@@ -65,6 +65,7 @@ function blockingProvider() {
 
 function makeSession(provider: unknown) {
   return new Session({
+    cwd: process.cwd(),
     tools: [] as never,
     provider: provider as never,
     systemMessage: 'test',

--- a/packages/agent-session/src/execution-root.ts
+++ b/packages/agent-session/src/execution-root.ts
@@ -1,3 +1,5 @@
+import { isAbsolute } from 'node:path';
+
 /**
  * The session's execution root. ARCH-010.
  *
@@ -18,6 +20,16 @@ export function requireExecutionRoot(cwd: unknown): string {
       'Session requires `cwd`: the absolute path this session executes in (ARCH-010). It feeds ' +
         'every hook input, CLAUDE_PROJECT_DIR, the permission root and the persisted record. Pass ' +
         '`process.cwd()` explicitly if that is genuinely what you mean.',
+    );
+  }
+  // ABSOLUTE, not merely present. A relative root is resolved against `process.cwd()` by everything
+  // downstream, so accepting one would let the ambient read this change removes back in through the
+  // VALUE instead of through its absence — the same defect wearing a different shape.
+  if (!isAbsolute(cwd)) {
+    throw new Error(
+      `Session requires an ABSOLUTE \`cwd\`; got ${JSON.stringify(cwd)} (ARCH-010). A relative ` +
+        'root is resolved against the process directory downstream, which is the ambient value this ' +
+        'field exists to replace. Resolve it at your composition root.',
     );
   }
   return cwd;

--- a/packages/agent-session/src/execution-root.ts
+++ b/packages/agent-session/src/execution-root.ts
@@ -1,0 +1,24 @@
+/**
+ * The session's execution root. ARCH-010.
+ *
+ * `Session` used to read `process.cwd()` in its constructor, and that ambient value became the
+ * session's identity everywhere it matters — every hook input, `CLAUDE_PROJECT_DIR`, the permission
+ * enforcer's root, the persisted record. A session could not be TOLD where it ran, so a subagent ran
+ * in its parent's directory rather than its own workspace, while the subagent spawn contract had
+ * declared `cwd` required all along.
+ *
+ * Making it a required TypeScript field is necessary and not sufficient. This package's tsconfig
+ * excludes `*.test.ts`, and a JavaScript consumer is not type-checked at all — so without a runtime
+ * check the field would simply be `undefined`, and the session would report a root it does not have
+ * while everything downstream quietly used nothing. Silence is not success: refuse instead.
+ */
+export function requireExecutionRoot(cwd: unknown): string {
+  if (typeof cwd !== 'string' || cwd.length === 0) {
+    throw new Error(
+      'Session requires `cwd`: the absolute path this session executes in (ARCH-010). It feeds ' +
+        'every hook input, CLAUDE_PROJECT_DIR, the permission root and the persisted record. Pass ' +
+        '`process.cwd()` explicitly if that is genuinely what you mean.',
+    );
+  }
+  return cwd;
+}

--- a/packages/agent-session/src/session-base.ts
+++ b/packages/agent-session/src/session-base.ts
@@ -1,3 +1,4 @@
+import { requireExecutionRoot } from './execution-root.js';
 import { TurnClaim } from './turn-claim.js';
 
 import type { ContextWindowTracker, TAutoCompactThreshold } from './context-window-tracker.js';
@@ -26,6 +27,12 @@ export abstract class SessionBase {
   protected abstract model: string;
   protected abstract systemMessage: string;
   protected abstract messageCount: number;
+  /** ARCH-010: the session's execution root — owned here, with the check that it was supplied. */
+  protected readonly cwd: string;
+
+  protected constructor(cwd: string) {
+    this.cwd = requireExecutionRoot(cwd);
+  }
   /**
    * RUNTIME-003: the turn currently running, and its owner. Was a bare `AbortController | null` that
    * `run()` overwrote, which is why `abort()` and `isRunning()` below could answer about a turn that
@@ -68,6 +75,17 @@ export abstract class SessionBase {
 
   getSessionId(): string {
     return this.sessionId;
+  }
+
+  /**
+   * The session's execution root (ARCH-010).
+   *
+   * Readable because a caller that derives something FROM the session — a fork, a subagent, a hook
+   * input — must be able to ask which root this session actually runs in. Re-deriving it from
+   * `process.cwd()` is how the two silently diverged.
+   */
+  getCwd(): string {
+    return this.cwd;
   }
 
   getSystemMessage(): string {

--- a/packages/agent-session/src/session-types.ts
+++ b/packages/agent-session/src/session-types.ts
@@ -44,6 +44,20 @@ export interface ISessionOptions {
   systemMessage: string;
   /** Terminal I/O for permission prompts */
   terminal: ITerminalOutput;
+  /**
+   * The session's execution root. REQUIRED — ARCH-010.
+   *
+   * This field did not exist. `Session` read `process.cwd()` in its constructor and that ambient
+   * value became the session's identity everywhere it matters: every hook input,
+   * `CLAUDE_PROJECT_DIR`, `PermissionEnforcer`'s root, and the persisted record. Meanwhile the
+   * subagent spawn contract has always declared `cwd` REQUIRED — and the in-process runner passed
+   * none, because there was no option to pass it to. A session that cannot be told where it runs
+   * silently runs wherever the process happens to be, which for a subagent is not its own workspace.
+   *
+   * A caller that genuinely means "this process's directory" passes `process.cwd()` where a reader
+   * can see the decision.
+   */
+  cwd: string;
   /** Permission and hook configuration */
   permissions?: { allow: string[]; deny: string[] };
   hooks?: Record<string, unknown>;

--- a/packages/agent-session/src/session.ts
+++ b/packages/agent-session/src/session.ts
@@ -79,7 +79,6 @@ export class Session extends SessionBase {
   protected messageCount = 0;
   private readonly terminal: ITerminalOutput;
   private readonly sessionStore?: ISessionStore;
-  private readonly cwd: string;
   private readonly hooks?: Record<string, unknown>;
   private readonly hookTypeExecutors?: IHookTypeExecutor[];
   private readonly onTextDeltaCallback?: (delta: string) => void;
@@ -97,14 +96,13 @@ export class Session extends SessionBase {
   private readonly transcriptPath: string | undefined;
 
   constructor(options: ISessionOptions) {
-    super();
+    super(options.cwd);
     const { tools, provider, systemMessage } = options;
 
     this.terminal = options.terminal;
     this.sessionStore = options.sessionStore;
     this.systemMessage = systemMessage;
     this.toolSchemas = tools.map((tool) => tool.schema);
-    this.cwd = process.cwd();
     this.sessionLogger = options.sessionLogger;
     this.hooks = options.hooks;
     this.hookTypeExecutors = options.hookTypeExecutors;

--- a/packages/agent-subagent-runner/src/child-process-subagent-worker.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-worker.ts
@@ -82,6 +82,20 @@ function readSessionUsage(
   }
 }
 
+/**
+ * The root this subagent runs in — ARCH-010.
+ *
+ * `ISubagentSpawnRequest.cwd` has always been required; this worker simply never read it, so
+ * `createDefaultTools()` was called with no argument and the child's file tools had no containment
+ * boundary at all. A worktree-isolated job runs in its worktree, which is the point of the isolation.
+ *
+ * One reader rather than two call sites, because the tools and the session being told DIFFERENT roots
+ * is the same class of defect as neither being told one.
+ */
+function subagentRoot(payload: ISubagentWorkerStartPayload): string {
+  return payload.request.worktreePath ?? payload.request.cwd;
+}
+
 async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<void> {
   try {
     const provider = createProviderFromProfile(
@@ -96,7 +110,10 @@ async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<v
       agentDefinition: payload.agentDefinition,
       parentConfig: payload.parentConfig,
       parentContext: payload.parentContext,
-      parentTools: createDefaultTools(),
+      // ARCH-010: the spawn request already carries the root (`ISubagentSpawnRequest.cwd` is
+      // required); this call simply never passed it, so every tool the child built was unconfined.
+      parentTools: createDefaultTools({ cwd: subagentRoot(payload) }),
+      cwd: subagentRoot(payload),
       provider,
       terminal: NOOP_TERMINAL,
       sessionId: payload.jobId,

--- a/packages/agent-subagent-runner/src/child-process-subagent-worker.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-worker.ts
@@ -1,5 +1,5 @@
 import { sumHistoryUsage } from '@robota-sdk/agent-core';
-import { createProviderFromProfile } from '@robota-sdk/agent-executor';
+import { createProviderFromProfile, subagentExecutionRoot } from '@robota-sdk/agent-executor';
 import {
   createDefaultTools,
   createSubagentLogger,
@@ -82,20 +82,6 @@ function readSessionUsage(
   }
 }
 
-/**
- * The root this subagent runs in — ARCH-010.
- *
- * `ISubagentSpawnRequest.cwd` has always been required; this worker simply never read it, so
- * `createDefaultTools()` was called with no argument and the child's file tools had no containment
- * boundary at all. A worktree-isolated job runs in its worktree, which is the point of the isolation.
- *
- * One reader rather than two call sites, because the tools and the session being told DIFFERENT roots
- * is the same class of defect as neither being told one.
- */
-function subagentRoot(payload: ISubagentWorkerStartPayload): string {
-  return payload.request.worktreePath ?? payload.request.cwd;
-}
-
 async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<void> {
   try {
     const provider = createProviderFromProfile(
@@ -110,10 +96,12 @@ async function runInitialPrompt(payload: ISubagentWorkerStartPayload): Promise<v
       agentDefinition: payload.agentDefinition,
       parentConfig: payload.parentConfig,
       parentContext: payload.parentContext,
-      // ARCH-010: the spawn request already carries the root (`ISubagentSpawnRequest.cwd` is
-      // required); this call simply never passed it, so every tool the child built was unconfined.
-      parentTools: createDefaultTools({ cwd: subagentRoot(payload) }),
-      cwd: subagentRoot(payload),
+      // ARCH-010: the spawn request already carries the root; this call simply never passed it, so
+      // every tool the child built was unconfined. Same reader as the session root below — the tools
+      // and the session being told DIFFERENT roots is the same class of defect as neither being told
+      // one.
+      parentTools: createDefaultTools({ cwd: subagentExecutionRoot(payload.request) }),
+      cwd: subagentExecutionRoot(payload.request),
       provider,
       terminal: NOOP_TERMINAL,
       sessionId: payload.jobId,

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -62,18 +62,24 @@ const agent = new Robota({
 
 ## Built-in Tools
 
+Every tool that touches the filesystem is a FACTORY taking the containment root it operates in
+(`cwd`, required — ARCH-010). There is no ready-made instance to import: one bound at import time can
+carry no root, and a file tool with no root has no boundary.
+
 | Export                | Tool Name       | Description                                                                   |
 | --------------------- | --------------- | ----------------------------------------------------------------------------- |
-| `shellTool`           | Shell           | Execute host shell commands; OS-aware (POSIX `sh`/`bash`, Windows PowerShell) |
-| `bashTool`            | Bash            | Model-familiar alias of `Shell` — same OS-aware implementation                |
-| `readTool`            | Read            | Read file contents with line numbers (cat -n)                                 |
-| `writeTool`           | Write           | Write content to a file (creates parent dirs)                                 |
-| `editTool`            | Edit            | Replace a specific string in a file                                           |
-| `globTool`            | Glob            | Find files matching a glob pattern (fast-glob)                                |
-| `grepTool`            | Grep            | Search file contents with regex patterns                                      |
+| `createShellTool`     | Shell           | Execute host shell commands; OS-aware (POSIX `sh`/`bash`, Windows PowerShell) |
+| `createBashTool`      | Bash            | Model-familiar alias of `Shell` — same OS-aware implementation                |
+| `createReadTool`      | Read            | Read file contents with line numbers (cat -n)                                 |
+| `createWriteTool`     | Write           | Write content to a file (creates parent dirs)                                 |
+| `createEditTool`      | Edit            | Replace a specific string in a file                                           |
+| `createGlobTool`      | Glob            | Find files matching a glob pattern (fast-glob)                                |
+| `createGrepTool`      | Grep            | Search file contents with regex patterns                                      |
 | `webFetchTool`        | WebFetch        | Fetch URL content (HTML-to-text conversion)                                   |
 | `webSearchTool`       | WebSearch       | Web search via Brave Search API                                               |
 | `askUserQuestionTool` | AskUserQuestion | Model asks the user structured questions (options/multi-select/free text)     |
+
+The last three stay instances: they touch no filesystem, so there is no root to contain them by.
 
 `AskUserQuestion` lets the model ask the user 1–4 structured questions mid-turn through the injected
 ask port (CMD-004); each environment renders it its own way (Ink dialog, web modal, programmatic
@@ -81,7 +87,7 @@ pre-answer), and headless runs get a structured `unavailable` result instead of 
 
 `Shell` and `Bash` are two registered names for one OS-aware implementation: the shell is resolved per-OS and the tool description names the active OS/shell so the model writes the right syntax (e.g. macOS BSD vs Linux GNU utilities differ).
 
-Factory exports (`createBashTool`, `createReadTool`, `createWriteTool`, `createEditTool`) accept an optional `sandboxClient`. The default singleton exports keep host-local behavior.
+The sandbox-aware factories (`createBashTool`, `createReadTool`, `createWriteTool`, `createEditTool`) also accept an optional `sandboxClient`; without one they run against the host filesystem, contained by `cwd`.
 
 ## Sandbox Execution
 
@@ -96,8 +102,11 @@ import { Sandbox } from 'e2b';
 const e2b = await Sandbox.create();
 const sandboxClient = new E2BSandboxClient({ sandbox: e2b });
 
-const bashTool = createBashTool({ sandboxClient });
-const readTool = createReadTool({ sandboxClient });
+// `cwd` is required even with a sandbox client: it is the root inside the sandbox, and the host
+// path guard still applies to any tool that falls through to the host filesystem.
+const cwd = '/workspace';
+const bashTool = createBashTool({ sandboxClient, cwd });
+const readTool = createReadTool({ sandboxClient, cwd });
 ```
 
 The package does not depend on E2B directly. `E2BSandboxClient` adapts an E2B-compatible object with `commands.run`, `files.read`, `files.write`, and optional `createSnapshot`, `pause`, `connect`, or factory methods supplied by the application. `snapshot()` returns a provider-owned resumable workspace reference; `restore(snapshotId)` hydrates the adapter from that reference. `InMemorySandboxClient` is available for deterministic tests and contract verification.

--- a/packages/agent-tools/README.md
+++ b/packages/agent-tools/README.md
@@ -31,16 +31,32 @@ const weatherTool = createZodFunctionTool(
 ### Use Built-in Tools
 
 ```typescript
-import { bashTool, readTool, globTool, grepTool } from '@robota-sdk/agent-tools';
+import {
+  createBashTool,
+  createReadTool,
+  createGlobTool,
+  createGrepTool,
+} from '@robota-sdk/agent-tools';
 import { Robota } from '@robota-sdk/agent-core';
 import type { IAIProvider } from '@robota-sdk/agent-core';
 
 declare const provider: IAIProvider;
+
+// A file tool is built against an explicit containment root and refuses anything outside it
+// (ARCH-010). There is no ready-made instance to import: one bound at import time can carry no root,
+// and a file tool without a root has no boundary.
+const cwd = process.cwd();
+
 const agent = new Robota({
   name: 'DevAgent',
   aiProviders: [provider],
   defaultModel: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-  tools: [bashTool, readTool, globTool, grepTool],
+  tools: [
+    createBashTool({ cwd }),
+    createReadTool({ cwd }),
+    createGlobTool({ cwd }),
+    createGrepTool({ cwd }),
+  ],
 });
 ```
 

--- a/packages/agent-tools/docs/SPEC.md
+++ b/packages/agent-tools/docs/SPEC.md
@@ -154,18 +154,28 @@ Types owned by this package (SSOT):
 
 ### Public API: Built-in CLI Tools
 
-| Export                | Kind   | Tool Name         | Description                                                                                                  |
-| --------------------- | ------ | ----------------- | ------------------------------------------------------------------------------------------------------------ |
-| `shellTool`           | Object | `Shell`           | Execute host shell commands; OS-aware (POSIX `sh`/`bash`, Windows PowerShell)                                |
-| `bashTool`            | Object | `Bash`            | Model-familiar alias of `Shell` — same OS-aware implementation                                               |
-| `readTool`            | Object | `Read`            | Read file contents with line numbers (cat -n)                                                                |
-| `writeTool`           | Object | `Write`           | Write content to a file (creates parent dirs)                                                                |
-| `editTool`            | Object | `Edit`            | Replace a specific string in a file                                                                          |
-| `globTool`            | Object | `Glob`            | Find files matching a glob pattern (fast-glob)                                                               |
-| `grepTool`            | Object | `Grep`            | Regex content search — modes: files_with_matches/content/count; `headLimit` caps results                     |
-| `webFetchTool`        | Object | `WebFetch`        | Fetch URL content with HTML-to-text conversion                                                               |
-| `webSearchTool`       | Object | `WebSearch`       | Web search over the `IWebSearchProvider` port (default provider: Brave Search adapter)                       |
-| `askUserQuestionTool` | Object | `AskUserQuestion` | Model-issued structured questions (options/multi-select/free text) via `IToolExecutionContext.ask` (CMD-005) |
+| Export                | Kind    | Tool Name         | Description                                                                                                  |
+| --------------------- | ------- | ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `createShellTool`     | Factory | `Shell`           | Execute host shell commands; OS-aware (POSIX `sh`/`bash`, Windows PowerShell)                                |
+| `createBashTool`      | Factory | `Bash`            | Model-familiar alias of `Shell` — same OS-aware implementation                                               |
+| `createReadTool`      | Factory | `Read`            | Read file contents with line numbers (cat -n)                                                                |
+| `createWriteTool`     | Factory | `Write`           | Write content to a file (creates parent dirs)                                                                |
+| `createEditTool`      | Factory | `Edit`            | Replace a specific string in a file                                                                          |
+| `createGlobTool`      | Factory | `Glob`            | Find files matching a glob pattern (fast-glob)                                                               |
+| `createGrepTool`      | Factory | `Grep`            | Regex content search — modes: files_with_matches/content/count; `headLimit` caps results                     |
+| `webFetchTool`        | Object  | `WebFetch`        | Fetch URL content with HTML-to-text conversion                                                               |
+| `webSearchTool`       | Object  | `WebSearch`       | Web search over the `IWebSearchProvider` port (default provider: Brave Search adapter)                       |
+| `askUserQuestionTool` | Object  | `AskUserQuestion` | Model-issued structured questions (options/multi-select/free text) via `IToolExecutionContext.ask` (CMD-005) |
+
+**These are factories, not instances — ARCH-010.** This package used to also export a ready-made
+`readTool`/`writeTool`/`editTool`/`globTool`/`grepTool`/`shellTool`/`bashTool` for each of them. A
+module-level instance is bound at import time and can carry no containment root, and the guard's
+default was to allow — so importing one produced a file tool with no boundary. `pack-coding` had
+already written the consequence into its own source ("their `Read` will happily return
+`/etc/hostname`"), and the child-process subagent worker was reaching them through
+`createDefaultTools()` with no argument. They had no in-repo consumer; every assembly already built
+per-session tools. The `cwd` those factories take is now REQUIRED, so the case cannot recur by
+omission, and the guard refuses rather than allows if it somehow does.
 
 `AskUserQuestion` (CMD-005) consumes the injected `IToolExecutionContext.ask` port (CMD-004): each of
 its 1–4 questions maps onto the `IActionRequest` SSOT and is rendered by the attached environment; a
@@ -246,8 +256,8 @@ as a contract, not as incidental strings:
   mechanism instead (an exact-match `oldString` requirement).
 - **Override seam on every factory.** Every builtin factory accepts
   `IBuiltinToolDescriptionOptions.description`, which replaces the default text verbatim so a
-  consumer can supply deployment-specific guidance at its composition root. The exported singleton
-  instances (`globTool`, `writeTool`, …) are the factories' defaults.
+  consumer can supply deployment-specific guidance at its composition root. Omitting it yields the
+  neutral default text.
 
 Contract tests: `src/__tests__/builtin-descriptions.test.ts` (policy-phrase absence, derived
 names, registry-subset routing hints, override seam) and `src/__tests__/web-search-provider.test.ts`
@@ -302,7 +312,7 @@ None. This package defines no tool classes; the factories construct core's `Func
 
 ### Gaps
 
-- **Built-in tools** -- `globTool` still needs dedicated unit coverage beyond provider-agnostic composition tests.
+- **Built-in tools** -- `Glob` still needs dedicated unit coverage beyond provider-agnostic composition tests.
 - **IToolInvocationResult** -- No tests verifying the result shape contract.
 
 ## Dependencies

--- a/packages/agent-tools/src/__tests__/builtin-descriptions.test.ts
+++ b/packages/agent-tools/src/__tests__/builtin-descriptions.test.ts
@@ -5,31 +5,49 @@
  * - a description-override seam on every builtin factory.
  */
 
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, it, expect } from 'vitest';
 
-import { editTool } from '../builtins/edit-tool.js';
-import { globTool } from '../builtins/glob-tool.js';
-import { grepTool } from '../builtins/grep-tool.js';
-import { createShellTool, shellTool } from '../builtins/shell-tool.js';
-import { writeTool } from '../builtins/write-tool.js';
+import { createEditTool } from '../builtins/edit-tool.js';
+import { createGlobTool } from '../builtins/glob-tool.js';
+import { createGrepTool } from '../builtins/grep-tool.js';
+import { createShellTool } from '../builtins/shell-tool.js';
+import { createWriteTool } from '../builtins/write-tool.js';
+
+/**
+ * ARCH-010 made the containment root a required constructor argument and deleted the module-level
+ * singletons this file used to read descriptions from. Every case here asks a tool for its DESCRIPTION
+ * and never touches the filesystem, so the root is inert — it is named once, here, so that inertness is
+ * visible rather than implied, and it is the OS temp directory rather than the repo so a case that ever
+ * did reach the disk could not read the source tree.
+ */
+const DESCRIPTION_ROOT = tmpdir();
+/** A second inert root, used only to show the default description does not vary with it. */
+const OTHER_DESCRIPTION_ROOT = join(tmpdir(), 'neut002-other-root');
 
 describe('builtin descriptions carry no foreign product policy (NEUT-002)', () => {
   it('Write does not forbid documentation/README files (workflow policy, not mechanism)', () => {
-    expect(writeTool.getDescription()).not.toMatch(/NEVER create documentation|README files/i);
+    expect(createWriteTool({ cwd: DESCRIPTION_ROOT }).getDescription()).not.toMatch(
+      /NEVER create documentation|README files/i,
+    );
   });
 
   it('Glob does not reference a nonexistent "Agent tool"', () => {
-    expect(globTool.getDescription()).not.toMatch(/Agent tool/);
+    expect(createGlobTool({ cwd: DESCRIPTION_ROOT }).getDescription()).not.toMatch(/Agent tool/);
   });
 
   it('Grep references the default shell tool name `Shell`, not `Bash`', () => {
-    const description = grepTool.getDescription();
+    const description = createGrepTool({ cwd: DESCRIPTION_ROOT }).getDescription();
     expect(description).not.toMatch(/Bash command/);
     expect(description).toContain('Shell');
   });
 
   it('Edit does not claim an unenforced read-first contract', () => {
-    expect(editTool.getDescription()).not.toMatch(/must use the Read tool at least once/i);
+    expect(createEditTool({ cwd: DESCRIPTION_ROOT }).getDescription()).not.toMatch(
+      /must use the Read tool at least once/i,
+    );
   });
 });
 
@@ -38,37 +56,62 @@ describe('description override seam on every builtin factory (NEUT-002)', () => 
 
   it('createShellTool / createBashTool accept a description override', async () => {
     const mod = await import('../builtins/shell-tool.js');
-    expect(mod.createShellTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
-    expect(mod.createBashTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
+    expect(
+      mod.createShellTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
+    expect(
+      mod.createBashTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
   });
 
   it('createReadTool accepts a description override', async () => {
     const mod = await import('../builtins/read-tool.js');
-    expect(mod.createReadTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
+    expect(
+      mod.createReadTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
   });
 
   it('createWriteTool accepts a description override', async () => {
     const mod = await import('../builtins/write-tool.js');
-    expect(mod.createWriteTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
+    expect(
+      mod.createWriteTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
   });
 
   it('createEditTool accepts a description override', async () => {
     const mod = await import('../builtins/edit-tool.js');
-    expect(mod.createEditTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
+    expect(
+      mod.createEditTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
   });
 
-  it('createGlobTool exists and accepts a description override (singleton unchanged)', async () => {
+  it('createGlobTool exists and accepts a description override (default text is root-independent)', async () => {
     const mod = await import('../builtins/glob-tool.js');
     expect(typeof mod.createGlobTool).toBe('function');
-    expect(mod.createGlobTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
-    expect(mod.createGlobTool().getDescription()).toBe(globTool.getDescription());
+    expect(
+      mod.createGlobTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
+    // ARCH-010 deleted the singleton this used to compare against. The claim it stood for survives:
+    // omitting `description` yields the built-in default, and the containment root does not alter it.
+    const defaultDescription = mod.createGlobTool({ cwd: DESCRIPTION_ROOT }).getDescription();
+    expect(defaultDescription).not.toBe(OVERRIDE);
+    expect(defaultDescription).toBe(
+      mod.createGlobTool({ cwd: OTHER_DESCRIPTION_ROOT }).getDescription(),
+    );
   });
 
-  it('createGrepTool exists and accepts a description override (singleton unchanged)', async () => {
+  it('createGrepTool exists and accepts a description override (default text is root-independent)', async () => {
     const mod = await import('../builtins/grep-tool.js');
     expect(typeof mod.createGrepTool).toBe('function');
-    expect(mod.createGrepTool({ description: OVERRIDE }).getDescription()).toBe(OVERRIDE);
-    expect(mod.createGrepTool().getDescription()).toBe(grepTool.getDescription());
+    expect(
+      mod.createGrepTool({ cwd: DESCRIPTION_ROOT, description: OVERRIDE }).getDescription(),
+    ).toBe(OVERRIDE);
+    // Same inversion of subject as Glob above: the deleted singleton's role was to pin the default.
+    const defaultDescription = mod.createGrepTool({ cwd: DESCRIPTION_ROOT }).getDescription();
+    expect(defaultDescription).not.toBe(OVERRIDE);
+    expect(defaultDescription).toBe(
+      mod.createGrepTool({ cwd: OTHER_DESCRIPTION_ROOT }).getDescription(),
+    );
   });
 
   it('createWebFetchTool exists and accepts a description override', async () => {
@@ -93,7 +136,7 @@ describe('description override seam on every builtin factory (NEUT-002)', () => 
 
 describe('shell routing hints derive from the registered tool set (NEUT-002)', () => {
   it('default description keeps all dedicated-tool routing hints (default assembly unchanged)', () => {
-    const description = shellTool.getDescription();
+    const description = createShellTool({ cwd: DESCRIPTION_ROOT }).getDescription();
     expect(description).toContain('Use Glob');
     expect(description).toContain('Use Grep');
     expect(description).toContain('Use Read');
@@ -101,7 +144,10 @@ describe('shell routing hints derive from the registered tool set (NEUT-002)', (
   });
 
   it('with only Shell registered, routing hints to unregistered siblings are omitted', () => {
-    const description = createShellTool({ availableTools: ['Shell'] }).getDescription();
+    const description = createShellTool({
+      cwd: DESCRIPTION_ROOT,
+      availableTools: ['Shell'],
+    }).getDescription();
     expect(description).not.toContain('Use Glob');
     expect(description).not.toContain('Use Grep');
     expect(description).not.toContain('Use Read');
@@ -109,7 +155,10 @@ describe('shell routing hints derive from the registered tool set (NEUT-002)', (
   });
 
   it('routing hints mention exactly the registered subset', () => {
-    const description = createShellTool({ availableTools: ['Shell', 'Glob'] }).getDescription();
+    const description = createShellTool({
+      cwd: DESCRIPTION_ROOT,
+      availableTools: ['Shell', 'Glob'],
+    }).getDescription();
     expect(description).toContain('Use Glob');
     expect(description).not.toContain('Use Grep');
     expect(description).not.toContain('Use Edit');
@@ -119,7 +168,9 @@ describe('shell routing hints derive from the registered tool set (NEUT-002)', (
 describe('grep description derives the shell tool name (NEUT-002)', () => {
   it('createGrepTool({ shellToolName }) names that tool in the default text', async () => {
     const mod = await import('../builtins/grep-tool.js');
-    const description = mod.createGrepTool({ shellToolName: 'Terminal' }).getDescription();
+    const description = mod
+      .createGrepTool({ cwd: DESCRIPTION_ROOT, shellToolName: 'Terminal' })
+      .getDescription();
     expect(description).toContain('Terminal');
     expect(description).not.toContain('Shell');
   });

--- a/packages/agent-tools/src/__tests__/enumeration-containment.test.ts
+++ b/packages/agent-tools/src/__tests__/enumeration-containment.test.ts
@@ -70,25 +70,78 @@ afterAll(() => {
 /**
  * CONTROL — pins WHY the fix is shaped the way it is (the same role SEC-006's R4 control test played).
  *
- * With no containment root the tools are unchanged: an escaping symlink is followed and out-of-root
- * content is returned. This is the exact behaviour the contained cases below must NOT show, and it is
- * what every registered `Glob`/`Grep` did before SEC-007, because the factories took no `cwd` at all.
+ * The contained cases below assert that out-of-root content is ABSENT. That assertion is worth
+ * nothing unless the walk would otherwise reach it, so this pair proves the escape is real: the
+ * symlink IS followed and the canary IS returned when the root does not exclude it.
+ *
+ * The control is driven with a WIDER root (`root`, the parent of both `workdir` and `outside`), not
+ * with no root at all. It used to use no root, which worked only because the guard was fail-open —
+ * so the control was measuring the disarmed guard rather than the walk, and ARCH-010 closing that
+ * default turned it red. A control that depends on a defect elsewhere stops being a control the
+ * moment that defect is fixed. This shape isolates the one property it is here to establish.
  */
-describe('CONTROL — an unconstrained Glob/Grep really does escape through the symlink', () => {
-  it('Glob enumerates out-of-root files through the escaping symlink', async () => {
-    const result = await runTool(createGlobTool(), { pattern: '**/*.txt', path: workdir });
+describe('CONTROL — the escape really is reachable when the root does not exclude it', () => {
+  /**
+   * Glob's control uses a `..` TRAVERSAL rather than the symlink, because those are guarded by two
+   * different mechanisms and only one of them is still observable here. A contained Glob sets
+   * `followSymbolicLinks: false`, so under ANY root a symlinked entry is never emitted at all — the
+   * old symlink control could only see the escape in the rootless mode ARCH-010 removes. The per-
+   * result canonical check is what this pair is a control FOR, and a traversal pattern is what
+   * reaches it: `../outside/secret.txt` survives the wide root and is dropped by the narrow one.
+   */
+  it('Glob enumerates out-of-root files through a traversal pattern', async () => {
+    const result = await runTool(createGlobTool({ cwd: root }), {
+      pattern: '../outside/*.txt',
+      path: workdir,
+    });
     expect(result.success).toBe(true);
-    expect(result.output).toMatch(/escape\/secret\.txt/);
+    expect(result.output).toMatch(/outside\/secret\.txt/);
+  });
+
+  it('…and the narrow root drops that same traversal', async () => {
+    const result = await runTool(createGlobTool({ cwd: workdir }), {
+      pattern: '../outside/*.txt',
+      path: workdir,
+    });
+    expect(result.success).toBe(true);
+    expect(result.output).not.toMatch(/secret\.txt/);
   });
 
   it('Grep returns the out-of-root file CONTENT through the escaping symlink', async () => {
-    const result = await runTool(createGrepTool(), {
+    const result = await runTool(createGrepTool({ cwd: root }), {
       pattern: CANARY,
       path: workdir,
       outputMode: 'content',
     });
     expect(result.success).toBe(true);
     expect(result.output).toContain(CANARY);
+  });
+});
+
+/**
+ * ARCH-010 — and with NO root the tools refuse rather than roam. The old control above relied on this
+ * being the opposite; it is the whole point of the change.
+ *
+ * `cwd` is now REQUIRED on the factory, so a TypeScript caller cannot build a rootless tool at all —
+ * these cases have to reach past the type to construct one. That is not a contrived shape: this
+ * package ships to JavaScript consumers who get no type check, and the whole reason the guard fails
+ * closed rather than merely being required is that a type is not a runtime boundary.
+ */
+describe('a rootless Glob/Grep enumerates nothing (ARCH-010)', () => {
+  it('Glob returns no out-of-root entry when no containment root is configured', async () => {
+    const rootless = createGlobTool({} as never);
+    const result = await runTool(rootless, { pattern: '**/*.txt', path: workdir });
+    expect(result.output ?? '').not.toMatch(/secret\.txt/);
+  });
+
+  it('Grep discloses no content when no containment root is configured', async () => {
+    const rootless = createGrepTool({} as never);
+    const result = await runTool(rootless, {
+      pattern: CANARY,
+      path: workdir,
+      outputMode: 'content',
+    });
+    expect(result.output ?? '').not.toContain(CANARY);
   });
 });
 

--- a/packages/agent-tools/src/__tests__/grep-tool-concurrency.test.ts
+++ b/packages/agent-tools/src/__tests__/grep-tool-concurrency.test.ts
@@ -39,7 +39,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 });
 
 // Import AFTER the mock so grep-tool binds to the instrumented readFile.
-const { grepTool } = await import('../builtins/grep-tool.js');
+const { createGrepTool } = await import('../builtins/grep-tool.js');
 
 interface IGrepResult {
   success: boolean;
@@ -47,8 +47,12 @@ interface IGrepResult {
   error?: string;
 }
 
-async function runGrep(args: Record<string, unknown>): Promise<IGrepResult> {
-  const wrapper = await grepTool.execute(args as Parameters<typeof grepTool.execute>[0]);
+// ARCH-010 — the context-free `grepTool` singleton is gone and the root is a required argument, so the
+// tool is built against the fixture this suite creates. The root is the scan's boundary, so it has to be
+// the fixture: bound anywhere wider, the in-flight counts below would be measuring somebody else's files.
+async function runGrep(root: string, args: Record<string, unknown>): Promise<IGrepResult> {
+  const tool = createGrepTool({ cwd: root });
+  const wrapper = await tool.execute(args as Parameters<typeof tool.execute>[0]);
   const data = (wrapper as { data: unknown }).data;
   return (typeof data === 'string' ? JSON.parse(data) : data) as IGrepResult;
 }
@@ -76,7 +80,11 @@ describe('grepTool bounded concurrency (CLI-042)', () => {
     readTracker.maxInFlight = 0;
     readTracker.enabled = true;
     try {
-      const result = await runGrep({ pattern: 'needle', path: fixtureDir, outputMode: 'count' });
+      const result = await runGrep(fixtureDir, {
+        pattern: 'needle',
+        path: fixtureDir,
+        outputMode: 'count',
+      });
       expect(result.success).toBe(true);
       expect(result.output.split('\n')).toHaveLength(FILE_COUNT);
     } finally {

--- a/packages/agent-tools/src/__tests__/grep-tool.test.ts
+++ b/packages/agent-tools/src/__tests__/grep-tool.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { grepTool } from '../builtins/grep-tool.js';
+import { createGrepTool } from '../builtins/grep-tool.js';
 
 interface IGrepResult {
   success: boolean;
@@ -10,8 +10,15 @@ interface IGrepResult {
   error?: string;
 }
 
-async function runGrep(args: Record<string, unknown>): Promise<IGrepResult> {
-  const wrapper = await grepTool.execute(args as Parameters<typeof grepTool.execute>[0]);
+/**
+ * ARCH-010 — the containment root is a required constructor argument and the context-free `grepTool`
+ * singleton is gone, so the tool is built per ROOT. This suite works in two independent tmpdirs, so it
+ * takes two tools: binding both to one root (or to `process.cwd()`) would search outside the fixture
+ * each case created.
+ */
+async function runGrep(root: string, args: Record<string, unknown>): Promise<IGrepResult> {
+  const tool = createGrepTool({ cwd: root });
+  const wrapper = await tool.execute(args as Parameters<typeof tool.execute>[0]);
   const data = (wrapper as { data: unknown }).data;
   return (typeof data === 'string' ? JSON.parse(data) : data) as IGrepResult;
 }
@@ -46,7 +53,11 @@ describe('grepTool', () => {
   });
 
   it('TC-01: count mode returns path:count rows for matching files only', async () => {
-    const result = await runGrep({ pattern: 'alpha', path: fixtureDir, outputMode: 'count' });
+    const result = await runGrep(fixtureDir, {
+      pattern: 'alpha',
+      path: fixtureDir,
+      outputMode: 'count',
+    });
     expect(result.success).toBe(true);
     const rows = result.output.split('\n').sort();
     expect(rows).toHaveLength(3);
@@ -56,7 +67,7 @@ describe('grepTool', () => {
   });
 
   it('TC-02: headLimit caps results and appends a truncation marker', async () => {
-    const result = await runGrep({
+    const result = await runGrep(fixtureDir, {
       pattern: 'alpha',
       path: fixtureDir,
       outputMode: 'files_with_matches',
@@ -69,7 +80,7 @@ describe('grepTool', () => {
   });
 
   it('TC-02: without headLimit all results are returned', async () => {
-    const result = await runGrep({
+    const result = await runGrep(fixtureDir, {
       pattern: 'alpha',
       path: fixtureDir,
       outputMode: 'files_with_matches',
@@ -79,33 +90,33 @@ describe('grepTool', () => {
   });
 
   it('TC-03: schema accepts count mode and headLimit; rejects non-positive headLimit', async () => {
-    const ok = await runGrep({
+    const ok = await runGrep(fixtureDir, {
       pattern: 'alpha',
       path: fixtureDir,
       outputMode: 'count',
       headLimit: 5,
     });
     expect(ok.success).toBe(true);
-    await expect(runGrep({ pattern: 'alpha', path: fixtureDir, headLimit: 0 })).rejects.toThrow(
-      /validation/i,
-    );
+    await expect(
+      runGrep(fixtureDir, { pattern: 'alpha', path: fixtureDir, headLimit: 0 }),
+    ).rejects.toThrow(/validation/i);
   });
 
   it('TC-03: description mentions only schema-supported parameters', () => {
-    const description = grepTool.schema.description ?? '';
+    const description = createGrepTool({ cwd: fixtureDir }).schema.description ?? '';
     expect(description).toContain("'count'");
     expect(description).toContain('headLimit');
     expect(description).not.toContain('head_limit');
   });
 
   it('TC-04: files_with_matches returns matching file paths', async () => {
-    const result = await runGrep({ pattern: 'delta', path: fixtureDir });
+    const result = await runGrep(fixtureDir, { pattern: 'delta', path: fixtureDir });
     expect(result.success).toBe(true);
     expect(result.output.trim().endsWith('b.txt')).toBe(true);
   });
 
   it('TC-04: content mode includes context lines with markers', async () => {
-    const result = await runGrep({
+    const result = await runGrep(fixtureDir, {
       pattern: 'beta',
       path: join(fixtureDir, 'a.txt'),
       outputMode: 'content',
@@ -117,7 +128,7 @@ describe('grepTool', () => {
   });
 
   it('TC-04: glob filter restricts searched files', async () => {
-    const result = await runGrep({ pattern: 'alpha', path: fixtureDir, glob: '*.md' });
+    const result = await runGrep(fixtureDir, { pattern: 'alpha', path: fixtureDir, glob: '*.md' });
     expect(result.output.split('\n')).toHaveLength(1);
     expect(result.output.trim().endsWith('c.md')).toBe(true);
   });
@@ -126,8 +137,8 @@ describe('grepTool', () => {
     for (const mode of ['files_with_matches', 'content', 'count'] as const) {
       const args: Record<string, unknown> = { pattern: 'alpha', path: bulkDir, outputMode: mode };
       if (mode === 'content') args.contextLines = 1;
-      const first = await runGrep(args);
-      const second = await runGrep(args);
+      const first = await runGrep(bulkDir, args);
+      const second = await runGrep(bulkDir, args);
       expect(first.success).toBe(true);
       expect(second.output).toBe(first.output);
     }
@@ -137,7 +148,7 @@ describe('grepTool', () => {
     // files_with_matches order IS the enumeration order the sequential
     // implementation used; content/count output must be the concatenation of
     // per-file results in exactly that order.
-    const filesResult = await runGrep({ pattern: 'alpha', path: bulkDir });
+    const filesResult = await runGrep(bulkDir, { pattern: 'alpha', path: bulkDir });
     const fileOrder = filesResult.output.split('\n');
     expect(fileOrder).toHaveLength(80);
 
@@ -148,10 +159,10 @@ describe('grepTool', () => {
         outputMode: mode,
       };
       if (mode === 'content') dirArgs.contextLines = 1;
-      const dirResult = await runGrep(dirArgs);
+      const dirResult = await runGrep(bulkDir, dirArgs);
       const perFileOutputs: string[] = [];
       for (const filePath of fileOrder) {
-        const single = await runGrep({ ...dirArgs, path: filePath });
+        const single = await runGrep(bulkDir, { ...dirArgs, path: filePath });
         perFileOutputs.push(single.output);
       }
       expect(dirResult.output).toBe(perFileOutputs.join('\n'));
@@ -159,7 +170,7 @@ describe('grepTool', () => {
   });
 
   it('returns an error result for an invalid regex', async () => {
-    const result = await runGrep({ pattern: '([', path: fixtureDir });
+    const result = await runGrep(fixtureDir, { pattern: '([', path: fixtureDir });
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid regex');
   });

--- a/packages/agent-tools/src/__tests__/path-guard.test.ts
+++ b/packages/agent-tools/src/__tests__/path-guard.test.ts
@@ -8,8 +8,12 @@ import { checkPathWithinCwd } from '../builtins/path-guard.js';
 describe('checkPathWithinCwd', () => {
   const cwd = '/project/root';
 
-  it('returns undefined when cwd is not set', () => {
-    expect(checkPathWithinCwd('/etc/passwd', undefined)).toBeUndefined();
+  // ARCH-010 inverted this. It used to assert `undefined` — "no objection" — which is what let a
+  // rootless `Read` return `/etc/hostname`. A guard with no configured boundary now refuses.
+  it('REFUSES when cwd is not set', () => {
+    const error = checkPathWithinCwd('/etc/passwd', undefined);
+    expect(error).toBeDefined();
+    expect(error).toMatch(/no containment root/i);
   });
 
   it('returns undefined for path inside cwd', () => {

--- a/packages/agent-tools/src/__tests__/sandbox-tools.test.ts
+++ b/packages/agent-tools/src/__tests__/sandbox-tools.test.ts
@@ -10,6 +10,14 @@ import {
 } from '../index.js';
 import type { ISandboxRunOptions, IToolInvocationResult } from '../index.js';
 
+/**
+ * ARCH-010 made `cwd` — the HOST working-directory root — a required constructor argument. Every tool
+ * below is built with a sandbox client, and the sandbox seam is taken BEFORE the host path guard, so
+ * this root is never consulted: it names the sandbox root the fixtures use so the two read consistently
+ * rather than pointing the host guard at somewhere real that no case here can reach.
+ */
+const SANDBOX_HOST_ROOT = '/workspace';
+
 async function executeTool(
   tool: IToolWithEventService,
   parameters: TToolParameters,
@@ -30,7 +38,7 @@ describe('sandbox-aware built-in tools', () => {
       },
     });
 
-    const result = await executeTool(createBashTool({ sandboxClient }), {
+    const result = await executeTool(createBashTool({ sandboxClient, cwd: SANDBOX_HOST_ROOT }), {
       command: 'npm test',
       timeout: 1234,
       workingDirectory: '/workspace',
@@ -53,24 +61,33 @@ describe('sandbox-aware built-in tools', () => {
       },
     });
 
-    const readResult = await executeTool(createReadTool({ sandboxClient }), {
-      filePath: '/workspace/source.ts',
-    });
+    const readResult = await executeTool(
+      createReadTool({ sandboxClient, cwd: SANDBOX_HOST_ROOT }),
+      {
+        filePath: '/workspace/source.ts',
+      },
+    );
     expect(readResult.success).toBe(true);
     expect(readResult.output).toContain('1\tconst value = 1;');
 
-    const editResult = await executeTool(createEditTool({ sandboxClient }), {
-      filePath: '/workspace/source.ts',
-      oldString: 'const value = 1;',
-      newString: 'const value = 2;',
-    });
+    const editResult = await executeTool(
+      createEditTool({ sandboxClient, cwd: SANDBOX_HOST_ROOT }),
+      {
+        filePath: '/workspace/source.ts',
+        oldString: 'const value = 1;',
+        newString: 'const value = 2;',
+      },
+    );
     expect(editResult.success).toBe(true);
     expect(sandboxClient.getFile('/workspace/source.ts')).toBe('const value = 2;\n');
 
-    const writeResult = await executeTool(createWriteTool({ sandboxClient }), {
-      filePath: '/workspace/generated.ts',
-      content: 'export const generated = true;\n',
-    });
+    const writeResult = await executeTool(
+      createWriteTool({ sandboxClient, cwd: SANDBOX_HOST_ROOT }),
+      {
+        filePath: '/workspace/generated.ts',
+        content: 'export const generated = true;\n',
+      },
+    );
     expect(writeResult.success).toBe(true);
     expect(sandboxClient.getFile('/workspace/generated.ts')).toBe(
       'export const generated = true;\n',

--- a/packages/agent-tools/src/__tests__/shell-tool.test.ts
+++ b/packages/agent-tools/src/__tests__/shell-tool.test.ts
@@ -5,21 +5,31 @@ import { createShellTool, createBashTool } from '../builtins/shell-tool';
 
 import type { IToolInvocationResult } from '../types/tool-result.js';
 
+/**
+ * ARCH-010 made `cwd` required. For `Shell` it is the DEFAULT WORKING DIRECTORY and deliberately not a
+ * containment boundary (see the shell-tool file header), so the host process directory is what these
+ * cases already ran in — it is now said out loud instead of being the implicit fallback. Nothing here
+ * reads or writes a file: the cases assert names, the OS-aware description, and one `echo` round-trip.
+ */
+const SHELL_ROOT = process.cwd();
+
 describe('createShellTool / createBashTool', () => {
   it('registers under the Shell and Bash names', () => {
-    expect(createShellTool().getName()).toBe('Shell');
-    expect(createBashTool().getName()).toBe('Bash');
+    expect(createShellTool({ cwd: SHELL_ROOT }).getName()).toBe('Shell');
+    expect(createBashTool({ cwd: SHELL_ROOT }).getName()).toBe('Bash');
   });
 
   it('builds an OS-aware description that names the active shell + syntax hint', () => {
     const shell = resolvePlatformShell();
-    const description = createShellTool().getDescription();
+    const description = createShellTool({ cwd: SHELL_ROOT }).getDescription();
     expect(description).toContain(shell.label);
     expect(description).toContain(shell.syntaxHint);
   });
 
   it('both aliases share the same OS-aware description', () => {
-    expect(createBashTool().getDescription()).toBe(createShellTool().getDescription());
+    expect(createBashTool({ cwd: SHELL_ROOT }).getDescription()).toBe(
+      createShellTool({ cwd: SHELL_ROOT }).getDescription(),
+    );
   });
 
   /**
@@ -33,7 +43,7 @@ describe('createShellTool / createBashTool', () => {
    * the resolved shell round-trips a command, never how fast the OS can start it.
    */
   it('executes a command via the resolved host shell (POSIX round-trip)', async () => {
-    const raw = await createShellTool().execute({ command: 'echo shell-ok' });
+    const raw = await createShellTool({ cwd: SHELL_ROOT }).execute({ command: 'echo shell-ok' });
     const result = JSON.parse(raw.data as string) as IToolInvocationResult;
     expect(result.success).toBe(true);
     expect(result.output.trim()).toContain('shell-ok');

--- a/packages/agent-tools/src/__tests__/shell-working-directory.test.ts
+++ b/packages/agent-tools/src/__tests__/shell-working-directory.test.ts
@@ -79,9 +79,12 @@ describe('Shell — the configured containment root is the DEFAULT working direc
   );
 
   it(
-    'falls back to the host process cwd when no root is configured',
+    'runs in the host process cwd when that is the configured root',
     async () => {
-      const result = await runTool(createShellTool(), { command: 'pwd' });
+      // ARCH-010 made `cwd` REQUIRED, so "no root configured" is no longer constructible through the
+      // factory — a caller that means the host process directory now says so where a reader can see it.
+      // The observable this case was always about is unchanged: that directory is where the command runs.
+      const result = await runTool(createShellTool({ cwd: process.cwd() }), { command: 'pwd' });
       expect(realpathSync(result.output.trim())).toBe(realpathSync(process.cwd()));
     },
     SPAWN_TIMEOUT_MS,

--- a/packages/agent-tools/src/builtins/__tests__/containment-fail-closed.test.ts
+++ b/packages/agent-tools/src/builtins/__tests__/containment-fail-closed.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { createReadTool } from '../read-tool.js';
+import { checkPathWithinCwd, isWithinCwd } from '../path-guard.js';
+
+/**
+ * ARCH-010 — the containment guard used to be FAIL-OPEN: with no root configured it answered
+ * "allowed" and every builtin let the path through.
+ *
+ * That default is why the strongest multi-sighting in the architecture audit exists. `pack-coding`
+ * documented the consequence in its own source — "file tools constructed with no options carry a
+ * DISARMED working-directory guard: their `Read` will happily return `/etc/hostname`" — and the
+ * child-process subagent worker called `createDefaultTools()` with no argument, so that is exactly
+ * what a subagent got.
+ *
+ * A guard whose default is "allow" is not a guard; it is a guard that has to be remembered. The
+ * root is now required by the contract, and the predicate refuses when it is absent, so forgetting
+ * it fails loudly at the type level and closed at runtime rather than silently returning content.
+ */
+const OUTSIDE = '/etc/hostname';
+
+describe('containment is fail-closed without a root (ARCH-010)', () => {
+  it('isWithinCwd REFUSES when no containment root is configured', () => {
+    // Was `true`. Nothing about "I do not know where the boundary is" means "inside it".
+    expect(isWithinCwd(OUTSIDE, undefined)).toBe(false);
+  });
+
+  it('isWithinCwd still answers normally when a root IS configured', () => {
+    // The inversion must not turn the guard into a blanket refusal — it still has to say yes.
+    expect(isWithinCwd(`${process.cwd()}/package.json`, process.cwd())).toBe(true);
+    expect(isWithinCwd(OUTSIDE, process.cwd())).toBe(false);
+  });
+
+  it('checkPathWithinCwd returns a refusal, not undefined, when no root is configured', () => {
+    const error = checkPathWithinCwd(OUTSIDE, undefined);
+    // `undefined` here means "no objection" and is what let the read proceed.
+    expect(error).toBeDefined();
+    const parsed = JSON.parse(error ?? '{}') as { success: boolean; error?: string };
+    expect(parsed.success).toBe(false);
+    // The message has to say WHICH failure this is: an unconfigured guard is an assembly bug, and a
+    // caller told only "outside the working directory" would go looking for the wrong thing.
+    expect(parsed.error).toMatch(/no containment root/i);
+  });
+
+  it('a Read built with no containment root REFUSES an absolute path instead of returning it', async () => {
+    // The end-to-end shape of the defect, stated as `pack-coding`'s doc comment states it. This is
+    // the tool a subagent got from the bare `createDefaultTools()` call.
+    // Reaching past the type on purpose: `cwd` is REQUIRED now, so a TypeScript caller cannot build
+    // this. A JavaScript consumer can, which is why the guard refuses at runtime rather than trusting
+    // the type to be the boundary.
+    const read = createReadTool({} as never);
+    const result = (await read.execute({ filePath: OUTSIDE })) as { data: string };
+    const parsed = JSON.parse(result.data) as { success: boolean; error?: string; output?: string };
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/no containment root/i);
+    // The measured failure before the fix was not an assertion about a flag — it was the file. This
+    // returned `[File: /etc/hostname (1 lines)]\n1\tserver`.
+    expect(parsed.output ?? '').not.toMatch(/etc\/hostname/);
+  });
+});

--- a/packages/agent-tools/src/builtins/__tests__/shell-tool-cancellation.test.ts
+++ b/packages/agent-tools/src/builtins/__tests__/shell-tool-cancellation.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import { createShellTool } from '../shell-tool';
 
+// ARCH-010 made `cwd` required. `Shell`'s cwd is the DEFAULT WORKING DIRECTORY, not a containment
+// boundary, and neither case below touches the filesystem — `sleep`/`echo` only need somewhere to run.
+const SHELL_ROOT = process.cwd();
+
 describe('shell tool cancellation (CORE-018)', () => {
   it('an external abort kills the running child and settles as failed/Aborted', async () => {
-    const tool = createShellTool();
+    const tool = createShellTool({ cwd: SHELL_ROOT });
     const controller = new AbortController();
 
     const pending = tool.execute(
@@ -24,7 +28,7 @@ describe('shell tool cancellation (CORE-018)', () => {
   }, 10_000);
 
   it('an already-aborted signal short-circuits before spawn', async () => {
-    const tool = createShellTool();
+    const tool = createShellTool({ cwd: SHELL_ROOT });
     const controller = new AbortController();
     controller.abort();
 

--- a/packages/agent-tools/src/builtins/edit-tool.ts
+++ b/packages/agent-tools/src/builtins/edit-tool.ts
@@ -37,7 +37,7 @@ const EditSchema = z.object({
 
 type TEditArgs = z.infer<typeof EditSchema>;
 
-async function editFileTool(args: TEditArgs, options: ISandboxToolOptions = {}): Promise<string> {
+async function editFileTool(args: TEditArgs, options: ISandboxToolOptions): Promise<string> {
   const { filePath, oldString, newString, replaceAll = false } = args;
 
   if (!options.sandboxClient) {
@@ -123,7 +123,7 @@ async function editFileTool(args: TEditArgs, options: ISandboxToolOptions = {}):
 /**
  * Create an EditTool instance — register with Robota agent tools registry.
  */
-export function createEditTool(options: ISandboxBuiltinToolOptions = {}): FunctionTool {
+export function createEditTool(options: ISandboxBuiltinToolOptions): FunctionTool {
   return createZodFunctionTool(
     'Edit',
     options.description ?? DEFAULT_EDIT_DESCRIPTION,
@@ -133,8 +133,3 @@ export function createEditTool(options: ISandboxBuiltinToolOptions = {}): Functi
     },
   );
 }
-
-/**
- * EditTool instance — register with Robota agent tools registry.
- */
-export const editTool = createEditTool();

--- a/packages/agent-tools/src/builtins/glob-tool.ts
+++ b/packages/agent-tools/src/builtins/glob-tool.ts
@@ -143,7 +143,7 @@ const DEFAULT_GLOB_DESCRIPTION =
 /**
  * Create a GlobTool instance — register with Robota agent tools registry.
  */
-export function createGlobTool(options: IContainedBuiltinToolOptions = {}): FunctionTool {
+export function createGlobTool(options: IContainedBuiltinToolOptions): FunctionTool {
   return createZodFunctionTool(
     'Glob',
     options.description ?? DEFAULT_GLOB_DESCRIPTION,
@@ -153,12 +153,3 @@ export function createGlobTool(options: IContainedBuiltinToolOptions = {}): Func
     },
   );
 }
-
-/**
- * GlobTool instance — register with Robota agent tools registry.
- *
- * UNCONTAINED, deliberately: a module-level singleton can only ever be context-free. Assemblies that
- * have a session root MUST build their own via {@link createGlobTool} (`createDefaultTools`,
- * `createCodingPack`) — that is exactly what SEC-007 changed.
- */
-export const globTool = createGlobTool();

--- a/packages/agent-tools/src/builtins/glob-tool.ts
+++ b/packages/agent-tools/src/builtins/glob-tool.ts
@@ -103,10 +103,13 @@ async function globFileTool(
       ignore: ['**/node_modules/**', '**/.git/**'],
       dot: true,
       absolute: false,
-      // Contained: a symlinked directory is a BOUNDARY, not a doorway. Descending through one both
-      // escapes the sandbox and turns a single Glob call into a whole-disk walk when the link points
-      // at `/`. Unarmed (no containment root), fast-glob's default traversal is unchanged.
-      followSymbolicLinks: containmentRoot === undefined,
+      // A symlinked directory is a BOUNDARY, not a doorway. Descending through one both escapes the
+      // sandbox and turns a single Glob call into a whole-disk walk when the link points at `/`.
+      //
+      // Unconditional since ARCH-010. This used to be `containmentRoot === undefined` — following
+      // links when there was no root — but a rootless call now fails at `resolveSearchRoot` above and
+      // never reaches here, so that branch described a state that can no longer exist.
+      followSymbolicLinks: false,
     });
   } catch (err) {
     const result: IToolInvocationResult = {

--- a/packages/agent-tools/src/builtins/grep-tool.ts
+++ b/packages/agent-tools/src/builtins/grep-tool.ts
@@ -183,7 +183,7 @@ function buildGrepDescription(shellToolName: string): string {
 /**
  * Create a GrepTool instance — register with Robota agent tools registry.
  */
-export function createGrepTool(options: IGrepToolOptions = {}): FunctionTool {
+export function createGrepTool(options: IGrepToolOptions): FunctionTool {
   return createZodFunctionTool(
     'Grep',
     options.description ?? buildGrepDescription(options.shellToolName ?? DEFAULT_SHELL_TOOL_NAME),
@@ -193,11 +193,3 @@ export function createGrepTool(options: IGrepToolOptions = {}): FunctionTool {
     },
   );
 }
-
-/**
- * GrepTool instance — register with Robota agent tools registry.
- *
- * UNCONTAINED, deliberately — see the note on {@link globTool}. Assemblies with a session root build
- * their own through {@link createGrepTool}.
- */
-export const grepTool = createGrepTool();

--- a/packages/agent-tools/src/builtins/index.ts
+++ b/packages/agent-tools/src/builtins/index.ts
@@ -1,11 +1,11 @@
 // Built-in CLI tools
-export { shellTool, createShellTool, bashTool, createBashTool } from './shell-tool.js';
+export { createShellTool, createBashTool } from './shell-tool.js';
 export type { IShellToolOptions } from './shell-tool.js';
-export { readTool, createReadTool } from './read-tool.js';
-export { writeTool, createWriteTool } from './write-tool.js';
-export { editTool, createEditTool } from './edit-tool.js';
-export { globTool, createGlobTool } from './glob-tool.js';
-export { grepTool, createGrepTool } from './grep-tool.js';
+export { createReadTool } from './read-tool.js';
+export { createWriteTool } from './write-tool.js';
+export { createEditTool } from './edit-tool.js';
+export { createGlobTool } from './glob-tool.js';
+export { createGrepTool } from './grep-tool.js';
 export type { IGrepToolOptions } from './grep-tool.js';
 export { webFetchTool, createWebFetchTool, classifyFetchError } from './web-fetch-tool.js';
 export { webSearchTool, createWebSearchTool } from './web-search-tool.js';

--- a/packages/agent-tools/src/builtins/path-guard.ts
+++ b/packages/agent-tools/src/builtins/path-guard.ts
@@ -5,8 +5,12 @@ import { isPathInside } from '@robota-sdk/agent-core';
 import type { IToolInvocationResult } from '../types/tool-result.js';
 
 /**
- * Returns a JSON-serialized IToolInvocationResult error when filePath is outside cwd.
- * Returns undefined when the path is within cwd or cwd is not set.
+ * Returns a JSON-serialized IToolInvocationResult error when filePath is outside cwd, or when NO
+ * containment root is configured. Returns undefined only when the path is inside a configured root.
+ *
+ * This sentence used to end "or cwd is not set" — the fail-open default ARCH-010 removed. It sat
+ * directly above the two functions that implement the distinction, which is the worst place for a
+ * comment to say the opposite of the code.
  *
  * SEC-006: containment is decided on the CANONICAL (symlink-resolved) paths, via the shared
  * `isPathInside` SSOT in agent-core. A purely lexical `resolve()` + `startsWith` comparison let

--- a/packages/agent-tools/src/builtins/path-guard.ts
+++ b/packages/agent-tools/src/builtins/path-guard.ts
@@ -29,17 +29,38 @@ import type { IToolInvocationResult } from '../types/tool-result.js';
  * containment rule that could disagree with the first (SEC-006's stated defect, SEC-007 keeping it
  * true as the guard's reach widens).
  *
- * `cwd === undefined` means no containment root is configured and the guard is DISARMED — see
- * `pack-coding`'s `ICodingPackOptions.cwd`, which is required precisely so that cannot happen by
- * accident.
+ * `cwd === undefined` means no containment root is configured, and the answer is NO — ARCH-010.
+ *
+ * This used to return `true` there: with no root, everything was inside it. A guard whose default is
+ * "allow" is not a guard, it is a guard that has to be remembered, and the architecture audit found
+ * three independent layers that had forgotten. `pack-coding` had already written the consequence into
+ * its own source — "file tools constructed with no options carry a DISARMED working-directory guard:
+ * their `Read` will happily return `/etc/hostname`" — and the child-process subagent worker called
+ * `createDefaultTools()` with no argument, so a subagent got exactly that. Measured, not inferred:
+ * before this change a rootless `Read` of `/etc/hostname` returned the file.
+ *
+ * Refusing instead means a construction site that forgets the root fails loudly on its first file
+ * access rather than silently running unconfined. The root is also required by the tool factories now,
+ * so reaching this branch at all is an assembly bug — which is why the error says so specifically
+ * rather than reporting an ordinary out-of-root path.
  */
 export function isWithinCwd(filePath: string, cwd: string | undefined): boolean {
-  if (cwd === undefined) return true;
+  if (cwd === undefined) return false;
   return isPathInside(cwd, filePath);
 }
 
 export function checkPathWithinCwd(filePath: string, cwd: string | undefined): string | undefined {
-  if (cwd === undefined) return undefined;
+  if (cwd === undefined) {
+    const result: IToolInvocationResult = {
+      success: false,
+      output: '',
+      error:
+        `Access denied: "${filePath}" cannot be checked because no containment root is ` +
+        'configured for this tool. This is an assembly bug, not a path problem — the tool was ' +
+        'constructed without a `cwd`, so it has no boundary to enforce (ARCH-010).',
+    };
+    return JSON.stringify(result);
+  }
 
   if (!isWithinCwd(filePath, cwd)) {
     const result: IToolInvocationResult = {
@@ -56,16 +77,21 @@ export function checkPathWithinCwd(filePath: string, cwd: string | undefined): s
 /**
  * Resolve an LLM-supplied search root for an ENUMERATING tool, and refuse one that escapes (SEC-007).
  *
- * A relative `requested` anchors to the CONTAINMENT ROOT when one is configured, not to
- * `process.cwd()`: anchoring them to two different directories is how a "contained" search silently
- * starts somewhere else. `error` carries the tool-result JSON to return, or is `undefined` when the
- * root is allowed.
+ * A relative `requested` anchors to the CONTAINMENT ROOT, not to `process.cwd()`: anchoring them to
+ * two different directories is how a "contained" search silently starts somewhere else. `error`
+ * carries the tool-result JSON to return, or is `undefined` when the root is allowed.
+ *
+ * With no root there is nothing to anchor to, so this refuses rather than reaching for the process
+ * directory (ARCH-010). The previous `cwd ?? process.cwd()` was that reach: harmless once the guard
+ * below refuses anyway, but it read as a supported fallback, which is the pattern being removed.
  */
 export function resolveSearchRoot(
   requested: string | undefined,
   cwd: string | undefined,
 ): { root: string; error: string | undefined } {
-  const base = cwd ?? process.cwd();
-  const root = requested ? resolve(base, requested) : base;
+  if (cwd === undefined) {
+    return { root: '', error: checkPathWithinCwd(requested ?? '', undefined) };
+  }
+  const root = requested ? resolve(cwd, requested) : cwd;
   return { root, error: checkPathWithinCwd(root, cwd) };
 }

--- a/packages/agent-tools/src/builtins/read-tool.ts
+++ b/packages/agent-tools/src/builtins/read-tool.ts
@@ -98,7 +98,7 @@ function formatReadResult(
   return JSON.stringify(result);
 }
 
-async function readFileTool(args: TReadArgs, options: ISandboxToolOptions = {}): Promise<string> {
+async function readFileTool(args: TReadArgs, options: ISandboxToolOptions): Promise<string> {
   const { filePath, offset, limit = DEFAULT_LIMIT } = args;
   const startLine = offset !== undefined && offset > 0 ? offset : 1;
 
@@ -171,7 +171,7 @@ async function readFileTool(args: TReadArgs, options: ISandboxToolOptions = {}):
 /**
  * Create a ReadTool instance — register with Robota agent tools registry.
  */
-export function createReadTool(options: ISandboxBuiltinToolOptions = {}): FunctionTool {
+export function createReadTool(options: ISandboxBuiltinToolOptions): FunctionTool {
   return createZodFunctionTool(
     'Read',
     options.description ?? DEFAULT_READ_DESCRIPTION,
@@ -181,8 +181,3 @@ export function createReadTool(options: ISandboxBuiltinToolOptions = {}): Functi
     },
   );
 }
-
-/**
- * ReadTool instance — register with Robota agent tools registry.
- */
-export const readTool = createReadTool();

--- a/packages/agent-tools/src/builtins/shell-tool.ts
+++ b/packages/agent-tools/src/builtins/shell-tool.ts
@@ -99,15 +99,19 @@ async function runInSandbox(
  */
 async function runShell(
   args: TShellArgs,
-  options: ISandboxToolOptions = {},
+  options: ISandboxToolOptions,
   signal?: AbortSignal,
 ): Promise<string> {
   const { command, timeout: rawTimeout = DEFAULT_TIMEOUT_MS, workingDirectory } = args;
   const timeout = Math.min(rawTimeout, 600_000);
-  // SEC-007: the configured containment root is the DEFAULT working directory (see the file header
-  // for why it is not a boundary). Without this, an assembly that scoped its file tools to a
-  // workspace still ran every shell command in whatever directory the host process was started in.
-  const effectiveCwd = workingDirectory ?? options.cwd ?? process.cwd();
+  // SEC-007: the configured root is the DEFAULT working directory (see the file header for why it is
+  // not a boundary). Without this, an assembly that scoped its file tools to a workspace still ran
+  // every shell command in whatever directory the host process was started in.
+  //
+  // ARCH-010 removed a third `?? process.cwd()` link from this chain. `options.cwd` is required now,
+  // so that link was unreachable — and an unreachable fallback still reads as a supported one, which
+  // is how the ambient-root habit spreads. A caller that means the process directory says so.
+  const effectiveCwd = workingDirectory ?? options.cwd;
   if (options.sandboxClient) {
     return runInSandbox(command, timeout, workingDirectory ?? options.cwd, options);
   }
@@ -243,19 +247,13 @@ function createHostShellTool(name: string, options: IShellToolOptions): Function
  * Create a `Shell` tool instance — register with the Robota agent tools registry.
  * The description is resolved at creation time for the host's active shell.
  */
-export function createShellTool(options: IShellToolOptions = {}): FunctionTool {
+export function createShellTool(options: IShellToolOptions): FunctionTool {
   return createHostShellTool('Shell', options);
 }
 
 /**
  * Create a `Bash` tool instance — the model-familiar alias of the same OS-aware shell tool.
  */
-export function createBashTool(options: IShellToolOptions = {}): FunctionTool {
+export function createBashTool(options: IShellToolOptions): FunctionTool {
   return createHostShellTool('Bash', options);
 }
-
-/** `Shell` tool instance — register with the Robota agent tools registry. */
-export const shellTool = createShellTool();
-
-/** `Bash` tool instance — model-familiar alias of {@link shellTool}. */
-export const bashTool = createBashTool();

--- a/packages/agent-tools/src/builtins/shell-tool.ts
+++ b/packages/agent-tools/src/builtins/shell-tool.ts
@@ -112,6 +112,19 @@ async function runShell(
   // so that link was unreachable — and an unreachable fallback still reads as a supported one, which
   // is how the ambient-root habit spreads. A caller that means the process directory says so.
   const effectiveCwd = workingDirectory ?? options.cwd;
+  if (effectiveCwd === undefined) {
+    // Only reachable from a caller that skipped the type — `options.cwd` is required. Refusing beats
+    // letting `spawn` silently inherit the process directory, which was the last ambient root in this
+    // package and the one contract violation that produced no message at all (ARCH-010).
+    return JSON.stringify({
+      success: false,
+      output: '',
+      error:
+        'Shell tool has no working directory: it was constructed without a `cwd` (ARCH-010). This ' +
+        'is an assembly bug — the tool would otherwise run in whatever directory the host process ' +
+        'was started in.',
+    });
+  }
   if (options.sandboxClient) {
     return runInSandbox(command, timeout, workingDirectory ?? options.cwd, options);
   }

--- a/packages/agent-tools/src/builtins/tool-options.ts
+++ b/packages/agent-tools/src/builtins/tool-options.ts
@@ -24,11 +24,14 @@ export interface IBuiltinToolDescriptionOptions {
  */
 export interface IContainedBuiltinToolOptions extends IBuiltinToolDescriptionOptions {
   /**
-   * When set, the tool's filesystem access is confined to this directory: an out-of-root search root
-   * is refused, and no entry whose CANONICAL path escapes the root is enumerated. Relative paths the
-   * model supplies resolve against this root rather than `process.cwd()`.
+   * The directory the tool's filesystem access is confined to. REQUIRED — ARCH-010. An out-of-root
+   * search root is refused, no entry whose CANONICAL path escapes the root is enumerated, and relative
+   * paths the model supplies resolve against this root rather than `process.cwd()`.
+   *
+   * Required rather than optional because the guard used to be fail-open when it was absent, so
+   * omitting it produced an unbounded enumerator rather than an error.
    */
-  cwd?: string;
+  cwd: string;
 }
 
 /** Options for builtin factories that also operate on the sandbox/host filesystem. */

--- a/packages/agent-tools/src/builtins/write-tool.ts
+++ b/packages/agent-tools/src/builtins/write-tool.ts
@@ -23,7 +23,7 @@ const WriteSchema = z.object({
 
 type TWriteArgs = z.infer<typeof WriteSchema>;
 
-async function writeFileTool(args: TWriteArgs, options: ISandboxToolOptions = {}): Promise<string> {
+async function writeFileTool(args: TWriteArgs, options: ISandboxToolOptions): Promise<string> {
   const { filePath, content } = args;
 
   if (!options.sandboxClient) {
@@ -57,7 +57,7 @@ async function writeFileTool(args: TWriteArgs, options: ISandboxToolOptions = {}
 /**
  * Create a WriteTool instance — register with Robota agent tools registry.
  */
-export function createWriteTool(options: ISandboxBuiltinToolOptions = {}): FunctionTool {
+export function createWriteTool(options: ISandboxBuiltinToolOptions): FunctionTool {
   return createZodFunctionTool(
     'Write',
     options.description ?? DEFAULT_WRITE_DESCRIPTION,
@@ -67,8 +67,3 @@ export function createWriteTool(options: ISandboxBuiltinToolOptions = {}): Funct
     },
   );
 }
-
-/**
- * WriteTool instance — register with Robota agent tools registry.
- */
-export const writeTool = createWriteTool();

--- a/packages/agent-tools/src/index.ts
+++ b/packages/agent-tools/src/index.ts
@@ -101,13 +101,13 @@ export type {
 } from './implementations/function-tool/types';
 
 // Built-in CLI tools
-export { shellTool, createShellTool, bashTool, createBashTool } from './builtins/shell-tool';
+export { createShellTool, createBashTool } from './builtins/shell-tool';
 export type { IShellToolOptions } from './builtins/shell-tool';
-export { readTool, createReadTool } from './builtins/read-tool';
-export { writeTool, createWriteTool } from './builtins/write-tool';
-export { editTool, createEditTool } from './builtins/edit-tool';
-export { globTool, createGlobTool } from './builtins/glob-tool';
-export { grepTool, createGrepTool } from './builtins/grep-tool';
+export { createReadTool } from './builtins/read-tool';
+export { createWriteTool } from './builtins/write-tool';
+export { createEditTool } from './builtins/edit-tool';
+export { createGlobTool } from './builtins/glob-tool';
+export { createGrepTool } from './builtins/grep-tool';
 export type { IGrepToolOptions } from './builtins/grep-tool';
 export { webFetchTool, createWebFetchTool } from './builtins/web-fetch-tool';
 export { webSearchTool, createWebSearchTool } from './builtins/web-search-tool';

--- a/packages/agent-tools/src/sandbox/types.ts
+++ b/packages/agent-tools/src/sandbox/types.ts
@@ -120,13 +120,19 @@ export interface ISandboxClient {
 export interface ISandboxToolOptions {
   sandboxClient?: ISandboxClient;
   /**
-   * The tool's working-directory root on the host (non-sandbox) path.
+   * The tool's working-directory root on the host (non-sandbox) path. REQUIRED — ARCH-010.
    *
    * For the tools that read and enumerate — `Read`/`Write`/`Edit` and, since SEC-007, `Glob`/`Grep` —
    * this is a CONTAINMENT boundary: access outside it is refused, decided on canonical (symlink-
    * resolved) paths. For `Shell`/`Bash` it is the DEFAULT working directory and deliberately not a
    * boundary — a cwd guard on arbitrary command execution is undone by the first `cd` (see the
    * shell-tool file header).
+   *
+   * It is required because it was optional: with no root the containment guard used to answer
+   * "allowed", so a construction site that simply forgot supplied an unsandboxed `Read`. The audit
+   * found three layers that had. Optional here means the boundary is a convention each caller may or
+   * may not follow, and a boundary nobody is obliged to supply is not a boundary. Callers that
+   * genuinely mean "this process's directory" now say `process.cwd()` where a reader can see it.
    */
-  cwd?: string;
+  cwd: string;
 }

--- a/packages/dag-nodes/tool/src/__tests__/path-containment.test.ts
+++ b/packages/dag-nodes/tool/src/__tests__/path-containment.test.ts
@@ -11,9 +11,10 @@
  * The threat model is the one part A already accepted for `file-read`/`file-write` in this same
  * package family: a `.dag.json` is a shareable, LLM-authorable document. The `tool` node was strictly
  * worse than the `file-*` nodes it sits beside — `toolName: "read"` with an absolute path bypassed
- * `file-read`'s containment entirely, because `config.cwd` is optional and `checkPathWithinCwd` is a
- * NO-OP when `cwd` is `undefined`. The guard was disarmed by omission, which is exactly what
- * `pack-coding` makes `cwd` REQUIRED to prevent.
+ * `file-read`'s containment entirely, because `config.cwd` is optional and `checkPathWithinCwd` WAS a
+ * NO-OP when `cwd` was `undefined` (ARCH-010 has since made that case refuse, and made the root a
+ * required constructor argument). The guard was disarmed by omission, which is exactly what
+ * `pack-coding` made `cwd` REQUIRED to prevent.
  *
  * And `config.cwd` could not have been the boundary even when set: it comes out of the same
  * LLM-authorable document as the path it is supposed to contain, so `{"cwd":"/"}` disarms it. A root
@@ -35,7 +36,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { globTool, grepTool } from '@robota-sdk/agent-tools';
+import { createGlobTool, createGrepTool } from '@robota-sdk/agent-tools';
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 
 import { ToolNodeDefinition } from '../index.js';
@@ -98,20 +99,37 @@ async function run(
   };
 }
 
-describe('CONTROL — the singletons this node handed out really do escape', () => {
-  it('globTool enumerates out-of-root files through the escaping symlink', async () => {
-    const raw = await globTool.execute({ pattern: '**/*.txt' } as Parameters<
-      typeof globTool.execute
-    >[0]);
-    expect(JSON.stringify(raw.data)).toContain('escape/outside.txt');
+/**
+ * ARCH-010 INVERTED this block. It was a CONTROL asserting the opposite of what it now asserts: that
+ * the module-level `globTool`/`grepTool` this node used to hand out really did escape, because a guard
+ * with no root answered "allowed" and a singleton can never have a root. Those singletons are deleted
+ * and the root is a required constructor argument, so the escape is no longer constructible and the
+ * control has nothing left to demonstrate. What replaces it is the same demonstration from the other
+ * side: the SAME two tools, built the way this node builds them, do not reach through the symlink.
+ */
+describe('CONTROL — the tools this node hands out are rooted, and do not escape (ARCH-010)', () => {
+  it('Glob does not enumerate out-of-root files through the escaping symlink', async () => {
+    const glob = createGlobTool({ cwd: workdir });
+    const raw = await glob.execute({ pattern: '**/*.txt' } as Parameters<typeof glob.execute>[0]);
+    // The in-root hit first: an absence assertion that holds because nothing ran at all would prove
+    // nothing, and that is the shape an inverted assertion fails in.
+    expect(JSON.stringify(raw.data)).toContain('inside.txt');
+    expect(JSON.stringify(raw.data)).not.toContain('escape/outside.txt');
   });
 
-  it('grepTool returns the out-of-root file CONTENT through the escaping symlink', async () => {
-    const raw = await grepTool.execute({
-      pattern: 'SECRET-VALUE',
-      outputMode: 'content',
-    } as Parameters<typeof grepTool.execute>[0]);
-    expect(JSON.stringify(raw.data)).toContain('SECRET-VALUE');
+  it('Grep does not return the out-of-root file CONTENT through the escaping symlink', async () => {
+    const grep = createGrepTool({ cwd: workdir });
+    const args = { outputMode: 'content' } as const;
+    const inRoot = await grep.execute({ ...args, pattern: 'nested-ordinary' } as Parameters<
+      typeof grep.execute
+    >[0]);
+    // Same positive control: the search does reach the files inside the root.
+    expect(JSON.stringify(inRoot.data)).toContain('nested-ordinary');
+
+    const raw = await grep.execute({ ...args, pattern: 'SECRET-VALUE' } as Parameters<
+      typeof grep.execute
+    >[0]);
+    expect(JSON.stringify(raw.data)).not.toContain('SECRET-VALUE');
   });
 });
 

--- a/packages/dag-nodes/tool/src/tool-factories.ts
+++ b/packages/dag-nodes/tool/src/tool-factories.ts
@@ -31,9 +31,11 @@ export type FunctionTool = ITool;
  * A builtin factory, always given a containment root (SEC-007).
  *
  * `cwd` is REQUIRED here rather than optional, for the reason `pack-coding`'s `ICodingPackOptions`
- * makes it required: `checkPathWithinCwd` is a NO-OP when `cwd` is `undefined`, so an optional root is
- * a guard that disarms itself by omission. The two builtins that reach the network (`web-fetch`,
- * `web-search`) have no filesystem path to contain and ignore it.
+ * makes it required: `checkPathWithinCwd` USED TO BE a no-op when `cwd` was `undefined`, so an optional
+ * root was a guard that disarmed itself by omission. ARCH-010 made the guard refuse instead, and made
+ * `cwd` required on the `agent-tools` factories too — so this is now the same rule stated at three
+ * layers rather than the only thing enforcing it. The two builtins that reach the network
+ * (`web-fetch`, `web-search`) have no filesystem path to contain and ignore it.
  */
 export type ToolFactory = (options: { cwd: string }) => FunctionTool;
 
@@ -49,8 +51,8 @@ export const TOOL_FACTORIES: Readonly<Record<string, ToolFactory>> = {
   shell: (o) => createShellTool(o),
   bash: (o) => createBashTool(o),
   // SEC-007: built per invocation and bound to the root, not the module-level `globTool`/`grepTool`
-  // singletons this node used to hand back. Those are documented as UNCONTAINED precisely because a
-  // singleton is context-free by construction — there is nothing for a containment root to bind to.
+  // singletons this node used to hand back. A singleton is context-free by construction — there is
+  // nothing for a containment root to bind to — which is why ARCH-010 deleted them outright.
   glob: (o) => createGlobTool(o),
   grep: (o) => createGrepTool(o),
   'web-fetch': () => webFetchTool,

--- a/packages/pack-coding/docs/SPEC.md
+++ b/packages/pack-coding/docs/SPEC.md
@@ -44,11 +44,14 @@ bundled — NOT the product-shell/settings/provider command infrastructure (`/pr
 The pack is built by `createCodingPack({ cwd, sandboxClient })`. **There is deliberately NO module-level
 `codingPack` constant**, and that absence is a safety property, not an omission:
 
-- `agent-tools`' `checkPathWithinCwd` is a **no-op when `cwd` is `undefined`**. Tools constructed with no
-  options therefore carry a **disarmed** working-directory guard — their `Read` will return
-  `/etc/hostname`.
-- Before ARCH-006 that was inert: `agent-framework` always built its own context-bound default tier, and
-  its first-wins name dedupe kept that instance over a pack's.
+- `agent-tools`' `checkPathWithinCwd` USED TO BE a no-op when `cwd` was `undefined`. Tools constructed
+  with no options therefore carried a disarmed working-directory guard — their `Read` returned
+  `/etc/hostname`. **ARCH-010 inverted that**: the guard now refuses when no root is configured, and
+  `cwd` is required by the tool factories themselves. This pack's rule is no longer the only thing
+  standing between a context-free construction and an unsandboxed `Read` — but it remains right, and
+  it is why the pack was already correct when the audit found three layers that were not.
+- Before ARCH-006 the hole was inert here: `agent-framework` always built its own context-bound default
+  tier, and its first-wins name dedupe kept that instance over a pack's.
 - ARCH-006 lets a product hand the WHOLE tool surface to its packs (`defaultTools: []`). A context-free
   pack in that position is an **unsandboxed `Read`/`Write`/`Edit`**. A zero-option export would be a loaded
   gun aimed at the very seam this pack exists to demonstrate.

--- a/packages/pack-coding/src/__tests__/coding-pack.test.ts
+++ b/packages/pack-coding/src/__tests__/coding-pack.test.ts
@@ -40,7 +40,9 @@ async function invoke(
 describe("codingPack — contributes exactly robota's current coding toolset", () => {
   it("bundles the same tools (by name) that robota's createDefaultTools() ships by default", () => {
     // No adapters supplied → the always-present coding toolset (retrieval/computer are adapter-gated, absent).
-    const defaultToolNames = createDefaultTools().map((tool) => tool.getName());
+    // ARCH-010 — `createDefaultTools` now requires the root. It is `CWD`, the same root the pack under
+    // test is built with, so the two sides of this comparison are assembled alike; only NAMES are read.
+    const defaultToolNames = createDefaultTools({ cwd: CWD }).map((tool) => tool.getName());
     const packToolNames = (createCodingPack({ cwd: CWD }).tools ?? []).map((tool) =>
       tool.getName(),
     );

--- a/packages/pack-coding/src/coding-pack.ts
+++ b/packages/pack-coding/src/coding-pack.ts
@@ -20,12 +20,16 @@ import type { ISandboxClient } from '@robota-sdk/agent-tools';
  * The session context robota's coding tools are bound to.
  *
  * `cwd` is **required, not optional** — and that is the whole point of this factory. `agent-tools`'
- * `checkPathWithinCwd` is a NO-OP when `cwd` is `undefined`, so file tools constructed with no options
- * carry a DISARMED working-directory guard: their `Read` will happily return `/etc/hostname`. Before
+ * `checkPathWithinCwd` USED TO BE a no-op when `cwd` was `undefined`, so file tools constructed with no
+ * options carried a DISARMED working-directory guard: their `Read` returned `/etc/hostname`. Before
  * ARCH-006 that was inert, because the framework's own context-bound default tier always won a name
- * collision. Now that a product can hand the entire tool surface to its packs (`defaultTools: []`), a
- * context-free pack would be an unsandboxed `Read`/`Write`/`Edit`. Requiring `cwd` makes the scoping
- * decision impossible to forget.
+ * collision. Once a product could hand the entire tool surface to its packs (`defaultTools: []`), a
+ * context-free pack became an unsandboxed `Read`/`Write`/`Edit`.
+ *
+ * ARCH-010 has since fixed the layer below: the guard refuses when no root is configured, and the tool
+ * factories require `cwd` themselves. This requirement is therefore no longer load-bearing on its own —
+ * it is the precedent the audit's fix followed, and it stays because the scoping decision should be
+ * impossible to forget at every layer, not only the lowest one.
  */
 export interface ICodingPackOptions {
   /**

--- a/packages/pack-coding/src/index.ts
+++ b/packages/pack-coding/src/index.ts
@@ -4,8 +4,8 @@
  * command modules (`/shell`, `/editor`), and the coding subagents (`general-purpose`, `Explore`, `Plan`).
  *
  * The pack is built by a FACTORY that takes the session's working directory — there is deliberately no
- * context-free constant, because a pack whose file tools carry no `cwd` has a disarmed working-directory
- * path guard (ARCH-006). See `createCodingPack`.
+ * context-free constant, because a pack whose file tools carry no `cwd` had a disarmed working-directory
+ * path guard (ARCH-006; the guard itself was made fail-closed by ARCH-010). See `createCodingPack`.
  */
 
 export { createCodingPack } from './coding-pack.js';

--- a/scripts/external-proof/fixture/src/mode-a.ts
+++ b/scripts/external-proof/fixture/src/mode-a.ts
@@ -17,7 +17,7 @@ import { check, checkEqual, checkThrows, mode, note, section } from './harness.j
 
 /**
  * ARCH-006: the pack is built by a FACTORY bound to the session's working directory — a context-free pack
- * would carry a disarmed working-directory path guard on its file tools. A consumer builds it exactly as
+ * would carry a disarmed working-directory path guard on its file tools (ARCH-010 has since made that guard fail closed; the pack's rule is now the same one stated a layer up). A consumer builds it exactly as
  * robota's own shell does, with the cwd it assembles the session under.
  */
 const codingPack = createCodingPack({ cwd: process.cwd() });

--- a/scripts/external-proof/fixture/src/mode-c.ts
+++ b/scripts/external-proof/fixture/src/mode-c.ts
@@ -31,7 +31,7 @@ import { check, checkEqual, mode, note, section } from './harness.js';
 
 /**
  * ARCH-006: the pack is built by a FACTORY bound to the session's working directory — a context-free pack
- * would carry a disarmed working-directory path guard on its file tools. A consumer builds it exactly as
+ * would carry a disarmed working-directory path guard on its file tools (ARCH-010 has since made that guard fail closed; the pack's rule is now the same one stated a layer up). A consumer builds it exactly as
  * robota's own shell does, with the cwd it assembles the session under.
  */
 const codingPack = createCodingPack({ cwd: process.cwd() });
@@ -171,7 +171,12 @@ export async function runModeC(): Promise<void> {
     (options.agentDefinitions ?? []).some((definition) => definition.name === 'acme-triager'),
   );
   section('C5 — the tool axis at PARITY with the command and subagent axes (ARCH-006)');
-  const frameworkDefaultToolNames = createDefaultTools().map((tool) => tool.getName());
+  // ARCH-010: `cwd` is required. This proof only compares tool NAMES, so any root would do — which
+  // is exactly why it must be an explicit one rather than an omission: the omission is what used to
+  // produce a tool set with no containment boundary at all.
+  const frameworkDefaultToolNames = createDefaultTools({ cwd: process.cwd() }).map((tool) =>
+    tool.getName(),
+  );
   const codingPackToolNames = (codingPack.tools ?? []).map((tool) => tool.getName());
   check(
     'a pack tool the framework does NOT ship is genuinely additive — it reaches the runtime',
@@ -260,7 +265,7 @@ export async function runModeC(): Promise<void> {
   );
   note(
     'SAFETY: a pack that owns the tool surface MUST carry the session context. `createCodingPack` takes a ' +
-      'REQUIRED `cwd` for exactly that reason — `agent-tools` disarms its working-directory path guard ' +
+      'REQUIRED `cwd` for exactly that reason — `agent-tools` USED TO disarm its working-directory path guard ' +
       'when `cwd` is undefined, so a context-free pack paired with `defaultTools: []` would ship an ' +
       'unsandboxed Read/Write/Edit. There is deliberately no context-free `codingPack` constant.',
   );

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -51,7 +51,7 @@
   "packages/agent-provider-openai-compatible/src/qwen/responses-parser.ts": 302,
   "packages/agent-session/src/permission-enforcer.ts": 324,
   "packages/agent-session/src/session-run.ts": 323,
-  "packages/agent-session/src/session.ts": 321,
+  "packages/agent-session/src/session.ts": 319,
   "packages/agent-transport-tui/src/App.tsx": 605,
   "packages/agent-transport-tui/src/InputArea.tsx": 318,
   "packages/agent-transport-tui/src/TuiInteractionChannel.ts": 695,

--- a/scripts/harness/spec-surface-baseline.json
+++ b/scripts/harness/spec-surface-baseline.json
@@ -2,7 +2,7 @@
   "@robota-sdk/agent-cli": 1,
   "@robota-sdk/agent-command": 140,
   "@robota-sdk/agent-core": 146,
-  "@robota-sdk/agent-executor": 19,
+  "@robota-sdk/agent-executor": 1,
   "@robota-sdk/agent-framework": 160,
   "@robota-sdk/agent-interface-transport": 4,
   "@robota-sdk/agent-playground": 26,


### PR DESCRIPTION
> **BREAKING.** Seven public exports removed from `@robota-sdk/agent-tools`; `cwd` is now required on five published interfaces. Migration in `.changeset/arch-010-execution-root-required.md`.

## What was wrong

The strongest multi-sighting in the architecture audit — three independent auditors, at three heights, each traced a different symptom to the same missing field. **A subagent could read files outside its intended root and get content back rather than an error.**

The containment guard was **fail-open**: `isWithinCwd(path, undefined)` returned `true`, so with no root, everything was inside it. A construction site that simply forgot supplied an unsandboxed `Read`. `pack-coding` had already written the consequence into its own source — *"file tools constructed with no options carry a DISARMED working-directory guard: their `Read` will happily return `/etc/hostname`"* — and the child-process subagent worker called `createDefaultTools()` with **no argument at all**.

Measured, not inferred. Before this change:

```
{"success":true,"output":"[File: /etc/hostname (1 lines)]\n1\tserver"}
```

## The fix, in the order the task's own risk note requires

**Invert first, then require.** Requiring the field without inverting the default would leave every not-yet-migrated site silently unprotected. A rootless guard now refuses, with an error naming the real fault — *"no containment root is configured … this is an assembly bug, not a path problem"* — rather than an ordinary out-of-root message.

**`cwd` is REQUIRED** on `ISandboxToolOptions`, `IContainedBuiltinToolOptions`, `ICreateDefaultToolsOptions`, `ISessionOptions` and `ISubagentOptions`. The `= {}` default parameter is gone from every builtin factory — that default was the mechanism by which "forgot the root" was legal.

**Required by type is not sufficient.** `agent-session`'s tsconfig excludes `*.test.ts` and JS consumers are not typechecked at all, so `SessionBase` also refuses a missing, empty, non-string **or relative** root at runtime. Relative matters: it would be resolved against `process.cwd()` downstream, letting the ambient read back in through the *value* instead of its absence.

**Every call site the type system then named**, each fixed with the root already in scope. The `worktreePath ?? cwd` rule — written out at both runners — now lives once as `subagentExecutionRoot` in the package that owns the spawn request.

**Seven context-free singletons deleted.** A module-level instance is bound at import time and can carry no root, so after the inversion they could only refuse. No in-repo consumer; every assembly already built per-session tools. Keeping them would ship seven exports that always fail — the declared-but-unreachable shape this audit is about.

## Two control tests that depended on the defect

`enumeration-containment`'s CONTROL pair proved the escape was real by running with **no root** — which worked only *because* the guard was fail-open, so closing it turned the control red. Grep's control now uses a wider root; Glob's uses a `..` traversal, because a contained Glob sets `followSymbolicLinks: false` and cannot observe a symlink escape under any root. `dag-nodes/tool`'s CONTROL asserted the fail-open behaviour outright and is inverted, with a positive control first so the absence assertion cannot pass because nothing ran.

A control that depends on a defect elsewhere stops being a control the moment that defect is fixed.

## Evidence

**Red-proved.** Restoring the fail-open guard and the constructor's `?? process.cwd()`: 8 cases fail on named assertions, no timeouts. The independent reviewer reproduced this in a throwaway worktree and found **10** — two I had not counted.

Whole workspace green: build, typecheck, every package's tests, and `verify-like-ci` apart from a scan that reads this session's own transcript narrative and therefore cannot run in CI at all.

Ratchets pass **without being loosened**: `file-size` (moving `cwd` ownership into `SessionBase` shrank `session.ts` below baseline — re-frozen here), and `spec-public-surface`, where `agent-executor`'s SPEC subsections were missing the `### Public API: …` prefix the scan matches on, so its whole table was invisible; prefixing drops its undocumented count 19 → 1, also re-frozen.

## Review

One round: 6 SHOULD, 5 CONSIDER, 4 NIT — all resolved. The largest: four sites still asserted, **in the present tense**, the exact security behaviour this PR inverted, including `pack-coding`'s SPEC. `path-guard.ts` quotes that very sentence as the reason it now refuses. A package SPEC stating a false security property is worse than no note, so all four are restated in the past tense.

Also from the review: the measured breach site had no test (the type forces *a* root, not the *right* one — a regression to `process.cwd()` would compile and stay green), two sandbox doc examples invisible to `check-doc-examples` behind `doc-example-skip`, and no changeset for a major surface change.

## Scope

P2 (the DAG half) remains, with a finding recorded in the task that changes its shape: `IWorkspaceLayout` — the seam the synthesis named as ready to use — holds a path **relative** to the project dir describing where workflow *definitions* live, not an absolute execution root, and `INodeExecutionContext` has 57 consumers. It needs a design pass, not a mechanical edit.

Closes ARCH-010 P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso