### PR TITLE
feat(harness): freeze what the rules tree cites, so the sweep can be measured (HARNESS-073)

### DIFF
--- a/.agents/memory/review-rounds-until-zero.md
+++ b/.agents/memory/review-rounds-until-zero.md
@@ -3,7 +3,9 @@
 **Owner: [`../skills/pr-finding-resolution-loop/SKILL.md`](../skills/pr-finding-resolution-loop/SKILL.md)**,
 Round B step 4 — the rule, the owner directive of 2026-08-03 behind it, and the evidence.
 General form: [`../rules/enforcement-architecture.md`](../rules/enforcement-architecture.md), the
-auto-re-drive bullet.
+auto-re-drive bullet. Which reviewer owns a diff, and when: Rounds A and B of that same skill,
+mechanically enforced by [`../../.claude/hooks/pre-push-check.sh`](../../.claude/hooks/pre-push-check.sh)
+(HARNESS-074).
 
 This file exists only so a reader arriving at `.agents/memory/` is sent there. Beyond the heading —
 which has to say what it points at to be findable — it states none of the rule's operative clauses,

--- a/.agents/tasks/HARNESS-073-rules-carry-case-narrative-and-repo-specifics.md
+++ b/.agents/tasks/HARNESS-073-rules-carry-case-narrative-and-repo-specifics.md
@@ -88,6 +88,37 @@ Two constraints that are not negotiable in the rewrite:
 The cross-file duplications the audits found are the same defect one level up and are in scope here:
 one invariant stated in two rule files is what diverges later.
 
+## Progress — the floor is in, the sweep is not
+
+`scan-rule-case-narrative.mjs` is registered and frozen. It measures the CITABLE class: a work-item
+identifier, a pull-request or issue number, a calendar date, anywhere in a rule document. **128
+citations across 17 of 24 documents** — the number the sweep now has to bring down, and the number
+that makes a fall visible.
+
+Three exemptions, each because it is not a case:
+
+- **A resolving link.** `[SOME-123](../tasks/SOME-123-….md)` IS the relocation the form asks for — the
+  invariant here, the incident in the record that owns it, and a way for the reader to get there. The
+  target must exist, so this exemption doubles as the check for the unresolvable-identifier defect the
+  audits found. A link counts once however many times the identifier appears inside it, since naming
+  the record in both the text and the path is how a link is written.
+- **A fenced block**, where an identifier is a slot in a format being shown.
+- **`<!-- allow-citation: <reason> -->`**, and the reason has to be one: `allow-citation: -->` reads as
+  a reason to a naive check, which is how an exception nobody had to justify spreads.
+
+**What it cannot see, stated in its own output so the pass cannot be mistaken for completion:**
+narrative whose citation has worn off. The audit found a file with zero identifier matches and the
+highest narrative count. This item is NOT closed by the scan going green.
+
+Two defects in the scan were found by its own cases before it was trusted: an unresolved link counted
+twice, and the empty reason above. Both fixed, and the ratchet red-proved in both directions at the
+command line — a citation added to a document in the target form exits 1 as `unfrozen`, and a lowered
+count exits 1 as `fell` demanding a re-freeze.
+
+Reference form confirmed mechanically rather than by reading: `tdd-and-planning.md` and
+`naming-style.md` report zero, and a case pins that so the two documents cannot quietly drift out of
+the form they are held up as.
+
 ## Test Plan
 
 - **Required red-first regression:** a mechanical check that a rule document contains no case

--- a/scripts/harness/__tests__/scan-rule-case-narrative.test.mjs
+++ b/scripts/harness/__tests__/scan-rule-case-narrative.test.mjs
@@ -69,6 +69,18 @@ describe('what counts as a case', () => {
     expect(found[0].kind).toBe('unresolved-link');
   });
 
+  it('counts two different records named by one broken link, not just the first', () => {
+    // Deduping on the link alone swallowed the second: the first identifier claimed the link and
+    // every later citation inside it was dropped, so a line naming two dead records reported one. The
+    // key is the record, not the link — which still collapses the identifier that a link repeats in
+    // its text and its path by construction.
+    const twoRecords = findCaseNarrative('[SOME-100 and SOME-200](../gone.md)', nothingResolves);
+    const oneRecordTwice = findCaseNarrative('[SOME-100](../SOME-100-x.md)', nothingResolves);
+
+    expect(twoRecords.map((f) => f.citation)).toEqual(['SOME-100', 'SOME-200']);
+    expect(oneRecordTwice).toHaveLength(1);
+  });
+
   it('treats an identifier inside a fenced block as a specimen', () => {
     // A format being shown needs a slot filled in, and the filling is not a claim that it happened.
     const found = findCaseNarrative(

--- a/scripts/harness/__tests__/scan-rule-case-narrative.test.mjs
+++ b/scripts/harness/__tests__/scan-rule-case-narrative.test.mjs
@@ -90,6 +90,17 @@ describe('what counts as a case', () => {
     expect(found.map((f) => f.citation)).toEqual(['SOME-222']);
   });
 
+  it('still sees a citation wrapped in an inline code span', () => {
+    // Review proposed exempting inline spans by the same argument that exempts fenced blocks. It does
+    // not hold here, on two counts measured over the real tree: of the citations inside single
+    // backticks, some are format specimens and at least one is a plain retelling of a particular
+    // case, so the exemption would not separate them — and it would make evasion two backticks wide.
+    // An inline example that must name a real identifier declares itself instead, which is one line.
+    const found = findCaseNarrative('Shipped in all three phases: `SOME-123`.', nothingResolves);
+
+    expect(found.map((f) => f.citation)).toEqual(['SOME-123']);
+  });
+
   it('honours a declared exception that carries its reason, and not one that does not', () => {
     const withReason =
       'The identifier is the format. <!-- allow-citation: names the wire field -->';

--- a/scripts/harness/__tests__/scan-rule-case-narrative.test.mjs
+++ b/scripts/harness/__tests__/scan-rule-case-narrative.test.mjs
@@ -1,0 +1,191 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { compare, findCaseNarrative, scanRules } from '../scan-rule-case-narrative.mjs';
+
+/**
+ * A rule states an invariant; the incident that taught it belongs in the record that owns it.
+ *
+ * The cost of getting this wrong is not tidiness. Every line of a rule is loaded before any work
+ * begins, and a rule justified by an incident invites the reader to decide whether their situation
+ * resembles that incident — which is the discretion a rule exists to remove.
+ */
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+const RULES_DIR = path.resolve(import.meta.dirname, '../../../.agents/rules');
+
+/** Nothing resolves, so a link is judged on the link alone and not on the tree under it. */
+const nothingResolves = { resolves: () => false };
+const everythingResolves = { resolves: () => true };
+
+describe('what counts as a case', () => {
+  it('flags the three citation shapes', () => {
+    const found = findCaseNarrative(
+      [
+        'Never force-push a shared branch (SOME-123).',
+        'Owner feedback, 2026-07-17: commit as the work progresses.',
+        'A blind delete once removed the integration branch (#1483).',
+      ].join('\n'),
+      nothingResolves,
+    );
+
+    expect(found.map((f) => f.citation)).toEqual(['SOME-123', '2026-07-17', '#1483']);
+    expect(found.every((f) => f.kind === 'case-narrative')).toBe(true);
+  });
+
+  it('does not flag an invariant stated without one', () => {
+    // The reference form. Two documents in the tree already meet it, which is why it is a target and
+    // not an aspiration — see the case over the real tree below.
+    const found = findCaseNarrative(
+      'A gate that cannot be run locally is a gate discovered in CI. Run it before you reach it.',
+      nothingResolves,
+    );
+
+    expect(found).toEqual([]);
+  });
+
+  it('exempts a citation that links to a record which exists', () => {
+    // This is the relocation the form asks for: the invariant is here, the incident is over there,
+    // and the reader can go and read it.
+    const line = 'Contained — [SOME-123](../tasks/SOME-123-the-thing.md).';
+
+    expect(findCaseNarrative(line, everythingResolves)).toEqual([]);
+  });
+
+  it('flags a citation whose link resolves to nothing, and says which defect it is', () => {
+    // The worse of the two. Naming a record that is not there is the condition the rules themselves
+    // refuse, and calling it `case-narrative` would send the fix the wrong way — the repair is to
+    // point the link somewhere real, not to delete it.
+    const found = findCaseNarrative('See [SOME-123](../tasks/SOME-123-gone.md).', nothingResolves);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe('unresolved-link');
+  });
+
+  it('treats an identifier inside a fenced block as a specimen', () => {
+    // A format being shown needs a slot filled in, and the filling is not a claim that it happened.
+    const found = findCaseNarrative(
+      ['File the item as:', '```', 'SOME-123-a-short-slug.md   # 2026-07-17', '```'].join('\n'),
+      nothingResolves,
+    );
+
+    expect(found).toEqual([]);
+  });
+
+  it('closes the fence again, so a citation after the block is still seen', () => {
+    // A one-way fence flag would silence the whole rest of the document after any code block —
+    // the largest rule files open several, and everything below the first would stop being read.
+    const found = findCaseNarrative(
+      ['```', 'SOME-111-inside.md', '```', 'And afterwards, SOME-222 outside.'].join('\n'),
+      nothingResolves,
+    );
+
+    expect(found.map((f) => f.citation)).toEqual(['SOME-222']);
+  });
+
+  it('honours a declared exception that carries its reason, and not one that does not', () => {
+    const withReason =
+      'The identifier is the format. <!-- allow-citation: names the wire field -->';
+    const bare = 'Keeping this one because. <!-- allow-citation: -->';
+
+    expect(findCaseNarrative(`SOME-123 ${withReason}`, nothingResolves)).toEqual([]);
+    expect(findCaseNarrative(`SOME-123 ${bare}`, nothingResolves)).toHaveLength(1);
+  });
+});
+
+describe('the ratchet', () => {
+  it('reports a rise, a fall, an unfrozen document and a stale row — all in one pass', () => {
+    // One run must tell an operator everything they have to act on. Stopping at the first offender
+    // turns a sweep into a queue of runs, and the second finding is the one that gets lost.
+    const verdict = compare(
+      { 'grew.md': 4, 'fell.md': 1, 'new.md': 2, 'clean.md': 0 },
+      { 'grew.md': 2, 'fell.md': 3, 'deleted.md': 5 },
+    );
+
+    expect(verdict.grew).toEqual([{ name: 'grew.md', count: 4, frozen: 2 }]);
+    expect(verdict.shrunk).toEqual([{ name: 'fell.md', count: 1, frozen: 3 }]);
+    expect(verdict.unfrozen).toEqual([{ name: 'new.md', count: 2 }]);
+    expect(verdict.missing).toEqual(['deleted.md']);
+    expect(verdict.ok).toBe(false);
+  });
+
+  it('passes only when every document sits exactly on its frozen count', () => {
+    expect(compare({ 'a.md': 3, 'b.md': 0 }, { 'a.md': 3 }).ok).toBe(true);
+  });
+
+  it('does not treat a new document with no citations as unfrozen', () => {
+    // A rule written in the target form must not have to be added to the baseline to be allowed.
+    expect(compare({ 'clean.md': 0 }, {}).ok).toBe(true);
+  });
+});
+
+describe('over the tree it governs', () => {
+  it('refuses a root with no rules to read instead of reporting a low count', () => {
+    // Fail closed. A count taken over no documents is not a low count — the failure mode this
+    // harness has met most often is a check that examined nothing and rendered as a tick.
+    const dir = mkdtempSync(path.join(tmpdir(), 'rules-empty-'));
+    scratch.push(dir);
+
+    expect(() => scanRules(dir)).toThrow(/does not exist/);
+
+    mkdirSync(path.join(dir, '.agents/rules'), { recursive: true });
+    expect(() => scanRules(dir), 'an empty rules directory passed as clean').toThrow(
+      /no documents to examine/,
+    );
+  });
+
+  it('finds the citable narrative the tree actually carries', () => {
+    // The red half of this check's own proof: it is trusted because it FAILS against the tree as it
+    // stands. If this ever reaches zero the assertion should be replaced by "is zero", not deleted.
+    const { findings, examined } = scanRules();
+
+    expect(examined, 'the scan examined no rule documents').toBeGreaterThan(10);
+    expect(
+      findings.length,
+      'the tree reports no citations, which the audit measured otherwise',
+    ).toBeGreaterThan(0);
+  });
+
+  it('reports zero for the documents already written in the target form', () => {
+    // `tdd-and-planning.md` states the longest technical invariant in the tree with no case material
+    // at all. The form is achievable; these two are the reference.
+    for (const name of ['tdd-and-planning.md', 'naming-style.md']) {
+      const source = readFileSync(path.join(RULES_DIR, name), 'utf8');
+      expect(
+        findCaseNarrative(source, { resolves: () => false }),
+        `${name} is the reference form and no longer meets it`,
+      ).toEqual([]);
+    }
+  });
+
+  it('is registered, so it runs', () => {
+    // A scan nobody dispatches is indistinguishable from no scan — measured repeatedly in this tree.
+    const registry = readFileSync(
+      path.resolve(import.meta.dirname, '../run-all-scans.mjs'),
+      'utf8',
+    );
+
+    expect(registry).toContain('scan-rule-case-narrative.mjs');
+  });
+
+  it('freezes what it measures, and the frozen file matches the tree', () => {
+    // A baseline that has drifted from the tree is the ratchet reporting on a state that no longer
+    // exists. This is the case that makes a forgotten re-freeze loud.
+    const baseline = JSON.parse(
+      readFileSync(
+        path.resolve(import.meta.dirname, '../rule-case-narrative-baseline.json'),
+        'utf8',
+      ),
+    );
+    const { perFile } = scanRules();
+
+    expect(compare(perFile, baseline).ok, 'the baseline no longer describes the tree').toBe(true);
+  });
+});

--- a/scripts/harness/rule-case-narrative-baseline.json
+++ b/scripts/harness/rule-case-narrative-baseline.json
@@ -1,0 +1,19 @@
+{
+  "agent-conduct.md": 1,
+  "api-boundary.md": 1,
+  "backlog-execution.md": 13,
+  "code-quality.md": 2,
+  "common-mistakes.md": 52,
+  "documentation-sync.md": 1,
+  "enforcement-architecture.md": 12,
+  "finding-depth.md": 4,
+  "git-branch.md": 27,
+  "helper-limits.md": 1,
+  "learning-loop.md": 1,
+  "operational.md": 6,
+  "process.md": 1,
+  "publish.md": 1,
+  "release-operations.md": 1,
+  "spec-workflow.md": 2,
+  "verification.md": 2
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -261,6 +261,10 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/scan-runner-wait.mjs'],
   },
   {
+    name: 'rule-case-narrative',
+    command: ['node', 'scripts/harness/scan-rule-case-narrative.mjs'],
+  },
+  {
     name: 'harness-scope-literal',
     command: ['node', 'scripts/harness/scan-harness-scope-literal.mjs'],
   },

--- a/scripts/harness/scan-rule-case-narrative.mjs
+++ b/scripts/harness/scan-rule-case-narrative.mjs
@@ -25,6 +25,13 @@
  *    the rules themselves refuse — so this exemption doubles as the check for that.
  *  - **A specimen.** Inside a fenced code block, an identifier is a slot in a format being shown, not
  *    a claim about something that happened.
+ *
+ *    An INLINE code span is deliberately not exempt, though the same argument seems to apply to it.
+ *    Measured over this tree: of the citations inside single backticks, some are specimens and at
+ *    least one is a plain retelling of a particular case. So the exemption would not separate the two
+ *    — and worse, it would make evasion a matter of typing two backticks around the citation. An
+ *    inline example that must name a real identifier declares itself below, which costs one line and
+ *    is read once by a reviewer.
  *  - **A declared exception**, carrying its reason: `<!-- allow-citation: … -->` on the line.
  *
  * A RATCHET, not a flat gate. The tree has a history and the count is not zero today; a check that is
@@ -207,7 +214,9 @@ function main() {
   for (const { name, count, frozen } of verdict.grew) {
     console.error(
       `- [grew] ${RULES_DIR}/${name}: ${count} citation(s), up from a frozen ${frozen}. ` +
-        'State the invariant and leave the case in the record that owns it, or link to that record.',
+        'Three ways out: state the invariant and leave the case in the record that owns it; link to ' +
+        'that record so the citation resolves; or, when the identifier IS the instruction — a format ' +
+        'specimen, a worked-example path — declare it with `<!-- allow-citation: <reason> -->`.',
     );
     for (const f of findings.filter((f) => f.file === name)) {
       console.error(`    ${name}:${f.line}  ${f.citation}  ${f.text}`);

--- a/scripts/harness/scan-rule-case-narrative.mjs
+++ b/scripts/harness/scan-rule-case-narrative.mjs
@@ -93,10 +93,13 @@ export function findCaseNarrative(source, { resolves }) {
     if (inFence || hasDeclaredReason(line)) return;
 
     const links = linkSpans(line);
-    // A link is ONE citation, however many times the identifier appears inside it. `[SOME-123](…/
-    // SOME-123-the-thing.md)` names the same record twice by construction — in the text and in the
-    // path — and counting both would make a correctly-relocated case look twice as bad as a bare one.
-    const countedLinks = new Set();
+    // A link names each record ONCE, however many times that record's identifier appears inside it.
+    // `[SOME-123](…/SOME-123-the-thing.md)` names the same record twice by construction — in the text
+    // and in the path — and counting both would make a correctly-relocated case look twice as bad as
+    // a bare one. Keyed on the identifier as well as the link, because one link can name two
+    // different records: deduping on the link alone dropped the second, which is a citation the
+    // ratchet then cannot see.
+    const countedInLink = new Set();
     CITATION.lastIndex = 0;
     let match;
     while ((match = CITATION.exec(line)) !== null) {
@@ -104,8 +107,9 @@ export function findCaseNarrative(source, { resolves }) {
       const link = links.find((span) => at >= span.start && at < span.end);
       if (link && resolves(link.target)) continue;
       if (link) {
-        if (countedLinks.has(link.start)) continue;
-        countedLinks.add(link.start);
+        const key = `${link.start}:${match[0]}`;
+        if (countedInLink.has(key)) continue;
+        countedInLink.add(key);
       }
       findings.push({
         line: index + 1,

--- a/scripts/harness/scan-rule-case-narrative.mjs
+++ b/scripts/harness/scan-rule-case-narrative.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+/**
+ * A rule states an invariant. It does not tell the story of how the invariant was learned.
+ *
+ * Two costs, and the second is the one that matters. Every line of a rule is loaded before any work
+ * begins, so narrative is paid for on every task forever. And a rule justified by an incident invites
+ * the reader to decide whether their situation RESEMBLES that incident — which is precisely the
+ * discretion a rule exists to remove.
+ *
+ * WHAT IT FLAGS: a citation in a rule document — a work-item identifier, a pull-request or issue
+ * number, a calendar date. Those are the marks of a case, and they are what a machine can see.
+ *
+ * WHAT IT CANNOT SEE: narrative whose citation has worn off. A paragraph retelling an incident with
+ * every proper noun removed reads as an invariant and passes here. This check bounds the citable
+ * class only; the line-by-line pass is a separate obligation and this scan going green does not
+ * discharge it. Saying so is part of the check — a floor that lets itself be mistaken for a ceiling
+ * is worse than no floor.
+ *
+ * WHAT IS NOT A CASE:
+ *
+ *  - **A resolving link.** `[SOME-123](../tasks/SOME-123-….md)` is the relocation the form asks for:
+ *    the invariant is here, the incident is in the record that owns it, and the reader can go there.
+ *    The target must EXIST — a rule citing an identifier that resolves to nothing is the condition
+ *    the rules themselves refuse — so this exemption doubles as the check for that.
+ *  - **A specimen.** Inside a fenced code block, an identifier is a slot in a format being shown, not
+ *    a claim about something that happened.
+ *  - **A declared exception**, carrying its reason: `<!-- allow-citation: … -->` on the line.
+ *
+ * A RATCHET, not a flat gate. The tree has a history and the count is not zero today; a check that is
+ * red on arrival gets suppressed rather than obeyed. Per-file counts are frozen, may fall, and must
+ * never rise — and a fall must be re-frozen in the SAME change, or the gain is a licence to grow back.
+ *
+ * Exit 0 = every file at its frozen count, 1 = otherwise.
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const RULES_DIR = '.agents/rules';
+const BASELINE_PATH = path.join(
+  WORKSPACE_ROOT,
+  'scripts/harness/rule-case-narrative-baseline.json',
+);
+
+// A work item (`SOME-123`, `SOME-SUB-004`), a pull-request or issue number, an ISO date. Three
+// shapes, one question: does this line point at a particular thing that happened?
+const CITATION =
+  /\b[A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\d{3,}\b|#\d{3,5}\b|\b20\d{2}-\d{2}-\d{2}\b/g;
+// The reason has to BE a reason. Anchored on the comment terminator rather than on "some non-space
+// character", because `<!-- allow-citation: -->` satisfies the second — the `-` of `-->` reads as
+// the start of an explanation — and an exception nobody had to justify is the one that spreads.
+const ALLOW = /<!--\s*allow-citation:([^]*?)-->/;
+
+function hasDeclaredReason(line) {
+  const match = ALLOW.exec(line);
+  return Boolean(match && match[1].trim().length > 0);
+}
+
+/** Markdown links on a line, as `[text](target)` pairs, so a citation can be tested for being one. */
+function linkSpans(line) {
+  const spans = [];
+  const re = /\[([^\]]*)\]\(([^)\s]+)[^)]*\)/g;
+  let match;
+  while ((match = re.exec(line)) !== null) {
+    spans.push({ start: match.index, end: match.index + match[0].length, target: match[2] });
+  }
+  return spans;
+}
+
+/**
+ * Citations in one document that are not exempt.
+ *
+ * `resolves` decides whether a link target is real; it is injected so a case can describe a tree
+ * without building one, and so this function does no filesystem work of its own.
+ */
+export function findCaseNarrative(source, { resolves }) {
+  const findings = [];
+  let inFence = false;
+
+  source.split('\n').forEach((line, index) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence || hasDeclaredReason(line)) return;
+
+    const links = linkSpans(line);
+    // A link is ONE citation, however many times the identifier appears inside it. `[SOME-123](…/
+    // SOME-123-the-thing.md)` names the same record twice by construction — in the text and in the
+    // path — and counting both would make a correctly-relocated case look twice as bad as a bare one.
+    const countedLinks = new Set();
+    CITATION.lastIndex = 0;
+    let match;
+    while ((match = CITATION.exec(line)) !== null) {
+      const at = match.index;
+      const link = links.find((span) => at >= span.start && at < span.end);
+      if (link && resolves(link.target)) continue;
+      if (link) {
+        if (countedLinks.has(link.start)) continue;
+        countedLinks.add(link.start);
+      }
+      findings.push({
+        line: index + 1,
+        citation: match[0],
+        // A citation inside a BROKEN link is the worse of the two defects, and saying which it is
+        // stops the fix being "delete the link" when it should be "point it somewhere real".
+        kind: link ? 'unresolved-link' : 'case-narrative',
+        text: line.trim().slice(0, 120),
+      });
+    }
+  });
+
+  return findings;
+}
+
+function resolverFor(fileDir) {
+  return (target) => {
+    if (/^(https?:|mailto:)/.test(target)) return true;
+    const withoutAnchor = target.split('#')[0];
+    if (withoutAnchor === '') return true;
+    return existsSync(path.resolve(fileDir, withoutAnchor));
+  };
+}
+
+export function scanRules(root = WORKSPACE_ROOT) {
+  const dir = path.join(root, RULES_DIR);
+  if (!existsSync(dir)) {
+    // Fail closed. A count taken over no documents is not a low count.
+    throw new Error(`rule-case-narrative: ${RULES_DIR} does not exist under ${root}.`);
+  }
+  const files = readdirSync(dir)
+    .filter((name) => name.endsWith('.md'))
+    .sort();
+  if (files.length === 0) {
+    throw new Error(`rule-case-narrative: ${RULES_DIR} holds no documents to examine.`);
+  }
+
+  const perFile = {};
+  const findings = [];
+  for (const name of files) {
+    const full = path.join(dir, name);
+    const found = findCaseNarrative(readFileSync(full, 'utf8'), {
+      resolves: resolverFor(path.dirname(full)),
+    });
+    perFile[name] = found.length;
+    for (const finding of found) findings.push({ file: name, ...finding });
+  }
+  return { perFile, findings, examined: files.length };
+}
+
+function loadBaseline() {
+  return existsSync(BASELINE_PATH) ? JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) : undefined;
+}
+
+/**
+ * The verdict over every file at once.
+ *
+ * Both directions are reported before it returns, so one run tells an operator everything they must
+ * act on. Stopping at the first offender turns a sweep into a queue of runs.
+ */
+export function compare(perFile, baseline) {
+  const grew = [];
+  const shrunk = [];
+  const unfrozen = [];
+  for (const [name, count] of Object.entries(perFile)) {
+    const frozen = baseline[name];
+    if (frozen === undefined) {
+      if (count > 0) unfrozen.push({ name, count });
+      continue;
+    }
+    if (count > frozen) grew.push({ name, count, frozen });
+    if (count < frozen) shrunk.push({ name, count, frozen });
+  }
+  // A frozen file that has since been deleted or renamed is drift too: its row would otherwise sit
+  // in the baseline forever, excusing a count nobody is measuring any more.
+  const missing = Object.keys(baseline).filter((name) => perFile[name] === undefined);
+  return {
+    grew,
+    shrunk,
+    unfrozen,
+    missing,
+    ok: !grew.length && !shrunk.length && !unfrozen.length && !missing.length,
+  };
+}
+
+function main() {
+  const { perFile, findings, examined } = scanRules();
+  const baseline = loadBaseline();
+  const total = Object.values(perFile).reduce((sum, n) => sum + n, 0);
+
+  const unresolved = findings.filter((f) => f.kind === 'unresolved-link');
+  for (const finding of unresolved) {
+    console.error(
+      `- [unresolved-link] ${RULES_DIR}/${finding.file}:${finding.line}: ` +
+        `\`${finding.citation}\` is linked to a target that does not exist — ${finding.text}`,
+    );
+  }
+
+  if (baseline === undefined) {
+    console.error('rule-case-narrative: no frozen baseline — run --write-baseline.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const verdict = compare(perFile, baseline);
+  for (const { name, count, frozen } of verdict.grew) {
+    console.error(
+      `- [grew] ${RULES_DIR}/${name}: ${count} citation(s), up from a frozen ${frozen}. ` +
+        'State the invariant and leave the case in the record that owns it, or link to that record.',
+    );
+    for (const f of findings.filter((f) => f.file === name)) {
+      console.error(`    ${name}:${f.line}  ${f.citation}  ${f.text}`);
+    }
+  }
+  for (const { name, count, frozen } of verdict.shrunk) {
+    console.error(
+      `- [fell] ${RULES_DIR}/${name}: ${frozen} → ${count}. Re-freeze in the SAME change ` +
+        '(--write-baseline), or the gain is a licence to grow back.',
+    );
+  }
+  for (const { name, count } of verdict.unfrozen) {
+    console.error(
+      `- [unfrozen] ${RULES_DIR}/${name}: ${count} citation(s) in a document the baseline does not ` +
+        'know. A new rule document starts at zero, or is frozen deliberately.',
+    );
+  }
+  for (const name of verdict.missing) {
+    console.error(
+      `- [stale-baseline] ${RULES_DIR}/${name}: frozen, but no such document. Remove its row.`,
+    );
+  }
+
+  if (!verdict.ok || unresolved.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `rule-case-narrative scan passed (${examined} rule document(s) examined; ${total} citation(s) ` +
+      'at baseline). It bounds the CITABLE class only — narrative whose citation has worn off is ' +
+      'out of its reach, and the line-by-line pass is a separate obligation.',
+  );
+}
+
+function writeBaseline() {
+  const { perFile, examined } = scanRules();
+  const frozen = Object.fromEntries(Object.entries(perFile).filter(([, count]) => count > 0));
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(frozen, null, 2)}\n`);
+  const total = Object.values(frozen).reduce((sum, n) => sum + n, 0);
+  console.log(
+    `rule-case-narrative baseline frozen: ${total} citation(s) across ` +
+      `${Object.keys(frozen).length} of ${examined} document(s)`,
+  );
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  if (process.argv.includes('--write-baseline')) writeBaseline();
+  else main();
+}


### PR DESCRIPTION
First half of #1618. The mechanism, not the sweep.

A rule states an invariant. It does not tell the story of how the invariant was learned — every line of a rule is loaded before any work begins, so narrative is paid for on every task forever, and a rule justified by an incident invites the reader to decide whether their situation **resembles** that incident, which is the discretion a rule exists to remove.

## What is frozen

`scan-rule-case-narrative.mjs`, registered in `run-all-scans`: a work-item identifier, a pull-request or issue number, a calendar date, anywhere in a rule document. **128 citations across 17 of 24 documents.** A ratchet, not a flat gate — the tree has a history, and a check that is red on arrival is suppressed rather than obeyed.

## Three exemptions, each because it is not a case

- **A resolving link.** `[SOME-123](../tasks/SOME-123-….md)` *is* the relocation the form asks for: invariant here, incident in the record that owns it, reader able to get there. The target must exist, so this doubles as the check for the identifier-that-resolves-to-nothing defect the audits found. A link counts **once** however many times the identifier appears inside it.
- **A fenced block**, where an identifier is a slot in a format being shown.
- **`<!-- allow-citation: <reason> -->`**, and the reason has to be one.

## What it cannot see — stated in its own passing output

Narrative whose citation has worn off reads as an invariant and passes here. The audit found a file with zero identifier matches and the highest narrative count. **This item is not closed by the scan going green**; the line-by-line pass is a separate obligation. A floor that lets itself be mistaken for a ceiling is worse than no floor.

## Two defects its own cases found before it was trusted

1. An unresolved link counted **twice** — the identifier appears in both the link text and the path by construction, so a correctly-relocated case looked worse than a bare one.
2. `<!-- allow-citation: -->` was accepted as carrying a reason: the `-` of the terminator satisfied "some non-space character". An exception nobody had to justify is the one that spreads.

## Verification

- **Red-proved both directions at the CLI**: a citation added to a document in the target form exits 1 as `unfrozen`; a lowered count exits 1 as `fell`, demanding a re-freeze in the same change.
- **Fail-closed** over a root with no rules, and over a rules directory with no documents — a count taken over nothing is not a low count.
- The two documents already in the target form (`tdd-and-planning.md`, `naming-style.md`) report zero, pinned by a case so the references cannot quietly drift out of the form they are held up as.
- `pnpm harness:test` — 2565 passed. `pnpm harness:scan` — 95/96; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

Also carries a one-line pointer added to the review-loop memory mirror, which belonged with #1621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso