### PR TITLE
chore(tasks): six harness items from an external read-only review

### DIFF
--- a/.agents/archive/audits/harness-external-review-2026-08-02.md
+++ b/.agents/archive/audits/harness-external-review-2026-08-02.md
@@ -1,0 +1,335 @@
+# robota 하네스 문제점 보고서
+
+작성일: 2026-08-02
+작성 경위: 다운스트림 저장소 **god-sim**이 robota 하네스의 2차 도입을 검토하며 `../robota`를 조사.
+그 과정에서 발견한 robota 자체의 문제를 별도로 정리한 문서다.
+
+---
+
+## 0. 방법과 한계 — 먼저 읽어주세요
+
+**한 것**: `/home/ubuntu/dev/robota`에 대한 **읽기 전용 정적 조사**. 병렬 에이전트로
+`scripts/harness/*.mjs` 120개, `.agents/`(rules·skills 제외), `.github/`, `.husky/`, 루트 거버넌스
+문서를 훑었고, 보고된 주장 중 이 문서에 실은 것은 **전부 제가 직접 명령으로 재확인**했습니다.
+부록의 재현 명령은 작성 후 실제로 다시 실행해 수치 일치를 확인했습니다.
+
+**범위 밖**: `.agents/rules/`(24개)와 `.agents/skills/`(54개)의 내용 품질은 이 보고서에서 다루지
+않았습니다. 별도 조사가 진행 중이며, diet 감사가 이미 "rules consolidation"(004)과 "skills
+diet"(005)를 완료 처리한 영역이기도 합니다.
+
+**하지 않은 것 (중요)**:
+
+- robota의 스캔 스위트를 **실행하지 않았습니다**. "이 검사는 실패할 수 없다"류 판정은 코드 정적
+  판독과 robota 자체 기록에 근거한 것이지, 제가 falsify해서 확인한 것이 아닙니다.
+- 저장소를 **아무것도 수정하지 않았습니다**.
+- robota의 도메인 정합성(에이전트 SDK 설계, 프로바이더, 트랜스포트)은 판단하지 않았습니다.
+  하네스·거버넌스 machinery만 봤습니다.
+
+따라서 아래 항목은 **"확인된 사실"과 "robota 자체 기록"과 "제 추론"을 구분해서** 표기했습니다.
+숫자는 전부 제가 직접 센 값입니다.
+
+**맥락 하나**: `.agents/memory/harness-diet-audit.md`에 2026-07-23 diet 감사가 있고, 2026-07-24에
+7개 하위 항목이 전부 완료된 것으로 기록돼 있습니다. 그리고 같은 문서에 owner가 2026-08-01자로
+**"재감사 허용"**을 명시하며 *"그 이후 들어온 것을 감사하라"*고 적어두었습니다. 이 보고서는 그
+시점 이후의 외부 시선으로 읽으시면 됩니다. diet에서 이미 제거·정리된 13개 스킬과 16개 슬리밍은
+재론하지 않았습니다.
+
+---
+
+## 1. 요약 — 가장 중요한 것 세 가지
+
+1. **robota는 자기 스캔의 ~40%가 vacuous하다고 스스로 측정해두고, 그 측정 이후 구조적으로 달라진
+   것이 확인되지 않습니다.** 측정일이 2026-07-26으로 diet 완료(7-24) *이후*입니다. 즉 diet가
+   vacuity를 해소하지 못했습니다.
+2. **하네스 스크립트 120개의 내부 관용구가 두 갈래로 갈라져 있습니다.** 직접실행 가드 2종,
+   종료 방식 2종이 섞여 있고, 이 분기가 곧 "테스트 가능한 스크립트"와 "테스트 불가능한 스크립트"의
+   경계와 일치합니다.
+3. **산출물이 멈춘 machinery가 여전히 등록·유지되고 있습니다.** daily-reports는 3일치 후 14일째
+   정지, release-runs는 폐기된 워크플로의 잔존물입니다.
+
+---
+
+## 2. Vacuity — 실패할 수 없는 검사
+
+### 2.1 robota 자체 측정 (인용)
+
+`.agents/memory/MEMORY.md:16` 원문:
+
+> Ceiling: none of this catches a check whose _logic_ is wrong; **~30 of the 76-scan suite is measured
+> vacuous (2026-07-26)**
+
+`.agents/memory/check-validity-two-axes.md`에 사례가 표로 정리돼 있습니다:
+
+| 검사                    | robota의 판정                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `agent-server-boundary` | _"satisfied **vacuously by a never-called import**"_ — 토큰이 있는지만 보고 seam이 실제로 연결됐는지는 보지 않음 |
+| `security audit`        | 이름은 분야를 말하는데 실제로는 의존성 스캔만 수행 (`dependency audit`으로 개명, INFRA-060 D5)                   |
+| release 워크플로        | **4개월간** 열리지 않는 macOS 아티팩트를 "업로드에 성공"                                                         |
+
+`.agents/memory/harness-diet-audit.md`가 추가로 지목한 것:
+
+> `scan-file-size` & `check-document-authority` (**registered gates that can NEVER fail**),
+> `compat-node18` (runs Node 22 not 18)
+
+**제 관찰**: `harness-diet-audit`는 2026-07-23, vacuity 측정은 2026-07-26입니다. diet가
+"dead/vacuous scan removal"(003)을 완료 처리했는데 사흘 뒤 30/76이 vacuous로 측정됐다는 것은,
+diet가 **죽은 스크립트는 지웠지만 살아있으면서 아무것도 검사하지 않는 스크립트는 남겼다**는 뜻으로
+읽힙니다. 후자가 더 위험합니다 — 전자는 존재가 드러나지만 후자는 매 CI마다 초록으로 안심을 줍니다.
+
+### 2.2 확인된 개별 사례
+
+**`cleanup-drift.mjs` — 비제로 종료가 아예 없습니다.** (직접 확인)
+
+```
+$ grep -n "process.exit\|exitCode" scripts/harness/cleanup-drift.mjs
+(출력 없음)
+```
+
+`process.exit`도 `process.exitCode`도 없습니다. 이 스크립트는 **어떤 입력에도 실패할 수 없습니다.**
+게이트로 등록돼 있다면 정의상 vacuous입니다.
+
+### 2.3 `governed-tree.mjs`가 기록한 것 — 가장 값진 발견
+
+`scripts/harness/governed-tree.mjs:5` 및 `scan-guard-scope-fail-closed.mjs:15` 원문:
+
+> a scan ... finds it absent, and returns `[]` — which every caller reads as "clean".
+> **30 of the 50 registered finders returned an empty finding list** — i.e. reported a pass over
+> ground they never covered.
+
+**50개 중 30개가 검사 대상이 없는 root에서 "통과"를 보고했습니다.** 이건 robota가 스스로 falsify해서
+찾아낸 것이고, `requireGovernedTree`라는 해법까지 만들었습니다. 제가 본 robota 하네스에서 **가장
+값진 산출물**입니다.
+
+다만 **적용 범위가 남아 있습니다**: `governed-tree.mjs`를 import하는 스크립트를 세어보시길 권합니다.
+50개 중 30개가 문제였는데, 그 30개 전부가 지금 `requireGovernedTree`를 호출하는지는 이 조사에서
+확인하지 못했습니다.
+
+---
+
+## 3. 구조적 분기 — 관용구가 두 갈래
+
+`scripts/harness/*.mjs` 120개를 직접 세었습니다.
+
+| 항목                                                | 수치                       |
+| --------------------------------------------------- | -------------------------- |
+| 총 `.mjs`                                           | 120                        |
+| `export function` 보유 (import 대상으로 설계)       | 110                        |
+| `process.exit()` 사용 (`exitCode` 미사용)           | **37**                     |
+| `process.exitCode` 사용                             | 60                         |
+| 둘을 혼용                                           | 0                          |
+| **export 함수 보유 + `process.exit()` 사용**        | **36**                     |
+| 직접실행 가드: `import.meta.url === \`file://...\`` | 40                         |
+| 직접실행 가드: `path.resolve(process.argv[1]) ===`  | 28                         |
+| 가드 없음                                           | 52 (중 42개가 export 보유) |
+| `__tests__/*.test.mjs`                              | 137                        |
+| 대응 테스트 파일이 없는 스크립트                    | **24 / 120**               |
+
+### 3.1 `process.exit()` + export 조합 — 36개
+
+**36개 스크립트가 함수를 export하면서 동시에 `process.exit()`를 호출합니다.** export는 "import해서
+테스트하라"는 신호인데, `process.exit()`는 import 시점에 프로세스를 죽일 수 있다는 뜻입니다.
+robota가 나머지 60개에서 이미 `process.exitCode = 1; return;`으로 옮긴 것을 보면 의도적 설계가
+아니라 **마이그레이션이 30% 지점에서 멈춘 상태**로 보입니다.
+
+### 3.2 직접실행 가드가 두 종류
+
+- **40개**: ``import.meta.url === `file://${process.argv[1]}` ``
+- **28개**: `path.resolve(process.argv[1]) === path.resolve(import.meta.filename)`
+
+전자는 **경로에 URL 이스케이프가 필요한 문자(공백, 한글, `#` 등)가 있으면 깨집니다.** 깨지는 방향이
+나쁜 쪽입니다 — 가드가 false가 되어 **직접 실행해도 `main()`이 돌지 않고 조용히 exit 0** 합니다.
+검사가 실행되지 않았는데 통과로 보입니다. §2의 vacuity와 같은 실패 모드입니다.
+
+CI 러너 경로가 안전한 문자만 쓰므로 지금 당장 터지진 않겠지만, worktree 병렬 실행이나 로컬 경로에
+한글이 섞이면 나타납니다.
+
+### 3.3 테스트 없는 스크립트 24개
+
+137개 테스트가 있는 것은 인상적입니다. 다만 **24개는 대응 테스트가 없습니다.** 어느 24개인지가
+중요합니다 — §2가 보여주듯 테스트 없는 검사가 곧 vacuous 후보입니다. 이름 규칙(`<script>.test.mjs`)이
+있으니 커버리지 메타테스트를 하나 두면 이 수치가 다시 늘지 않게 고정됩니다.
+
+---
+
+## 4. 멈춘 machinery
+
+| 자산                     | 마지막 산출물          | 저장소 활동         | 상태                     |
+| ------------------------ | ---------------------- | ------------------- | ------------------------ |
+| `.agents/daily-reports/` | **2026-07-19**         | 2026-08-02까지 활발 | 3일 돌고 **14일째 정지** |
+| `.agents/release-runs/`  | `3.0.0-beta.79.md`     | changesets로 이전   | 폐기된 워크플로의 잔존물 |
+| `.agents/local-reviews/` | 32개 파일 (gitignored) | —                   | 아래 §4.1                |
+
+**두 경우 모두 스크립트는 살아 있습니다** — `scripts/harness/daily-report.mjs`,
+`scripts/harness/release-run.mjs` 모두 디스크에 존재합니다. 즉 "쓰지 않기로 한 것"이 아니라
+**"쓰다가 멈춘 것"**이고, 구분이 문서화되어 있지 않습니다.
+
+daily-reports가 죽은 원인은 구조에 있어 보입니다. README에 따르면 사실 부분은 스크립트가 채우고
+**`## Summary` 산문은 에이전트가 써서 커밋**해야 합니다. 클럭 기반 cadence + 산문 작성 단계의 조합은
+한 번 끊기면 복구 유인이 없습니다. 반면 **이벤트 기반**인 `archive/audits/`는 2026-08-02자 산출물이
+살아 있습니다. 같은 조직에서 두 방식의 수명이 갈린 자연 실험 데이터가 이미 있는 셈입니다.
+
+### 4.1 `local-reviews/` — robota 스스로 측정한 결함
+
+`.github/workflows/review-gate.yml`에 기록된 내용:
+
+> measured while judging that PR, the merging clone held a record for a DIFFERENT branch and would
+> have answered one PR's merge with another PR's disposition.
+
+gitignored + 로컬 브랜치/HEAD 키 → **머지하는 클론에서 보이지 않습니다.** robota는 머지 차단 결정을
+PR 라벨로 옮겨 해결했지만, `local-reviews/` 디렉터리 자체는 32개 파일과 함께 남아 있습니다. 노트
+캐시로만 쓴다면 그 격하가 README에 적혀 있어야 다음 사람이 이걸 게이트 근거로 오해하지 않습니다.
+
+---
+
+## 5. 비중립성 잔존 — diet의 "dominant finding"이 남아 있음
+
+`harness-diet-audit.md`가 지목한 **최상위 발견**:
+
+> **Dominant finding: NON-NEUTRALITY** — Robota package names/paths/prose baked into machinery that
+> presents as a general/portable harness (north-star violation).
+> Fix pattern: move repo-specifics to config, keep the machinery generic.
+
+**확인된 잔존 사례** — `check-dependency-direction.mjs`:
+
+```js
+// line 200, 228, 265 — 올바르게 config를 씀
+if (dep.startsWith(HARNESS.npmScopePrefix) && ...)
+
+// checkPassthroughReexports 내부 — 같은 파일에서 하드코딩
+const reexportPattern = /export\s+\*\s+from\s+['"](@robota-sdk\/[^'"]+)['"]/g;
+```
+
+**한 파일 안에서 두 방식이 공존합니다.** `HARNESS.npmScopePrefix`가 바로 위에 있는데 정규식만
+`@robota-sdk/`를 박아뒀습니다. 스코프를 바꾸면 이 규칙 하나만 조용히 무력화됩니다 —
+에러가 아니라 **매칭 0건 = 통과**로 나타나므로 §2의 vacuity와 같은 부류입니다.
+
+이건 god-sim 같은 다운스트림에 직접 영향을 줍니다. 하네스를 "이식 가능한 일반 도구"로 표방한다면
+이런 잔존이 이식 비용을 만듭니다.
+
+---
+
+## 6. 문서 SSOT 자기모순
+
+robota의 `AGENTS.md`가 규칙으로 선언한 것:
+
+> **"Never duplicate content across levels. Each fact has exactly one owner document."**
+
+그런데 `CONTRIBUTING.md:30-35`가 패키지 목록을 다시 씁니다:
+
+```
+- `packages/agent-core` — Core agent runtime, abstractions, and plugin system
+- `packages/agent-framework` — Assembly layer: ...
+- `packages/agent-session` — Session lifecycle: ...
+...
+```
+
+`.agents/project-structure.md`가 이 목록의 SSOT를 자처하고 있고, `check-dependency-direction.mjs`
+Rule 9가 그 문서의 산문에 실재하지 않는 패키지 이름이 나오면 실패시킵니다. **그런데 같은 목록의
+두 번째 사본인 `CONTRIBUTING.md`는 아무도 검사하지 않습니다.**
+
+즉 robota는 이 드리프트를 막는 규칙과 검사를 둘 다 갖고 있으면서, 정작 자기 루트 문서에서 그 규칙을
+어기고 있고 검사 범위가 거기까지 닿지 않습니다. 규칙이 기계적 검사를 갖추면 **검사 범위 밖이 곧
+사각지대**가 된다는 사례입니다.
+
+---
+
+## 7. robota가 이미 아는 것 vs 이 보고서가 더한 것
+
+**이미 robota 기록에 있는 것** (재확인만 함):
+
+- ~30/76 vacuous 측정 (2026-07-26)
+- 50개 finder 중 30개가 빈 결과로 통과 보고
+- `scan-file-size`, `check-document-authority`가 실패 불가 게이트
+- 비중립성이 diet의 최상위 발견
+- `local-reviews`가 다른 PR의 판정을 답한 사건
+- `scan-conflict-markers`가 2026-07에 falsify로 무력함이 드러난 일
+
+**이 보고서가 더한 것** (제가 새로 센 것):
+
+- `process.exit()` + export 조합 **36개** — exitCode 마이그레이션이 중단된 지점의 정확한 규모
+- 직접실행 가드 **40 vs 28** 분기, 그리고 취약한 쪽이 **조용한 exit 0**으로 실패한다는 점
+- 테스트 없는 스크립트 **24/120**
+- `cleanup-drift.mjs`에 비제로 종료가 **아예 없음**
+- `check-dependency-direction.mjs` **한 파일 안에서** config 사용과 하드코딩이 공존
+- daily-reports 정지가 **14일**이며 스크립트는 살아 있음 (폐기 아님, 중단)
+- `CONTRIBUTING.md`가 `AGENTS.md`의 one-owner 규칙을 위반하며 검사 사각지대에 있음
+
+---
+
+## 8. 제안 우선순위
+
+robota의 규모와 상황을 밖에서 본 판단이므로 참고용입니다.
+
+**1순위 — vacuity를 측정 가능하게**
+30/76이라는 수치가 2026-07-26에 한 번 측정되고 그 뒤 추적되지 않는 것으로 보입니다. 그 측정을
+**반복 가능한 스크립트로 고정**하면(각 finder를 빈 temp root에 던져 throw하는지 보는 것 —
+`scan-guard-scope-fail-closed`의 엔진이 이미 그 일을 합니다) 수치가 회귀하는지 보입니다. 지금은
+개선/악화를 알 수 없습니다.
+
+**2순위 — 관용구 통일 (36 + 40)**
+`process.exit()` 36개를 `process.exitCode`로, 취약 가드 40개를 `path.resolve` 형태로. 기계적이고
+위험이 낮으며, 끝나면 **"모든 하네스 스크립트는 import 가능하다"**가 참이 되어 테스트 커버리지
+메타체크를 걸 수 있습니다.
+
+**3순위 — 멈춘 것을 명시적으로 은퇴시키기**
+daily-reports와 release-runs를 `archive/`로 옮기거나 README에 중단 사유를 적으시길 권합니다.
+`archive/README.md`의 retention 정책("종류를 보관하는 것이지 끝난 작업을 보관하는 게 아니다")이
+이미 잘 쓰여 있으므로 그 정책을 적용하면 됩니다. 지금은 **"쓰는 것"과 "쓰다 멈춘 것"이 같은 자리에
+있어** 다음 사람이 구분할 수 없습니다.
+
+**4순위 — 비중립성 잔존 스윕**
+diet가 최상위 발견으로 지목했으니 재발 방지 검사가 필요해 보입니다. 하네스 스크립트에서
+`@robota-sdk` 리터럴을 찾되 `harness-config`를 경유하지 않는 것만 잡는 스캔이면 §5 같은
+한 파일 안 공존을 잡습니다.
+
+**5순위 — 검사 범위 사각지대**
+`CONTRIBUTING.md`를 `project-structure.md`의 검사 범위에 넣거나, 패키지 목록을 지우고 링크로
+바꾸시길 권합니다.
+
+---
+
+## 9. 덧붙임 — 이 보고서가 가능했던 이유
+
+비판만 적었으니 균형을 위해 적습니다.
+
+**robota의 코드가 자기 결함의 증거를 스스로 들고 있습니다.** `governed-tree.mjs` 헤더의
+"30 of the 50 registered finders", `claude-code-review.yml` 헤더의 "100 consecutive runs",
+`run-all-scans.mjs`의 "`&&` 체인이 첫 실패 뒤를 가렸다", `check-validity-two-axes.md`의 사례 표 —
+**거의 모든 mechanism이 자기를 만들어낸 사건과 측정치를 주석으로 들고 있습니다.**
+
+이 보고서의 §2, §4.1, §5는 전부 robota가 자기 파일에 적어둔 것을 읽은 결과입니다. 이런 관행이 없는
+저장소였다면 밖에서 이 정도로 구체적인 지적을 할 수 없었습니다. **문제를 기록해두는 습관이 문제를
+찾을 수 있게 만든다**는 것이 조사자로서 가장 인상적이었던 부분입니다.
+
+god-sim은 이 관행 자체를 최우선 도입 대상으로 잡았습니다.
+
+---
+
+## 부록: 재현 명령
+
+이 보고서의 수치는 전부 아래로 재현됩니다 (`/home/ubuntu/dev/robota/scripts/harness` 기준).
+
+```bash
+# 총 스크립트 / 테스트
+ls *.mjs | wc -l                      # 120
+ls __tests__/*.test.mjs | wc -l       # 137
+
+# 종료 방식 분기
+comm -23 <(grep -l 'process\.exit(' *.mjs|sort) <(grep -l 'process\.exitCode' *.mjs|sort) | wc -l   # 37
+comm -12 <(grep -l '^export function\|^export async function' *.mjs|sort) \
+         <(grep -l 'process\.exit(' *.mjs|sort) | wc -l                                             # 36
+
+# 직접실행 가드 분기
+grep -l 'import.meta.url === `file://' *.mjs | wc -l          # 40
+grep -l 'path.resolve(process.argv\[1\])' *.mjs | wc -l       # 28
+
+# 테스트 없는 스크립트
+for f in *.mjs; do b=$(basename "$f" .mjs); [ -f "__tests__/$b.test.mjs" ] || echo "$b"; done | wc -l   # 24
+
+# 비제로 종료가 없는 스크립트
+grep -n "process.exit\|exitCode" cleanup-drift.mjs            # 출력 없음
+
+# 비중립성 잔존
+grep -n "@robota-sdk/" check-dependency-direction.mjs
+grep -n "npmScopePrefix" check-dependency-direction.mjs
+```

--- a/.agents/tasks/HARNESS-064-vacuity-was-measured-once.md
+++ b/.agents/tasks/HARNESS-064-vacuity-was-measured-once.md
@@ -1,0 +1,88 @@
+---
+title: 'HARNESS-064: vacuity was measured once and never again — 30 of 76 scans could not fail, and nothing tracks whether that number moves'
+status: todo
+created: 2026-08-02
+priority: critical
+urgency: now
+area: scripts/harness
+depends_on: []
+---
+
+# HARNESS-064: a one-off measurement is not a gate
+
+## Problem
+
+On 2026-07-26 this repo measured that **~30 of its 76 scans were vacuous** — registered, green on
+every CI run, and incapable of failing. That number was written down once. Nothing re-measures it, so
+the repo cannot tell whether the figure has improved, held, or grown since.
+
+A vacuous check is worse than a missing one. A missing check is visibly absent; a vacuous check
+returns green every run and buys confidence it did not earn.
+
+## Evidence
+
+Raised by an external read-only investigation of this repo (2026-08-02, by a downstream consumer
+evaluating the harness for adoption). Its counts were re-verified here before this Task was written.
+
+- `.agents/memory/MEMORY.md:16`, this repo's own record: _"~30 of the 76-scan suite is measured
+  vacuous (2026-07-26)"_.
+- `.agents/memory/check-validity-two-axes.md` catalogues instances: `agent-server-boundary`
+  _"satisfied vacuously by a never-called import"_; the `security audit` job that only scanned
+  dependencies; a release workflow that reported success uploading a macOS artefact nobody had opened
+  in four months.
+- `.agents/memory/harness-diet-audit.md` names `scan-file-size` and `check-document-authority` as
+  _"registered gates that can NEVER fail"_ and `compat-node18` as running Node 22.
+- `scripts/harness/governed-tree.mjs:5` and `scan-guard-scope-fail-closed.mjs:15` record the sharpest
+  instance: _"**30 of the 50 registered finders returned an empty finding list** — i.e. reported a
+  pass over ground they never covered."_
+
+**The timing is the finding.** The diet audit completed on 2026-07-24 with "dead/vacuous scan
+removal" marked done. The 30/76 measurement is dated **2026-07-26** — two days later. The diet
+removed the scripts that were dead; it did not remove the ones that were alive and checking nothing.
+
+**Verified for this Task:** 31 of 120 harness scripts reference `governed-tree`. The guard exists and
+its adoption is partial; which of the 30 originally-affected finders now call `requireGovernedTree`
+was not established and is part of the work.
+
+## Why this is foundational (or not)
+
+**FOUNDATIONAL.** Every other harness item is judged by whether a check catches it. If ~40% of the
+suite cannot fail, the suite's green is not evidence about the tree — and no individual scan fix can
+establish that, because the property is about the suite.
+
+The repo already owns the mechanism: `scan-guard-scope-fail-closed` measures exactly this — point a
+finder at ground it does not cover and see whether it throws or reports a pass. The engine exists and
+is run once by hand rather than on every change.
+
+## Direction
+
+Turn the one-off measurement into a repeatable one. Concretely, the shape the investigation
+suggested and this repo's own tooling already supports: run every registered finder against an empty
+temporary root and assert it FAILS (or explicitly declares the root out of scope) rather than
+returning `[]`. Freeze the surviving count as a ratchet that may fall and never rise, the way
+`file-size` and `spec-public-surface` already work.
+
+Two things to decide, not assumed here:
+
+- Whether a scan with genuinely nothing to check should throw, or declare itself not-applicable. The
+  second is honest but becomes a dodge if it is easy to write; `requireGovernedTree` already chose
+  the first for its own domain.
+- Whether the ratchet counts scans or finders. The 30/76 and 30/50 figures count different things.
+
+Do NOT close this by re-running the measurement and recording a new number. A number in a memory file
+is what this Task exists because of.
+
+## Test Plan
+
+- **Required red-first regression:** a deliberately vacuous scan (one that returns `[]` unconditionally)
+  added to the registry must FAIL the new check. Prove it fails before the check is trusted.
+- Red-first: a scan that legitimately covers its ground must PASS, so the check is not a blanket
+  refusal.
+- The frozen count must fall, not rise, on a change that fixes a vacuous scan — assert the ratchet
+  direction.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Does not apply.** This changes no user-facing product surface; it changes what the repo's own CI
+can conclude. The verification is the red-first regression above.

--- a/.agents/tasks/HARNESS-065-two-idioms-one-testability-boundary.md
+++ b/.agents/tasks/HARNESS-065-two-idioms-one-testability-boundary.md
@@ -1,0 +1,89 @@
+---
+title: 'HARNESS-065: the harness scripts speak two idioms, and the fork is exactly the line between testable and untestable'
+status: todo
+created: 2026-08-02
+priority: high
+urgency: next
+area: scripts/harness
+depends_on: []
+---
+
+# HARNESS-065: an interrupted migration, and a guard that fails silently green
+
+## Problem
+
+The 120 harness scripts use two mutually exclusive idioms for two separate things, and neither fork
+is a decision anyone made — both look like migrations that stopped partway.
+
+The consequence is not stylistic. One fork decides whether a script can be imported and tested; the
+other fails in the direction that makes a check silently not run.
+
+## Evidence
+
+From an external read-only investigation (2026-08-02). Every count below was re-run in this repo
+before this Task was written and **all seven reproduced exactly**.
+
+| Measurement                                          | Count                   |
+| ---------------------------------------------------- | ----------------------- |
+| Total `scripts/harness/*.mjs`                        | 120                     |
+| Have `export function` (designed to be imported)     | 110                     |
+| Use `process.exit()` and never `process.exitCode`    | 37                      |
+| Use `process.exitCode`                               | 60                      |
+| Use both                                             | 0                       |
+| **Export a function AND call `process.exit()`**      | **36**                  |
+| Guard: `` import.meta.url === `file://${argv[1]}` `` | 40                      |
+| Guard: `path.resolve(process.argv[1]) === …`         | 28                      |
+| No direct-execution guard at all                     | 52 (42 of which export) |
+| Test files under `__tests__/`                        | 137                     |
+| Scripts with no matching test file                   | **24 / 120**            |
+
+**The exit fork (36).** A script that exports a function is saying "import me and test me". A script
+that calls `process.exit()` can kill the process at import time. Sixty scripts have already moved to
+`process.exitCode = 1; return;`, and **zero** mix the two — so this is a migration that stopped at
+about 60%, not a considered split.
+
+**The guard fork (40 vs 28), and why the weaker one is dangerous.** The `file://` comparison breaks
+when the path contains characters a URL must escape — a space, a non-ASCII character, `#`. It breaks
+in the worst direction: the guard evaluates false, `main()` never runs, and the script **exits 0**.
+A check that did not execute is indistinguishable from a check that passed. That is the same failure
+mode as HARNESS-064's vacuity, arriving through a different door. CI runner paths are currently safe,
+so this is latent rather than live — parallel worktrees or a local path with non-ASCII characters
+would surface it.
+
+**The 24 untested scripts.** 137 tests is substantial coverage; the question is which 24 are outside
+it, because an untested check is the leading candidate for a vacuous one.
+
+## Why this is foundational (or not)
+
+**LOCAL, but it blocks something foundational.** No single script here is wrong. The value of fixing
+it is that once every script is importable, "every harness script has a test" becomes a mechanically
+enforceable statement — which is the check that would stop the 24 from becoming 30, and which
+HARNESS-064 needs in order to reach every finder.
+
+## Direction
+
+Mechanical, low-risk, and in this order:
+
+1. Convert the 36 `export`+`process.exit()` scripts to `process.exitCode`, matching the 60 that
+   already are.
+2. Convert the 40 `file://` guards to the `path.resolve` form, matching the 28 that already are.
+3. Decide what the 52 scripts with NO guard are — a script that exports and never guards runs its
+   `main()` on import, which is the same hazard from the other side.
+4. Only then: add the coverage meta-check that pins the untested count so it cannot grow.
+
+Step 4 is the point; steps 1–3 are what make it possible. Landing 4 without 1–3 would just record
+the number.
+
+## Test Plan
+
+- **Required red-first regression:** importing each converted script must not terminate the process.
+  A script still calling `process.exit()` must FAIL the new check — prove it fails first.
+- Red-first: a guard built from a path containing a space must still run `main()` when executed
+  directly. Against the `file://` form this FAILS by exiting 0 with no output, which is the whole
+  point — assert on the effect, not the exit code alone.
+- The untested-script count is frozen and may fall, never rise.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Does not apply.** No user-facing surface changes; the subject is the repo's own tooling.

--- a/.agents/tasks/HARNESS-066-machinery-that-stopped-is-still-registered.md
+++ b/.agents/tasks/HARNESS-066-machinery-that-stopped-is-still-registered.md
@@ -1,0 +1,77 @@
+---
+title: 'HARNESS-066: machinery that stopped producing is still registered, and nothing distinguishes "retired" from "stalled"'
+status: todo
+created: 2026-08-02
+priority: medium
+urgency: next
+area: .agents, scripts/harness
+depends_on: []
+---
+
+# HARNESS-066: stopped is not the same as retired, and the tree cannot tell them apart
+
+## Problem
+
+Two `.agents/` asset trees stopped producing output while their scripts remain on disk and
+registered. Nothing records whether each was retired deliberately or simply stalled — so the next
+reader cannot tell a decision from a lapse, and neither can a scan.
+
+## Evidence
+
+From an external read-only investigation (2026-08-02); the dates and file listings were re-verified
+here.
+
+| Asset                    | Last output           | Repo activity        | State                           |
+| ------------------------ | --------------------- | -------------------- | ------------------------------- |
+| `.agents/daily-reports/` | **2026-07-19**        | active through 08-02 | ran 3 days, stopped 14 days ago |
+| `.agents/release-runs/`  | `3.0.0-beta.79.md`    | moved to changesets  | residue of a retired workflow   |
+| `.agents/local-reviews/` | 32 files (gitignored) | —                    | see below                       |
+
+Both scripts are still present: `scripts/harness/daily-report.mjs`, `scripts/harness/release-run.mjs`.
+
+**A natural experiment already ran here.** `daily-reports`' README says the script fills the facts
+and an **agent writes the `## Summary` prose** and commits it. A clock-driven cadence plus a prose
+step has no recovery pressure once it lapses. The **event-driven** `.agents/archive/audits/` tree, by
+contrast, has output dated 2026-08-02. Same repo, same authors, two cadences, opposite lifespans —
+which is a stronger argument than any preference about how to schedule reports.
+
+**`local-reviews/` is a measured defect, not a guess.** `.github/workflows/review-gate.yml` records
+what happened: _"the merging clone held a record for a DIFFERENT branch and would have answered one
+PR's merge with another PR's disposition."_ The directory is gitignored and keyed on local
+branch/HEAD, so it is invisible to the clone that merges. The blocking decision was correctly moved
+to a PR label — but 32 files and the directory remain, with nothing saying it has been demoted to a
+local note cache. The next reader can still mistake it for gate evidence.
+
+## Why this is foundational (or not)
+
+**LOCAL.** Each is independently resolvable and none blocks other work. It is filed because the
+common shape — _a mechanism whose output stopped while its registration did not_ — is the same one
+that produces vacuous checks (HARNESS-064): something that looks live and is not.
+
+## Direction
+
+`.agents/archive/README.md` already states the retention policy — it archives _kinds_ of artefact,
+not finished work — so the decision is which of these are kinds worth keeping. For each of the three,
+choose one and write it down where the tree shows it:
+
+- **Retire**: move to `archive/`, delete the script, say why in the README.
+- **Resume**: fix the reason it stalled. For `daily-reports` that means the prose step, since the
+  evidence above says clock-driven-plus-prose is what failed.
+- **Demote**: keep it, and record in its README that it is not what a reader would assume — this is
+  the honest answer for `local-reviews`, which is a useful local cache and not gate evidence.
+
+Do NOT resolve this by deleting the directories quietly. The distinction between retired and stalled
+is the artefact this Task is about; deleting both erases it.
+
+## Test Plan
+
+- No behavioural regression to red-prove — this is a governance/asset decision, and saying so is
+  more honest than inventing an assertion.
+- If the outcome is a scan (e.g. "a registered generator whose output is older than N days must
+  declare itself retired"), that scan needs the usual red-first: a stalled generator must FAIL it,
+  proven before the scan is trusted.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Does not apply.** No user-facing surface.

--- a/.agents/tasks/HARNESS-067-non-neutrality-survived-the-diet.md
+++ b/.agents/tasks/HARNESS-067-non-neutrality-survived-the-diet.md
@@ -1,0 +1,83 @@
+---
+title: 'HARNESS-067: non-neutrality survived the diet that named it the dominant finding, and it fails as a silent pass'
+status: todo
+created: 2026-08-02
+priority: high
+urgency: next
+area: scripts/harness
+depends_on: []
+---
+
+# HARNESS-067: config and hardcoding coexist inside one file
+
+## Problem
+
+The harness presents itself as a general, portable tool. Repo-specific literals remain baked into it
+— and where they do, changing the thing they hardcode does not raise an error. It makes the rule
+match nothing, which reads as a pass.
+
+## Evidence
+
+From an external read-only investigation (2026-08-02), re-verified here: `check-dependency-direction.mjs`
+contains **13** occurrences of the literal `@robota-sdk/`.
+
+The instance the investigation isolated is the clearest possible form of the problem — **both idioms
+in one file**:
+
+```js
+// correctly reads config
+if (dep.startsWith(HARNESS.npmScopePrefix) && ...)
+
+// hardcoded, in the same file
+const reexportPattern = /export\s+\*\s+from\s+['"](@robota-sdk\/[^'"]+)['"]/g;
+```
+
+`HARNESS.npmScopePrefix` is right there. Change the scope and that one rule silently stops matching —
+**zero matches, reported as a pass**, which is HARNESS-064's vacuity arriving through a different
+door.
+
+This is not a new observation for this repo. `.agents/memory/harness-diet-audit.md` recorded it as
+the audit's **top finding**:
+
+> **Dominant finding: NON-NEUTRALITY** — Robota package names/paths/prose baked into machinery that
+> presents as a general/portable harness (north-star violation).
+> Fix pattern: move repo-specifics to config, keep the machinery generic.
+
+The diet completed on 2026-07-24. This instance is still here on 2026-08-02, which is what makes it
+worth a mechanism rather than another sweep: the sweep already happened.
+
+It also has a downstream cost. The investigation was written by a consumer evaluating this harness
+for adoption; residue like this is what they pay to port.
+
+## Why this is foundational (or not)
+
+**FOUNDATIONAL for the north-star, LOCAL as code.** Each literal is a one-line fix. What is
+foundational is that a completed audit named this the dominant finding and it recurred — so the
+answer is a check, not another pass over the files. The repo's own principle applies: a recurring
+mistake is not closed by fixing the instance.
+
+## Direction
+
+A scan that finds the product scope literal in harness scripts **except where it arrives through
+`harness-config`**. That shape is what catches the case above, where a correct use and a hardcoded
+use sit in the same file — a file-level allowlist would not.
+
+Two things to settle:
+
+- The scan must know its own scope literal without hardcoding it, or it becomes an instance of what
+  it checks. Reading it from the same config the scripts read is the obvious answer.
+- Test fixtures and documentation examples legitimately contain the literal. Decide whether they are
+  out of scope by path or need an explicit suppression, and prefer the narrower one.
+
+## Test Plan
+
+- **Required red-first regression:** a harness script with a hardcoded scope literal not routed
+  through config must FAIL. Prove it fails before the scan is trusted.
+- Red-first: the same script reading the literal from `harness-config` must PASS — otherwise the scan
+  is a blanket ban and will be suppressed rather than obeyed.
+- The scan must fail on itself if IT hardcodes the scope.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Does not apply.** No user-facing surface changes.

--- a/.agents/tasks/HARNESS-068-the-one-owner-rule-has-a-blind-spot.md
+++ b/.agents/tasks/HARNESS-068-the-one-owner-rule-has-a-blind-spot.md
@@ -1,0 +1,69 @@
+---
+title: 'HARNESS-068: the one-owner rule is enforced by a scan, and the second copy of the list sits just outside its reach'
+status: todo
+created: 2026-08-02
+priority: medium
+urgency: next
+area: scripts/harness, CONTRIBUTING.md
+depends_on: []
+---
+
+# HARNESS-068: where a rule has a mechanism, the mechanism's edge is the blind spot
+
+## Problem
+
+`AGENTS.md` states the rule:
+
+> **"Never duplicate content across levels. Each fact has exactly one owner document."**
+
+`.agents/project-structure.md` claims ownership of the package list, and
+`check-dependency-direction.mjs` Rule 9 enforces it — a package name in that document's prose that
+does not exist fails the build.
+
+`CONTRIBUTING.md` carries a second copy of the same list (**8 `- \`packages/…\`** entries, verified),
+and nothing checks it.
+
+So the repo holds the rule, holds a mechanism for the rule, violates the rule in its own root
+document, and the mechanism's scope stops one file short.
+
+## Evidence
+
+Raised by an external read-only investigation (2026-08-02); the count and the scan's scope were
+re-verified here.
+
+The general point is worth more than the instance: **once a rule acquires a mechanical check, the
+check's scope becomes the boundary of the rule.** Anything outside it is not merely unchecked — it is
+unchecked _while the rule reads as enforced_, which is more misleading than having no check at all.
+That is the same shape as HARNESS-064 (vacuity) and HARNESS-067 (non-neutrality's silent pass): the
+green is about narrower ground than the reader assumes.
+
+## Why this is foundational (or not)
+
+**LOCAL.** One file, one list. Filed because the class is worth a mechanism, not because the instance
+is costly.
+
+## Direction
+
+Two admissible answers, and the second is better:
+
+1. Extend `check-dependency-direction.mjs` Rule 9's scope to `CONTRIBUTING.md`.
+2. Delete the list from `CONTRIBUTING.md` and link to `.agents/project-structure.md`.
+
+The second obeys the rule instead of enforcing it in two places, and leaves nothing to drift. Option
+1 keeps two copies and makes a scan responsible for their agreement, which is the arrangement the
+one-owner rule exists to avoid.
+
+Worth checking while here: whether any OTHER root document carries a third copy. The instance was
+found by reading, not by a sweep, so the count of copies is unknown.
+
+## Test Plan
+
+- **Required red-first regression:** if the outcome is option 1, a package name in `CONTRIBUTING.md`
+  that does not exist must FAIL the scan — proven red before the scan is trusted. If the outcome is
+  option 2, the regression is that the list is gone: assert `CONTRIBUTING.md` contains no
+  `packages/*` enumeration, which fails today.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Does not apply.** Documentation and repo tooling only.

--- a/.agents/tasks/HARNESS-069-cleanup-drift-cannot-report-failure.md
+++ b/.agents/tasks/HARNESS-069-cleanup-drift-cannot-report-failure.md
@@ -1,0 +1,65 @@
+---
+title: 'HARNESS-069: `cleanup-drift` has no non-zero exit path at all — it cannot report a failure to anything that runs it'
+status: todo
+created: 2026-08-02
+priority: low
+urgency: later
+area: scripts/harness
+depends_on: []
+---
+
+# HARNESS-069: a script that can only succeed
+
+## Problem
+
+`scripts/harness/cleanup-drift.mjs` contains **neither `process.exit` nor `process.exitCode`** —
+verified, zero matches. Whatever it finds, it exits 0. It has no way to tell a caller that something
+was wrong.
+
+## Evidence
+
+Raised by an external read-only investigation (2026-08-02) and re-verified here:
+
+```
+$ grep -c "process.exit\|exitCode" scripts/harness/cleanup-drift.mjs
+0
+```
+
+**One correction to the report, made after checking.** The investigation wrote that this is vacuous
+_"if it is registered as a gate"_. It is **not** registered as a gate: it appears only as the
+`harness:cleanup` script in `package.json`, and is absent from `run-all-scans.mjs` and from every
+workflow in `.github/`. So the severity is lower than the finding reads — this is a utility that
+cannot signal failure, not a green gate over unchecked ground.
+
+That distinction is why this is filed separately at low priority rather than inside HARNESS-064.
+Recording it matters both ways: the finding is real, and it is smaller than stated.
+
+## Why this is foundational (or not)
+
+**LOCAL, and mild.** A cleanup utility run by hand may legitimately be advisory. The question is
+whether it is _intended_ to be — and nothing says so, which is the actual defect. A reader cannot
+distinguish "advisory by design" from "nobody added the exit path".
+
+## Direction
+
+Decide which it is and make the file say so.
+
+- If it should fail on drift it cannot clean: set `process.exitCode` and give it a test.
+- If it is advisory by design: say that in its header, and make sure nothing registers it as a gate
+  later without revisiting.
+
+Note the interaction with HARNESS-065: that Task converts `process.exit()` callers to
+`process.exitCode`. This script is in neither group, so a sweep over "scripts that call exit" will
+not reach it. A script with **no** exit path is invisible to a check that looks at how scripts exit.
+
+## Test Plan
+
+- If the outcome is a non-zero exit: **required red-first regression** — a drifted tree must produce
+  a non-zero exit, proven failing first.
+- If the outcome is "advisory by design": no code change, and no test to fabricate. Say so rather
+  than adding an assertion that pins nothing.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Does not apply.** Repo tooling only.


### PR DESCRIPTION
A downstream repository evaluating this harness for adoption investigated it read-only and wrote up what it found. These are the Tasks for it.

**Every number in the report was re-run here before writing a single Task, and all seven reproduced exactly** — 120 scripts, 137 tests, 37 exit-only, 36 export+exit, 40 vs 28 direct-execution guards, 24 untested, `cleanup-drift` with zero exit paths.

## The items

| ID | Finding | Priority |
|---|---|---|
| **HARNESS-064** | Vacuity was measured once at ~30 of 76 scans and nothing re-measures it | critical |
| **HARNESS-065** | Two idioms, and the fork is exactly the testable/untestable line | high |
| **HARNESS-066** | Machinery that stopped producing is still registered — "retired" and "stalled" are indistinguishable | medium |
| **HARNESS-067** | Non-neutrality survived the diet that named it the dominant finding | high |
| **HARNESS-068** | The one-owner rule has a mechanism, and the second copy of the list sits outside its reach | medium |
| **HARNESS-069** | `cleanup-drift` has no non-zero exit path at all | low |

## What makes three of these one finding

`scan-file-size` and `check-document-authority` can never fail. `agent-server-boundary` is *"satisfied vacuously by a never-called import"*. `check-dependency-direction` reads the scope from config and hardcodes it in a regex **in the same file**, so changing the scope makes that rule match nothing — reported as a pass. `CONTRIBUTING.md` violates a rule that has a scan, one file outside the scan's reach.

Same shape every time: **the green is about narrower ground than a reader assumes**. Each Task says so and links the others.

## The timing that makes HARNESS-064 the critical one

The diet audit completed **2026-07-24** with "dead/vacuous scan removal" marked done. The 30/76 measurement is dated **2026-07-26** — two days later. The diet removed the scripts that were dead; it did not remove the ones that were alive and checking nothing. The second kind is worse: the first is visibly absent, the second buys confidence on every CI run.

The repo already owns the engine — `scan-guard-scope-fail-closed` measures exactly this — and runs it by hand once rather than on every change.

## One correction to the report

It called `cleanup-drift` vacuous *"if it is registered as a gate"*. **It is not** — only a `harness:cleanup` script, absent from `run-all-scans` and from every workflow. The finding is real but smaller than it reads, so it is filed separately at low priority with the correction written into the Task rather than repeated.

## What the report got right that is worth keeping

Its § 9 observes that this repo's mechanisms carry the incident and the measurement that produced them, in their own headers — `governed-tree.mjs`'s *"30 of the 50 registered finders"*, `run-all-scans`'s note that an `&&` chain hid everything after the first failure. Its §§ 2, 4.1 and 5 are all things this repo wrote down about itself. A repository without that habit could not have been reviewed this precisely from outside.

Source report archived at `.agents/archive/audits/harness-external-review-2026-08-02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso