### PR TITLE
fix(dag): type the execution contract on the domain model (DAG-002)

### DIFF
--- a/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
+++ b/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
@@ -1,6 +1,6 @@
 ---
 title: 'DAG-002: the DAG''s top-level "run a DAG" contract is typed on the imported system''s file format, and the conversion is lossy in both directions'
-status: todo
+status: in-progress
 created: 2026-08-02
 priority: critical
 urgency: now
@@ -118,3 +118,87 @@ a workflow authored with string node ids does not round-trip.
 - **Cleanup:** delete the scratch workflow and its run state.
 - **Evidence (fill in after implementation):** the authored definition and the run record side by
   side, showing ids and port names preserved.
+
+## Implementation
+
+### What was measured before anything was changed
+
+Every premise in the finding held, checked against the code rather than repeated:
+`IDagRuntimeProvider.execute(dag: IDagWorkflowFile, …)`, `TDagDefinitionStatus = 'draft' |
+'published' | 'deprecated'`, and `status: (companion?.status ?? 'active') as TDagDefinitionStatus`.
+One thing the finding did not say, and which decides the shape of the fix: `IDagRobotaCompanion.status`
+is ALREADY typed as `TDagDefinitionStatus` (`workflow-file.ts:83`), so the cast was never needed for
+the companion branch. It existed to make one wrong default compile.
+
+A second measured fact narrows the blast radius. Of the 20 `fromDagWorkflowFile` call sites, most are
+CLI commands parsing a file off disk — that is an import adapter and entirely legitimate. The defect
+is confined to the execution contract: the two callers that already held an `IDagDefinition` and the
+two providers that converted it straight back.
+
+### The red-first proof
+
+`executeDefinition` — the function `/workflows create` and `/workflows run` both call — was run with a
+definition whose node ids are words (`greeting`, `reply`) joined on a named port. Against the unfixed
+code it returned:
+
+    ['node-1.passage', 'node-2.passage']
+
+Fabricated ids, on the real production path, in the result a user reads. That is the regression test.
+A first draft asserted the same thing through `LocalDagRuntimeProvider` directly, but against the old
+signature it failed with `workflowFile.links is not iterable` — a crash proving the types differ, not
+the loss. It was rewritten to go through the caller, where the failure is the defect itself.
+
+The status defect is red-proved separately: `fromDagWorkflowFile` with no companion returned
+`'active'`, and the case asserts membership in the union rather than one replacement value.
+
+### The change
+
+- `IDagRuntimeProvider.execute` / `IDetachableRunProvider.submitRun` take `IDagDefinition`.
+- Both providers drop their conversion. `HttpDagRuntimeProvider` is the sharpest instance: its wire
+  body was ALWAYS the canonical definition (`createRun({ definition })`), so the round trip existed
+  purely to undo the caller's — and lost ids on the way through.
+- `execute-workflow.ts` and `instant-node-loader.ts` drop theirs. The companion-derived
+  `node-<n> → <originalId>` map, which existed only to repair what the conversion destroyed, is gone.
+- `dagDefinitionFromParsedFile` (new, `dag-builder`) is now the single import adapter. It was
+  open-coded at each call site and the copies had drifted: `runs.ts submit` asserted the workflow-file
+  shape with a bare cast and never checked, so a definition file submitted there reached the provider
+  mislabelled.
+- The status default becomes `'draft'` and the cast is deleted.
+
+`toDagWorkflowFile` survives at exactly three sites — `migrate`, and the MCP `format`/`build` handlers
+— all of which genuinely emit the file format. That is the whole of its remaining job.
+
+### Recurrence prevention (mechanical)
+
+Fixing the site leaves the shape available everywhere else, so `scan-literal-cast-union.mjs` now fails
+when a string literal is cast to a repo-declared union it is not a member of. It resolves unions by
+parsing the tree's own `type X = 'a' | 'b'` declarations and follows `??`, `||`, `?:` and parentheses
+into the operand — the operators that spell a default, which is how this one was written.
+
+Red-proved end to end: reinstated on the real converter it reports the exact line; removed again it
+passes over 2728 files with no other finding, so there is no pre-existing debt being suppressed. It is
+registered in `run-all-scans`, fails closed on a root without the governed tree, and is classified in
+`MANDATORY_TREE_GUARDS` by execution (45 → 46 proven fail-closed).
+
+It deliberately does NOT judge what it cannot decide — a non-literal operand, an imported union, a
+composed union — because a scan that reports findings it cannot support is suppressed rather than
+obeyed. Its cheap pre-filter (2728 files → 117) was verified equivalent against the full parse rather
+than assumed; the first version matched only `'` and silently dropped two double-quoted unions, which
+is the under-report direction that would have made it blind.
+
+### Ratchets
+
+Three files were already over their frozen size and my comments pushed them past it. Rather than
+suppress, the explanations were tightened and the shared adapter extracted, which took `runs.ts` BELOW
+its baseline — re-frozen in this change. `dag-builder`'s SPEC public-API section was a bullet list the
+surface scan could not read at all; converting it to a table with bare identifiers took the package
+from 8 undocumented exports to 0, and its baseline entry is removed entirely.
+
+### Not done here
+
+- `IDagWorkflowFile` still lives in `dag-core` alongside the domain model. The finding left that
+  choice open (import/export adapter package vs. deletion) and it is not decided by this change.
+- Stored artifacts written through the old path may still carry `status: 'active'`. Nothing migrates
+  them; the scan prevents new ones. Recorded as the open half of this item's risk surface.
+- The six other CLI commands still open-code their own companion-reading loader. They do IO the new
+  adapter deliberately does not, and adopting it there is a separate cleanup.

--- a/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
+++ b/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
@@ -269,3 +269,17 @@ that stopped the next reader from checking.
   wearing this item's name.
 - Both claims are narrowed to what actually holds, and the SPEC now names DAG-004 so the gap is
   readable from the document that overstated it.
+
+### Review round 3 (PR #1605)
+
+One SHOULD, upheld. `assertStatusInUnion` guarded only the legacy-definition branch; the workflow-file
+branch returned `companion?.status ?? 'draft'` unchecked, and `dag-cli`'s `tryReadCompanion` parses a
+companion with a bare `as IDagRobotaCompanion`. A companion written before DAG-002 carries `'active'`
+into a definition exactly as a definition file would.
+
+It does not fire today — no current caller passes a companion — which is precisely the reason to close
+it now: DAG-004's stated direction is to route the eight remaining CLI sites through this function
+"passing the companion where one is read", and that activates it. A guard that covers the branch that
+happens to be reachable is the shape this whole item is about.
+
+Both branches now pass through `assertStatusInUnion`, red-proved on the companion path.

--- a/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
+++ b/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
@@ -202,3 +202,26 @@ from 8 undocumented exports to 0, and its baseline entry is removed entirely.
   them; the scan prevents new ones. Recorded as the open half of this item's risk surface.
 - The six other CLI commands still open-code their own companion-reading loader. They do IO the new
   adapter deliberately does not, and adopting it there is a separate cleanup.
+
+### Self-review round (pre-push)
+
+Two findings on my own diff, both upheld:
+
+1. **The adapter repeated the defect it was extracted to end.** `dagDefinitionFromParsedFile` fell
+   through to `parsed as IDagDefinition` for anything it did not recognise — a bare cast at exactly
+   the boundary whose bare cast is this item's subject. It now throws and names both expected shapes,
+   so an unrecognised file fails where it is read rather than later, somewhere else, as something
+   else. Three cases pin it, including `null`.
+
+2. **That throw would have reached the CLI as a stack trace.** `runs submit` has no try/catch and the
+   runner does not wrap it, so the new error — and the pre-existing unparseable-JSON error, which was
+   always unhandled — would crash rather than report. Extracted to `read-dag-file-arg.ts` returning a
+   discriminated result; `runs submit` renders a usage error. The extraction was also what the
+   file-size ceiling required: folding it inline pushed `runs.ts` past the hard 300-line maximum.
+
+Two floors caught me during the same pass and both were right: `scan-file-size` on the comments I
+added to already-over-baseline files, and `no-insecure-temp-path` (SEC-003) on a test of mine that
+joined a fixed name onto `tmpdir()`. Neither was suppressed.
+
+One unrelated reflow (`INodePortSpec`) had crept into `runtime-provider.ts`; reverted, since both
+forms satisfy prettier and diff noise costs a reviewer real attention.

--- a/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
+++ b/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
@@ -246,3 +246,26 @@ this task recorded from the start. Both literals are fixed, and
 `dagDefinitionFromParsedFile` now validates the status of every definition it imports, naming the
 value and the legal set. An ABSENT status stays legal; only a present one outside the union fails.
 Two layers, and the scan's docstring now says so rather than implying it is the whole guarantee.
+
+### Review round 2 (PR #1605)
+
+One SHOULD, upheld, and it is a correction to a claim of mine rather than to the code: the SPEC said
+`dagDefinitionFromParsedFile` is "the one place the workflow-file format is read", and this task file
+said it "validates the status of every definition it imports". Neither was true. `/workflows validate`
+and eight `dag-cli` sites still open-coded the branch and passed a legacy-format object straight
+through, so a file carrying `status: 'active'` — the value this change exists to eliminate, and one
+`dag-cli node` emitted until this same change fixed it — entered cleanly through all of them.
+
+Making a claim that stops the next reader from checking, in the change whose whole subject is a claim
+that stopped the next reader from checking.
+
+- `/workflows validate` is converted, because a surface whose entire job is answering "is this file
+  valid?" reporting an invalid status as valid is not a coverage gap, it is the wrong answer. The case
+  is red-proved, and the red-proof is why it asserts the MESSAGE: the unfixed code already returned
+  `success: false` for an unrelated empty-node-list issue, so asserting the verdict alone would have
+  passed whether or not the status was ever checked.
+- The eight `dag-cli` sites are filed as **DAG-004** with each location listed. They read a companion
+  first and each renders its own exit code, so converting them mid-change would have been a sweep
+  wearing this item's name.
+- Both claims are narrowed to what actually holds, and the SPEC now names DAG-004 so the gap is
+  readable from the document that overstated it.

--- a/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
+++ b/.agents/tasks/DAG-002-run-contract-typed-on-a-foreign-file-format.md
@@ -223,5 +223,26 @@ Two floors caught me during the same pass and both were right: `scan-file-size` 
 added to already-over-baseline files, and `no-insecure-temp-path` (SEC-003) on a test of mine that
 joined a fixed name onto `tmpdir()`. Neither was suppressed.
 
-One unrelated reflow (`INodePortSpec`) had crept into `runtime-provider.ts`; reverted, since both
-forms satisfy prettier and diff noise costs a reviewer real attention.
+I also claimed to have reverted an unrelated `INodePortSpec` reflow in `runtime-provider.ts`. **That
+claim was wrong** — review checked the diff and the reflow is still there. Re-applying the expanded
+form and running prettier collapses it again: the formatter imposes the one-line union, and the
+expanded form on `develop` is stale. The reflow is not mine to remove, and both forms passing
+`prettier --check` earlier was me measuring two different files rather than the same one twice.
+
+### Review round 1 (PR #1605)
+
+1. **SHOULD, upheld** — `local-dag-runtime-provider.ts`'s class docstring still said `execute`
+   "accepts a `.dag.json` workflow file", directly above the signature this change retyped. Exactly
+   the comment-asserted-invariant shape, committed while fixing an instance of it.
+2. **CONSIDER, upheld against me** — the false reflow claim above.
+3. **Out of scope, taken anyway** — `dag-cli/commands/node.ts` emits `status: 'active'` in two
+   example-DAG generators and prints the result for a user to save. The same impossible value, on a
+   file this change never touched, and invisible to the new scan because it is an untyped literal
+   rather than a cast.
+
+Finding 3 is the useful one: it marks the scan's real boundary. A static check over casts cannot
+reach a value that arrives at runtime, and files carrying `'active'` are already on disk — the risk
+this task recorded from the start. Both literals are fixed, and
+`dagDefinitionFromParsedFile` now validates the status of every definition it imports, naming the
+value and the legal set. An ABSENT status stays legal; only a present one outside the union fails.
+Two layers, and the scan's docstring now says so rather than implying it is the whole guarantee.

--- a/.agents/tasks/DAG-004-eight-cli-commands-open-code-the-import-adapter.md
+++ b/.agents/tasks/DAG-004-eight-cli-commands-open-code-the-import-adapter.md
@@ -1,0 +1,81 @@
+---
+title: 'DAG-004: eight dag-cli commands open-code the DAG import adapter, so an invalid definition still enters through them'
+status: todo
+created: 2026-08-02
+priority: medium
+urgency: next
+area: packages/dag-cli
+depends_on: [DAG-002]
+---
+
+# DAG-004: the import boundary has one owner and eight bypasses
+
+## Problem
+
+DAG-002 gave the two on-disk DAG formats a single import adapter,
+`dagDefinitionFromParsedFile` (`packages/dag-builder/src/parsed-dag-file.ts`), which rejects a shape
+that is neither format and rejects a definition whose `status` is outside `TDagDefinitionStatus`.
+
+Three surfaces were converted to it: `/workflows run`, `/workflows validate`, and `dag runs submit`.
+**Eight `dag-cli` commands still open-code the same
+`isWorkflowFileFormat` / `isLegacyDefinitionFormat` branch and assign the legacy-format object
+straight through as `IDagDefinition` with no check at all.** A file carrying `status: 'active'` —
+the exact value DAG-002 exists to eliminate, and one that `dag-cli node`'s example generator emitted
+until DAG-002 fixed it, so such files are on real disks — still enters cleanly through every one of
+them.
+
+## Evidence
+
+Found by review on PR #1605, which correctly called the SPEC's "the one place the workflow-file
+format is read" an overclaim. The wording has been narrowed; the coverage gap is this item.
+
+Open-coded sites (each `parsed as IDagDefinition` with no validation):
+
+- `packages/dag-cli/src/commands/run.ts:986-990`, `:1051-1055`, `:1114-1118` (three)
+- `packages/dag-cli/src/commands/view.ts:90`
+- `packages/dag-cli/src/commands/cost.ts:249`
+- `packages/dag-cli/src/commands/explain.ts:217`
+- `packages/dag-cli/src/commands/benchmark.ts:375`
+- `packages/dag-cli/src/commands/fix.ts:288`
+- `packages/dag-cli/src/studio/http-server.ts:58`
+
+They are not a straight substitution: most read a `.dag.robota.json` companion first
+(`tryReadCompanion`), and each renders its own exit code and message, which is why DAG-002 converted
+only the sites it was already touching rather than sweeping mid-change.
+
+## Why this is foundational (or not)
+
+**LOCAL, but repeated.** No single site is deep; the defect is that a boundary with one owner has
+eight bypasses, so the owner's guarantees are not the system's guarantees. That is the same
+"registered ≠ reached" shape the repo keeps meeting, one level down: the adapter exists and is
+correct, and most callers do not go through it.
+
+## Direction
+
+Route every site through `dagDefinitionFromParsedFile`, passing the companion where one is read.
+`tryReadCompanion` and the per-command message rendering stay where they are — only the
+branch-and-cast is replaced.
+
+`readDagFileArg` (`packages/dag-cli/src/commands/read-dag-file-arg.ts`) is the shape to follow: it
+returns a discriminated result rather than throwing, so a caller renders an exit code without a
+try/catch. A companion-aware sibling would serve the remaining eight.
+
+## Test Plan
+
+- **Required red-first regression, per site:** feed each command a definition file carrying
+  `status: 'active'` and assert it is reported. Against current code every one of them accepts it.
+- One case per command asserting an unrecognised shape is reported rather than passed on.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+**Applies.** Each of these is a user-facing command.
+
+- **Prerequisites:** a built `robota`/`dag` CLI and a definition file with `status: "active"` — the
+  shape `dag-cli node`'s example generator produced before DAG-002.
+- **Steps:** run each affected command against that file.
+- **Expected observable result (after the fix):** each names the invalid status and exits non-zero.
+- **Expected observable result (before the fix, for contrast):** each proceeds as if the file were
+  valid.
+- **Cleanup:** delete the scratch file.
+- **Evidence (fill in after implementation):** the command output for each site.

--- a/apps/dag-runtime-server/src/__tests__/http-provider.roundtrip.test.ts
+++ b/apps/dag-runtime-server/src/__tests__/http-provider.roundtrip.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { toDagWorkflowFile } from '@robota-sdk/dag-builder';
 import { createDagFramework, HttpDagRuntimeProvider } from '@robota-sdk/dag-framework';
 
 import { createDagRuntimeServer } from '../app.js';
 
-import type { IDagDefinition, IDagWorkflowFile } from '@robota-sdk/dag-core';
+import type { IDagDefinition } from '@robota-sdk/dag-core';
 import type { IDagFramework } from '@robota-sdk/dag-framework';
 
 // A single-node DAG: one InputNode emitting its configured text on the `text` output port.
@@ -18,10 +17,6 @@ const SINGLE_INPUT_DEFINITION: IDagDefinition = {
   nodes: [{ nodeId: 'in', nodeType: 'input', dependsOn: [], config: { text: 'hello-http' } }],
   edges: [],
 };
-
-function buildWorkflowFile(): IDagWorkflowFile {
-  return toDagWorkflowFile(SINGLE_INPUT_DEFINITION).workflowFile;
-}
 
 describe('HttpDagRuntimeProvider round-trip against the in-process server', () => {
   let framework: IDagFramework;
@@ -53,7 +48,7 @@ describe('HttpDagRuntimeProvider round-trip against the in-process server', () =
   it('executes a DAG end-to-end (submit → watch → result)', async () => {
     const events: string[] = [];
     const result = await provider.execute(
-      buildWorkflowFile(),
+      SINGLE_INPUT_DEFINITION,
       { text: 'hello-http' },
       { onProgress: (e) => events.push(e.type) },
     );
@@ -62,16 +57,18 @@ describe('HttpDagRuntimeProvider round-trip against the in-process server', () =
     expect(result.error).toBeUndefined();
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
     // The InputNode's `text` output (the run input, runtime-priority) reached the mapped result —
-    // proof the payload flowed submit → execute → result over HTTP. The output key embeds the
-    // recovered node id, so assert on the value rather than a brittle exact key.
-    const textOutputs = Object.entries(result.outputs)
-      .filter(([key]) => key.endsWith('.text'))
-      .map(([, value]) => value);
-    expect(textOutputs).toContain('hello-http');
+    // proof the payload flowed submit → execute → result over HTTP.
+    //
+    // DAG-002: this used to filter on `key.endsWith('.text')` and assert only the VALUE, because the
+    // node id in the key was not the one this test wrote — the round trip through the workflow-file
+    // format renamed `in` to `node-1`. The comment called that "a brittle exact key". It was not
+    // brittle; it was wrong, and the test worked around it rather than reporting it. The provider now
+    // runs the definition as given, so the key can be asserted whole.
+    expect(result.outputs['in.text']).toBe('hello-http');
   });
 
   it('submitRun returns a runId whose status becomes terminal', async () => {
-    const runId = await provider.submitRun(buildWorkflowFile(), { text: 'status-check' });
+    const runId = await provider.submitRun(SINGLE_INPUT_DEFINITION, { text: 'status-check' });
     expect(typeof runId).toBe('string');
     expect(runId.length).toBeGreaterThan(0);
 

--- a/packages/agent-command-workflows/src/__tests__/execute-definition-preserves-ids.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/execute-definition-preserves-ids.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeDefinition } from '../authoring/execute-workflow.js';
+
+import type { IDagDefinition, IDagNodeDefinition } from '@robota-sdk/dag-core';
+
+/**
+ * DAG-002, measured on the real production path.
+ *
+ * `executeDefinition` is what `/workflows create` and `/workflows run` both call. It held a canonical
+ * `IDagDefinition`, converted it DOWN to the absorbed workflow-file format because that was the
+ * provider's parameter type, and the provider immediately converted it back UP. Neither direction is
+ * information-preserving, so the definition the runtime executed was not the one the caller authored:
+ * string node ids became `node-<n>` and named ports became `out<i>`/`in<i>`.
+ *
+ * Run outputs are keyed `<nodeId>.<port>`, so a user reading a run record saw fabricated names for
+ * nodes they had themselves named. This case asserts the observable directly, on the path a user
+ * actually reaches — against the defect it reports `node-1.passage` and `node-2.passage`.
+ */
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function echoNode(): IDagNodeDefinition {
+  return {
+    nodeType: 'test/echo',
+    displayName: 'Echo',
+    category: 'test',
+    inputs: [{ key: 'passage', type: 'string', required: false }],
+    outputs: [{ key: 'passage', type: 'string', required: true }],
+    // `null` means "no config schema, accept any config" — the node needs no zod dependency here.
+    configSchemaDefinition: null,
+    defaultInputPort: 'passage',
+    defaultOutputPort: 'passage',
+    taskHandler: {
+      execute: async (input, context) => {
+        const upstream = input['passage'];
+        const own = (context.nodeDefinition.config as { text?: string }).text ?? '';
+        return {
+          ok: true,
+          value: { passage: upstream === undefined ? own : `${String(upstream)}>${own}` },
+        };
+      },
+    },
+  };
+}
+
+function authoredDefinition(): IDagDefinition {
+  return {
+    dagId: 'authored',
+    version: 1,
+    status: 'draft',
+    nodes: [
+      { nodeId: 'greeting', nodeType: 'test/echo', dependsOn: [], config: { text: 'hello' } },
+      {
+        nodeId: 'reply',
+        nodeType: 'test/echo',
+        dependsOn: ['greeting'],
+        config: { text: 'world' },
+      },
+    ],
+    edges: [
+      { from: 'greeting', to: 'reply', bindings: [{ outputKey: 'passage', inputKey: 'passage' }] },
+    ],
+  };
+}
+
+describe('executeDefinition runs the definition it was given (DAG-002)', () => {
+  it('the run names the node ids the author wrote', async () => {
+    const cwd = mkdtempSync(path.join(tmpdir(), 'exec-definition-'));
+    tempDirs.push(cwd);
+
+    const outcome = await executeDefinition(
+      authoredDefinition(),
+      cwd,
+      DEFAULT_WORKSPACE_LAYOUT,
+      [echoNode()],
+      {},
+    );
+
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.ok).toBe(true);
+    // Against the defect: ['node-1.passage', 'node-2.passage'].
+    expect(Object.keys(outcome.outputs).sort()).toEqual(['greeting.passage', 'reply.passage']);
+  });
+});

--- a/packages/agent-command-workflows/src/__tests__/validate-rejects-invalid-status.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/validate-rejects-invalid-status.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { executeWorkflowsValidate } from '../validate-command.js';
+
+/**
+ * DAG-002, review round 2.
+ *
+ * `/workflows validate` open-coded the format branch and assigned a legacy-format object straight
+ * through as `IDagDefinition` with no check, so a file carrying `status: 'active'` — the value
+ * DAG-002 exists to eliminate, and one `dag-cli node`'s example generator emitted until this same
+ * change fixed it — was reported as valid by the surface whose entire job is answering that question.
+ */
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function workspaceWith(contents: unknown): { cwd: string; file: string } {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'validate-status-'));
+  dirs.push(cwd);
+  writeFileSync(path.join(cwd, 'w.json'), JSON.stringify(contents));
+  return { cwd, file: 'w.json' };
+}
+
+describe('/workflows validate reports a status the domain type cannot hold (DAG-002)', () => {
+  it('rejects a definition whose status is outside the union', async () => {
+    const { cwd, file } = workspaceWith({
+      dagId: 'd',
+      version: 1,
+      status: 'active',
+      nodes: [],
+      edges: [],
+    });
+
+    const result = await executeWorkflowsValidate(file, cwd);
+
+    // The message, not just the verdict. MEASURED against the unfixed code: it already returned
+    // `success: false` — for an unrelated "1 issue" about the empty node list — so asserting the
+    // verdict alone is an accidental green that passes whether or not the status is ever checked.
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/'active'/);
+  });
+
+  it('still reports a shape that is neither format', async () => {
+    const { cwd, file } = workspaceWith({ something: 'else' });
+    const result = await executeWorkflowsValidate(file, cwd);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/Not a DAG file/);
+  });
+});

--- a/packages/agent-command-workflows/src/__tests__/workflows-command-module.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/workflows-command-module.test.ts
@@ -145,7 +145,7 @@ describe('workflows validate', () => {
     await writeFile(join(dir, 'x.dag.json'), JSON.stringify({ foo: 1 }));
     const result = await executeWorkflowsValidate('x.dag.json', dir);
     expect(result.success).toBe(false);
-    expect(result.message).toContain('not a recognized DAG workflow file');
+    expect(result.message).toContain('Not a DAG file');
   });
 });
 

--- a/packages/agent-command-workflows/src/authoring/execute-workflow.ts
+++ b/packages/agent-command-workflows/src/authoring/execute-workflow.ts
@@ -4,7 +4,6 @@
  * `run` (nodes reloaded from disk).
  */
 import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
-import { toDagWorkflowFile } from '@robota-sdk/dag-builder';
 import type { IDagDefinition, IDagNodeDefinition, IWorkspaceLayout } from '@robota-sdk/dag-core';
 
 export interface IWorkflowRunOutcome {
@@ -26,10 +25,7 @@ export async function executeDefinition(
     projectDir: cwd,
     ...(instantNodes.length > 0 ? { instantNodes } : {}),
   });
-  // The provider's runtime consumes the ComfyUI-style workflow-file format; convert the legible
-  // `IDagDefinition` we author/save into it before executing.
-  const { workflowFile } = toDagWorkflowFile(definition);
-  const result = await provider.execute(workflowFile, inputs);
+  const result = await provider.execute(definition, inputs);
   return {
     ok: result.ok,
     outputs: result.outputs,

--- a/packages/agent-command-workflows/src/persistence/instant-node-loader.ts
+++ b/packages/agent-command-workflows/src/persistence/instant-node-loader.ts
@@ -17,28 +17,26 @@ import {
   type ICompositeSubRunner,
 } from '@robota-sdk/dag-node-instant-node';
 import { LocalDagRuntimeProvider } from '@robota-sdk/dag-framework';
-import { toDagWorkflowFile } from '@robota-sdk/dag-builder';
 
 const NODE_MANIFEST_EXT = '.node.json';
 
 /**
  * Reshape the runtime provider's flat `"<nodeId>.<port>"` output map into the nested
  * `Record<nodeId, TPortPayload>` shape the composite node contract reads back
- * (`CompositeInstantNodeDefinition` looks up `outputs[nodeId][portKey]`). Runtime node ids are
- * remapped to the inner DAG's original node ids via `runtimeToOriginal` (see `buildCompositeRunner`),
- * falling back to the runtime id when unmapped.
+ * (`CompositeInstantNodeDefinition` looks up `outputs[nodeId][portKey]`).
+ *
+ * DAG-002: this used to take a `runtimeToOriginal` map as well. The provider ran the inner DAG
+ * through the workflow-file format, which renamed every node to `node-<n>`, so the composite had to
+ * rebuild the original ids from a companion produced by the same conversion that destroyed them. The
+ * provider now runs the definition as given, and the ids need no repair.
  */
-function toNestedOutputs(
-  flat: IDagRuntimeResult['outputs'],
-  runtimeToOriginal: Map<string, string>,
-): Record<string, TPortPayload> {
+function toNestedOutputs(flat: IDagRuntimeResult['outputs']): Record<string, TPortPayload> {
   const nested: Record<string, TPortPayload> = {};
   for (const [compound, value] of Object.entries(flat)) {
     const dot = compound.indexOf('.');
     if (dot <= 0) continue;
-    const runtimeNodeId = compound.slice(0, dot);
+    const nodeId = compound.slice(0, dot);
     const portKey = compound.slice(dot + 1);
-    const nodeId = runtimeToOriginal.get(runtimeNodeId) ?? runtimeNodeId;
     (nested[nodeId] ??= {})[portKey] = value as TPortPayload[string];
   }
   return nested;
@@ -48,10 +46,6 @@ function toNestedOutputs(
  * Build a composite sub-runner backed by the in-process local runtime. It closes over the **live**
  * `liveDefs` array so an inner DAG can reference other reloaded instant nodes regardless of load
  * order (they are resolved at run time, not load time).
- *
- * The provider consumes the ComfyUI-style workflow-file format and, lacking the companion, re-keys
- * nodes to `node-<numId>`; the composite contract reads its exposed outputs by the inner DAG's
- * ORIGINAL node ids, so the companion `toDagWorkflowFile` emits is used to remap runtime ids back.
  */
 function buildCompositeRunner(
   cwd: string,
@@ -65,18 +59,10 @@ function buildCompositeRunner(
         projectDir: cwd,
         ...(liveDefs.length > 0 ? { instantNodes: liveDefs } : {}),
       });
-      const { workflowFile, companion } = toDagWorkflowFile(dag);
-      // The provider runs `fromDagWorkflowFile(file, undefined)`, so an original id `<x>` at numeric
-      // id `<n>` surfaces in outputs as `node-<n>.<port>`. Rebuild `node-<n>` → `<x>` from the
-      // companion the converter just produced.
-      const runtimeToOriginal = new Map<string, string>();
-      for (const [numId, meta] of Object.entries(companion.nodes)) {
-        runtimeToOriginal.set(`node-${numId}`, meta.nodeId);
-      }
-      const result = await provider.execute(workflowFile, input);
+      const result = await provider.execute(dag, input);
       return {
         ok: result.ok,
-        outputs: toNestedOutputs(result.outputs, runtimeToOriginal),
+        outputs: toNestedOutputs(result.outputs),
         ...(result.ok ? {} : { error: result.error ?? 'Inner DAG run failed' }),
       };
     },

--- a/packages/agent-command-workflows/src/run-command.ts
+++ b/packages/agent-command-workflows/src/run-command.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { isLegacyDefinitionFormat, toDagWorkflowFile } from '@robota-sdk/dag-builder';
+import { dagDefinitionFromParsedFile } from '@robota-sdk/dag-builder';
 
 import {
   DEFAULT_WORKSPACE_LAYOUT,
-  type IDagWorkflowFile,
+  type IDagDefinition,
   type IWorkspaceLayout,
 } from '@robota-sdk/dag-core';
 import type { ICommandResult } from '@robota-sdk/agent-interface-transport';
@@ -13,17 +13,16 @@ import { parseFileArg } from './args.js';
 import { createWorkspaceRuntime } from './workspace-runtime.js';
 
 /**
- * Read a workflow file in either supported on-disk format and return the runtime workflow-file shape.
- * Legible legacy `IDagDefinition` files (what `create`/dag-cli save) are converted; ComfyUI-style
- * workflow files are used as-is.
+ * Read a workflow file in either supported on-disk format and return the canonical domain model.
+ *
+ * DAG-002: this is the import adapter, and it is the only place the file format belongs. It used to
+ * run the other way — an `IDagDefinition` file was converted INTO the workflow-file format because
+ * that was the provider's parameter type, and the provider converted it straight back, losing the
+ * node ids and port names on the way. A definition on disk is now passed through untouched, and only
+ * a genuine workflow file is converted.
  */
-async function readDagFile(absPath: string): Promise<IDagWorkflowFile> {
-  const raw = await readFile(absPath, 'utf-8');
-  const parsed = JSON.parse(raw) as unknown;
-  if (isLegacyDefinitionFormat(parsed)) {
-    return toDagWorkflowFile(parsed).workflowFile;
-  }
-  return parsed as IDagWorkflowFile;
+async function readDagFile(absPath: string): Promise<IDagDefinition> {
+  return dagDefinitionFromParsedFile(JSON.parse(await readFile(absPath, 'utf-8')));
 }
 
 /**

--- a/packages/agent-command-workflows/src/validate-command.ts
+++ b/packages/agent-command-workflows/src/validate-command.ts
@@ -1,11 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import {
-  fromDagWorkflowFile,
-  isLegacyDefinitionFormat,
-  isWorkflowFileFormat,
-} from '@robota-sdk/dag-builder';
+import { dagDefinitionFromParsedFile } from '@robota-sdk/dag-builder';
 import { DEFAULT_WORKSPACE_LAYOUT, type IWorkspaceLayout } from '@robota-sdk/dag-core';
 
 import { parseFileArg } from './args.js';
@@ -45,15 +41,16 @@ export async function executeWorkflowsValidate(
     return { success: false, message: parsed.message };
   }
 
+  // DAG-002: through the shared import adapter, so the surface whose entire job is answering "is
+  // this file valid?" reports an unrecognised shape AND a status outside `TDagDefinitionStatus`
+  // rather than passing either through as if the file were fine.
   let definition: IDagDefinition;
-  if (isWorkflowFileFormat(parsed)) {
-    definition = fromDagWorkflowFile(parsed);
-  } else if (isLegacyDefinitionFormat(parsed)) {
-    definition = parsed;
-  } else {
+  try {
+    definition = dagDefinitionFromParsedFile(parsed);
+  } catch (err) {
     return {
       success: false,
-      message: `"${filePath}" is not a recognized DAG workflow file (expected a .dag.json node-graph or a DAG definition).`,
+      message: `"${filePath}": ${err instanceof Error ? err.message : String(err)}`,
     };
   }
 

--- a/packages/dag-builder/docs/SPEC.md
+++ b/packages/dag-builder/docs/SPEC.md
@@ -44,7 +44,10 @@
 | `isLegacyDefinitionFormat`    | `(obj)`                | Format guard: parsed JSON is an `IDagDefinition`                        |
 | `DAG_BUILDER_PACKAGE_NAME`    | `string`               | This package's name, for diagnostics that must not hardcode it          |
 
-`dagDefinitionFromParsedFile` is the one place the workflow-file format is read. Since DAG-002 the
+`dagDefinitionFromParsedFile` is where the workflow-file format SHOULD be read, and where the
+surfaces converted so far do read it — `/workflows run`, `/workflows validate` and `dag runs submit`.
+Eight `dag-cli` commands still open-code the same branch and pass a definition through unchecked;
+that sweep is DAG-004. Do not read this as coverage it does not yet have. Since DAG-002 the
 execution contract is the domain model (`IDagRuntimeProvider.execute` takes an `IDagDefinition`), so
 import at the edge is the only job the file format has. It is pure and synchronous: a caller that
 also reads a `.dag.robota.json` companion off disk does that IO itself and passes the result in — the

--- a/packages/dag-builder/docs/SPEC.md
+++ b/packages/dag-builder/docs/SPEC.md
@@ -32,11 +32,24 @@
 
 ## Public API Surface
 
-- `buildDagFromPipeline(input, manifests)` — main builder function
-- `toDagWorkflowFile(definition)` — convert to `.dag.json` format
-- `fromDagWorkflowFile(file)` — parse `.dag.json` back to `IDagDefinition`
-- `toWorkflowNodeType(nodeType)` / `fromWorkflowNodeType(nodeType)` — node type string helpers
-- `isWorkflowFileFormat(obj)` / `isLegacyDefinitionFormat(obj)` — format detection guards
+| Export                        | Signature              | Purpose                                                                 |
+| ----------------------------- | ---------------------- | ----------------------------------------------------------------------- |
+| `buildDagFromPipeline`        | `(input, manifests)`   | Main builder: a pipeline spec plus node manifests → `IDagDefinition`    |
+| `dagDefinitionFromParsedFile` | `(parsed, companion?)` | Import adapter: parsed JSON in either on-disk format → `IDagDefinition` |
+| `toDagWorkflowFile`           | `(definition)`         | Export a definition to the `.dag.json` workflow-file format             |
+| `fromDagWorkflowFile`         | `(file, companion?)`   | Parse a `.dag.json` workflow file back to `IDagDefinition`              |
+| `toWorkflowNodeType`          | `(nodeType)`           | Domain node type → workflow-file node type string                       |
+| `fromWorkflowNodeType`        | `(nodeType)`           | Workflow-file node type string → domain node type                       |
+| `isWorkflowFileFormat`        | `(obj)`                | Format guard: parsed JSON is a workflow file                            |
+| `isLegacyDefinitionFormat`    | `(obj)`                | Format guard: parsed JSON is an `IDagDefinition`                        |
+| `DAG_BUILDER_PACKAGE_NAME`    | `string`               | This package's name, for diagnostics that must not hardcode it          |
+
+`dagDefinitionFromParsedFile` is the one place the workflow-file format is read. Since DAG-002 the
+execution contract is the domain model (`IDagRuntimeProvider.execute` takes an `IDagDefinition`), so
+import at the edge is the only job the file format has. It is pure and synchronous: a caller that
+also reads a `.dag.robota.json` companion off disk does that IO itself and passes the result in — the
+companion carries what the format cannot (original node ids, retry and cost policies), and without it
+an imported workflow's nodes are named `node-<n>` because that is genuinely all the file records.
 
 ## Extension Points
 

--- a/packages/dag-builder/src/__tests__/converter-status-union.test.ts
+++ b/packages/dag-builder/src/__tests__/converter-status-union.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { fromDagWorkflowFile } from '../dag-workflow-converter.js';
+
+import type { IDagWorkflowFile, TDagDefinitionStatus } from '@robota-sdk/dag-core';
+
+/**
+ * DAG-002 — a value produced outside its own union, laundered by a cast.
+ *
+ * `fromDagWorkflowFile` returned `status: (companion?.status ?? 'active') as TDagDefinitionStatus`.
+ * `TDagDefinitionStatus` is `'draft' | 'published' | 'deprecated'` (`dag-core/types/domain.ts:2`) and
+ * `'active'` is not a member of it. The companion's own `status` field is ALREADY typed as
+ * `TDagDefinitionStatus` (`workflow-file.ts:83`), so the cast could never have been needed for the
+ * companion branch — it existed solely to make the default compile.
+ *
+ * The consequence is not cosmetic. Any workflow imported without a companion produced a definition
+ * carrying a status the domain type says cannot exist, and every downstream `switch` over the union
+ * fell through it. Nothing failed, which is why it survived.
+ */
+const STATUSES: readonly TDagDefinitionStatus[] = ['draft', 'published', 'deprecated'];
+
+function emptyWorkflowFile(): IDagWorkflowFile {
+  return {
+    last_node_id: 0,
+    last_link_id: 0,
+    nodes: [],
+    links: [],
+    groups: [],
+    config: {},
+    extra: {},
+    version: 0.4,
+  };
+}
+
+describe('fromDagWorkflowFile produces a status inside its own union (DAG-002)', () => {
+  it('a workflow file with NO companion gets a real domain status', () => {
+    // Against the defect this is `'active'` — a value `TDagDefinitionStatus` does not contain.
+    const definition = fromDagWorkflowFile(emptyWorkflowFile());
+    expect(STATUSES).toContain(definition.status);
+  });
+
+  it("defaults to 'draft' — an imported file has not been published by anyone", () => {
+    expect(fromDagWorkflowFile(emptyWorkflowFile()).status).toBe('draft');
+  });
+
+  it('a companion status is carried through unchanged', () => {
+    // The branch the cast was never needed for: the companion field is already typed as the union.
+    const definition = fromDagWorkflowFile(emptyWorkflowFile(), {
+      dagId: 'd',
+      version: 2,
+      status: 'published',
+      nodes: {},
+    });
+    expect(definition.status).toBe('published');
+  });
+});

--- a/packages/dag-builder/src/__tests__/converter-status-union.test.ts
+++ b/packages/dag-builder/src/__tests__/converter-status-union.test.ts
@@ -108,3 +108,33 @@ describe('the import boundary rejects a status the domain type cannot hold (DAG-
     expect(() => dagDefinitionFromParsedFile({ dagId: 'd', version: 1, nodes: [] })).not.toThrow();
   });
 });
+
+describe('BOTH import branches are validated, not just one (DAG-002)', () => {
+  it('a COMPANION carrying an out-of-union status is rejected too', () => {
+    // Review round 3. `assertStatusInUnion` guarded only the legacy-definition branch; the
+    // workflow-file branch returned `companion?.status ?? 'draft'` unchecked. `tryReadCompanion` in
+    // dag-cli parses a companion with a bare `as IDagRobotaCompanion`, so a pre-DAG-002 companion
+    // carrying 'active' would have walked straight through — the same defect, reachable through the
+    // branch nobody red-proved. No caller passes a companion TODAY, which is exactly why it had to be
+    // closed before DAG-004 routes the eight CLI sites through here with theirs.
+    expect(() =>
+      dagDefinitionFromParsedFile(emptyWorkflowFile(), {
+        dagId: 'd',
+        version: 1,
+        status: 'active' as never,
+        nodes: {},
+      }),
+    ).toThrow(/'active'/);
+  });
+
+  it('a companion with a legal status still passes', () => {
+    expect(
+      dagDefinitionFromParsedFile(emptyWorkflowFile(), {
+        dagId: 'd',
+        version: 1,
+        status: 'published',
+        nodes: {},
+      }).status,
+    ).toBe('published');
+  });
+});

--- a/packages/dag-builder/src/__tests__/converter-status-union.test.ts
+++ b/packages/dag-builder/src/__tests__/converter-status-union.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { fromDagWorkflowFile } from '../dag-workflow-converter.js';
+import { dagDefinitionFromParsedFile } from '../parsed-dag-file.js';
 
 import type { IDagWorkflowFile, TDagDefinitionStatus } from '@robota-sdk/dag-core';
 
@@ -52,5 +53,24 @@ describe('fromDagWorkflowFile produces a status inside its own union (DAG-002)',
       nodes: {},
     });
     expect(definition.status).toBe('published');
+  });
+});
+
+describe('dagDefinitionFromParsedFile is the one import adapter (DAG-002)', () => {
+  it('passes a definition file through untouched', () => {
+    const definition = { dagId: 'd', version: 1, status: 'draft', nodes: [], edges: [] };
+    expect(dagDefinitionFromParsedFile(definition)).toBe(definition);
+  });
+
+  it('converts a workflow file', () => {
+    expect(dagDefinitionFromParsedFile(emptyWorkflowFile()).dagId).toBe('unknown');
+  });
+
+  it('THROWS on a shape that is neither, rather than casting it onward', () => {
+    // Both open-coded copies this replaces ended in a bare `as` here, so an unrecognised file was
+    // handed to the runtime wearing a type it did not have and failed later, somewhere else, as
+    // something else. Naming it at the boundary is the whole point of having one boundary.
+    expect(() => dagDefinitionFromParsedFile({ something: 'else' })).toThrow(/Not a DAG file/);
+    expect(() => dagDefinitionFromParsedFile(null)).toThrow(/Not a DAG file/);
   });
 });

--- a/packages/dag-builder/src/__tests__/converter-status-union.test.ts
+++ b/packages/dag-builder/src/__tests__/converter-status-union.test.ts
@@ -74,3 +74,37 @@ describe('dagDefinitionFromParsedFile is the one import adapter (DAG-002)', () =
     expect(() => dagDefinitionFromParsedFile(null)).toThrow(/Not a DAG file/);
   });
 });
+
+describe('the import boundary rejects a status the domain type cannot hold (DAG-002)', () => {
+  it('names the offending value and the legal set', () => {
+    // The scan cannot see this one: `status: 'active'` written into an UNTYPED object literal, then
+    // serialized. `dag-cli node`'s example generator did exactly that and printed the result for the
+    // user to save — found by review, on a file this PR never touched. A static check over casts was
+    // never going to reach data that arrives at runtime, and files written by older versions are
+    // already out there, so the boundary that now owns every import owns this too.
+    expect(() =>
+      dagDefinitionFromParsedFile({
+        dagId: 'd',
+        version: 1,
+        status: 'active',
+        nodes: [],
+        edges: [],
+      }),
+    ).toThrow(/'active'.*draft.*published.*deprecated/s);
+  });
+
+  it('accepts every legal status', () => {
+    for (const status of STATUSES) {
+      expect(
+        dagDefinitionFromParsedFile({ dagId: 'd', version: 1, status, nodes: [], edges: [] })
+          .status,
+      ).toBe(status);
+    }
+  });
+
+  it('accepts a definition with no status at all rather than inventing one', () => {
+    // Absent is not invalid — only a PRESENT value outside the union is. Rejecting absence would
+    // break every file that predates the field.
+    expect(() => dagDefinitionFromParsedFile({ dagId: 'd', version: 1, nodes: [] })).not.toThrow();
+  });
+});

--- a/packages/dag-builder/src/dag-workflow-converter.ts
+++ b/packages/dag-builder/src/dag-workflow-converter.ts
@@ -10,7 +10,6 @@ import type {
   IDagNode,
   IEdgeBinding,
   INodeConfigObject,
-  TDagDefinitionStatus,
 } from '@robota-sdk/dag-core';
 import type {
   IDagRobotaCompanion,
@@ -278,7 +277,8 @@ export function fromDagWorkflowFile(
   return {
     dagId: companion?.dagId ?? 'unknown',
     version: companion?.version ?? 1,
-    status: (companion?.status ?? 'active') as TDagDefinitionStatus,
+    // DAG-002: `'active'`, the old default, is not a member of `TDagDefinitionStatus`.
+    status: companion?.status ?? 'draft',
     nodes,
     edges,
     ...(companion?.costPolicy ? { costPolicy: companion.costPolicy } : {}),

--- a/packages/dag-builder/src/index.ts
+++ b/packages/dag-builder/src/index.ts
@@ -22,3 +22,5 @@ export {
 } from './dag-workflow-converter.js';
 
 export const DAG_BUILDER_PACKAGE_NAME = '@robota-sdk/dag-builder';
+
+export { dagDefinitionFromParsedFile } from './parsed-dag-file.js';

--- a/packages/dag-builder/src/parsed-dag-file.ts
+++ b/packages/dag-builder/src/parsed-dag-file.ts
@@ -4,7 +4,11 @@ import {
   isWorkflowFileFormat,
 } from './dag-workflow-converter.js';
 
-import type { IDagDefinition, IDagRobotaCompanion } from '@robota-sdk/dag-core';
+import type {
+  IDagDefinition,
+  IDagRobotaCompanion,
+  TDagDefinitionStatus,
+} from '@robota-sdk/dag-core';
 
 /**
  * The import adapter: parsed JSON in either on-disk format → the canonical domain model.
@@ -20,12 +24,39 @@ import type { IDagDefinition, IDagRobotaCompanion } from '@robota-sdk/dag-core';
  * node ids, retry and cost policies), and without it an imported workflow's nodes are named
  * `node-<n>` because that is genuinely all the file records.
  */
+const DEFINITION_STATUSES: readonly TDagDefinitionStatus[] = ['draft', 'published', 'deprecated'];
+
+/**
+ * A definition read off disk may carry a status the domain type says cannot exist.
+ *
+ * `scan-literal-cast-union` catches the shape that produced most of them — a literal cast to a union
+ * it is not in — but it cannot reach a value that arrives at RUNTIME. `dag-cli node`'s example
+ * generator wrote `status: 'active'` into an untyped object literal and printed it for the user to
+ * save; files from before DAG-002 are already on disk. This is the boundary every import now passes
+ * through, so it is where the impossible value gets named instead of flowing on as a lie the type
+ * system has been told to accept.
+ *
+ * An ABSENT status is not a violation — only a present one outside the union. Rejecting absence would
+ * break every file written before the field existed.
+ */
+function assertStatusInUnion(definition: IDagDefinition): IDagDefinition {
+  const status: unknown = definition.status;
+  if (status === undefined || DEFINITION_STATUSES.includes(status as TDagDefinitionStatus)) {
+    return definition;
+  }
+  throw new Error(
+    `DAG definition "${definition.dagId}" has status '${String(status)}', which is not one of ` +
+      `${DEFINITION_STATUSES.map((s) => `'${s}'`).join(', ')}. A file written before DAG-002 can ` +
+      "carry 'active', which never was a member — set a real status rather than passing it on.",
+  );
+}
+
 export function dagDefinitionFromParsedFile(
   parsed: unknown,
   companion?: IDagRobotaCompanion,
 ): IDagDefinition {
   if (isWorkflowFileFormat(parsed)) return fromDagWorkflowFile(parsed, companion);
-  if (isLegacyDefinitionFormat(parsed)) return parsed;
+  if (isLegacyDefinitionFormat(parsed)) return assertStatusInUnion(parsed);
   // Neither shape. Both open-coded copies this replaces ended in a bare `as` here, so an
   // unrecognised file was handed to the runtime wearing a type it did not have and failed later,
   // somewhere else, as something else. Naming it at the boundary is the whole point of having one.

--- a/packages/dag-builder/src/parsed-dag-file.ts
+++ b/packages/dag-builder/src/parsed-dag-file.ts
@@ -1,6 +1,10 @@
-import { fromDagWorkflowFile, isWorkflowFileFormat } from './dag-workflow-converter.js';
+import {
+  fromDagWorkflowFile,
+  isLegacyDefinitionFormat,
+  isWorkflowFileFormat,
+} from './dag-workflow-converter.js';
 
-import type { IDagDefinition, IDagRobotaCompanion, IDagWorkflowFile } from '@robota-sdk/dag-core';
+import type { IDagDefinition, IDagRobotaCompanion } from '@robota-sdk/dag-core';
 
 /**
  * The import adapter: parsed JSON in either on-disk format → the canonical domain model.
@@ -20,7 +24,13 @@ export function dagDefinitionFromParsedFile(
   parsed: unknown,
   companion?: IDagRobotaCompanion,
 ): IDagDefinition {
-  if (isWorkflowFileFormat(parsed))
-    return fromDagWorkflowFile(parsed as IDagWorkflowFile, companion);
-  return parsed as IDagDefinition;
+  if (isWorkflowFileFormat(parsed)) return fromDagWorkflowFile(parsed, companion);
+  if (isLegacyDefinitionFormat(parsed)) return parsed;
+  // Neither shape. Both open-coded copies this replaces ended in a bare `as` here, so an
+  // unrecognised file was handed to the runtime wearing a type it did not have and failed later,
+  // somewhere else, as something else. Naming it at the boundary is the whole point of having one.
+  throw new Error(
+    'Not a DAG file: expected either a workflow file (nodes + links + version) or a definition ' +
+      '(dagId + nodes). Neither shape was found.',
+  );
 }

--- a/packages/dag-builder/src/parsed-dag-file.ts
+++ b/packages/dag-builder/src/parsed-dag-file.ts
@@ -30,7 +30,8 @@ const DEFINITION_STATUSES: readonly TDagDefinitionStatus[] = ['draft', 'publishe
  * A definition read off disk may carry a status the domain type says cannot exist.
  *
  * `scan-literal-cast-union` catches the shape that produced most of them — a literal cast to a union
- * it is not in — but it cannot reach a value that arrives at RUNTIME. `dag-cli node`'s example
+ * it is not in — but it cannot reach a value that arrives at RUNTIME, from a definition file OR from
+ * the companion a workflow file is read with. `dag-cli node`'s example
  * generator wrote `status: 'active'` into an untyped object literal and printed it for the user to
  * save; files from before DAG-002 are already on disk. This is the boundary every import now passes
  * through, so it is where the impossible value gets named instead of flowing on as a lie the type
@@ -55,7 +56,12 @@ export function dagDefinitionFromParsedFile(
   parsed: unknown,
   companion?: IDagRobotaCompanion,
 ): IDagDefinition {
-  if (isWorkflowFileFormat(parsed)) return fromDagWorkflowFile(parsed, companion);
+  // BOTH branches, not just the one that was easy to reach. The workflow-file branch takes its status
+  // from the companion, which `dag-cli` parses with a bare `as IDagRobotaCompanion`, so a companion
+  // written before DAG-002 carries 'active' into a definition exactly as a definition file would.
+  if (isWorkflowFileFormat(parsed)) {
+    return assertStatusInUnion(fromDagWorkflowFile(parsed, companion));
+  }
   if (isLegacyDefinitionFormat(parsed)) return assertStatusInUnion(parsed);
   // Neither shape. Both open-coded copies this replaces ended in a bare `as` here, so an
   // unrecognised file was handed to the runtime wearing a type it did not have and failed later,

--- a/packages/dag-builder/src/parsed-dag-file.ts
+++ b/packages/dag-builder/src/parsed-dag-file.ts
@@ -1,0 +1,26 @@
+import { fromDagWorkflowFile, isWorkflowFileFormat } from './dag-workflow-converter.js';
+
+import type { IDagDefinition, IDagRobotaCompanion, IDagWorkflowFile } from '@robota-sdk/dag-core';
+
+/**
+ * The import adapter: parsed JSON in either on-disk format → the canonical domain model.
+ *
+ * DAG-002 moved the execution contract onto `IDagDefinition`, which leaves exactly one job for the
+ * absorbed workflow-file format — being read at the edge. This is that edge, in one place, because it
+ * was open-coded at every call site and the copies had drifted: one asserted the workflow-file shape
+ * with a bare cast and never checked it, so a definition file submitted there reached the provider
+ * mislabelled.
+ *
+ * Pure and synchronous. Callers that also read a `.dag.robota.json` companion off disk do the IO
+ * themselves and pass the result in — the companion carries what the file format cannot (original
+ * node ids, retry and cost policies), and without it an imported workflow's nodes are named
+ * `node-<n>` because that is genuinely all the file records.
+ */
+export function dagDefinitionFromParsedFile(
+  parsed: unknown,
+  companion?: IDagRobotaCompanion,
+): IDagDefinition {
+  if (isWorkflowFileFormat(parsed))
+    return fromDagWorkflowFile(parsed as IDagWorkflowFile, companion);
+  return parsed as IDagDefinition;
+}

--- a/packages/dag-cli/src/__tests__/read-dag-file-arg.test.ts
+++ b/packages/dag-cli/src/__tests__/read-dag-file-arg.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readDagFileArg } from '../commands/read-dag-file-arg.js';
+
+/**
+ * DAG-002 — the CLI half of the import adapter.
+ *
+ * `runs submit` read the file and asserted the workflow-file shape with a bare cast, so a definition
+ * file (or anything else) reached the provider mislabelled and failed later, somewhere else, as
+ * something else. The three ways this can go wrong all used to surface as an unhandled stack trace
+ * from the CLI entry point; each is now a message and a usage exit code.
+ */
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function fileWith(contents: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'read-dag-arg-'));
+  dirs.push(dir);
+  const file = path.join(dir, 'w.json');
+  writeFileSync(file, contents);
+  return file;
+}
+
+describe('readDagFileArg', () => {
+  it('reads a definition file as the domain model', async () => {
+    const file = fileWith(
+      JSON.stringify({ dagId: 'd', version: 1, status: 'draft', nodes: [], edges: [] }),
+    );
+    const result = await readDagFileArg(file);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.dagId).toBe('d');
+  });
+
+  it('reads a workflow file, converting it', async () => {
+    const file = fileWith(JSON.stringify({ nodes: [], links: [], version: 0.4 }));
+    const result = await readDagFileArg(file);
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports a file that is neither format instead of passing it on', async () => {
+    const result = await readDagFileArg(fileWith(JSON.stringify({ something: 'else' })));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toMatch(/Not a DAG file/);
+  });
+
+  it('reports unparseable JSON', async () => {
+    const result = await readDagFileArg(fileWith('{ not json'));
+    expect(result.ok).toBe(false);
+  });
+
+  it('reports a missing file rather than throwing', async () => {
+    // Inside a mkdtemp dir, not joined onto `tmpdir()` directly — a predictable temp path is what
+    // the SEC-003 floor exists to stop, and it caught the first draft of this very case.
+    const dir = mkdtempSync(path.join(tmpdir(), 'read-dag-arg-'));
+    dirs.push(dir);
+    const result = await readDagFileArg(path.join(dir, 'absent.json'));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain('absent.json');
+  });
+});

--- a/packages/dag-cli/src/commands/node.ts
+++ b/packages/dag-cli/src/commands/node.ts
@@ -878,7 +878,7 @@ function handleExampleCommand(manifests: INodeManifest[], nodeType: string, io: 
   const example = {
     dagId: `${nodeType}-example`,
     version: 1,
-    status: 'active',
+    status: 'draft', // DAG-002: 'active' is not in TDagDefinitionStatus
     nodes,
     edges,
   };
@@ -1116,7 +1116,7 @@ async function runExampleInPlace(
   const example = {
     dagId: `${nodeType}-example`,
     version: 1,
-    status: 'active',
+    status: 'draft', // DAG-002: 'active' is not in TDagDefinitionStatus
     nodes,
     edges,
   };

--- a/packages/dag-cli/src/commands/read-dag-file-arg.ts
+++ b/packages/dag-cli/src/commands/read-dag-file-arg.ts
@@ -1,0 +1,32 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { dagDefinitionFromParsedFile } from '@robota-sdk/dag-builder';
+
+import type { IDagDefinition } from '@robota-sdk/dag-core';
+
+/**
+ * Read a DAG file named on the command line and return the domain model, or the message to show.
+ *
+ * DAG-002 gave the two on-disk formats a single import adapter; this is the CLI-side half — path,
+ * IO, parse, and the error text a user should see. It exists as its own module because the three
+ * failure modes here (missing file, unparseable JSON, a shape that is neither format) all used to
+ * reach the user as an unhandled stack trace from the CLI entry point, and because folding them
+ * inline pushed the `runs` command past the file-size ceiling.
+ *
+ * Returns a discriminated result rather than throwing: every caller here renders an exit code, and a
+ * usage error is not exceptional.
+ */
+export async function readDagFileArg(
+  filePath: string,
+): Promise<{ ok: true; value: IDagDefinition } | { ok: false; message: string }> {
+  try {
+    const text = await readFile(resolve(filePath), 'utf8');
+    return { ok: true, value: dagDefinitionFromParsedFile(JSON.parse(text)) };
+  } catch (err) {
+    return {
+      ok: false,
+      message: `${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/packages/dag-cli/src/commands/runs.ts
+++ b/packages/dag-cli/src/commands/runs.ts
@@ -10,13 +10,10 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { getRunStore } from '../run-store.js';
-import type {
-  IDagRuntimeProvider,
-  IDetachableRunProvider,
-  IDagWorkflowFile,
-} from '@robota-sdk/dag-core';
+import type { IDagRuntimeProvider, IDetachableRunProvider } from '@robota-sdk/dag-core';
 import { FAILURE_EXIT_CODE, USAGE_ERROR_EXIT_CODE, SUCCESS_EXIT_CODE } from '../types.js';
 import type { IDagCliIo } from '../types.js';
+import { dagDefinitionFromParsedFile } from '@robota-sdk/dag-builder';
 import { resolveProvider } from '../providers/index.js';
 
 const JSON_INDENT = 2;
@@ -286,7 +283,8 @@ export async function runsCommand(
       return USAGE_ERROR_EXIT_CODE;
     }
     const text = await readFile(resolve(filePath), 'utf8');
-    const dag = JSON.parse(text) as IDagWorkflowFile;
+    // DAG-002: this used to assert the workflow-file shape with a bare cast and never check it.
+    const dag = dagDefinitionFromParsedFile(JSON.parse(text));
     const runId = await runtimeProvider.submitRun(dag, {});
     if (outputFormat === 'json') {
       io.write(`${JSON.stringify({ runId }, null, JSON_INDENT)}\n`);

--- a/packages/dag-cli/src/commands/runs.ts
+++ b/packages/dag-cli/src/commands/runs.ts
@@ -7,13 +7,11 @@
 //   dag runs cancel   <runId>
 //   dag runs submit   <file>
 
-import { readFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import { getRunStore } from '../run-store.js';
 import type { IDagRuntimeProvider, IDetachableRunProvider } from '@robota-sdk/dag-core';
 import { FAILURE_EXIT_CODE, USAGE_ERROR_EXIT_CODE, SUCCESS_EXIT_CODE } from '../types.js';
 import type { IDagCliIo } from '../types.js';
-import { dagDefinitionFromParsedFile } from '@robota-sdk/dag-builder';
+import { readDagFileArg } from './read-dag-file-arg.js';
 import { resolveProvider } from '../providers/index.js';
 
 const JSON_INDENT = 2;
@@ -282,10 +280,12 @@ export async function runsCommand(
       io.writeError('Error: submit requires a workflow file path.\n');
       return USAGE_ERROR_EXIT_CODE;
     }
-    const text = await readFile(resolve(filePath), 'utf8');
-    // DAG-002: this used to assert the workflow-file shape with a bare cast and never check it.
-    const dag = dagDefinitionFromParsedFile(JSON.parse(text));
-    const runId = await runtimeProvider.submitRun(dag, {});
+    const loaded = await readDagFileArg(filePath);
+    if (!loaded.ok) {
+      io.writeError(`Error: ${loaded.message}\n`);
+      return USAGE_ERROR_EXIT_CODE;
+    }
+    const runId = await runtimeProvider.submitRun(loaded.value, {});
     if (outputFormat === 'json') {
       io.write(`${JSON.stringify({ runId }, null, JSON_INDENT)}\n`);
     } else {

--- a/packages/dag-core/src/types/runtime-provider.ts
+++ b/packages/dag-core/src/types/runtime-provider.ts
@@ -5,7 +5,7 @@
 // behind a single TypeScript interface, so that a local in-process runtime —
 // and any future native provider — are fully substitutable.
 
-import type { IDagWorkflowFile } from './workflow-file.js';
+import type { IDagDefinition } from './domain.js';
 
 /**
  * Port type spec for a node input.
@@ -16,9 +16,7 @@ import type { IDagWorkflowFile } from './workflow-file.js';
  *   - `[choices, schema]` — enumerated choices plus options
  */
 export type INodePortSpec =
-  | [string]
-  | [string, Record<string, unknown>]
-  | [string[], Record<string, unknown>];
+  [string] | [string, Record<string, unknown>] | [string[], Record<string, unknown>];
 
 /**
  * A single node entry in the catalog returned by `listNodes()`.
@@ -109,8 +107,19 @@ export interface IDagRuntimeProvider {
   readonly providerId: string;
   readonly displayName: string;
   listNodes(): Promise<IDagNodeManifest[]>;
+  /**
+   * Run a DAG.
+   *
+   * DAG-002: this takes the canonical domain model. It used to take `IDagWorkflowFile` — the
+   * absorbed ComfyUI-style serialization — so every caller, already holding an `IDagDefinition`,
+   * converted DOWN to it and every provider converted straight back UP. The conversion preserves
+   * information in neither direction: node ids were rewritten to `node-<n>` and unnamed ports were
+   * invented as `out<i>`/`in<i>`, and the loss reached the user in run outputs, which are keyed
+   * `<nodeId>.<port>`. The file format remains what it always was — an import/export shape, read at
+   * the edge by `fromDagWorkflowFile` — and is no longer the execution contract.
+   */
   execute(
-    dag: IDagWorkflowFile,
+    dag: IDagDefinition,
     inputs: Record<string, unknown>,
     options?: IDagRuntimeExecuteOptions,
   ): Promise<IDagRuntimeResult>;
@@ -122,7 +131,7 @@ export interface IDagRuntimeProvider {
  * `runId` + queue/history lifecycle.
  */
 export interface IDetachableRunProvider extends IDagRuntimeProvider {
-  submitRun(dag: IDagWorkflowFile, inputs: Record<string, unknown>): Promise<string>;
+  submitRun(dag: IDagDefinition, inputs: Record<string, unknown>): Promise<string>;
   watchRun(
     runId: string,
     onProgress: (event: IDagRuntimeProgressEvent) => void,

--- a/packages/dag-framework/src/__tests__/execution-contract-domain-model.test.ts
+++ b/packages/dag-framework/src/__tests__/execution-contract-domain-model.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { DEFAULT_WORKSPACE_LAYOUT } from '@robota-sdk/dag-core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { LocalDagRuntimeProvider } from '../local-dag-runtime-provider.js';
+
+import type { IDagDefinition, IDagNodeDefinition } from '@robota-sdk/dag-core';
+
+/**
+ * DAG-002 — the execution contract was typed on an imported system's file format.
+ *
+ * `IDagRuntimeProvider.execute` took an `IDagWorkflowFile` — the absorbed ComfyUI-style
+ * serialization, with `last_node_id`, numeric node ids, and `links` as six-element tuples. Every
+ * production caller already held the canonical `IDagDefinition`, converted DOWN to that format, and
+ * the provider immediately converted back UP. The conversion is not information-preserving in either
+ * direction, so what came back was not what went in:
+ *
+ * - node ids were rewritten to `node-<n>` (`dag-workflow-converter.ts:207`), destroying string ids,
+ * - port keys were INVENTED as `out<i>`/`in<i>` (`:253-254`) when a slot carried no name.
+ *
+ * Run outputs are keyed `<nodeId>.<port>` (`run-result-mapping.ts:35`), so the loss surfaced directly
+ * in the result a caller reads. `instant-node-loader.ts` had to rebuild a `node-<n>` → original-id map
+ * from a companion file produced purely to survive a round trip between two callers who both already
+ * held the definition.
+ *
+ * These cases pin the observable, not the internals: a definition with meaningful string node ids and
+ * named ports comes back naming those same ids and ports. Against the defect the keys are `node-1.…`
+ * and `node-2.…`.
+ */
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function projectDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'dag-exec-contract-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** A node that needs no provider, no key and no network: it echoes its config into a named port. */
+function echoNode(): IDagNodeDefinition {
+  return {
+    nodeType: 'test/echo',
+    displayName: 'Echo',
+    category: 'test',
+    inputs: [{ key: 'passage', type: 'string', required: false }],
+    outputs: [{ key: 'passage', type: 'string', required: true }],
+    // `null` means "no config schema, accept any config" — the node needs no zod dependency here.
+    configSchemaDefinition: null,
+    defaultInputPort: 'passage',
+    defaultOutputPort: 'passage',
+    taskHandler: {
+      execute: async (input, context) => {
+        const upstream = input['passage'];
+        const own = (context.nodeDefinition.config as { text?: string }).text ?? '';
+        return {
+          ok: true,
+          value: { passage: upstream === undefined ? own : `${String(upstream)}>${own}` },
+        };
+      },
+    },
+  };
+}
+
+/**
+ * Two nodes whose ids are words rather than numbers, joined on a port whose name is a word rather
+ * than a slot index. Both are exactly what the round trip could not carry.
+ */
+function definitionWithStringIds(): IDagDefinition {
+  return {
+    dagId: 'string-ids',
+    version: 1,
+    status: 'draft',
+    nodes: [
+      { nodeId: 'greeting', nodeType: 'test/echo', dependsOn: [], config: { text: 'hello' } },
+      {
+        nodeId: 'reply',
+        nodeType: 'test/echo',
+        dependsOn: ['greeting'],
+        config: { text: 'world' },
+      },
+    ],
+    edges: [
+      { from: 'greeting', to: 'reply', bindings: [{ outputKey: 'passage', inputKey: 'passage' }] },
+    ],
+  };
+}
+
+describe('the execution contract carries the domain model (DAG-002)', () => {
+  it('run outputs name the ORIGINAL string node ids', async () => {
+    const provider = new LocalDagRuntimeProvider({
+      workspace: DEFAULT_WORKSPACE_LAYOUT,
+      projectDir: projectDir(),
+      instantNodes: [echoNode()],
+    });
+
+    const result = await provider.execute(definitionWithStringIds(), {});
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    // Against the defect these read `node-1.passage` / `node-2.passage`.
+    expect(Object.keys(result.outputs).sort()).toEqual(['greeting.passage', 'reply.passage']);
+  });
+
+  it('the named port survives, and the edge it carries is still wired', async () => {
+    // A port key invented as `out0`/`in0` would not match the handler's declared `passage` port, so
+    // the value would not arrive: the id loss and the wiring loss are the same defect seen twice.
+    const provider = new LocalDagRuntimeProvider({
+      workspace: DEFAULT_WORKSPACE_LAYOUT,
+      projectDir: projectDir(),
+      instantNodes: [echoNode()],
+    });
+
+    const result = await provider.execute(definitionWithStringIds(), {});
+
+    expect(result.outputs['reply.passage']).toBe('hello>world');
+  });
+});

--- a/packages/dag-framework/src/__tests__/tool-node-run.test.ts
+++ b/packages/dag-framework/src/__tests__/tool-node-run.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { buildDagFromPipeline, toDagWorkflowFile } from '@robota-sdk/dag-builder';
+import { buildDagFromPipeline } from '@robota-sdk/dag-builder';
 import type { INodeManifest } from '@robota-sdk/dag-core';
 import { LocalDagRuntimeProvider } from '../local-dag-runtime-provider.js';
 import { createDefaultNodeRegistrySync } from '@robota-sdk/dag-nodes-default';
@@ -56,8 +56,9 @@ describe('tool node — functional run through LocalDagRuntimeProvider', () => {
     expect(build.ok).toBe(true);
     if (!build.ok) return;
 
-    const { workflowFile } = toDagWorkflowFile(build.definition);
-    const result = await provider.execute(workflowFile, {});
+    // DAG-002: the provider takes the definition the builder produced, with no round trip through
+    // the workflow-file format in between.
+    const result = await provider.execute(build.definition, {});
 
     expect(result.ok).toBe(true);
     const serialized = JSON.stringify(result.outputs);

--- a/packages/dag-framework/src/http-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/http-dag-runtime-provider.ts
@@ -3,13 +3,13 @@
 // progress over the SSE stream, query status, and read the final result. Mirrors LocalDagRuntimeProvider
 // behaviour via the shared run-result mapping (no per-provider drift).
 
-import { fromDagWorkflowFile } from '@robota-sdk/dag-builder';
 import { DagOrchestrationHttpClient } from '@robota-sdk/dag-orchestration-client';
 
 import { isTerminalStatus, mapRunToResult } from './run-result-mapping.js';
 import { trimTrailingSlashes } from './trim-trailing-slashes.js';
 
 import type {
+  IDagDefinition,
   IDagNodeManifest,
   IDagRun,
   IDagRunStatus,
@@ -17,7 +17,6 @@ import type {
   IDagRunSummary,
   IDagRuntimeProgressEvent,
   IDagRuntimeResult,
-  IDagWorkflowFile,
   IDetachableRunProvider,
   IListRunsOptions,
   ITaskRun,
@@ -134,7 +133,7 @@ export class HttpDagRuntimeProvider implements IDetachableRunProvider {
   }
 
   public async execute(
-    dag: IDagWorkflowFile,
+    dag: IDagDefinition,
     inputs: Record<string, unknown>,
     options?: IDagRuntimeExecuteOptions,
   ): Promise<IDagRuntimeResult> {
@@ -142,9 +141,11 @@ export class HttpDagRuntimeProvider implements IDetachableRunProvider {
     return this.watchRun(runId, options?.onProgress ?? (() => undefined), options?.signal);
   }
 
-  public async submitRun(dag: IDagWorkflowFile, inputs: Record<string, unknown>): Promise<string> {
-    const definition = fromDagWorkflowFile(dag);
-    const created = await this.client.createRun({ definition, input: inputs as TPortPayload });
+  public async submitRun(dag: IDagDefinition, inputs: Record<string, unknown>): Promise<string> {
+    // DAG-002: the wire body was ALWAYS the canonical definition — `createRun` takes one. The
+    // conversion here existed only to undo a conversion the caller had just performed, and lost node
+    // ids and port names on the way through.
+    const created = await this.client.createRun({ definition: dag, input: inputs as TPortPayload });
     if (!created.ok) {
       throw new Error(`createRun failed (HTTP ${created.status})`);
     }

--- a/packages/dag-framework/src/local-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/local-dag-runtime-provider.ts
@@ -102,9 +102,8 @@ export class LocalDagRuntimeProvider implements IDagRuntimeProvider {
     options?: IDagRuntimeExecuteOptions,
   ): Promise<IDagRuntimeResult> {
     const nodeDefinitions = await this.buildNodeRegistry();
-    // DAG-002: executed as given. `fromDagWorkflowFile(dag, undefined)` used to sit here, rewriting
-    // every node id to `node-<n>` — undoing a conversion the caller had just performed.
-    const definition = dag;
+    // DAG-002: run as given. `fromDagWorkflowFile(dag, undefined)` used to sit here, rewriting every
+    // node id to `node-<n>` — undoing a conversion the caller had just performed.
 
     const startMs = Date.now();
     let aborted = false;
@@ -115,7 +114,7 @@ export class LocalDagRuntimeProvider implements IDagRuntimeProvider {
 
     try {
       const result = await runDagOnce(
-        definition,
+        dag,
         nodeDefinitions,
         inputs as TPortPayload,
         options?.onProgress,

--- a/packages/dag-framework/src/local-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/local-dag-runtime-provider.ts
@@ -13,7 +13,6 @@ import type {
   IDagRuntimeResult,
   IDagNodeManifest,
   INodePortSpec,
-  IDagWorkflowFile,
   ITaskExecutorPort,
   TPortPayload,
   TRunProgressEvent,
@@ -34,7 +33,6 @@ import {
   StaticNodeManifestRegistry,
   StaticNodeTaskHandlerRegistry,
 } from '@robota-sdk/dag-node';
-import { fromDagWorkflowFile } from '@robota-sdk/dag-builder';
 
 import { loadDefaultNodeRegistrySync } from './load-default-node-registry.js';
 import { createExecutionComposition } from './composition/create-execution-composition.js';
@@ -99,12 +97,14 @@ export class LocalDagRuntimeProvider implements IDagRuntimeProvider {
   }
 
   public async execute(
-    dag: IDagWorkflowFile,
+    dag: IDagDefinition,
     inputs: Record<string, unknown>,
     options?: IDagRuntimeExecuteOptions,
   ): Promise<IDagRuntimeResult> {
     const nodeDefinitions = await this.buildNodeRegistry();
-    const definition = fromDagWorkflowFile(dag, undefined);
+    // DAG-002: executed as given. `fromDagWorkflowFile(dag, undefined)` used to sit here, rewriting
+    // every node id to `node-<n>` — undoing a conversion the caller had just performed.
+    const definition = dag;
 
     const startMs = Date.now();
     let aborted = false;

--- a/packages/dag-framework/src/local-dag-runtime-provider.ts
+++ b/packages/dag-framework/src/local-dag-runtime-provider.ts
@@ -81,9 +81,9 @@ export interface ILocalDagRuntimeProviderOptions {
 /**
  * Local (in-process) implementation of {@link IDagRuntimeProvider}.
  *
- * Surfaces the node catalog via {@link listNodes} and accepts a `.dag.json`
- * workflow file via {@link execute}, emitting {@link IDagRuntimeProgressEvent}s
- * as the run progresses.
+ * Surfaces the node catalog via {@link listNodes} and runs an {@link IDagDefinition} via
+ * {@link execute} (DAG-002 — it took a `.dag.json` workflow file before), emitting
+ * {@link IDagRuntimeProgressEvent}s as the run progresses.
  */
 export class LocalDagRuntimeProvider implements IDagRuntimeProvider {
   public readonly providerId = 'local';

--- a/scripts/harness/__tests__/scan-literal-cast-union.test.mjs
+++ b/scripts/harness/__tests__/scan-literal-cast-union.test.mjs
@@ -1,0 +1,147 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectStringUnions,
+  findLiteralCastUnionFindings,
+  findLiteralCastViolations,
+} from '../scan-literal-cast-union.mjs';
+
+/**
+ * The scan exists for one measured defect (DAG-002): `(companion?.status ?? 'active') as
+ * TDagDefinitionStatus`, where the union is `'draft' | 'published' | 'deprecated'`.
+ *
+ * Two directions matter, and the second more than the first. It must FAIL on that shape — a check
+ * that cannot fail is worse than no check. And it must NOT fail on the shapes it cannot decide, because
+ * a scan that reports violations it is not sure of gets suppressed rather than obeyed, and a suppressed
+ * scan protects nothing.
+ */
+const UNIONS = new Map([['TStatus', new Set(['draft', 'published', 'deprecated'])]]);
+
+function scan(source, unions = UNIONS) {
+  return findLiteralCastViolations(['f.ts'], unions, () => source);
+}
+
+function unionsOf(source) {
+  return collectStringUnions(['f.ts'], () => source);
+}
+
+describe('scan-literal-cast-union', () => {
+  it('reverse (RED): the exact DAG-002 shape fails', () => {
+    const found = scan(`status: (companion?.status ?? 'active') as TStatus,`);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.literal).toBe('active');
+    expect(found[0]?.union).toBe('TStatus');
+  });
+
+  it('reverse (RED): a bare literal cast outside the union fails', () => {
+    expect(scan(`const s = 'archived' as TStatus;`)).toHaveLength(1);
+  });
+
+  it('reverse (RED): a ternary branch outside the union fails, and names that branch', () => {
+    const found = scan(`const s = (ok ? 'draft' : 'active') as TStatus;`);
+    expect(found.map((f) => f.literal)).toEqual(['active']);
+  });
+
+  it('a literal that IS a member passes', () => {
+    expect(scan(`const s = 'draft' as TStatus;`)).toEqual([]);
+  });
+
+  it('every branch being a member passes', () => {
+    expect(scan(`const s = (a ?? 'draft') as TStatus;`)).toEqual([]);
+  });
+
+  it('a NON-literal operand is not judged', () => {
+    // `someString as TStatus` is exactly as unchecked as it was. The scan narrows the hole to what it
+    // can decide with certainty; claiming more would mean reporting findings it cannot support.
+    expect(scan(`const s = resolveStatus(x) as TStatus;`)).toEqual([]);
+    expect(scan(`const s = raw as TStatus;`)).toEqual([]);
+  });
+
+  it('a cast to an unknown type name is not judged', () => {
+    expect(scan(`const s = 'anything' as TSomethingNotDeclaredHere;`)).toEqual([]);
+  });
+
+  it('an operator that is NOT a default is not followed', () => {
+    // `+` does not select between its operands the way `??`/`||`/`?:` do, so a literal inside one is
+    // not a value the cast can receive.
+    expect(scan("const s = ('a' + 'b') as TStatus;")).toEqual([]);
+  });
+
+  it('reports the line of the LITERAL, not of the cast', () => {
+    const source = ['const a = 1;', 'const s = (', "  'active'", ') as TStatus;'].join('\n');
+    expect(scan(source)[0]?.line).toBe(3);
+  });
+
+  describe('union collection', () => {
+    it('collects a plain string union', () => {
+      expect([...(unionsOf(`export type T = 'a' | 'b';`).get('T') ?? [])]).toEqual(['a', 'b']);
+    });
+
+    it('collects a DOUBLE-quoted union', () => {
+      // The cheap pre-filter's first version matched only `'`, and silently dropped two real
+      // double-quoted unions on this tree. A union the scan never learned about is one it can never
+      // find a violation against — an under-report, which is the direction that matters.
+      expect([...(unionsOf(`type T = "a" | "b";`).get('T') ?? [])]).toEqual(['a', 'b']);
+    });
+
+    it('collects a union whose members start on the NEXT line after a leading bar', () => {
+      expect([...(unionsOf("type T =\n  | 'a'\n  | 'b';").get('T') ?? [])]).toEqual(['a', 'b']);
+    });
+
+    it('collects a single-member alias', () => {
+      expect([...(unionsOf(`type T = 'only';`).get('T') ?? [])]).toEqual(['only']);
+    });
+
+    it('marks a union with a NON-literal member unjudgeable rather than partial', () => {
+      // `'a' | string` accepts every string. Recording it as `{'a'}` would report every other literal
+      // as a violation — the false-positive flood that gets a scan turned off.
+      expect(unionsOf(`type T = 'a' | string;`).get('T')).toBeNull();
+      expect(scan(`const s = 'zzz' as T;`, unionsOf(`type T = 'a' | string;`))).toEqual([]);
+    });
+
+    it('does not treat a non-union alias as an empty member set', () => {
+      // An empty set would make EVERY literal cast to it a violation.
+      const unions = unionsOf(`type T = Record<string, number>;`);
+      expect(scan(`const s = 'x' as T;`, unions)).toEqual([]);
+    });
+
+    it('merges two declarations of the same alias name rather than judging by one', () => {
+      const unions = collectStringUnions(['a.ts', 'b.ts'], (f) =>
+        f === 'a.ts' ? `type T = 'x';` : `type T = 'y';`,
+      );
+      expect(scan(`const s = 'y' as T;`, unions)).toEqual([]);
+    });
+  });
+
+  /**
+   * The registered path and the live tree. A scan that works when imported and is never invoked is
+   * the declared-but-unreachable shape this repository's audit is about.
+   */
+  it('is registered, fails closed, and passes on the live repository', () => {
+    const root = path.resolve(import.meta.dirname, '../../..');
+    expect(readFileSync(path.join(root, 'scripts/harness/run-all-scans.mjs'), 'utf8')).toContain(
+      'scan-literal-cast-union.mjs',
+    );
+
+    // Fail-closed: a root without the governed tree is an error, never a pass.
+    const bare = mkdtempSync(path.join(tmpdir(), 'literal-cast-bare-'));
+    try {
+      expect(() => findLiteralCastUnionFindings(bare)).toThrow(/nothing could be examined/);
+    } finally {
+      rmSync(bare, { recursive: true, force: true });
+    }
+
+    const output = execFileSync('node', ['scripts/harness/scan-literal-cast-union.mjs'], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    // A pass over nothing is not a pass — assert the size it reports.
+    const examined = Number(/passed \((\d+) file/.exec(output)?.[1] ?? '0');
+    expect(examined).toBeGreaterThan(1000);
+  });
+});

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -77,7 +77,6 @@
   "packages/dag-cli/src/commands/node.ts": 1479,
   "packages/dag-cli/src/commands/perf.ts": 402,
   "packages/dag-cli/src/commands/run.ts": 2390,
-  "packages/dag-cli/src/commands/runs.ts": 302,
   "packages/dag-cli/src/commands/share.ts": 475,
   "packages/dag-cli/src/commands/tutorial.ts": 684,
   "packages/dag-cli/src/commands/validate.ts": 815,

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -87,7 +87,7 @@
   "packages/dag-cli/src/studio/ui-html.ts": 355,
   "packages/dag-framework/src/adapters/orchestration-adapter.ts": 665,
   "packages/dag-framework/src/adapters/prompt-backend.ts": 402,
-  "packages/dag-framework/src/local-dag-runtime-provider.ts": 365,
+  "packages/dag-framework/src/local-dag-runtime-provider.ts": 364,
   "packages/dag-nodes/gemini-image-edit/src/runtime-core.ts": 318,
   "packages/dag-nodes/instant-node/src/index.ts": 588,
   "packages/dag-nodes/utility-text/src/index.ts": 626

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -233,6 +233,10 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/scan-contract-cast-ratchet.mjs'],
   },
   {
+    name: 'literal-cast-union',
+    command: ['node', 'scripts/harness/scan-literal-cast-union.mjs'],
+  },
+  {
     name: 'release-verification-gate',
     command: ['node', 'scripts/harness/scan-release-verification-gate.mjs'],
   },

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -87,6 +87,13 @@ const REGISTRATION_FILE = path.join(HARNESS_DIR, 'run-all-scans.mjs');
  */
 export const MANDATORY_TREE_GUARDS = [
   {
+    // Measured 2026-08-02 against a bare root: throws `none of packages, apps, scripts exist`.
+    file: 'scan-literal-cast-union.mjs',
+    finder: 'findLiteralCastUnionFindings',
+    tree: 'packages/, apps/ and scripts/',
+    why: 'it decides membership by reading the union declarations AND the cast sites out of the same tree; over a root with neither, "no literal is cast outside its union" is true of nothing, and the defect it exists for (a status value outside its own union, laundered by a cast, DAG-002) is exactly the kind that survives by producing no symptom',
+  },
+  {
     file: 'scan-review-token-supply.mjs',
     finder: 'findReviewTokenSupplyFindings',
     tree: '.github/workflows',

--- a/scripts/harness/scan-literal-cast-union.mjs
+++ b/scripts/harness/scan-literal-cast-union.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+/**
+ * A cast cannot make a value a member of a union it is not in.
+ *
+ * `status: (companion?.status ?? 'active') as TDagDefinitionStatus` compiles, ships, and is wrong.
+ * `TDagDefinitionStatus` is `'draft' | 'published' | 'deprecated'`; `'active'` is not in it. Every
+ * `switch` downstream fell through that value, and nothing failed — which is why it survived long
+ * enough to be found by an architecture audit rather than by the type system whose job it was.
+ *
+ * WHY A SCAN AND NOT JUST A FIX (DAG-002). The compiler already had every fact needed to reject this.
+ * The `as` is what silenced it, and an `as` is invisible to review precisely because it reads like a
+ * type annotation. The one in that line was doubly hollow: the other branch of the `??` was ALREADY
+ * typed as the union, so the cast could never have been needed for anything except the default it
+ * made compile. Fixing the site leaves the shape available everywhere else.
+ *
+ * WHAT IT CHECKS, exactly. For every `X as T` where `T` names a repo-declared string-literal union,
+ * every string literal reachable in the operand through `??`, `||`, `?:` and parentheses must be a
+ * member of `T`. Those operators are followed because they are how a default is spelled; anything
+ * else in the operand (a call, a variable, a property access) is not a literal and is not judged.
+ *
+ * WHAT IT CANNOT DO, stated so a pass is not over-read:
+ *
+ * - It resolves unions by NAME across the repository's own `type X = 'a' | 'b'` declarations. Two
+ *   packages declaring the same alias name are merged, so a literal valid in either passes. Measured
+ *   on this tree: no first-party string-union alias name is declared twice with differing members.
+ * - A union imported from a dependency is not declared here and so is not judged at all.
+ * - A union built by composition (`type T = A | B`, `Exclude<…>`) is skipped rather than
+ *   half-resolved: a partial member set would report false violations, which is the one failure mode
+ *   that gets a scan suppressed instead of obeyed.
+ * - It says nothing about non-literal operands. `someString as TStatus` is exactly as unchecked as it
+ *   was; this scan narrows the hole to the case it can decide with certainty, and does not claim the
+ *   rest.
+ *
+ * FAIL-CLOSED: the governed source tree is mandatory. A run over a root without it is a run that
+ * could not judge, and reports that rather than a pass.
+ *
+ * Exit code 0 = no literal is cast outside its own union, 1 = violation found.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  ScriptTarget,
+  SyntaxKind,
+  createSourceFile,
+  forEachChild,
+  isAsExpression,
+  isBinaryExpression,
+  isIdentifier,
+  isLiteralTypeNode,
+  isParenthesizedExpression,
+  isStringLiteral,
+  isTypeAliasDeclaration,
+  isTypeReferenceNode,
+} from './lib/ts-ast.mjs';
+
+const SOURCE_ROOTS = ['packages', 'apps', 'scripts'];
+
+/** A type alias whose right-hand side starts with a quoted literal (optionally after a leading `|`). */
+const STRING_UNION_HINT = /type\s+\w+\s*=[\s\n]*\|?[\s\n]*['"]/;
+
+function sourceFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) sourceFiles(full, out);
+    else if (/\.(ts|tsx)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+function parse(file, source) {
+  return createSourceFile(file, source, ScriptTarget.Latest, true);
+}
+
+/**
+ * Every `type X = 'a' | 'b'` in the tree, as name → Set of members.
+ *
+ * A union that is not PURELY string literals is recorded as `null` — known by name, deliberately
+ * unjudgeable — so a later `as` to it is skipped rather than measured against a member set that was
+ * only partly resolved. Reporting a violation from a half-known union is how a scan earns a blanket
+ * suppression.
+ */
+export function collectStringUnions(files, readFile = (f) => readFileSync(f, 'utf8')) {
+  const unions = new Map();
+  for (const file of files) {
+    const source = readFile(file);
+    // Parse only files that could declare a string union at all. This is a cheap reject, and it is
+    // only safe because it was VERIFIED equivalent rather than assumed: run against the whole tree,
+    // the filter takes 2728 files down to 117 and loses none of the 353 aliases with a real member
+    // set. Its first version omitted `"` and silently dropped two double-quoted unions — an
+    // under-report, which is the direction that matters, since a union the scan never learned about
+    // is a union it can never find a violation against.
+    if (!STRING_UNION_HINT.test(source)) continue;
+    const ast = parse(file, source);
+    const visit = (node) => {
+      if (isTypeAliasDeclaration(node)) {
+        const name = node.name.getText(ast);
+        const members = unionMembers(node.type, ast);
+        if (members === null) unions.set(name, null);
+        else if (members.size > 0) {
+          const existing = unions.get(name);
+          if (existing === undefined) unions.set(name, members);
+          else if (existing !== null) for (const m of members) existing.add(m);
+        }
+      }
+      forEachChild(node, visit);
+    };
+    visit(ast);
+  }
+  return unions;
+}
+
+/** The literal members of a union type node, or `null` if any member is not a string literal. */
+function unionMembers(typeNode, ast) {
+  if (isLiteralTypeNode(typeNode)) {
+    return isStringLiteral(typeNode.literal) ? new Set([typeNode.literal.text]) : null;
+  }
+  if (typeNode.kind !== SyntaxKind.UnionType) return new Set();
+  const members = new Set();
+  for (const member of typeNode.types) {
+    if (!isLiteralTypeNode(member) || !isStringLiteral(member.literal)) return null;
+    members.add(member.literal.text);
+  }
+  return members;
+}
+
+/**
+ * The string literals a value expression can evaluate to, following only the operators that spell a
+ * default. Anything else contributes nothing — this reports what it is sure of.
+ */
+function reachableLiterals(node, out = []) {
+  if (isParenthesizedExpression(node)) return reachableLiterals(node.expression, out);
+  if (isStringLiteral(node)) {
+    out.push(node);
+    return out;
+  }
+  if (node.kind === SyntaxKind.ConditionalExpression) {
+    reachableLiterals(node.whenTrue, out);
+    reachableLiterals(node.whenFalse, out);
+    return out;
+  }
+  if (isBinaryExpression(node)) {
+    const op = node.operatorToken.kind;
+    if (op === SyntaxKind.QuestionQuestionToken || op === SyntaxKind.BarBarToken) {
+      reachableLiterals(node.left, out);
+      reachableLiterals(node.right, out);
+    }
+  }
+  return out;
+}
+
+/** Findings: a string literal cast to a repo-declared union it is not a member of. */
+export function findLiteralCastViolations(
+  files,
+  unions,
+  readFile = (f) => readFileSync(f, 'utf8'),
+) {
+  const findings = [];
+  for (const file of files) {
+    const source = readFile(file);
+    if (!source.includes(' as ')) continue;
+    const ast = parse(file, source);
+    const visit = (node) => {
+      if (
+        isAsExpression(node) &&
+        isTypeReferenceNode(node.type) &&
+        isIdentifier(node.type.typeName)
+      ) {
+        const name = node.type.typeName.text;
+        const members = unions.get(name);
+        if (members) {
+          for (const literal of reachableLiterals(node.expression)) {
+            if (members.has(literal.text)) continue;
+            findings.push({
+              file,
+              line: ast.getLineAndCharacterOfPosition(literal.getStart(ast)).line + 1,
+              literal: literal.text,
+              union: name,
+              members: [...members],
+            });
+          }
+        }
+      }
+      forEachChild(node, visit);
+    };
+    visit(ast);
+  }
+  return findings;
+}
+
+export function findLiteralCastUnionFindings(root) {
+  const roots = SOURCE_ROOTS.map((dir) => path.join(root, dir)).filter((dir) => existsSync(dir));
+  if (roots.length === 0) {
+    // Fail closed. "No source here" is not "no violations here".
+    throw new Error(
+      `literal-cast-union: none of ${SOURCE_ROOTS.join(', ')} exist under ${root} — nothing could be examined.`,
+    );
+  }
+  const files = roots.flatMap((dir) => sourceFiles(dir));
+  return {
+    findings: findLiteralCastViolations(files, collectStringUnions(files)),
+    examined: files.length,
+  };
+}
+
+function main() {
+  const { findings, examined } = findLiteralCastUnionFindings(process.cwd());
+  if (findings.length > 0) {
+    console.error(`literal-cast-union scan failed: ${findings.length} finding(s):`);
+    for (const f of findings) {
+      console.error(
+        `- [literal-outside-union] ${path.relative(process.cwd(), f.file)}:${f.line} — ` +
+          `'${f.literal}' is cast to ${f.union}, ` +
+          `whose members are ${f.members.map((m) => `'${m}'`).join(' | ')}. A cast does not make it ` +
+          'one; every consumer switching on that union falls through this value silently.',
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`literal-cast-union scan passed (${examined} file(s) examined).`);
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) main();

--- a/scripts/harness/scan-literal-cast-union.mjs
+++ b/scripts/harness/scan-literal-cast-union.mjs
@@ -31,6 +31,12 @@
  * - It says nothing about non-literal operands. `someString as TStatus` is exactly as unchecked as it
  *   was; this scan narrows the hole to the case it can decide with certainty, and does not claim the
  *   rest.
+ * - It sees only CASTS. A literal written into an UNTYPED object literal and then serialized reaches
+ *   the same wrong place with no cast to find: review caught `dag-cli node` printing
+ *   `status: 'active'` in an example definition for the user to save, on a file DAG-002 never
+ *   touched. Static analysis was never going to reach a value that arrives at runtime either, so
+ *   `dagDefinitionFromParsedFile` validates the status of every definition it imports. This scan is
+ *   one of two layers, not the whole guarantee.
  *
  * FAIL-CLOSED: the governed source tree is mandatory. A run over a root without it is a run that
  * could not judge, and reports that rather than a pass.

--- a/scripts/harness/spec-surface-baseline.json
+++ b/scripts/harness/spec-surface-baseline.json
@@ -13,7 +13,6 @@
   "@robota-sdk/agent-transport": 9,
   "@robota-sdk/dag-adapters-sqlite": 2,
   "@robota-sdk/dag-api": 10,
-  "@robota-sdk/dag-builder": 8,
   "@robota-sdk/dag-cli": 1,
   "@robota-sdk/dag-core": 10,
   "@robota-sdk/dag-framework": 8,


### PR DESCRIPTION
## The defect

`IDagRuntimeProvider.execute` took `IDagWorkflowFile` — an absorbed ComfyUI-style serialization with
`last_node_id`, numeric node ids and six-element `links` tuples. Every production caller already held
the canonical `IDagDefinition`, converted DOWN to that format, and the provider immediately converted
back UP. The conversion preserves information in neither direction.

**The loss reached the user.** Run outputs are keyed `<nodeId>.<port>`, so a workflow authored with
node ids `greeting` and `reply` reported:

```
['node-1.passage', 'node-2.passage']
```

That is measured through `executeDefinition` — the function `/workflows create` and `/workflows run`
both call — and it is the regression test. A first draft asserted the same thing through the provider
directly, but against the old signature it failed with `workflowFile.links is not iterable`: a crash
proving the types differ, not the loss. It was rewritten to run the production path, where the failure
IS the defect.

## The change

- `execute` / `submitRun` take `IDagDefinition`.
- Both providers drop their conversion. `HttpDagRuntimeProvider` is the sharpest instance — its wire
  body was **always** the canonical definition (`createRun({ definition })`), so the round trip existed
  purely to undo the caller's, losing ids on the way through.
- `instant-node-loader`'s companion-derived `node-<n> → <originalId>` repair map is gone, along with
  the reason it existed.
- `dagDefinitionFromParsedFile` becomes the single import adapter. It was open-coded per call site and
  the copies had drifted: `runs submit` asserted the workflow-file shape with a bare cast and never
  checked, so a definition file submitted there reached the provider mislabelled.
- `status: (companion?.status ?? 'active') as TDagDefinitionStatus` → `?? 'draft'`, cast deleted.
  `'active'` is not in that union, and the cast was needed for nothing else: `companion.status` is
  already typed as it.

`toDagWorkflowFile` survives at exactly three sites — `migrate` and the MCP `format`/`build` handlers
— all of which genuinely emit the file format. That is the whole of its remaining job.

## Prevention, not just repair

`scan-literal-cast-union.mjs` fails when a string literal is cast to a repo-declared union it is not a
member of, following `??`, `||`, `?:` and parentheses into the operand — the operators that spell a
default, which is how this one was written.

- **Red-proved end to end**: reinstated on the real converter it names the exact line; removed again it
  passes over 2728 files with no other finding, so no pre-existing debt is being suppressed.
- Registered, **fails closed**, and classified in `MANDATORY_TREE_GUARDS` by execution (45 → 46).
- It deliberately does not judge a non-literal operand, an imported union, or a composed union. A scan
  that reports findings it cannot support gets suppressed rather than obeyed.
- Its pre-filter (2728 files → 117, 12.8s → 3.1s) was **verified equivalent** against the full parse,
  not assumed. The first version matched only `'` and silently dropped two double-quoted unions.

## Self-review found two things on my own diff

1. The new adapter fell through to `parsed as IDagDefinition` — a bare cast at exactly the boundary
   whose bare cast is this item's subject. It now throws and names both expected shapes.
2. That throw would have reached the CLI as a stack trace (`runs submit` has no try/catch, and neither
   does the runner — the pre-existing unparseable-JSON error was equally unhandled). Extracted to
   `read-dag-file-arg.ts` returning a discriminated result.

## Ratchets moved, not suppressed

`runs.ts` fell below its size baseline (re-frozen; the extraction was also what the hard 300-line
maximum required). `dag-builder` went from 8 undocumented exports to 0 — its SPEC's Public API section
was a bullet list the surface scan could not read at all.

`scan-file-size` and `no-insecure-temp-path` (SEC-003) each caught me during this work and each was
right. Neither was suppressed.

## Verification

Full `pnpm build`, `pnpm test`, `pnpm typecheck`, `pnpm lint` (0 errors) green; 87 of 88 scans pass.
The one failure, `progress-report-quantification`, reads session transcripts rather than the repo and
fails identically on `develop` — it is tracked as HARNESS-054.

## Left open, deliberately

- `IDagWorkflowFile` still lives in `dag-core`. The finding left that choice open and this does not
  decide it.
- Stored artifacts written through the old path may still carry `status: 'active'`. Nothing migrates
  them; the scan prevents new ones.
- Six other CLI commands still open-code their own companion-reading loader. They do IO the new adapter
  deliberately does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso