### PR TITLE
fix(harness): the debt ledger may shrink and never grow (HARNESS-064)

### DIFF
--- a/.agents/tasks/HARNESS-064-vacuity-was-measured-once.md
+++ b/.agents/tasks/HARNESS-064-vacuity-was-measured-once.md
@@ -138,3 +138,18 @@ as the CLI does over a deliberately wrong ceiling file and requires exit 1.
   as-is would certify a property they do not hold. Lowering that 14 means fixing those guards, one at
   a time, each with its own measurement.
 - **The 4 vacuous entries** are live instances, owned by HARNESS-052 and INFRA-060.
+
+### Review round 1 (PR #1604)
+
+One SHOULD, upheld: the reachability case mutated the real checked-in `guard-ledger-ceilings.json`
+and restored it in a `finally`, so a kill between the two — this scan's own docstring records a
+harness scan dying mid-run with no output — would leave the working tree holding a corrupted ceiling.
+An under-count is the direction a ratchet must never fail in, and every other path in the file already
+takes a `root` for exactly that reason.
+
+The loader is now parametrised (`GUARD_LEDGER_CEILINGS`) and the case points the spawned CLI at a
+temp copy, touching nothing tracked. That seam is itself a way past the ratchet, and cannot be closed
+by removing it — an argument would be the same hole spelled differently — so a run against anything
+but the frozen file now DECLARES that on both the pass and the fail path, and a case pins the
+declaration. The wiring red-proof was re-run against the change: deleting the line that calls
+`ledgerCeilingFindings` from `findGuardScopeFindings` still fails the reachability case.

--- a/.agents/tasks/HARNESS-064-vacuity-was-measured-once.md
+++ b/.agents/tasks/HARNESS-064-vacuity-was-measured-once.md
@@ -1,6 +1,6 @@
 ---
 title: 'HARNESS-064: vacuity was measured once and never again — 30 of 76 scans could not fail, and nothing tracks whether that number moves'
-status: todo
+status: in-progress
 created: 2026-08-02
 priority: critical
 urgency: now
@@ -86,3 +86,55 @@ is what this Task exists because of.
 
 **Does not apply.** This changes no user-facing product surface; it changes what the repo's own CI
 can conclude. The verification is the red-first regression above.
+
+## Progress
+
+### The premise was wrong for the axis that has a mechanism — corrected before acting
+
+This Task says the 30/76 measurement "was written down once" and "nothing re-measures it". For the
+**guard-scope axis that is false**, and finding out cost less than building a duplicate would have.
+
+`scripts/harness/scan-guard-scope-fail-closed.mjs` already:
+
+- DERIVES the finder set from the registration list and the source, so a new scan cannot be added
+  without being classified (rule 1);
+- EXECUTES every pinned guard against a root lacking its governed tree and requires a throw or a
+  finding — a behavioural assertion, not a source-pattern match (rule 2);
+- RE-EXECUTES every ledger entry's recorded verdict on every run and fails if it drifted (rule 3),
+  written because the ledger went stale within the hour it was first authored.
+
+Today it reports **45 guards proven fail-closed by execution, 4 measured vacuous and recorded
+unfixed, 14 fail-closed but unpinned**. The 30/76 figure is stale in both terms: the suite is 87
+scans now, and that number came from the OTHER axis in `check-validity-two-axes` — _does it check
+the right thing_ — which that memory itself records as a ceiling nothing catches.
+
+### What was actually missing: the ledger had no ceiling
+
+Rules 1–3 make every finder answer for itself and keep the ledger honest. None of them bounds its
+SIZE. `PENDING_CLASSIFICATION.length` appeared only in the pass message — so a new scan could be
+classified `pending` forever, and a new `vacuous` entry (a LIVE instance of the audited defect) could
+be added with a paragraph explaining it, and nothing would object.
+
+**Rule 4: the debt may shrink and never grow.** Two ceilings, frozen at the measured 4 vacuous and 14
+unpinned, in `scripts/harness/guard-ledger-ceilings.json`. They are separate because they mean
+different things — a vacuous entry is a live defect, an unpinned one is milder debt — and a rise in
+either fails with the instruction that fits it: _fix the guard, do not record it_ versus _pin it in
+`MANDATORY_TREE_GUARDS`_. A FALL also fails, demanding a re-freeze in the same change, because an
+unlocked gain is a licence to grow back.
+
+Red-proved four ways: a lowered `vacuous` ceiling fires with the right message, a lowered `unpinned`
+one likewise, a raised ceiling demands the re-freeze, and an ABSENT ceiling is a finding rather than a
+pass. Plus reachability — the first draft of those cases called the helper directly, so deleting the
+line wiring it into `findGuardScopeFindings` failed nothing; there is now a case that runs the scan
+as the CLI does over a deliberately wrong ceiling file and requires exit 1.
+
+### Remaining
+
+- **The second axis is still uncovered**, and this does not change that: whether a check examines the
+  RIGHT thing is not decidable by executing it against an empty root. `check-validity-two-axes`
+  records it as a ceiling; nothing here lifts it.
+- **The 14 unpinned guards.** Each is unpinned for a recorded reason — some fail closed only
+  INCIDENTALLY, via a stale-allowlist assertion rather than a deliberate check, so pinning them
+  as-is would certify a property they do not hold. Lowering that 14 means fixing those guards, one at
+  a time, each with its own measurement.
+- **The 4 vacuous entries** are live instances, owned by HARNESS-052 and INFRA-060.

--- a/scripts/harness/__tests__/scan-guard-scope-fail-closed.test.mjs
+++ b/scripts/harness/__tests__/scan-guard-scope-fail-closed.test.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -285,19 +285,28 @@ describe('rule 4 — the debt ledger may shrink and never grow (HARNESS-064)', (
    */
   it('a violated ceiling fails the SCAN, not just the helper', () => {
     const root = path.resolve(import.meta.dirname, '../../..');
-    const ceilingsPath = path.join(root, 'scripts/harness/guard-ledger-ceilings.json');
-    const original = readFileSync(ceilingsPath, 'utf8');
+    const frozen = JSON.parse(
+      readFileSync(path.join(root, 'scripts/harness/guard-ledger-ceilings.json'), 'utf8'),
+    );
+    // A TEMP ceiling file, never the checked-in one. Mutating the real file and restoring it in a
+    // `finally` leaves the working tree corrupted if the process is killed in between — and this
+    // scan's own docstring records a harness scan dying mid-run with no output.
+    const dir = mkdtempSync(path.join(tmpdir(), 'guard-ledger-'));
+    const ceilingsPath = path.join(dir, 'ceilings.json');
+    writeFileSync(ceilingsPath, JSON.stringify({ ...frozen, vacuous: frozen.vacuous - 1 }));
     try {
-      const frozen = JSON.parse(original);
-      writeFileSync(ceilingsPath, JSON.stringify({ ...frozen, vacuous: frozen.vacuous - 1 }));
       const result = spawnSync('node', ['scripts/harness/scan-guard-scope-fail-closed.mjs'], {
         cwd: root,
         encoding: 'utf8',
+        env: { ...process.env, GUARD_LEDGER_CEILINGS: ceilingsPath },
       });
       expect(result.status).toBe(1);
       expect(result.stdout).toMatch(/ledger-ceiling:vacuous/);
+      // The seam that made this case safe is itself a way past the ratchet, so a run that did not
+      // read the frozen file has to SAY so. Silent is the one thing it must not be.
+      expect(result.stdout).toMatch(/ceilings OVERRIDDEN via GUARD_LEDGER_CEILINGS=/);
     } finally {
-      writeFileSync(ceilingsPath, original);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/scripts/harness/__tests__/scan-guard-scope-fail-closed.test.mjs
+++ b/scripts/harness/__tests__/scan-guard-scope-fail-closed.test.mjs
@@ -1,3 +1,5 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -10,6 +12,7 @@ import {
   classificationFindings,
   derivedFinders,
   findGuardScopeFindings,
+  ledgerCeilingFindings,
   ledgerDriftFindings,
   MANDATORY_TREE_GUARDS,
   measuredVacuous,
@@ -224,5 +227,77 @@ describe('ledger freshness', () => {
 describe('the scan as a whole', () => {
   it('is green on this repository', async () => {
     expect(await findGuardScopeFindings(WORKSPACE_ROOT)).toEqual([]);
+  });
+});
+
+describe('rule 4 — the debt ledger may shrink and never grow (HARNESS-064)', () => {
+  /**
+   * Rules 1–3 make every finder answer for itself and keep the ledger honest, but they placed no
+   * bound on its SIZE. A new scan could be classified `pending` forever, and a new `vacuous` entry —
+   * a LIVE instance of the defect this scan audits — could be added with a paragraph explaining it,
+   * and nothing objected. The count appeared only in the pass message.
+   */
+  it('a new VACUOUS entry fails, because it is a new live instance of the audited defect', () => {
+    const findings = ledgerCeilingFindings({ vacuous: 0, unpinned: 99 });
+    expect(findings.map((f) => f.subject)).toContain('ledger-ceiling:vacuous');
+    expect(findings.find((f) => f.subject === 'ledger-ceiling:vacuous')?.detail).toMatch(
+      /fix the guard, do not record it/,
+    );
+  });
+
+  it('a new UNPINNED entry fails, and says to pin it instead', () => {
+    const findings = ledgerCeilingFindings({ vacuous: 99, unpinned: 0 });
+    expect(findings.find((f) => f.subject === 'ledger-ceiling:unpinned')?.detail).toMatch(
+      /Pin the guard in MANDATORY_TREE_GUARDS/,
+    );
+  });
+
+  it('a FALL must be re-frozen in the same change, not silently pocketed', () => {
+    // The other half of a ratchet. An unlocked gain is a licence to grow back to the old number,
+    // which is how a debt ceiling stops meaning anything.
+    const findings = ledgerCeilingFindings({ vacuous: 99, unpinned: 99 });
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) {
+      expect(finding.detail).toMatch(/DOWN from a frozen/);
+    }
+  });
+
+  it('an absent ceiling is a finding, not a pass', () => {
+    // "No ceiling recorded" must not read as "within the ceiling" — that is the vacuity this whole
+    // scan exists to catch, one level up again.
+    expect(ledgerCeilingFindings({}).map((f) => f.subject)).toEqual([
+      'ledger-ceiling:vacuous',
+      'ledger-ceiling:unpinned',
+    ]);
+  });
+
+  it('the live repository is at its frozen ceilings', () => {
+    expect(ledgerCeilingFindings()).toEqual([]);
+  });
+
+  /**
+   * REACHABILITY through the registered path, not just the exported function.
+   *
+   * The first draft of these cases called `ledgerCeilingFindings` directly, so deleting the line
+   * that wires it into `findGuardScopeFindings` failed nothing — the check existed and ran nowhere,
+   * which is the shape this scan audits. This runs the scan as the CLI does, over a deliberately
+   * wrong ceiling file, and requires a non-zero exit.
+   */
+  it('a violated ceiling fails the SCAN, not just the helper', () => {
+    const root = path.resolve(import.meta.dirname, '../../..');
+    const ceilingsPath = path.join(root, 'scripts/harness/guard-ledger-ceilings.json');
+    const original = readFileSync(ceilingsPath, 'utf8');
+    try {
+      const frozen = JSON.parse(original);
+      writeFileSync(ceilingsPath, JSON.stringify({ ...frozen, vacuous: frozen.vacuous - 1 }));
+      const result = spawnSync('node', ['scripts/harness/scan-guard-scope-fail-closed.mjs'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(1);
+      expect(result.stdout).toMatch(/ledger-ceiling:vacuous/);
+    } finally {
+      writeFileSync(ceilingsPath, original);
+    }
   });
 });

--- a/scripts/harness/guard-ledger-ceilings.json
+++ b/scripts/harness/guard-ledger-ceilings.json
@@ -1,0 +1,4 @@
+{
+  "vacuous": 4,
+  "unpinned": 14
+}

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -71,7 +71,7 @@
  * Exit code 0 = every classified guard behaves as declared, 1 = violation found.
  */
 
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -777,6 +777,69 @@ export async function ledgerDriftFindings(root = WORKSPACE_ROOT) {
 }
 
 /** Findings across all three rules. */
+/**
+ * Rule 4: THE DEBT MAY SHRINK AND NEVER GROW. HARNESS-064.
+ *
+ * Rules 1–3 make every finder answer for itself and keep the ledger honest, but they place no bound
+ * on its SIZE: a new scan could be classified `pending` forever, and a new `vacuous` entry — a live
+ * instance of the audited defect — could be added with a paragraph explaining it and nothing would
+ * object. The ledger was already a set of claims nobody re-measured before rule 3; without this it
+ * is a set of measurements nobody bounds.
+ *
+ * Two ceilings, because they mean different things. `vacuous` entries are live defects and their
+ * count is the one that matters most. `fail-closed` entries behave correctly but are not pinned, so
+ * they are debt of a milder kind. Both are frozen; both may fall.
+ *
+ * Lowering either means re-freezing in the SAME change, exactly like `file-size` and
+ * `spec-public-surface` — an unlocked gain is a licence to grow back.
+ */
+export function ledgerCeilingFindings(ceilings = loadLedgerCeilings()) {
+  const vacuous = measuredVacuous().length;
+  const unpinned = PENDING_CLASSIFICATION.length - vacuous;
+  const findings = [];
+  const check = (label, actual, frozen) => {
+    if (frozen === undefined) {
+      findings.push({
+        subject: `ledger-ceiling:${label}`,
+        detail: `${actual} entr(y/ies) with no frozen ceiling — run --write-ledger-ceilings.`,
+      });
+      return;
+    }
+    if (actual > frozen) {
+      findings.push({
+        subject: `ledger-ceiling:${label}`,
+        detail:
+          `${actual} entr(y/ies), up from a frozen ${frozen}. ` +
+          (label === 'vacuous'
+            ? 'A new vacuous entry is a NEW live instance of the defect this scan audits — fix the guard, do not record it.'
+            : 'Pin the guard in MANDATORY_TREE_GUARDS instead of adding to the ledger.'),
+      });
+      return;
+    }
+    if (actual < frozen) {
+      findings.push({
+        subject: `ledger-ceiling:${label}`,
+        detail:
+          `${actual} entr(y/ies), DOWN from a frozen ${frozen}. Re-freeze it in this same change ` +
+          '(`--write-ledger-ceilings`) — an unlocked gain is a licence to grow back.',
+      });
+    }
+  };
+  check('vacuous', vacuous, ceilings.vacuous);
+  check('unpinned', unpinned, ceilings.unpinned);
+  return findings;
+}
+
+const LEDGER_CEILINGS_PATH = path.join(
+  WORKSPACE_ROOT,
+  'scripts/harness/guard-ledger-ceilings.json',
+);
+
+function loadLedgerCeilings() {
+  if (!existsSync(LEDGER_CEILINGS_PATH)) return {};
+  return JSON.parse(readFileSync(LEDGER_CEILINGS_PATH, 'utf8'));
+}
+
 export async function findGuardScopeFindings(root = WORKSPACE_ROOT) {
   const findings = classificationFindings(root);
   for (const entry of MANDATORY_TREE_GUARDS) {
@@ -784,6 +847,9 @@ export async function findGuardScopeFindings(root = WORKSPACE_ROOT) {
     if (finding) findings.push(finding);
   }
   findings.push(...(await ledgerDriftFindings(root)));
+  // Only meaningful about the real tree — a temporary root has the same ledger, but the caller that
+  // hands one in is asking about tree-scope behaviour, not about this repo's debt.
+  if (root === WORKSPACE_ROOT) findings.push(...ledgerCeilingFindings());
   return findings;
 }
 
@@ -809,9 +875,17 @@ export async function main() {
   );
 }
 
+function writeLedgerCeilings() {
+  const vacuous = measuredVacuous().length;
+  const next = { vacuous, unpinned: PENDING_CLASSIFICATION.length - vacuous };
+  writeFileSync(LEDGER_CEILINGS_PATH, `${JSON.stringify(next, null, 2)}\n`);
+  process.stdout.write(`guard-ledger ceilings frozen: ${JSON.stringify(next)}\n`);
+}
+
 const isDirectExecution =
   process.argv[1] !== undefined &&
   path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
 if (isDirectExecution) {
-  await main();
+  if (process.argv.includes('--write-ledger-ceilings')) writeLedgerCeilings();
+  else await main();
 }

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -830,14 +830,27 @@ export function ledgerCeilingFindings(ceilings = loadLedgerCeilings()) {
   return findings;
 }
 
-const LEDGER_CEILINGS_PATH = path.join(
-  WORKSPACE_ROOT,
-  'scripts/harness/guard-ledger-ceilings.json',
-);
+/**
+ * Where the frozen ceilings live — overridable, like every other path in this file.
+ *
+ * `GUARD_LEDGER_CEILINGS` exists for the reachability case, which has to prove the ceiling check
+ * runs through the CLI and not merely as an exported helper. Its first version mutated the real
+ * checked-in file and restored it in a `finally`; a kill in between — and this file's own docstring
+ * records a harness scan dying mid-run with no output — would leave the working tree holding a
+ * corrupted ceiling, which is the one direction this ratchet must never fail in. Everything else
+ * here takes a `root` for exactly that reason.
+ */
+function ledgerCeilingsPath() {
+  return (
+    process.env['GUARD_LEDGER_CEILINGS'] ??
+    path.join(WORKSPACE_ROOT, 'scripts/harness/guard-ledger-ceilings.json')
+  );
+}
 
 function loadLedgerCeilings() {
-  if (!existsSync(LEDGER_CEILINGS_PATH)) return {};
-  return JSON.parse(readFileSync(LEDGER_CEILINGS_PATH, 'utf8'));
+  const file = ledgerCeilingsPath();
+  if (!existsSync(file)) return {};
+  return JSON.parse(readFileSync(file, 'utf8'));
 }
 
 export async function findGuardScopeFindings(root = WORKSPACE_ROOT) {
@@ -854,6 +867,17 @@ export async function findGuardScopeFindings(root = WORKSPACE_ROOT) {
 }
 
 export async function main() {
+  // A parametrised path is a bypass surface: point the ratchet at a permissive file and it passes
+  // over a ceiling nobody froze. It cannot be closed by removing the seam — an argument would be the
+  // same hole with a different spelling — so it is made SELF-DECLARING instead. A run against
+  // anything but the checked-in ceilings says so on both the pass and the fail path, which turns a
+  // silent bypass into one that has to be read past.
+  if (process.env['GUARD_LEDGER_CEILINGS'] !== undefined) {
+    process.stdout.write(
+      `guard-ledger ceilings OVERRIDDEN via GUARD_LEDGER_CEILINGS=${ledgerCeilingsPath()} — this ` +
+        'run did NOT check the frozen ceilings in scripts/harness/.\n',
+    );
+  }
   const findings = await findGuardScopeFindings();
   if (findings.length > 0) {
     process.stdout.write('guard-scope-fail-closed scan failed (HARNESS-052):\n');
@@ -878,7 +902,7 @@ export async function main() {
 function writeLedgerCeilings() {
   const vacuous = measuredVacuous().length;
   const next = { vacuous, unpinned: PENDING_CLASSIFICATION.length - vacuous };
-  writeFileSync(LEDGER_CEILINGS_PATH, `${JSON.stringify(next, null, 2)}\n`);
+  writeFileSync(ledgerCeilingsPath(), `${JSON.stringify(next, null, 2)}\n`);
   process.stdout.write(`guard-ledger ceilings frozen: ${JSON.stringify(next)}\n`);
 }
 


### PR DESCRIPTION
## The task's premise was wrong for the axis that has a mechanism

HARNESS-064 says the 30/76 vacuity measurement *"was written down once"* and *"nothing re-measures it"*. Checking that cost less than building a duplicate would have.

`scan-guard-scope-fail-closed` already:

- **derives** the finder set from the registration list and the source, so a new scan cannot be added without being classified;
- **executes** every pinned guard against a root lacking its governed tree and requires a throw or a finding — behavioural, not a source-pattern match;
- **re-executes** every ledger entry's recorded verdict on every run and fails if it drifted. That rule exists because the ledger went stale *within the hour it was first written*.

It reports **45 guards proven fail-closed by execution** today.

The 30/76 figure is stale in both terms — the suite is 87 scans now, and that number came from the *other* axis in `check-validity-two-axes` (*does it check the right thing*), which that memory itself records as a ceiling nothing catches. **This PR does not lift that ceiling**, and says so.

## What was actually missing

Rules 1–3 make every finder answer for itself and keep the ledger honest. **None of them bounds its size.** `PENDING_CLASSIFICATION.length` appeared only in the pass message — so a new scan could be classified `pending` forever, and a new `vacuous` entry (a **live instance of the defect this scan audits**) could be added with a paragraph explaining it, and nothing would object.

**Rule 4: the debt may shrink and never grow.** Two ceilings frozen at the measured **4 vacuous / 14 unpinned**, separate because they mean different things:

| Rise in | Message |
|---|---|
| `vacuous` | *fix the guard, do not record it* — it is a new live defect |
| `unpinned` | *pin it in `MANDATORY_TREE_GUARDS`* — milder debt |

A **fall** fails too, demanding the re-freeze in the same change: an unlocked gain is a licence to grow back.

## Evidence

Red-proved four ways — lowered `vacuous` ceiling, lowered `unpinned` ceiling, raised ceiling (demands re-freeze), and an **absent** ceiling being a finding rather than a pass.

Then a fifth, for reachability. The first draft of those cases called the helper directly, so deleting the line that wires it into `findGuardScopeFindings` **failed nothing** — the check existed and ran nowhere, which is precisely the shape this scan audits. There is now a case that runs the scan as the CLI does, over a deliberately wrong ceiling file, and requires exit 1.

Harness suite: 2384 pass.

## What remains

- The **second axis** — whether a check examines the right thing — is not decidable by executing a finder against an empty root. Unchanged, and stated rather than implied.
- The **14 unpinned guards** are each unpinned for a recorded reason; some fail closed only *incidentally*, via a stale-allowlist assertion rather than a deliberate check, so pinning them as-is would certify a property they do not hold. Lowering that number means fixing them one at a time.
- The **4 vacuous** entries are live instances owned by HARNESS-052 and INFRA-060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso