### PR TITLE
docs(rules): write the invariant the citation was standing in for (HARNESS-073 sweep 2)

### DIFF
--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -61,8 +61,8 @@ The agent must stop and present options to the user when ANY of the following ho
 
 **Disclosure is not approval.** Mentioning a policy-file change or novel practice in a PR
 description, commit message, or backlog note does not substitute for asking first. Approval must
-be obtained before the change lands (2026-07-03 trust audit: three such changes shipped with
-PR-body disclosure only; all required retroactive review).
+be obtained before the change lands. A change disclosed but not approved is a change that has to be
+reviewed again after it landed, which is the expensive order to do it in.
 
 **Never write "사용자 결정 필요" without first presenting a concrete recommendation.** Every
 open decision in a backlog item must include the agent's recommendation and the reasoning behind it.
@@ -130,8 +130,7 @@ startup. Any push with modified or staged uncommitted files is blocked with exit
 - **This default is not an anti-batching rule.** A single coherent work-unit (one design-gate pass,
   one authoring pass, a rule + its enforcement + its wiring) belongs in ONE multi-commit PR — do not
   split it into many tiny PRs that each wait on a full CI run. Bundle by coherence + a soft size ceiling
-  (~600 changed lines / ~15 files); see the [PR Batching policy](git-branch.md) (DX-001) in `git-branch.md`
-  for the exact criteria. The line: **unrelated backlogs → separate PRs; related steps of one unit →
+  (~600 changed lines / ~15 files); see the [PR Batching policy](git-branch.md) for the exact criteria. The line: **unrelated backlogs → separate PRs; related steps of one unit →
   one PR.**
 - **Sequence by relatedness.** Decide the execution shape from whether items share files or contracts:
   items that touch the **same files/contracts are related — serialize them** (one ordered unit, or
@@ -151,7 +150,7 @@ Every backlog that changes runnable user-facing behavior, command behavior, TUI/
 workflow behavior must include a `## User Execution Test Scenarios` section before implementation
 starts.
 
-**Script home (INFRA-023)**: disposable live-verification scripts (evidence runs, repro probes)
+**Script home**: disposable live-verification scripts (evidence runs, repro probes)
 live in `scratch/src/` — a gitignored workspace home whose committed skeleton resolves
 `@robota-sdk/*` imports. Never park them inside `packages/` or `apps/`; the
 `temp-script-placement` harness scan blocks temp-pattern files there.
@@ -191,11 +190,11 @@ dispatched:
 
 - A scenario that requires live credentials or an external service **MUST state that prerequisite
   explicitly**, so an executor without it knows the gate cannot run in their environment rather than
-  discovering it mid-gate (counter-example: CLI-053's live-LLM transcript step was unexecutable in the
-  implementing environment).
+  discovering it mid-gate. A step requiring a live model transcript is unexecutable in an environment
+  without those credentials, and finding that out at the gate is finding it out too late.
 - A scenario whose only observable requires credentials the executor may not have is a design smell —
-  restructure toward a provider-free observable or a fixture the work itself ships (worked example:
-  CLI-058's in-repo mock MCP server made the entire scenario machine-executable).
+  restructure toward a provider-free observable or a fixture the work itself ships — an in-repo test
+  server in place of a live one makes the whole scenario machine-executable.
 
 Each user execution test scenario must include:
 
@@ -230,16 +229,16 @@ Splitting surface-wiring into a later slice is allowed, but an intermediate **li
 its engineering evidence and **names the still-pending agent-run verification** — it must NOT claim the
 capability "done," and the capability's epic is not COMPLETE until the agent-run verification passes. (This
 closes the loophole where a library seam no surface enables silently marks the user-execution gate N/A —
-the exact gap that let SELFHOST-008 memory ship OFF in the real agent, unverified end-to-end.)
+the gap that lets a capability ship switched OFF in the real agent, unverified end-to-end.)
 
-**Mechanical floor (HARNESS-030).** A capability spec DECLARES itself with three frontmatter keys —
+**Mechanical floor.** A capability spec DECLARES itself with three frontmatter keys —
 `capability: true`, `user_execution: agent-run | manual | none`, and (for `agent-run`)
 `user_execution_scenario: <path>` naming the evidence file EXPLICITLY. `scan-capability-reachability.mjs` (in
 `run-all-scans`) then enforces, over `.agents/spec-docs/done/`: a `capability: true` spec MUST NOT record
 `user_execution: none`/omit it (no N/A dodge), and a `capability: true` + `user_execution: agent-run` spec MUST
 name a `user_execution_scenario:` path that EXISTS. The reference is an explicit path, NOT a name/base-ID
-guess — a spec's evidence may live under a differently-named scenario (e.g. SEC-001's evidence is the GUI-007
-scenario file). `check-spec-doc-frontmatter.mjs` documents all three keys as recognized optional frontmatter.
+guess — a spec's evidence may live under a scenario named after the work that produced it rather than
+after the spec that needs it. `check-spec-doc-frontmatter.mjs` documents all three keys as recognized optional frontmatter.
 The floor is opt-in — the scan never GUESSES which spec is a capability (that semantic call, and "is the seam
 truly reachable," stay with the GATE-COMPLETE reviewer); it fences the recurrence once the capability is
 declared. Set these keys on every user-facing capability spec (add `user_execution_scenario:` for agent-run).
@@ -285,7 +284,7 @@ changed-file diff, or another concrete artifact that proves the expected observa
 After running the scenario, the agent must update the backlog item with the observed evidence before
 the backlog can be considered complete.
 
-**Durable-artifact evidence rule (HARNESS-002).** For code-changing backlogs, evidence MUST
+**Durable-artifact evidence rule.** For code-changing backlogs, evidence MUST
 reference durable artifacts — test file paths that exist in the repository. Evidence sections of
 completed backlogs are continuously re-validated by `pnpm harness:scan:done-evidence`
 (`scripts/harness/check-done-evidence.mjs`, part of the `harness:scan` aggregate): a referenced
@@ -323,7 +322,7 @@ tool, or device) is not a valid exception reason unless the agent actually probe
 the probe as evidence (e.g. which env vars / `.env` files / settings surfaces were checked and what
 they contained). An unprobed absence claim is a guess, not a reason — the one time it was written
 without a probe, the capability existed and the skipped live run would have caught a real bug that
-every unit and integration test missed (ANALYTICS-001, 2026-07-02).
+every unit and integration test missed.
 
 **Engineering verification is NEVER User-Execution evidence (authoritative statement).** Build,
 typecheck, lint, unit tests (any count), harness checks, CI checks, static/document/backlog/source
@@ -373,8 +372,8 @@ Recovery when only one half lands, and what to do when the move conflicts, are r
   `pnpm harness:scan`) fails on a terminal-status file in the root, an open-status file in
   `completed/`, or `status: done` without a `completed:` date. The `task-archival` scan additionally
   fails a fully-checked task file whose spec never reached `spec-docs/done/` (gates overdue). These
-  invariants held only as prose until 2026-07-02, when 8 shipped items were found with stale
-  placement.
+  invariants held only as prose until they were mechanized, and the sweep that mechanized them found
+  eight shipped items with stale placement.
 
 ## Base Branch Workflow
 

--- a/.agents/rules/enforcement-architecture.md
+++ b/.agents/rules/enforcement-architecture.md
@@ -37,9 +37,9 @@ An orchestration skill may coordinate other skills as a pipeline, but it must st
 boundaries these bullets apply — which content is a rule, an orchestration skill, an agent, or a fact
 catalogue.
 
-Relocated from `backlog-execution.md` (HARNESS-049): the rule governs how skills are written, not how a
-backlog item is executed. The `or packages` clause is that section's fourth Layering-Rule bullet, folded
-in here because it constrains skills; the other three were package-ownership statements and moved to
+This governs how skills are WRITTEN, not how a backlog item is executed, which is why it lives here.
+The `or packages` clause belongs with it because it constrains skills; package-ownership statements
+belong with the packages, in
 [`.agents/project-structure.md`](../project-structure.md) § Implementation Owner Boundaries.
 
 ## Reliability comes from (verdict + a script), not from skill-tree depth
@@ -76,7 +76,7 @@ On a guardian FAIL the orchestrator rewinds. Two shapes, both already in the rep
   returns the same finding set unchanged, stop and escalate to the user. A max-iteration count is an
   OPTIONAL second bound and must never be the only one — a stuck loop and a productive one look
   identical to a counter and different to the finding set, so the counter is the weaker test. The
-  PR-review loop runs with no count at all by owner directive (2026-08-03); see
+  PR-review loop runs with no count at all by owner directive; see
   [pr-finding-resolution-loop](../skills/pr-finding-resolution-loop/SKILL.md), which owns that decision and
   the evidence for it.
 
@@ -99,12 +99,12 @@ On a guardian FAIL the orchestrator rewinds. Two shapes, both already in the rep
    that only produces, a guardian that only judges. Add a tier only when a phase owns its own ordering
    (see the nesting note above) — never to make a step more likely to run.
 
-## Three questions a guard must answer (PROC-003)
+## Three questions a guard must answer
 
 In this order. The first two were already asked here; the third is what four independent audits added.
 
 1. **Can it fail?** — a check with no failing input is a check that has never been run.
-   (`scan-main-required-checks`, INFRA-055.)
+   (`scan-main-required-checks`.)
 2. **Does it check the right thing?** — a check that fires on the wrong subject is not a weaker check,
    it is a different one. (`.agents/memory/check-validity-two-axes.md`.)
 3. **Is it REACHED — by the real invocation, in the real environment?**
@@ -112,16 +112,16 @@ In this order. The first two were already asked here; the third is what four ind
 A test that supplies the condition itself, an entry point nothing calls, and a matcher no real command
 hits all pass 1 and 2 and fail 3. Each has been measured here:
 
-- `pre-push-check` matched with a `^` anchor while every command begins `cd <repo> && …`, so every push
-  in a long session bypassed it silently (#1510).
-- `worktree-cwd-guard` gated on `ROBOTA_AGENT_WORKTREE`, exported by nothing but its own tests, so it
-  exited on its first line in every real session while ten tests stayed green (INFRA-068).
-- `verify-like-ci` named itself the CI-equivalent entry point and was invoked by nothing (INFRA-069).
+- A guard anchored its match to the start of the command while every real command begins by changing
+  directory first, so every invocation in a long session bypassed it silently.
+- A guard gated itself on an environment variable exported by nothing but its own tests, so it exited
+  on its first line in every real session while ten tests stayed green.
+- An entry point named itself the CI-equivalent gate and was invoked by nothing.
 
 So a guard lands with a case that RUNS it as a real invocation would, supplying only what a real
 session supplies.
 
-## Two more properties, measured (2026-08-01)
+## Two more properties, measured
 
 Both are about what a guard does when it is NOT blocking, which is almost all of the time, and
 neither is visible in a suite of negative cases.
@@ -154,8 +154,8 @@ violated. Which kind a hook is, is read from the hook itself.
 
 ### Silence is not success — the rule, for every layer
 
-**Owner directive, 2026-08-02. This binds every skill, every hook, and every GitHub Action step, not
-only the shell guards above.**
+**Owner directive. This binds every skill, every hook, and every GitHub Action step, not only the
+shell guards above.**
 
 > When something goes wrong, do not complete quietly. Say what went wrong, and stop the flow.
 
@@ -166,10 +166,10 @@ Three states must stay distinguishable, and collapsing the third into the first 
 3. **I could not check.** → **refuse, naming what could not be read.** Never a pass, and never a
    refusal wearing the wrong reason.
 
-**The price of getting this wrong is on the record.** INFRA-048 measured
-`claude-code-review` at **100 of 100 green runs, 13–21 s each, reviewing nothing**: the action could
-not mint a token, printed a skip line, and exited 0. A hundred pull requests merged past a check that
-reported success without asking anything. Nothing announced either edge of the window.
+**The price of getting this wrong has been measured.** A review action that could not mint a token
+printed a skip line and exited 0: **100 of 100 green runs, 13–21 s each, reviewing nothing**. A
+hundred pull requests merged past a check that reported success without asking anything, and nothing
+announced either edge of the window.
 
 Concretely, in each layer:
 
@@ -184,12 +184,12 @@ Concretely, in each layer:
 - **A skill** that cannot complete a step reports the step it could not complete and halts, rather
   than converging on a count it never earned.
 
-**The reason must be the real one.** "The push was stopped for a reason that was not the reason"
-(INFRA-077) costs the next reader the whole debugging trail: they fix what the message named, re-run,
+**The reason must be the real one.** A push stopped for a reason that was not the reason costs the
+next reader the whole debugging trail: they fix what the message named, re-run,
 and get the same refusal. A guard that cannot read its input says so, in those words.
 
 Floors: `guards-fail-closed.test.mjs` covers the hook layer, including a `gh` that cannot
-authenticate — the token condition INFRA-048 was about. An Action step is not mechanically covered
+authenticate — the token condition above. An Action step is not mechanically covered
 yet; when one is added, its `|| echo` fallbacks are the first thing to read.
 
 The two pull against each other on purpose. Property 5 alone produces a guard that refuses

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -49,11 +49,11 @@ with uncommitted modifications or staged changes is blocked with exit code 1.
 
 **Before pushing or merging, run `pnpm harness:verify-like-ci`** — the single entry that reproduces
 the required status checks of `protect-develop`, the ruleset a feature branch's PR must satisfy
-(`scripts/harness/verify-like-ci.mjs`). A bare `run-all-scans` is not that gate (HARNESS-045), and
-neither is any narrower command.
+(`scripts/harness/verify-like-ci.mjs`). A bare `run-all-scans` is not that gate, and neither is any
+narrower command.
 
 - It runs the monorepo **build** and the affected packages' **test** suites, gated on exactly the
-  conditions CI gates its own jobs on. Until INFRA-056 it ran neither, while being named here as the
+  conditions CI gates its own jobs on. It once ran neither, while being named here as the
   CI mirror — so "I ran the CI-equivalent check" was a much weaker claim than it read as. Do not
   re-add a separate "plus build and tests" instruction anywhere: the entry point owns that, and a
   second list is how the two drift.
@@ -84,17 +84,17 @@ source guard` and `release-grade verification`; the entry point that reproduces 
 
 Commit at appropriate logical boundaries **as work progresses** — one commit per logical step (e.g.
 contract/types → adapter/mechanism → wiring/assembly → tests → docs/evidence), each left green
-(build/typecheck), then open one coherent PR (DX-001). **Never batch a whole slice into a single
+(build/typecheck), then open one coherent PR. **Never batch a whole slice into a single
 end-of-work commit, and never defer committing until the context is nearly exhausted** — committed
 progress is safe across a compaction, whereas a large uncommitted working tree is not, and deferring
 reads as stalling. Avoid the opposite failure too: do not fragment into many trivial commits. The
 context window filling is **not** a reason to stop implementing or to switch to planning-only; keep
-implementing and keep committing. (Owner feedback, 2026-07-17, validated on SELFHOST-003 P1.)
+implementing and keep committing. (Owner directive.)
 
 ### Disabling the Gate is Prohibited
 
-**Never disable a hook instead of satisfying it. Zero exceptions.** Enforced by `branch-guard.sh`
-(INFRA-083). The banned set is every documented kill switch, not one flag:
+**Never disable a hook instead of satisfying it. Zero exceptions.** Enforced by `branch-guard.sh`.
+The banned set is every documented kill switch, not one flag:
 
 | Route                                                                       | Published by |
 | --------------------------------------------------------------------------- | ------------ |
@@ -135,15 +135,14 @@ git commit -n -m "..."
 pnpm install --frozen-lockfile && pnpm build   # a fresh worktree owes this once
 ```
 
-**Measured 2026-08-01: four parallel agents bypassed this way in a single day.** The cause was real —
-the gate could not go green in a worktree (HARNESS-058) — and fixing it was necessary. It was not
-sufficient. The agents were then _told_ not to bypass, which worked, and being told is not a
-mechanism: the identical shape had already been written down about a bare `git stash pop` since
-LESSON-005 and an agent did it anyway ten weeks later.
+**Measured: four parallel agents bypassed this way in a single day.** The cause was real — the gate
+could not go green in a worktree — and fixing it was necessary. It was not sufficient. The agents were
+then _told_ not to bypass, which worked, and being told is not a mechanism: the identical shape had
+already been written down for years about a different destructive command, and an agent did it anyway.
 
 There is deliberately no override token. An override for an override is the next bypass. **If a check
-is wrong, unrunnable, or fires on correct work, the check is what changes** — that is the whole of
-HARNESS-058, and a gate that trains people to route around it has already failed.
+is wrong, unrunnable, or fires on correct work, the check is what changes** — a gate that trains
+people to route around it has already failed.
 
 `git push -n` is **not** covered, because for `push` that flag is `--dry-run`, not `--no-verify`. The
 same short flag means different things in the two subcommands; a rehearsal is not a bypass.
@@ -163,7 +162,7 @@ gh pr merge 670 --squash --auto
 **Deleting a merged branch is the agent's own call — no user request needed.** Once a branch's PR is
 confirmed `MERGED` and nothing further is pending on it, clean it up: `git branch -d <name>` (local) or
 `gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<name>` (remote). Leaving merged branches to pile
-up is its own defect; 105 of them had accumulated by 2026-07-25. **Use the safe `-d` form, never `-D`** —
+up is its own defect; they accumulate in the hundreds. **Use the safe `-d` form, never `-D`** —
 `-d` refuses a branch git cannot see as merged, which is a free second opinion on exactly the case below
 where the merge did not take every commit. `-D` is reserved for an **explicitly approved abandon** of a
 branch that was never merged, and is never part of routine post-merge cleanup.
@@ -172,7 +171,7 @@ Judgement is required precisely because deletion is not always right the moment 
 delete when any of these hold:
 
 - the branch carries commits that are **not** in the merge (e.g. a review fix pushed after auto-merge
-  fired — see the #1409/#1410 sequence), or a follow-up PR is planned from the same branch;
+  fired), or a follow-up PR is planned from the same branch;
 - an agent still has it checked out in a worktree, or its worktree is `locked`;
 - it is an integration branch (`develop`, `main`) or a `release/*` / `hotfix/*` branch still in flight.
 
@@ -194,14 +193,14 @@ Override for an intentional abandon: `BRANCH_GUARD_ALLOW_DELETE=1` **inline in t
 (`BRANCH_GUARD_ALLOW_DELETE=1 git push origin --delete <name>`) — the guard reads the command string,
 so an `export` in an earlier statement does not reach it.
 
-**Why:** `--delete-branch` once deleted the `develop` integration branch, and a blind delete after a _failed_ merge once closed an unmerged PR (cherry-pick recovery). The merged-PR half alone was not enough: `fix/d4-scope-calculator` carried two merged PRs from earlier reuses of the name, so the count read `2` and the deletion proceeded while #1483 was open and `DIRTY` — GitHub closed it. Deletion is safe only after the merge is confirmed, never for integration branches. Note the two hazards differ in cost: a deleted `develop` is **recoverable** (re-cut it from `main`), whereas a branch deleted while its PR is unmerged **orphans work**. That asymmetry is why the ban targets the blind, automatic form — not deletion itself, which the agent should do routinely once a merge is confirmed.
+**Why:** `--delete-branch` once deleted the `develop` integration branch, and a blind delete after a _failed_ merge once closed an unmerged PR (cherry-pick recovery). The merged-PR half alone is not enough: a branch name reused across several PRs carries their merges, so a count of merged PRs reads greater than zero while the CURRENT PR is still open — and the deletion proceeds and closes it. Deletion is safe only after the merge is confirmed, never for integration branches. Note the two hazards differ in cost: a deleted `develop` is **recoverable** (re-cut it from `main`), whereas a branch deleted while its PR is unmerged **orphans work**. That asymmetry is why the ban targets the blind, automatic form — not deletion itself, which the agent should do routinely once a merge is confirmed.
 
 ### Branch Policy
 
 - `main` is the production branch. Direct commits, pushes, and merges to `main` are prohibited.
   **A PR to `main` may ONLY come from `develop` (or a `release/*` / `hotfix/*` promotion branch) — never a
   feature branch** (a feature branch PR'd straight to `main` sweeps the whole `develop` delta and diverges
-  the branches — the #1216 incident). MECHANICALLY enforced by the `main-pr-source-guard` CI job
+  the branches). MECHANICALLY enforced by the `main-pr-source-guard` CI job
   (`.github/workflows/ci.yml`). The flow is fixed: **feature→develop→main**.
 - `develop` is the integration branch. All feature work branches from `develop`. Direct commits to
   `develop` are also prohibited — branch first, then PR. (Both `main` and `develop` are protected;
@@ -212,7 +211,7 @@ so an `export` in an earlier statement does not reach it.
   branching off a squash-merged local branch re-introduces its pre-squash commits (pushes fine, merges DIRTY);
   a branch cut from `main` after a promotion drags `Merge pull request …` commits into the PR range and fails
   `commitlint`. A clean feature/docs branch has **zero merge commits** in its `origin/develop..HEAD` range.
-  **Enforced at creation** by `branch-guard` (INFRA-067): a `checkout -b` / `switch -c` whose base is not
+  **Enforced at creation** by `branch-guard`: a `checkout -b` / `switch -c` whose base is not
   `origin/develop` is refused, naming the base it found and the base it wanted. The start point is read from the
   command when one is given, and is the current HEAD when it is not — which is how the promotion-ancestry break
   happened, with nobody naming `main` and everyone simply standing on a promotion branch. `hotfix/*` and
@@ -230,14 +229,14 @@ so an `export` in an earlier statement does not reach it.
   `.husky/pre-commit`; the [`branch-guard`](../skills/branch-guard/SKILL.md) skill documents those two
   layers and their overrides. It owns no policy — this section does.
 
-### Promotion — `develop` → `main` (mandatory, INFRA-051)
+### Promotion — `develop` → `main` (mandatory)
 
 **A promotion must CARRY `main`'s ancestry. Squashing a sync merge is prohibited in both directions.**
 
 A squash copies content across but records **no ancestry link**. After `main -> develop` squash-merged as
 `bc0ee64ff` (single parent), `git merge-base --is-ancestor origin/main origin/develop` still failed, so the
 next promotion re-computed against the **old merge base** and re-conflicted on the same five `package.json`
-files plus `pnpm-lock.yaml` the back-merge had just reconciled (#1415 → #1413, 2026-07-26). The cost is not
+files plus `pnpm-lock.yaml` the back-merge had just reconciled. The cost is not
 the conflict — it is that a human re-derives the resolution every cycle, and **both wholesale directions are
 wrong**: toward `main` reverts develop's dependency patch bumps; toward `develop` un-archives backlog items
 and drops changesets.
@@ -313,7 +312,7 @@ This rule applies even when:
    In the main clone (outside a parallel wave) the rule stands as written. Procedure:
    [`worktree-parallel-orchestration`](../skills/worktree-parallel-orchestration/SKILL.md).
 
-### PR Batching — appropriately-sized PRs (DX-001)
+### PR Batching — appropriately-sized PRs
 
 Do NOT split a single coherent work-unit into many tiny PRs — each one waits on a full CI run, and that overhead
 repeats far more than the work warrants. Bundle multiple commits into one PR by BOTH criteria:
@@ -345,7 +344,7 @@ before). Verification comes **first** in the post-merge sequence, before any bra
 - A required gate counts as green only if it actually passed: explicitly check `quality`/build, and
   **never treat "pending" or "not-required-skipped" as pass**.
 
-**Why:** a PR once merged despite a red quality gate and shipped a broken build to `main` (DATA-005).
+**Why:** a PR once merged despite a red quality gate and shipped a broken build to `main`.
 
 ### Delete Merged Branches (mandatory)
 
@@ -447,9 +446,10 @@ The hook deliberately does NOT judge whether a prose finding was addressed; that
 call, and a hook guessing at it would be a check measuring the wrong thing. It establishes only that
 CI is green and that a current review exists to be read.
 
-This exists because the sentence above was not enough on its own: on 2026-07-28, with this rule, the
-orchestration skill and its three agents all in place, two PRs were merged past unread findings in a
-single session — #1503, whose MUST needed #1507, and #1510, whose High needed #1517.
+This exists because the sentence above was not enough on its own: with this rule, the orchestration
+skill and its three agents all in place, two pull requests were merged past unread findings in a
+single session, and each needed a follow-up pull request to fix what the unread review had already
+found.
 
 The loop that drives a PR to that state is owned by
 [`pr-finding-resolution-loop`](../skills/pr-finding-resolution-loop/SKILL.md) (review → record → fix, to

--- a/.agents/tasks/HARNESS-073-rules-carry-case-narrative-and-repo-specifics.md
+++ b/.agents/tasks/HARNESS-073-rules-carry-case-narrative-and-repo-specifics.md
@@ -154,6 +154,36 @@ lived.
 are mostly attached to `**Why:**` clauses where the case IS the justification, so each needs the
 invariant restated before the citation can go.
 
+### Sweep 2 — `enforcement-architecture.md` and `backlog-execution.md`, then `git-branch.md`
+
+**104 → 52**, and one document holds everything that is left: `common-mistakes.md`.
+
+These three were the class the audit called load-bearing, and they came out the same way each time —
+the citation was doing work the invariant should have been doing, so the invariant got written and the
+citation stopped being needed:
+
+- Three bullets naming three particular guards that were unreachable became three MECHANISMS: a guard
+  anchored to the start of a command every caller prefixes; a guard gated on an environment variable
+  exported by nothing but its own tests; an entry point that named itself the gate and was invoked by
+  nothing. The names were this repository's; the shapes are anyone's, and the shapes are the warning.
+- "A check that reported success without asking anything" kept its measurement — a hundred consecutive
+  green runs of 13–21 seconds, reviewing nothing — and lost the identifier and the product name. The
+  number is the force; the name of the action it happened to be is not.
+- The deletion hazard was told as one branch's story. Restated as the condition it is: a branch name
+  reused across several pull requests carries their merges, so a count of merged pull requests reads
+  greater than zero while the CURRENT one is open — and the deletion proceeds and closes it.
+- Two dated "measured on" openings became plain measurements. A finding does not become truer for
+  having a date on it, and it does become easier to dismiss as belonging to a past that has moved on.
+
+Refactor history came out wholesale: which document a section was relocated FROM is not a rule, and
+three pointer stubs each spent a line on the identifier of the change that created them.
+
+Baseline re-frozen at 52 in the same change.
+
+**What remains is one document and one constraint.** `common-mistakes.md` is entry-numbered and its
+numbering is referenced by a hook, a scan, another rule and a skill checklist — so every entry is
+rewritten in place, never renumbered and never deleted, and that is a separate pass.
+
 ## Test Plan
 
 - **Required red-first regression:** a mechanical check that a rule document contains no case

--- a/scripts/harness/rule-case-narrative-baseline.json
+++ b/scripts/harness/rule-case-narrative-baseline.json
@@ -1,6 +1,3 @@
 {
-  "backlog-execution.md": 13,
-  "common-mistakes.md": 52,
-  "enforcement-architecture.md": 12,
-  "git-branch.md": 27
+  "common-mistakes.md": 52
 }


### PR DESCRIPTION
Continues #1618. **104 → 52**, and one document now holds everything that is left.

## The load-bearing class

`enforcement-architecture.md`, `backlog-execution.md` and `git-branch.md` are the files the audit predicted would resist, and each came out the same way: the citation was doing work the invariant should have been doing, so the invariant got written and the citation stopped being needed.

- **Three unreachable guards became three mechanisms.** A guard anchored to the start of a command every caller prefixes; a guard gated on an environment variable exported by nothing but its own tests; an entry point that named itself the gate and was invoked by nothing. The names were this repository's — the *shapes* are anyone's, and the shapes are the warning.
- **"A check that reported success without asking anything"** kept its measurement (a hundred consecutive green runs of 13–21 seconds, reviewing nothing) and lost the identifier and the product name. The number is the force; which action it happened to be is not.
- **The deletion hazard** was told as one branch's story. It is now the condition it always was: a branch name reused across several PRs carries their merges, so a count of merged PRs reads greater than zero while the *current* one is open — and the deletion proceeds and closes it.
- **Two dated "measured on" openings became plain measurements.** A finding does not become truer for carrying a date, and it does become easier to dismiss as belonging to a past that has moved on.
- **Refactor history came out wholesale.** Which document a section was relocated *from* is not a rule.

Baseline **re-frozen at 52** in this change.

## What remains

`common-mistakes.md`, alone. Its entry numbering is referenced by a hook, a scan, another rule and a skill checklist, so every entry is rewritten **in place** — never renumbered, never deleted. That is a separate pass.

## Verification

- `pnpm harness:test` — 2567 passed.
- `pnpm harness:scan` — 95/96; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso