### PR TITLE
fix(transport): start() says which of its two meanings it has (ARCH-011 P1)

### DIFF
--- a/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
+++ b/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
@@ -1,6 +1,6 @@
 ---
 title: 'ARCH-011: `ITransportAdapter` is a four-member lifecycle stub, so six transports have each grown a private dialect and nothing mechanical can see the drift'
-status: todo
+status: in-progress
 created: 2026-08-02
 priority: critical
 urgency: now
@@ -129,3 +129,42 @@ without private dialects, and the scenario is to do it.
 - **Cleanup:** delete the scratch project.
 - **Evidence (fill in after implementation):** the consumer's source (showing no casts), and its
   console output across the three steps.
+
+## Progress
+
+### P1 — `start()` means one thing, and the deadlock is closed
+
+The synthesis lists this finding twice under theme T8, and the second listing is the one with a
+runnable failure: `ITransportAdapter.start()` meant "bind" in four implementations and "run to
+completion" in two, while `TransportRegistry.startAll` awaited each sequentially. Registering
+`headless` or `tui` first meant **every transport behind it never started** — no crash, no error,
+never reached.
+
+`start()` now says which it means: it resolves once the transport is SERVING. A transport whose whole
+job happens inside `start()` declares `runsToCompletion: true`, and the registry starts it without
+awaiting — keeping the promise, not dropping it, so `waitForCompletion()` is where its failure
+arrives. `headless-transport` and `tui-transport` declare it.
+
+`runsToCompletion` is optional, and that is a decision rather than an omission: "resolves once
+serving" is the ordinary case, so a transport that says nothing is asserting it, and the registry
+treats absence as `false` rather than guessing. That is the opposite call from ARCH-012's capability
+members, where silence had no safe reading — the difference is stated in the SPEC so the next reader
+does not have to infer which rule applies.
+
+Red-proved on both halves, separately: restoring the sequential await fails
+`expected 'pending' to be 'settled'`; dropping the promise instead of keeping it fails
+`promise resolved "undefined" instead of rejecting`.
+
+### Remaining — the conformance suite and the other axes
+
+The synthesis's direction has two parts and this is the first. What remains:
+
+- **The shared conformance suite** across all six transports, asserting one agreed answer per axis
+  (admission, cancellation verb, error shape, in-flight-on-disconnect, session surface). Without it
+  the contract still has as many meanings as it has adapters on those axes.
+- **The intersection types** (`& { getApp() }`, `& { getServer() }`, `& { onMessage }`,
+  `& { getExitCode() }`) that consumers depend on. The synthesis names narrowing them without
+  capability-scoped equivalents as the risk, and those equivalents are ARCH-012 P2.
+- **The capability gap** — HTTP exposing a subset of session methods, background-task/job-group/
+  execution-workspace WS-only. The synthesis says the new contract must be able to ASK this, not
+  necessarily answer it for every transport here.

--- a/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
+++ b/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
@@ -225,3 +225,21 @@ only. Same `if (current === ours)` check `TurnClaim.release` needed in RUNTIME-0
 
 **A rejection with no value was read as no failure.** `Promise.reject()` pushes `undefined`, and the
 `!== undefined` guard swallowed it. Presence, not equality.
+
+Third CI round, two SHOULDs, both about completeness rather than correctness.
+
+`agent-framework` was missing from the changeset although its public `IRuntimeHostHandle` gained a
+required member. Added.
+
+And the sharper one: **the failure route's real reach is narrower than the narrative.** `headless` —
+the transport that most obviously runs to completion — absorbs every failure inside its runner and
+always resolves, expressing failure through `getExitCode()`. So its actual failure mode does not
+reject and therefore never reaches `trackRunToCompletion` → `waitForCompletion` → serve-mode's
+`.catch`. The new tests use a synthetic `start()` that throws, which is a different shape from the
+one production has. The machinery is right for what it covers; the prose implied it covered more.
+Both SPEC and the transport header now say which channel carries what.
+
+**Open question recorded rather than answered:** should a run-to-completion transport be able to
+report failure BY RESULT (a non-zero exit code) as well as by rejection? Making `waitForCompletion`
+observe exit codes would change `headless`'s deliberate black-box contract (RUNTIME-001), so it is a
+design decision for the conformance-suite work, not a patch here.

--- a/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
+++ b/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
@@ -205,3 +205,23 @@ waiter — awaited signals alone. Exposing `IRuntimeHostHandle.waitForCompletion
 racing it is the same shape this branch fixed at the registry layer, one level up. It races it now;
 no run-to-completion transport is registered there today, and the wire is what stops that from
 mattering later.
+
+Second CI round, three more — and the first was a regression I introduced while fixing the previous
+round's SHOULD.
+
+**`--serve` tore itself down one microtask after it started serving.** Wiring
+`host.waitForCompletion()` into the process-lifetime wait, I settled on RESOLUTION as well as
+rejection. `waitForCompletion` resolves immediately when there is nothing to wait for, which is the
+ordinary case for `--serve` — so every ordinary run ended instantly. Only a FAILURE settles it now:
+`--serve`'s whole job is to stay alive until a signal or a host-executed exit. The binary e2e caught
+it (`serve host did not come up within 20000ms`), and that is the second time in this branch a fix
+for a review finding introduced a worse defect than the finding.
+
+**A stale settle deleted the CURRENT session's entry.** `this.running.delete(name)` keyed on the
+transport name with no ownership check, so a promise abandoned by `stopAll` could, on settling late,
+delete the entry a NEW session had put under the same name — and `waitForCompletion` would then
+resolve without waiting for work still in flight. The previous case covered the opposite ordering
+only. Same `if (current === ours)` check `TurnClaim.release` needed in RUNTIME-003.
+
+**A rejection with no value was read as no failure.** `Promise.reject()` pushes `undefined`, and the
+`!== undefined` guard swallowed it. Presence, not equality.

--- a/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
+++ b/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
@@ -189,3 +189,19 @@ Also: `stopAll` ignored the tracking entirely, so it reported success over live 
 `waitForCompletion` would hang on a transport whose `stop()` is a documented no-op. It abandons them
 explicitly, which is what makes its bounded best-effort contract honest — and what lets a session
 switch start from empty rather than overwrite a promise that then has no handler.
+
+CI review round: two more, and the first is the same class again.
+
+**A failure from a STOPPED session leaked into the next one.** `stopAll` emptied the failure array in
+place, but the handler attached to a still-in-flight `start()` cannot be detached — it fires after the
+stop and writes to whatever array it captured, which was the same instance the next session read. So
+"a later `startAll` starts from empty", which I had written into the code and the SPEC, was not true.
+The array is REPLACED now and the handler captures its own generation, so a stale write lands where
+nobody reads. The earlier stop case only exercised the resolve path; the new one rejects after the
+stop, and red-proves.
+
+**And the new route still had no production caller.** `serve-mode` — the `--serve` process-lifetime
+waiter — awaited signals alone. Exposing `IRuntimeHostHandle.waitForCompletion()` without anything
+racing it is the same shape this branch fixed at the registry layer, one level up. It races it now;
+no run-to-completion transport is registered there today, and the wire is what stops that from
+mattering later.

--- a/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
+++ b/.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md
@@ -168,3 +168,24 @@ The synthesis's direction has two parts and this is the first. What remains:
 - **The capability gap** — HTTP exposing a subset of session methods, background-task/job-group/
   execution-workspace WS-only. The synthesis says the new contract must be able to ASK this, not
   necessarily answer it for every transport here.
+
+### Review round — the failure route nothing could call
+
+Two MUSTs, both measured, and the second is this session's recurring class in a new shape.
+
+1. **`waitForCompletion()` was on the concrete registry only.** Both production `startAll` callers
+   hold `ITransportRegistryView`, which did not declare it, so neither could call it — and neither
+   did. The failure of a run-to-completion transport was stored in a map nothing could read, which is
+   WORSE than before, where `startAll` awaited it and the error reached the caller. It is on the view
+   now, and `IRuntimeHostHandle` exposes it to the caller that owns the process-lifetime wait.
+2. **Holding a promise is not handling it.** `this.running.set(name, transport.start())` keeps a
+   reference and attaches nothing, so a rejection between `startAll` returning and the caller reaching
+   `waitForCompletion` is an unhandled rejection — measured as exit code 1, bypassing shutdown. My
+   JSDoc and the SPEC both asserted the opposite. The handler is attached at start time now and the
+   outcome replayed, and the existing test could not have caught it because it awaited the two back to
+   back and never left the microtask drain. The new case puts a macrotask between them.
+
+Also: `stopAll` ignored the tracking entirely, so it reported success over live work and a subsequent
+`waitForCompletion` would hang on a transport whose `stop()` is a documented no-op. It abandons them
+explicitly, which is what makes its bounded best-effort contract honest — and what lets a session
+switch start from empty rather than overwrite a promise that then has no handler.

--- a/.changeset/arch-011-start-semantics.md
+++ b/.changeset/arch-011-start-semantics.md
@@ -2,6 +2,7 @@
 '@robota-sdk/agent-interface-transport': minor
 '@robota-sdk/agent-transport': minor
 '@robota-sdk/agent-transport-tui': minor
+'@robota-sdk/agent-framework': minor
 ---
 
 **ARCH-011: `ITransportAdapter.start()` now says which of its two meanings it has.**
@@ -30,8 +31,9 @@ const transport: ITransportAdapter = {
 
 `ITransportRegistryView` and `TransportRegistry` gain `waitForCompletion()`, which settles when every
 run-to-completion transport has finished and rejects with the first failure to occur — **any custom
-implementation of `ITransportRegistryView` must add it**. `IRuntimeHostHandle` gains the same method,
-so the caller that owns the process-lifetime wait can race it.
+implementation of `ITransportRegistryView` must add it**. `IRuntimeHostHandle` (`@robota-sdk/agent-framework`) gains the
+same method, so the caller that owns the process-lifetime wait can race it — **any consumer
+implementing or mocking that handle must add it**.
 
 The registry attaches the rejection handler when it starts such a transport rather than leaving it to
 whoever calls `waitForCompletion`: holding a promise is not handling it, and a rejection in the gap

--- a/.changeset/arch-011-start-semantics.md
+++ b/.changeset/arch-011-start-semantics.md
@@ -1,0 +1,36 @@
+---
+'@robota-sdk/agent-interface-transport': minor
+'@robota-sdk/agent-transport': minor
+'@robota-sdk/agent-transport-tui': patch
+---
+
+**ARCH-011: `ITransportAdapter.start()` now says which of its two meanings it has.**
+
+The contract said only `start(): Promise<void>`, and two readings coexisted. Four transports bound a
+port and returned; `headless` ran the entire prompt inside `start()` and `tui` blocked for the life of
+the UI. `TransportRegistry.startAll` awaited each in turn, so registering either of those first meant
+**every transport behind it never started** — no crash, no error, simply never reached.
+
+`start()` resolves once the transport is SERVING. A transport whose whole job happens inside `start()`
+declares the new optional `runsToCompletion: true`, and the registry starts it without awaiting:
+
+```ts
+const transport: ITransportAdapter = {
+  name: 'my-runner',
+  runsToCompletion: true, // start() does not return while this is alive
+  attach(session) {
+    /* … */
+  },
+  async start() {
+    await this.runEverything();
+  },
+  async stop() {},
+};
+```
+
+`TransportRegistry` gains `waitForCompletion()`, which settles when every run-to-completion transport
+has finished and rejects with the first failure. The promise is kept rather than dropped, because a
+transport whose entire job is inside `start()` is exactly the one whose failure matters.
+
+Existing transports need no change: absence of `runsToCompletion` means the ordinary "resolves once
+serving", which is what four of the six already did.

--- a/.changeset/arch-011-start-semantics.md
+++ b/.changeset/arch-011-start-semantics.md
@@ -1,7 +1,7 @@
 ---
 '@robota-sdk/agent-interface-transport': minor
 '@robota-sdk/agent-transport': minor
-'@robota-sdk/agent-transport-tui': patch
+'@robota-sdk/agent-transport-tui': minor
 ---
 
 **ARCH-011: `ITransportAdapter.start()` now says which of its two meanings it has.**
@@ -28,9 +28,15 @@ const transport: ITransportAdapter = {
 };
 ```
 
-`TransportRegistry` gains `waitForCompletion()`, which settles when every run-to-completion transport
-has finished and rejects with the first failure. The promise is kept rather than dropped, because a
-transport whose entire job is inside `start()` is exactly the one whose failure matters.
+`ITransportRegistryView` and `TransportRegistry` gain `waitForCompletion()`, which settles when every
+run-to-completion transport has finished and rejects with the first failure to occur — **any custom
+implementation of `ITransportRegistryView` must add it**. `IRuntimeHostHandle` gains the same method,
+so the caller that owns the process-lifetime wait can race it.
+
+The registry attaches the rejection handler when it starts such a transport rather than leaving it to
+whoever calls `waitForCompletion`: holding a promise is not handling it, and a rejection in the gap
+aborts the process. `stopAll()` abandons in-flight run-to-completion transports, since `stop()` is a
+no-op for both of them.
 
 Existing transports need no change: absence of `runsToCompletion` means the ordinary "resolves once
 serving", which is what four of the six already did.

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -161,6 +161,19 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
     const onSignal = (signal: NodeJS.Signals): void => settle(`received ${signal}`);
     process.once('SIGTERM', onSignal);
     process.once('SIGINT', onSignal);
+    // ARCH-011: a run-to-completion transport is started without being awaited, so this is the only
+    // thing watching it. Without this the process-lifetime wait would sit on signals alone while such
+    // a transport failed unobserved — the same "route nothing calls" shape the registry layer fixed.
+    // No such transport is registered here today; the wire is what stops that from mattering later.
+    void host
+      .waitForCompletion()
+      .then(() => settle('all run-to-completion transports finished'))
+      .catch((error: unknown) => {
+        process.stderr.write(
+          `transport failed: ${error instanceof Error ? error.message : String(error)}\n`,
+        );
+        settle('a transport failed');
+      });
     // CMD-004 Phase 2 (Stage B): late-bound serve-mode process adapter. A host-executed exit or
     // restart terminates the SHARED host serving ALL attached surfaces — the deliberate
     // local == remote decision (REMOTE-006): a remote driver is a full driver; a surface that only

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -162,18 +162,16 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
     process.once('SIGTERM', onSignal);
     process.once('SIGINT', onSignal);
     // ARCH-011: a run-to-completion transport is started without being awaited, so this is the only
-    // thing watching it. Without this the process-lifetime wait would sit on signals alone while such
-    // a transport failed unobserved — the same "route nothing calls" shape the registry layer fixed.
-    // No such transport is registered here today; the wire is what stops that from mattering later.
-    void host
-      .waitForCompletion()
-      .then(() => settle('all run-to-completion transports finished'))
-      .catch((error: unknown) => {
-        process.stderr.write(
-          `transport failed: ${error instanceof Error ? error.message : String(error)}\n`,
-        );
-        settle('a transport failed');
-      });
+    // thing watching it. ONLY A FAILURE settles the wait — `--serve`'s whole job is to stay alive
+    // until a signal or a host-executed exit, and `waitForCompletion()` RESOLVES IMMEDIATELY when
+    // there is nothing to wait for, which is the ordinary case here. Settling on resolution too meant
+    // every ordinary `--serve` run tore itself down one microtask after it started serving; the
+    // binary e2e caught it (`serve host did not come up within 20000ms`).
+    void host.waitForCompletion().catch((error: unknown) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`transport failed: ${detail}\n`);
+      settle('a transport failed');
+    });
     // CMD-004 Phase 2 (Stage B): late-bound serve-mode process adapter. A host-executed exit or
     // restart terminates the SHARED host serving ALL attached surfaces — the deliberate
     // local == remote decision (REMOTE-006): a remote driver is a full driver; a surface that only

--- a/packages/agent-framework/src/runtime/runtime-host.ts
+++ b/packages/agent-framework/src/runtime/runtime-host.ts
@@ -41,6 +41,15 @@ export interface IRuntimeHostHandle {
   readonly session: InteractiveSession;
   /** Stop the transports and shut the session down (bounded); idempotent. */
   shutdown(message?: string): Promise<void>;
+  /**
+   * Settle when every run-to-completion transport has finished, rejecting with the first failure
+   * (ARCH-011). Resolves immediately when there are none, which is the ordinary case.
+   *
+   * The caller owns the process-lifetime wait; this is what it races that wait against, so a
+   * transport whose entire job happens inside `start()` cannot fail unobserved. Without it the
+   * failure would sit in the registry with nothing able to ask for it.
+   */
+  waitForCompletion(): Promise<void>;
 }
 
 /**
@@ -56,6 +65,9 @@ export async function startRuntimeHost(opts: IRuntimeHostOptions): Promise<IRunt
   let stopped = false;
   return {
     session,
+    async waitForCompletion(): Promise<void> {
+      await opts.transportRegistry?.waitForCompletion();
+    },
     async shutdown(message = 'runtime host stopped'): Promise<void> {
       if (stopped) return;
       stopped = true;

--- a/packages/agent-interface-transport/docs/SPEC.md
+++ b/packages/agent-interface-transport/docs/SPEC.md
@@ -51,13 +51,13 @@ agent-transport
 
 Types owned by this package (SSOT):
 
-| Type                     | Kind      | File                   | Description                                                                                          |
-| ------------------------ | --------- | ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `ITransportAdapter`      | Interface | `transport-adapter.ts` | Core transport lifecycle: `name`, `attach(session: TSession)`, `start()`, `stop()`                   |
-| `ITransportConfig`       | Interface | `transport-config.ts`  | Persisted config shape: `{ enabled: boolean; options?: Record<string, unknown> }`                    |
-| `IConfigurableTransport` | Interface | `transport-config.ts`  | Extends `ITransportAdapter` with `defaultEnabled`, `optionsSchema`, and optional `validateOptions()` |
-| `ITransportEntry`        | Interface | `transport-config.ts`  | `{ transport: IConfigurableTransport<T>; config: ITransportConfig }` — registry item shape           |
-| `ITransportRegistryView` | Interface | `transport-config.ts`  | `getAll()`, `setEnabled()`, `startAll()`, `stopAll()` — registry management contract                 |
+| Type                     | Kind      | File                   | Description                                                                                              |
+| ------------------------ | --------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| `ITransportAdapter`      | Interface | `transport-adapter.ts` | Core transport lifecycle: `name`, `attach(session)`, `start()`, `stop()`, `runsToCompletion?` (ARCH-011) |
+| `ITransportConfig`       | Interface | `transport-config.ts`  | Persisted config shape: `{ enabled: boolean; options?: Record<string, unknown> }`                        |
+| `IConfigurableTransport` | Interface | `transport-config.ts`  | Extends `ITransportAdapter` with `defaultEnabled`, `optionsSchema`, and optional `validateOptions()`     |
+| `ITransportEntry`        | Interface | `transport-config.ts`  | `{ transport: IConfigurableTransport<T>; config: ITransportConfig }` — registry item shape               |
+| `ITransportRegistryView` | Interface | `transport-config.ts`  | `getAll()`, `setEnabled()`, `startAll()`, `stopAll()` — registry management contract                     |
 
 In addition to the transport-adapter contracts above, the package owns several further contract
 groups, each in its own file (all re-exported from `src/index.ts`):
@@ -146,13 +146,34 @@ export interface ITransportAdapter<TSession = unknown> {
   attach(session: TSession): void;
   start(): Promise<void>;
   stop(): Promise<void>;
+  readonly runsToCompletion?: boolean;
 }
 ```
 
 - `name` — unique human-readable identifier (e.g., `'ws'`, `'tui'`, `'headless'`)
 - `attach()` — called before `start()` to bind the transport to a session
-- `start()` — begin serving; idempotent
+- `start()` — begin serving; idempotent. **Resolves once the transport is SERVING, not when its work
+  is done** — unless it declares `runsToCompletion`
 - `stop()` — stop serving and release resources; idempotent
+- `runsToCompletion` — `true` when `start()` does not return while the transport is alive
+
+#### What `start()` means, and why it had to be said (ARCH-011)
+
+The contract used to say only `start(): Promise<void>`, and two readings coexisted. Four transports
+bound a port and returned. `headless` ran the entire prompt inside `start()`; `tui` blocked for the
+life of the UI. `TransportRegistry.startAll` awaited each in turn, so registering either of those
+first meant **every transport behind it never started** — no crash, no error, simply never reached.
+
+A transport whose whole job happens inside `start()` declares `runsToCompletion: true`, and the
+registry starts it without awaiting. Its promise is kept, not dropped: `TransportRegistry.waitForCompletion()`
+is where its result and its failure arrive, because the transport whose entire job is inside `start()`
+is exactly the one whose failure matters, and an unawaited rejection would be an unhandled promise
+rather than a reported error.
+
+`runsToCompletion` is the ONE optional member on this contract, and deliberately so: "resolves once
+serving" is the ordinary case, a transport that omits it is asserting that meaning, and the registry
+treats absence as `false` rather than guessing. Contrast `IInteractiveSession`'s capability members
+(ARCH-012), where silence had no safe reading and optionality was removed.
 
 ### `ITransportConfig`
 

--- a/packages/agent-interface-transport/docs/SPEC.md
+++ b/packages/agent-interface-transport/docs/SPEC.md
@@ -172,7 +172,14 @@ rather than a reported error.
 
 The route is wired: `ITransportRegistryView.waitForCompletion()` carries it, and
 `IRuntimeHostHandle.waitForCompletion()` exposes it to the caller that owns the process-lifetime
-wait. The first draft put the method on the concrete registry alone, where neither production caller
+wait.
+
+**What it actually covers**, stated because the apparatus is easy to read as wider than it is: a
+transport whose `start()` REJECTS. `headless` — the transport that most obviously runs to completion —
+absorbs every failure inside its runner and always resolves, expressing failure through
+`getExitCode()` instead; so it does not use this route today, and a non-zero exit code is not a
+rejection. Whether a run-to-completion transport should be able to report failure by result as well
+as by rejection is an open question recorded on ARCH-011, not something this contract answers. The first draft put the method on the concrete registry alone, where neither production caller
 — both hold the view — could reach it; a failure route nothing can call is not a route.
 
 `runsToCompletion` is the ONE optional member on this contract, and deliberately so: "resolves once

--- a/packages/agent-interface-transport/docs/SPEC.md
+++ b/packages/agent-interface-transport/docs/SPEC.md
@@ -170,6 +170,11 @@ is where its result and its failure arrive, because the transport whose entire j
 is exactly the one whose failure matters, and an unawaited rejection would be an unhandled promise
 rather than a reported error.
 
+The route is wired: `ITransportRegistryView.waitForCompletion()` carries it, and
+`IRuntimeHostHandle.waitForCompletion()` exposes it to the caller that owns the process-lifetime
+wait. The first draft put the method on the concrete registry alone, where neither production caller
+— both hold the view — could reach it; a failure route nothing can call is not a route.
+
 `runsToCompletion` is the ONE optional member on this contract, and deliberately so: "resolves once
 serving" is the ordinary case, a transport that omits it is asserting that meaning, and the registry
 treats absence as `false` rather than guessing. Contrast `IInteractiveSession`'s capability members

--- a/packages/agent-interface-transport/src/transport-adapter.ts
+++ b/packages/agent-interface-transport/src/transport-adapter.ts
@@ -7,6 +7,30 @@
 export interface ITransportAdapter<TSession = unknown> {
   readonly name: string;
   attach(session: TSession): void;
+
+  /**
+   * Begin serving. RESOLVES ONCE THE TRANSPORT IS SERVING, not when its work is done — unless
+   * `runsToCompletion` says otherwise.
+   *
+   * ARCH-011: the contract used to say only `start(): Promise<void>`, and two readings coexisted.
+   * Four transports bound a port and returned; `headless` ran the entire prompt inside `start()` and
+   * `tui` blocked for the life of the UI. `TransportRegistry.startAll` awaited each in turn, so
+   * registering either of those first meant every transport behind it never started — no crash, no
+   * error, simply never reached.
+   *
+   * A transport whose whole job happens inside `start()` declares `runsToCompletion`, and the
+   * registry starts it without waiting for it to finish.
+   */
   start(): Promise<void>;
   stop(): Promise<void>;
+
+  /**
+   * True when `start()` does not return while the transport is alive — it runs the work to
+   * completion, or blocks for the lifetime of a UI.
+   *
+   * Optional because "resolves once serving" is the ordinary case and the overwhelming majority; a
+   * transport that omits this is asserting the ordinary meaning. It is the ONE axis where silence has
+   * a safe reading, and the registry treats an absent value as `false` rather than guessing.
+   */
+  readonly runsToCompletion?: boolean;
 }

--- a/packages/agent-interface-transport/src/transport-config.ts
+++ b/packages/agent-interface-transport/src/transport-config.ts
@@ -25,6 +25,16 @@ export interface ITransportRegistryView<TSession = unknown> {
   getAll(): ITransportEntry<TSession>[];
   setEnabled(name: string, enabled: boolean): Promise<void>;
   startAll(session: TSession): Promise<void>;
+  /**
+   * Settle when every run-to-completion transport has finished, rejecting with the first failure to
+   * occur. Resolves immediately when there are none, which is the ordinary case.
+   *
+   * ARCH-011: on the VIEW, not only the concrete registry. A run-to-completion transport is started
+   * without being awaited, so this is the only place its failure can arrive — and the first draft put
+   * it on the class alone, where the two production callers, which both hold this view, could not
+   * reach it. A failure route nothing can call is not a route.
+   */
+  waitForCompletion(): Promise<void>;
   /** Best-effort: never rejects; per-transport stop failures come back in the result (CORE-013). */
   stopAll(): Promise<IDestroyResult>;
 }

--- a/packages/agent-transport-tui/src/tui-transport.ts
+++ b/packages/agent-transport-tui/src/tui-transport.ts
@@ -21,6 +21,9 @@ export class TuiTransport implements IConfigurableTransport<IInteractiveSession>
     // TuiTransport creates its own InteractiveSession internally via TuiInteractionChannel.
   }
 
+  /** ARCH-011: blocks for the life of the UI — declared so `startAll` does not wait for it. */
+  readonly runsToCompletion = true;
+
   async start(): Promise<void> {
     await renderApp(this.options);
   }

--- a/packages/agent-transport/docs/SPEC.md
+++ b/packages/agent-transport/docs/SPEC.md
@@ -164,5 +164,22 @@ delegated to the runner. Does not own interactive UI.
 ### `TransportRegistry`
 
 `register(transport)`, `getAll()`, `getEnabled()`, `setEnabled(name, enabled)`,
-`setOptions(name, options)`, `startAll(session)`, `stopAll()`. Reads/writes the `transports` block of
-a settings file at the path supplied to the constructor. Holds no concrete-transport import.
+`setOptions(name, options)`, `startAll(session)`, `waitForCompletion()`, `stopAll()`. Reads/writes the
+`transports` block of a settings file at the path supplied to the constructor. Holds no
+concrete-transport import.
+
+**Run-to-completion transports (ARCH-011).** `startAll` does not await a transport that declares
+`ITransportAdapter.runsToCompletion` — its `start()` does not return while it is alive, and awaiting
+it meant every transport registered behind it never started. The registry takes ownership of that
+promise: the rejection handler is attached at start time, not left to whoever calls
+`waitForCompletion` later, because merely holding a reference is not handling it and a rejection in
+the gap aborts the process.
+
+`waitForCompletion()` settles when every such transport has finished and rejects with the first
+failure to occur. It is on `ITransportRegistryView`, not only on this class, so the consumers that
+hold the view can actually reach it.
+
+`stopAll()` ABANDONS in-flight run-to-completion transports rather than awaiting them. `stop()` is a
+documented no-op for both of the transports that declare it, so awaiting would make `stopAll` neither
+bounded nor best-effort; abandoning also means a later `startAll` — a session switch does exactly
+this — starts from empty rather than overwriting a tracked promise.

--- a/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
+++ b/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
@@ -62,7 +62,7 @@ function blockingTransport(
     stop: async () => {},
     // ARCH-011: the declaration that makes the difference visible to the registry.
     runsToCompletion: true,
-  } as IConfigurableTransport<IInteractiveSession> & { release: () => void };
+  };
 }
 
 /** A registry over a real, empty settings file — `/dev/null` is not valid JSON. */
@@ -126,7 +126,7 @@ describe('startAll starts every transport (ARCH-011)', () => {
     // `start()` is exactly the one whose failure matters, and an unawaited rejection would be an
     // unhandled promise rather than a reported error.
     const registry = registryOverTempSettings();
-    const failing = {
+    const failing: IConfigurableTransport<IInteractiveSession> = {
       name: 'headless',
       defaultEnabled: true,
       attach: vi.fn(),
@@ -135,11 +135,52 @@ describe('startAll starts every transport (ARCH-011)', () => {
       },
       stop: async () => {},
       runsToCompletion: true,
-    } as unknown as IConfigurableTransport<IInteractiveSession>;
+    };
     registry.register(failing);
 
     await registry.startAll(createTestInteractiveSession());
 
     await expect(registry.waitForCompletion()).rejects.toThrow(/prompt failed/);
+  });
+
+  it('holds a failure across a MACROTASK — the shape a real consumer has', async () => {
+    // The window the first draft left open. Storing the promise is not attaching a handler: a
+    // rejection between `startAll` returning and the caller reaching `waitForCompletion` was an
+    // unhandled rejection, which on Node ≥15 aborts the process. Review measured exit code 1, with
+    // `startAll` having already resolved OK. The previous case awaited the two back to back and so
+    // never left the microtask drain, which is exactly why it did not catch this.
+    const registry = registryOverTempSettings();
+    registry.register({
+      name: 'headless',
+      defaultEnabled: true,
+      attach: vi.fn(),
+      start: async () => {
+        throw new Error('prompt failed');
+      },
+      stop: async () => {},
+      runsToCompletion: true,
+    });
+
+    await registry.startAll(createTestInteractiveSession());
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await expect(registry.waitForCompletion()).rejects.toThrow(/prompt failed/);
+  });
+
+  it('a stopped registry does not wait on work nobody will finish', async () => {
+    // `stop()` is a documented no-op for both run-to-completion transports, so awaiting them after
+    // `stopAll` would hang forever. Abandoning them is what makes `stopAll`'s bounded, best-effort
+    // contract honest — and it is what lets a session switch start from empty rather than
+    // overwriting a promise that then has no handler.
+    const started: string[] = [];
+    const registry = registryOverTempSettings();
+    const blocking = blockingTransport('tui', started);
+    registry.register(blocking);
+
+    await registry.startAll(createTestInteractiveSession());
+    await registry.stopAll();
+
+    expect(await within(registry.waitForCompletion())).toBe('settled');
+    blocking.release();
   });
 });

--- a/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
+++ b/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
@@ -183,4 +183,44 @@ describe('startAll starts every transport (ARCH-011)', () => {
     expect(await within(registry.waitForCompletion())).toBe('settled');
     blocking.release();
   });
+
+  it('a failure that arrives AFTER a stop does not leak into the next session', async () => {
+    // The handler attached to an in-flight `start()` cannot be detached, so it fires after the stop.
+    // Emptying the failure array in place left that write landing in the same instance the NEXT
+    // session read, and a failure from a stopped session was thrown as if it belonged to the current
+    // one — contradicting "a later startAll starts from empty". A session switch is exactly this
+    // shape, and the earlier stop case only exercised the resolve path.
+    const registry = registryOverTempSettings();
+    let failFirst!: (error: Error) => void;
+    let run = 0;
+    registry.register({
+      name: 'headless',
+      defaultEnabled: true,
+      attach: vi.fn(),
+      // A fresh promise per start, as a real transport gives: the FIRST session's fails, the second
+      // is healthy. Returning one shared promise would make the second session fail on its own
+      // account and prove nothing about leakage.
+      start: () => {
+        run += 1;
+        return run === 1
+          ? new Promise<void>((_resolve, reject) => {
+              failFirst = reject;
+            })
+          : Promise.resolve();
+      },
+      stop: async () => {},
+      runsToCompletion: true,
+    });
+
+    await registry.startAll(createTestInteractiveSession());
+    await registry.stopAll();
+
+    // The stopped session's transport fails only now.
+    failFirst(new Error('previous session died'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // A new session starts on the same registry, and finishes cleanly.
+    await registry.startAll(createTestInteractiveSession());
+    await expect(registry.waitForCompletion()).resolves.toBeUndefined();
+  });
 });

--- a/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
+++ b/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
@@ -223,4 +223,56 @@ describe('startAll starts every transport (ARCH-011)', () => {
     await registry.startAll(createTestInteractiveSession());
     await expect(registry.waitForCompletion()).resolves.toBeUndefined();
   });
+
+  it("a STALE settle does not drop the current session's entry for the same transport", async () => {
+    // The ordering the previous case did not cover. Session A starts `headless`; `stopAll` abandons
+    // it while its promise is still live; session B starts the same-named transport; only THEN does
+    // A's promise settle. Deleting by name alone dropped B's entry, and `waitForCompletion` resolved
+    // without waiting for work that was still in flight — silently losing the guarantee this whole
+    // change exists to add.
+    const registry = registryOverTempSettings();
+    const finishers: Array<() => void> = [];
+    registry.register({
+      name: 'headless',
+      defaultEnabled: true,
+      attach: vi.fn(),
+      start: () =>
+        new Promise<void>((resolve) => {
+          finishers.push(resolve);
+        }),
+      stop: async () => {},
+      runsToCompletion: true,
+    });
+
+    await registry.startAll(createTestInteractiveSession()); // session A
+    await registry.stopAll();
+    await registry.startAll(createTestInteractiveSession()); // session B, same name
+
+    finishers[0]?.(); // A settles LATE
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // B is still running, so this must NOT settle yet.
+    expect(await within(registry.waitForCompletion(), 100)).toBe('pending');
+
+    finishers[1]?.();
+    expect(await within(registry.waitForCompletion())).toBe('settled');
+  });
+
+  it('a rejection with no value is still a failure', async () => {
+    // `Promise.reject()` pushes `undefined`, and an `!== undefined` check read that as "no failure".
+    const registry = registryOverTempSettings();
+    registry.register({
+      name: 'headless',
+      defaultEnabled: true,
+      attach: vi.fn(),
+      start: () => Promise.reject(),
+      stop: async () => {},
+      runsToCompletion: true,
+    });
+
+    await registry.startAll(createTestInteractiveSession());
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await expect(registry.waitForCompletion()).rejects.toBeUndefined();
+  });
 });

--- a/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
+++ b/packages/agent-transport/src/__tests__/transport-registry.start-all.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TransportRegistry } from '../transport-registry.js';
+
+import type {
+  IConfigurableTransport,
+  IInteractiveSession,
+} from '@robota-sdk/agent-interface-transport';
+
+/**
+ * ARCH-011 — `start()` did not mean the same thing in every transport, and `startAll` awaited each
+ * one in turn.
+ *
+ * Four transports treat `start()` as BIND: attach to a port, return, keep serving. Two treat it as
+ * RUN TO COMPLETION — `headless-transport.ts` runs the whole prompt inside it, and
+ * `tui-transport.ts` blocks for the life of the UI. `startAll` awaited them sequentially, so
+ * registering either one first meant every transport behind it never started at all. Not a crash, not
+ * an error: they were simply never reached, and nothing said so.
+ *
+ * The contract said only `start(): Promise<void>`, which is why two readings of it could coexist for
+ * as long as they did. It says which one it means now, and a transport that runs to completion
+ * declares itself so the registry can start it without blocking the rest.
+ */
+function bindingTransport(
+  name: string,
+  started: string[],
+): IConfigurableTransport<IInteractiveSession> {
+  return {
+    name,
+    defaultEnabled: true,
+    attach: vi.fn(),
+    start: async () => {
+      started.push(name);
+    },
+    stop: async () => {},
+  };
+}
+
+/** The shape `headless` and `tui` have: `start()` does not return while the transport is alive. */
+function blockingTransport(
+  name: string,
+  started: string[],
+): IConfigurableTransport<IInteractiveSession> & { release: () => void } {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    name,
+    defaultEnabled: true,
+    release,
+    attach: vi.fn(),
+    start: async () => {
+      started.push(name);
+      await held;
+    },
+    stop: async () => {},
+    // ARCH-011: the declaration that makes the difference visible to the registry.
+    runsToCompletion: true,
+  } as IConfigurableTransport<IInteractiveSession> & { release: () => void };
+}
+
+/** A registry over a real, empty settings file — `/dev/null` is not valid JSON. */
+function registryOverTempSettings(): TransportRegistry {
+  const dir = mkdtempSync(path.join(tmpdir(), 'transport-registry-'));
+  const file = path.join(dir, 'settings.json');
+  writeFileSync(file, '{}');
+  tempDirs.push(dir);
+  return new TransportRegistry(file);
+}
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Settle or report that it did not — never hang the suite to make a point about hanging. */
+async function within<T>(promise: Promise<T>, ms = 250): Promise<'settled' | 'pending'> {
+  let timer: ReturnType<typeof setTimeout>;
+  const pending = new Promise<'pending'>((resolve) => {
+    timer = setTimeout(() => resolve('pending'), ms);
+  });
+  try {
+    return await Promise.race([promise.then(() => 'settled' as const), pending]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+describe('startAll starts every transport (ARCH-011)', () => {
+  it('a transport whose start() runs to completion does not block the ones behind it', async () => {
+    const started: string[] = [];
+    const registry = registryOverTempSettings();
+    const blocking = blockingTransport('headless', started);
+    registry.register(blocking);
+    registry.register(bindingTransport('http', started));
+
+    const outcome = await within(registry.startAll(createTestInteractiveSession()));
+
+    // Against the defect this is `'pending'`, and `started` is `['headless']` — the HTTP transport
+    // was never reached.
+    expect(outcome).toBe('settled');
+    expect(started).toEqual(['headless', 'http']);
+
+    blocking.release();
+  });
+
+  it('still starts a purely binding set in order, and awaits each', async () => {
+    const started: string[] = [];
+    const registry = registryOverTempSettings();
+    registry.register(bindingTransport('http', started));
+    registry.register(bindingTransport('ws', started));
+
+    expect(await within(registry.startAll(createTestInteractiveSession()))).toBe('settled');
+    expect(started).toEqual(['http', 'ws']);
+  });
+
+  it('surfaces a run-to-completion transport that FAILS, rather than losing it', async () => {
+    // Not awaiting it must not mean not watching it. A transport whose whole job happens inside
+    // `start()` is exactly the one whose failure matters, and an unawaited rejection would be an
+    // unhandled promise rather than a reported error.
+    const registry = registryOverTempSettings();
+    const failing = {
+      name: 'headless',
+      defaultEnabled: true,
+      attach: vi.fn(),
+      start: async () => {
+        throw new Error('prompt failed');
+      },
+      stop: async () => {},
+      runsToCompletion: true,
+    } as unknown as IConfigurableTransport<IInteractiveSession>;
+    registry.register(failing);
+
+    await registry.startAll(createTestInteractiveSession());
+
+    await expect(registry.waitForCompletion()).rejects.toThrow(/prompt failed/);
+  });
+});

--- a/packages/agent-transport/src/headless/headless-transport.ts
+++ b/packages/agent-transport/src/headless/headless-transport.ts
@@ -3,6 +3,11 @@
  *
  * Wraps createHeadlessRunner into the unified ITransportAdapter interface.
  * After start() completes, getExitCode() returns the runner's exit code.
+ *
+ * ARCH-011: this transport declares `runsToCompletion`, so a registry does not await it — read
+ * `getExitCode()` only after `waitForCompletion()`, never straight after `startAll()`. Note that the
+ * runner ABSORBS failures and always resolves, so failure arrives here as a non-zero exit code and
+ * never as a rejection: `waitForCompletion()` will not report it.
  */
 
 import { createHeadlessRunner } from './headless-runner.js';

--- a/packages/agent-transport/src/headless/headless-transport.ts
+++ b/packages/agent-transport/src/headless/headless-transport.ts
@@ -28,6 +28,9 @@ export function createHeadlessTransport(
     attach(s: IInteractiveSession) {
       session = s;
     },
+    // ARCH-011: `start()` here runs the entire prompt. Declared, so `startAll` does not await it and
+    // block every transport registered behind this one.
+    runsToCompletion: true,
     async start() {
       if (!session) throw new Error('No session attached. Call attach() first.');
       const runner = createHeadlessRunner({ session, outputFormat: options.outputFormat });

--- a/packages/agent-transport/src/transport-registry.ts
+++ b/packages/agent-transport/src/transport-registry.ts
@@ -18,6 +18,8 @@ import type {
 export class TransportRegistry {
   private readonly entries = new Map<string, IConfigurableTransport<IInteractiveSession>>();
   private readonly settingsPath: string;
+  /** ARCH-011: in-flight `start()` promises of run-to-completion transports, by name. */
+  private readonly running = new Map<string, Promise<void>>();
 
   constructor(settingsPath: string) {
     this.settingsPath = settingsPath;
@@ -59,12 +61,35 @@ export class TransportRegistry {
     writeSettings(this.settingsPath, settings);
   }
 
+  /**
+   * Start every enabled transport. ARCH-011.
+   *
+   * A transport that declares `runsToCompletion` is started WITHOUT being awaited — its `start()`
+   * does not return while it is alive, and awaiting it meant every transport behind it never
+   * started. Its promise is kept, not dropped: `waitForCompletion()` is where its result and its
+   * failure arrive, because a transport whose entire job happens inside `start()` is exactly the one
+   * whose failure matters, and an unawaited rejection would be an unhandled promise instead of a
+   * reported error.
+   */
   async startAll(session: IInteractiveSession): Promise<void> {
     const enabled = this.getEnabled();
     for (const transport of enabled) {
       transport.attach(session);
+      if (transport.runsToCompletion === true) {
+        this.running.set(transport.name, transport.start());
+        continue;
+      }
       await transport.start();
     }
+  }
+
+  /**
+   * Settle when every run-to-completion transport has finished, rejecting with the first failure.
+   *
+   * Resolves immediately when there are none, which is the ordinary case.
+   */
+  async waitForCompletion(): Promise<void> {
+    await Promise.all([...this.running.values()]);
   }
 
   /**

--- a/packages/agent-transport/src/transport-registry.ts
+++ b/packages/agent-transport/src/transport-registry.ts
@@ -110,15 +110,20 @@ export class TransportRegistry {
     // Captured at TRACK time. A stop replaces `this.failures`, so a handler that fires afterwards
     // records into the array of the generation it belonged to — which nobody reads.
     const sink = this.failures;
-    const tracked = promise.then(
-      () => {
+    // Deleted only if it is still OURS. The key is the transport name, and a stale promise from a
+    // stopped session settles late — deleting by name alone would drop the CURRENT session's entry
+    // for the same transport, and `waitForCompletion` would then resolve without waiting for work
+    // that is still in flight.
+    let tracked: Promise<void>;
+    const clearIfOurs = (): void => {
+      if (this.running.get(name) === tracked) {
         this.running.delete(name);
-      },
-      (error: unknown) => {
-        this.running.delete(name);
-        sink.push(error);
-      },
-    );
+      }
+    };
+    tracked = promise.then(clearIfOurs, (error: unknown) => {
+      clearIfOurs();
+      sink.push(error);
+    });
     this.running.set(name, tracked);
   }
 
@@ -128,9 +133,10 @@ export class TransportRegistry {
    */
   async waitForCompletion(): Promise<void> {
     await Promise.all([...this.running.values()]);
-    const first = this.failures.shift();
-    if (first !== undefined) {
-      throw first;
+    // Presence, not `!== undefined`: `Promise.reject()` with no value pushes `undefined`, and an
+    // equality check would read that as "no failure" and swallow it.
+    if (this.failures.length > 0) {
+      throw this.failures.shift();
     }
   }
 

--- a/packages/agent-transport/src/transport-registry.ts
+++ b/packages/agent-transport/src/transport-registry.ts
@@ -20,8 +20,16 @@ export class TransportRegistry {
   private readonly settingsPath: string;
   /** ARCH-011: in-flight `start()` promises of run-to-completion transports, by name. */
   private readonly running = new Map<string, Promise<void>>();
-  /** Failures of run-to-completion transports, held until `waitForCompletion` asks for them. */
-  private readonly failures: unknown[] = [];
+  /**
+   * Failures of run-to-completion transports, held until `waitForCompletion` asks for them.
+   *
+   * REPLACED on `stopAll`, not emptied. A handler attached to a still-in-flight `start()` cannot be
+   * detached, so it fires after the stop and writes to whatever array it captured. Emptying the array
+   * in place left that write landing in the SAME instance a later session was reading, so a failure
+   * from a stopped session was thrown as if it belonged to the current one. Replacing it means the
+   * stale handler writes to an array nobody holds.
+   */
+  private failures: unknown[] = [];
 
   constructor(settingsPath: string) {
     this.settingsPath = settingsPath;
@@ -99,13 +107,16 @@ export class TransportRegistry {
    * switch does exactly this — does not accumulate or overwrite them.
    */
   private trackRunToCompletion(name: string, promise: Promise<void>): void {
+    // Captured at TRACK time. A stop replaces `this.failures`, so a handler that fires afterwards
+    // records into the array of the generation it belonged to — which nobody reads.
+    const sink = this.failures;
     const tracked = promise.then(
       () => {
         this.running.delete(name);
       },
       (error: unknown) => {
         this.running.delete(name);
-        this.failures.push(error);
+        sink.push(error);
       },
     );
     this.running.set(name, tracked);
@@ -136,7 +147,7 @@ export class TransportRegistry {
     // honest: `waitForCompletion` after a stop resolves rather than hanging on work nobody will
     // finish, and a later `startAll` (a session switch does this) starts from empty.
     this.running.clear();
-    this.failures.length = 0;
+    this.failures = [];
     for (const transport of this.entries.values()) {
       try {
         await transport.stop();

--- a/packages/agent-transport/src/transport-registry.ts
+++ b/packages/agent-transport/src/transport-registry.ts
@@ -20,6 +20,8 @@ export class TransportRegistry {
   private readonly settingsPath: string;
   /** ARCH-011: in-flight `start()` promises of run-to-completion transports, by name. */
   private readonly running = new Map<string, Promise<void>>();
+  /** Failures of run-to-completion transports, held until `waitForCompletion` asks for them. */
+  private readonly failures: unknown[] = [];
 
   constructor(settingsPath: string) {
     this.settingsPath = settingsPath;
@@ -76,7 +78,7 @@ export class TransportRegistry {
     for (const transport of enabled) {
       transport.attach(session);
       if (transport.runsToCompletion === true) {
-        this.running.set(transport.name, transport.start());
+        this.trackRunToCompletion(transport.name, transport.start());
         continue;
       }
       await transport.start();
@@ -84,12 +86,41 @@ export class TransportRegistry {
   }
 
   /**
-   * Settle when every run-to-completion transport has finished, rejecting with the first failure.
+   * Take ownership of a run-to-completion transport's promise.
    *
-   * Resolves immediately when there are none, which is the ordinary case.
+   * The handler is attached HERE, not left to `waitForCompletion`. Merely storing the promise does
+   * not attach one: a rejection between `startAll` returning and the caller getting round to
+   * `waitForCompletion` is an unhandled rejection, which on Node ≥15 aborts the process — measured,
+   * exit code 1, bypassing shutdown entirely. The first draft's comment claimed the opposite. The
+   * outcome is recorded and replayed instead, so the failure arrives when it is asked for and never
+   * escapes in the meantime.
+   *
+   * The entry is dropped once it settles, so a registry that is stopped and started again — a session
+   * switch does exactly this — does not accumulate or overwrite them.
+   */
+  private trackRunToCompletion(name: string, promise: Promise<void>): void {
+    const tracked = promise.then(
+      () => {
+        this.running.delete(name);
+      },
+      (error: unknown) => {
+        this.running.delete(name);
+        this.failures.push(error);
+      },
+    );
+    this.running.set(name, tracked);
+  }
+
+  /**
+   * Settle when every run-to-completion transport has finished, rejecting with the first failure to
+   * occur. Resolves immediately when there are none, which is the ordinary case.
    */
   async waitForCompletion(): Promise<void> {
     await Promise.all([...this.running.values()]);
+    const first = this.failures.shift();
+    if (first !== undefined) {
+      throw first;
+    }
   }
 
   /**
@@ -99,6 +130,13 @@ export class TransportRegistry {
    */
   async stopAll(): Promise<IDestroyResult> {
     const errors: Error[] = [];
+    // ARCH-011: a run-to-completion transport is ABANDONED here, not awaited. `stopAll`'s contract is
+    // best-effort and bounded (CORE-013); waiting on a transport whose `stop()` is a documented no-op
+    // — which both of them are — would make it neither. Dropping the tracking is what makes it
+    // honest: `waitForCompletion` after a stop resolves rather than hanging on work nobody will
+    // finish, and a later `startAll` (a session switch does this) starts from empty.
+    this.running.clear();
+    this.failures.length = 0;
     for (const transport of this.entries.values()) {
       try {
         await transport.stop();


### PR DESCRIPTION
## What was wrong

`ITransportAdapter.start()` said only `Promise<void>`, and **two incompatible readings coexisted**. Four transports bound a port and returned. `headless` ran the entire prompt inside `start()`; `tui` blocked for the life of the UI. `TransportRegistry.startAll` awaited each in turn — so registering either of those first meant **every transport behind it never started**. No crash, no error, simply never reached.

## The fix

`start()` resolves once the transport is **serving**. A transport whose whole job happens inside it declares `runsToCompletion: true`, and the registry starts it without awaiting.

`runsToCompletion` is optional, and that is a decision rather than an omission: "resolves once serving" is the ordinary case, four of six already did it, so a transport that says nothing asserts that meaning and the registry reads absence as `false` rather than guessing. That is the **opposite** call from ARCH-012's capability members, where silence had no safe reading and the optionality was removed. The SPEC states the difference so the next reader does not have to infer which rule applies.

## The review round is the interesting part

The first draft stored the run-to-completion promise in a map and called that "keeping it". Review measured two things:

**1. Nothing could call the failure route.** `waitForCompletion()` was on the concrete registry only; both production `startAll` callers hold `ITransportRegistryView`, which did not declare it. The failure sat in a map nothing could read — **worse than before this branch**, where `startAll` awaited and the error reached the caller. It is on the view now, and `IRuntimeHostHandle` exposes it to the caller that owns the process-lifetime wait.

**2. Holding a promise is not handling it.** A rejection between `startAll` returning and the caller reaching `waitForCompletion` is an unhandled rejection — measured as **exit code 1, bypassing shutdown**. My JSDoc and the SPEC both asserted the opposite. The handler is attached at start time now.

The existing test could not have caught that: it awaited the two back to back and never left the microtask drain. The new case puts a macrotask between them, which is the shape a real consumer has.

Also: `stopAll` ignored the tracking entirely — reporting success over live work, and leaving a later `waitForCompletion` to hang on a transport whose `stop()` is a documented no-op. It abandons them explicitly, which makes its bounded best-effort contract honest and lets a session switch start from empty.

## Evidence

Each fix red-proves on its own:

| Reverted | Fails with |
|---|---|
| sequential await | `expected 'pending' to be 'settled'` |
| `void start().catch()` instead of keeping it | `promise resolved "undefined" instead of rejecting` |
| store the bare promise | **Unhandled Rejection** |
| don't clear on `stopAll` | `expected 'pending' to be 'settled'` |

Whole workspace green.

## Scope

P1 closes the runnable failure. The shared conformance suite across all six transports — and the other drifted axes (admission, cancellation verb, error shape, in-flight-on-disconnect, session surface) — remain, recorded on the task. The intersection-type half depends on ARCH-012 P2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso