### PR TITLE
chore(backlog): HARNESS-074 done — with the guard its own test plan asked for

### DIFF
--- a/.agents/tasks/completed/HARNESS-074-the-review-loop-duplicates-the-reviewer.md
+++ b/.agents/tasks/completed/HARNESS-074-the-review-loop-duplicates-the-reviewer.md
@@ -1,7 +1,8 @@
 ---
 title: 'HARNESS-074: the review machinery performs a second review instead of resolving the first'
-status: todo
+status: done
 created: 2026-08-03
+completed: 2026-08-03
 priority: high
 urgency: now
 area: .agents/skills, .claude/hooks, scripts/harness
@@ -127,6 +128,20 @@ push. Its readers were enumerated mechanically rather than assumed — `pre-push
 gate that reads a record; `merge-gate.sh` reads a pull-request label and `review-gate.yml` reads
 code-scanning results and labels. That enumeration is written into `.agents/local-reviews/README.md`
 so the next reader need not re-derive it.
+
+**Step 3's guard was missing when the first pull request merged, and this is the correction.** Round B
+had been rewritten in #1615 to read the review rather than dispatch one — but nothing checked it, and
+this item's own test plan asks for exactly that check. Prose that used to be wrong, corrected, with no
+mechanism behind it, is the state this repository files items about; leaving it that way while marking
+the item done would have been the claim without the evidence.
+
+The guard reads DISPATCH language, not the agent's name: Round B legitimately mentions
+`pr-review-reviewer` once while describing what the local round does, and a check that banned the name
+would have forced that sentence out. It uses `dispatchedAgents` — the same reading the orchestration
+map's own drift check uses — so there is one definition of "this skill dispatches that agent".
+
+Red-proved against the Round B that shipped before #1615: `dispatchedAgents` returns
+`['pr-review-reviewer']` there and `[]` now.
 
 **Step 5 — `pr-review-reviewer` keeps both of its uses,** unchanged: the local diff before a pull
 request exists, and the tree diff in `delegated-refactor-green-gate`. Neither is a second opinion on

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { isReviewed, recordPathFor } from '../record-local-review.mjs';
+import { dispatchedAgents } from '../scan-orchestration-map.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/pre-push-check.sh');
@@ -567,6 +568,21 @@ describe('the skill still puts the round before the push', () => {
     // push — so this pins the narrowed claim rather than the phrase it replaced.
     expect(skill).toMatch(/before the pull request exists/i);
     expect(skill).toMatch(/harness:review:record/);
+  });
+
+  it('never dispatches a reviewer on the open pull request', () => {
+    // HARNESS-074's own test plan. Round B once dispatched `pr-review-reviewer` on the OPEN pull
+    // request — a second review of what CI had already reviewed, without the comment history, so it
+    // could not see which findings an earlier round had answered. Correcting the prose is not the
+    // guard; this is, and it must not fire on the sentence in Round B that MENTIONS the agent while
+    // describing what the local round does, which is why it reads dispatch language rather than the
+    // name. `dispatchedAgents` is the same reading the orchestration map's own drift check uses.
+    const roundB = skill.slice(skill.indexOf('### Round B'));
+
+    expect(
+      dispatchedAgents(roundB, ['pr-review-reviewer', 'architecture-auditor', 'proposal-reviewer']),
+      'the loop dispatches a reviewer on an open pull request, which is the duplication it exists to prevent',
+    ).toEqual([]);
   });
 
   it('says the round stops once the pull request is open, as the hook does', () => {


### PR DESCRIPTION
Follow-up to #1621. Two things that should have ridden along with it.

## The guard the item's test plan required

HARNESS-074's test plan asks for "a check that the pull-request loop does not dispatch a reviewer agent — proven to FAIL against the state before this item". Round B was rewritten in #1615 to READ the review instead of dispatching one, but **nothing checked it**. Corrected prose with no mechanism behind it is the state this repository files items about, and marking the item done without the guard would have been the claim without the evidence.

The guard reads **dispatch language, not the agent's name**: Round B legitimately mentions `pr-review-reviewer` once while describing what the local round does, and a check that banned the name would have forced that sentence out. It calls `dispatchedAgents` — the same reading the orchestration map's own drift check uses — so "this skill dispatches that agent" has one definition, not two.

**Red-proved** against the Round B that shipped before #1615:

```
PRE-FIX Round B dispatches: [ 'pr-review-reviewer' ]
CURRENT Round B dispatches: []
```

## The completion move

`HARNESS-074` → `.agents/tasks/completed/` with its date, and the evidence paragraph recording what the guard covers and how it was proved.

## Verification

- `pnpm harness:test` — 2550 passed.
- `pnpm harness:scan` — 94/95; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso