### PR TITLE
fix(hooks): one deadline for every network call a guard makes (INFRA-079)

### DIFF
--- a/.agents/tasks/completed/INFRA-079-a-hook-waits-on-the-network-without-a-deadline.md
+++ b/.agents/tasks/completed/INFRA-079-a-hook-waits-on-the-network-without-a-deadline.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-079: two hooks block a command on a network call with no deadline'
-status: todo
+status: done
 created: 2026-08-03
+completed: 2026-08-03
 priority: low
 urgency: later
 area: .claude/hooks
@@ -48,6 +49,42 @@ the same answer:
 State each answer where the call is, so the next reader does not have to re-derive which way "closed"
 points for that gate. Whatever the deadline is, it belongs in one place both hooks read, not typed
 twice.
+
+## Implementation
+
+**The direction asked which way "closed" points per hook. Counting the call sites dissolved the
+question.** All eleven already treat an unanswered lookup as a refusal — the substitution yields
+empty and empty fails the comparison that would have let the command through — so a timeout is not a
+new verdict, it is one more way the lookup did not answer, and it lands on the behaviour each site
+already has. Nothing had to be decided per hook.
+
+**The item named two hooks; there were three.** `merge-gate.sh` holds seven of the eleven calls and
+blocks a merge on every one of them. Scope widened rather than filed again: one hook is a habit, two
+is a convention, three is the convention already being general.
+
+**And the deadline was not a new idea here — it was an existing one applied once.**
+`branch-guard.sh` already carried a hand-rolled watchdog, with its hard-won details in comments (no
+`timeout` on a stock macOS; `wait` rather than `kill -0` polling, because a reaped-but-not-yet-waited
+child answers "alive" and would burn the whole deadline on every SUCCESS; the watchdog's stdout
+detached, because a command substitution does not return while any process holds its pipe). That
+function guarded ONE of eleven queries. It is now `lib/bounded-gh.sh`, and all eleven go through it.
+
+**A timeout must not be reported as the other empty answer.** "No open pull request" and "we could
+not ask" both come back empty, and reporting the first when the second happened costs the reader the
+whole debugging trail — they fix what the message named, re-run, and get the same refusal. The helper
+returns 0 answered / 1 failed / 2 expired, and announces the expiry itself, once, rather than having
+it re-derived at eleven sites. Whether it expired is read from a marker the watchdog writes, not from
+whether the watchdog process is still alive — that would reintroduce the reaping question the
+`kill -0` comment rejects, and would report an expired deadline as an ordinary failure.
+
+**Measured, not argued.** With a `gh` that never returns, the push guard waited **61 s and then said
+nothing about why**; bounded, it stops at its deadline and names it. Red-proved for all three hooks:
+60.0 s, 60.0 s, 60.0 s before the change, against an assertion of under 30.
+
+One correction worth recording: an intermediate check of "are any bare `gh` calls left" reported none
+while one remained. The pattern required the call to open its own command substitution, and
+`pre-push-check`'s call sits inside `$(cd … && \n gh …)` — multi-line, and preceded by another
+command. A method that cannot see a shape reports the absence of that shape as a clean bill.
 
 ## Test Plan
 

--- a/.agents/tasks/completed/INFRA-079-a-hook-waits-on-the-network-without-a-deadline.md
+++ b/.agents/tasks/completed/INFRA-079-a-hook-waits-on-the-network-without-a-deadline.md
@@ -53,12 +53,12 @@ twice.
 ## Implementation
 
 **The direction asked which way "closed" points per hook. Counting the call sites dissolved the
-question.** All eleven already treat an unanswered lookup as a refusal — the substitution yields
+question.** All twelve already treat an unanswered lookup as a refusal — the substitution yields
 empty and empty fails the comparison that would have let the command through — so a timeout is not a
 new verdict, it is one more way the lookup did not answer, and it lands on the behaviour each site
 already has. Nothing had to be decided per hook.
 
-**The item named two hooks; there were three.** `merge-gate.sh` holds seven of the eleven calls and
+**The item named two hooks; there were three.** `merge-gate.sh` holds seven of the twelve calls and
 blocks a merge on every one of them. Scope widened rather than filed again: one hook is a habit, two
 is a convention, three is the convention already being general.
 
@@ -67,13 +67,13 @@ is a convention, three is the convention already being general.
 `timeout` on a stock macOS; `wait` rather than `kill -0` polling, because a reaped-but-not-yet-waited
 child answers "alive" and would burn the whole deadline on every SUCCESS; the watchdog's stdout
 detached, because a command substitution does not return while any process holds its pipe). That
-function guarded ONE of eleven queries. It is now `lib/bounded-gh.sh`, and all eleven go through it.
+function guarded ONE of twelve queries. It is now `lib/bounded-gh.sh`, and all twelve go through it.
 
 **A timeout must not be reported as the other empty answer.** "No open pull request" and "we could
 not ask" both come back empty, and reporting the first when the second happened costs the reader the
 whole debugging trail — they fix what the message named, re-run, and get the same refusal. The helper
 returns 0 answered / 1 failed / 2 expired, and announces the expiry itself, once, rather than having
-it re-derived at eleven sites. Whether it expired is read from a marker the watchdog writes, not from
+it re-derived at every site. Whether it expired is read from a marker the watchdog writes, not from
 whether the watchdog process is still alive — that would reintroduce the reaping question the
 `kill -0` comment rejects, and would report an expired deadline as an ordinary failure.
 
@@ -81,10 +81,21 @@ whether the watchdog process is still alive — that would reintroduce the reapi
 nothing about why**; bounded, it stops at its deadline and names it. Red-proved for all three hooks:
 60.0 s, 60.0 s, 60.0 s before the change, against an assertion of under 30.
 
-One correction worth recording: an intermediate check of "are any bare `gh` calls left" reported none
+Two corrections worth recording, and the second is the sharper one.
+
+An intermediate check of "are any bare `gh` calls left" reported none
 while one remained. The pattern required the call to open its own command substitution, and
 `pre-push-check`'s call sits inside `$(cd … && \n gh …)` — multi-line, and preceded by another
 command. A method that cannot see a shape reports the absence of that shape as a clean bill.
+
+And the count in the first version of this record — and in the helper's own header, and in the commit
+message — was **eleven**. It is twelve: branch-guard 4, merge-gate 7, pre-push 1, counted by the
+command below rather than by hand. In a change whose whole argument is that counting the call sites
+dissolved the design question, the count was the thing not counted. Review found it.
+
+```sh
+grep -c 'bounded_gh ' .claude/hooks/{branch-guard,merge-gate,pre-push-check}.sh
+```
 
 ## Test Plan
 

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -17,6 +17,8 @@ INPUT=$(cat)
 # single owner of the repository, branch and scrubbed-git facts. See lib/hook-facts.sh.
 # shellcheck source=lib/hook-facts.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+# shellcheck source=lib/bounded-gh.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/bounded-gh.sh"
 
 # Extract tool_name without jq — match "tool_name":"Bash"
 # Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
@@ -596,10 +598,7 @@ while read -r STMT_START STMT_LEN; do
       echo "[branch-guard] Blocked: refusing to delete protected branch '$DELETE_BRANCH_NAME'." >&2
       exit 2
     fi
-    MERGED_COUNT=""
-    if command -v gh >/dev/null 2>&1; then
-      MERGED_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state merged --json number --jq 'length' 2>/dev/null || echo "")
-    fi
+    MERGED_COUNT=$(bounded_gh pr list --head "$DELETE_BRANCH_NAME" --state merged --json number --jq 'length' || echo "")
     if [[ -z "$MERGED_COUNT" ]]; then
       echo "[branch-guard] Blocked: cannot confirm a MERGED PR for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
       echo "[branch-guard] Verify the merge landed (gh pr view <n> --json state == MERGED), then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
@@ -620,18 +619,15 @@ while read -r STMT_START STMT_LEN; do
     # outcome this guard exists to prevent, waved through by the guard itself.
     #
     # So ask the question that actually matters: is anything OPEN on this branch right now?
-    OPEN_COUNT=""
-    if command -v gh >/dev/null 2>&1; then
-      OPEN_COUNT=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null || echo "")
-    fi
+    OPEN_COUNT=$(bounded_gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number --jq 'length' || echo "")
     if [[ -z "$OPEN_COUNT" ]]; then
       echo "[branch-guard] Blocked: cannot confirm whether an OPEN PR exists for '$DELETE_BRANCH_NAME' (gh unavailable / query failed)." >&2
       echo "[branch-guard] Unable to determine is not the same as safe. Check by hand, then override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
       exit 2
     fi
     if [[ "$OPEN_COUNT" != "0" ]]; then
-      OPEN_LIST=$(gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number,mergeStateStatus \
-        --jq '[.[] | "#\(.number) (\(.mergeStateStatus))"] | join(", ")' 2>/dev/null || echo "")
+      OPEN_LIST=$(bounded_gh pr list --head "$DELETE_BRANCH_NAME" --state open --json number,mergeStateStatus \
+        --jq '[.[] | "#\(.number) (\(.mergeStateStatus))"] | join(", ")' || echo "")
       echo "[branch-guard] Blocked: '$DELETE_BRANCH_NAME' still has an OPEN PR — $OPEN_LIST." >&2
       echo "[branch-guard] Deleting it now CLOSES that PR. A merged PR earlier in this branch's history does not make deletion safe." >&2
       echo "[branch-guard] Merge or close it deliberately first. Intentional abandon? Override: BRANCH_GUARD_ALLOW_DELETE=1" >&2
@@ -703,58 +699,18 @@ while read -r STMT_START STMT_LEN; do
     # written without it.
     MERGED_REFS=""
     MERGED_REFS_READ=false
+    #
+    # Bounded, because this runs on every branch creation. This path was once entirely local; it makes
+    # a network call now, and a SLOW response is not a failed one — unbounded, a stalled connection
+    # holds the branch creation open instead of taking the fallback below.
+    #
+    # The bound comes from the shared helper, which is where the deadline and every hard-won detail of
+    # enforcing it lives. That helper's original was written HERE, for this one query, while ten other
+    # calls in this directory had no bound at all — which is how a convention ends up applied once.
     MERGED_LIMIT=500
-    #
-    # Bounded, because this runs on every branch creation. Before this check the path was entirely
-    # local; it now makes a network call, and a SLOW response is not a failed one — without a limit a
-    # stalled connection would hang the hook indefinitely instead of taking the fallback below.
-    #
-    # The bound is hand-rolled rather than delegated to `timeout`, which is absent on a stock macOS.
-    # Branching on whether it exists would leave the promise above true on one platform and silently
-    # false on another, with the untested path being the one nobody runs — the shape of defect this
-    # directory has spent the week removing. One path, everywhere.
-    GH_TIMEOUT=10
-    bounded_merged_refs() {
-      local out pid watcher rc
-      out=$(mktemp) || return 1
-      (gh pr list --state merged --limit "$MERGED_LIMIT" --json headRefName,headRefOid \
-        --jq '.[] | "\(.headRefName) \(.headRefOid)"' >"$out" 2>/dev/null) &
-      pid=$!
-
-      # A watchdog rather than a `kill -0` polling loop. Polling asks "is the child still alive", and a
-      # child that has exited but not yet been reaped can still answer yes — on a shell where it does,
-      # every successful query would burn the whole deadline and then be thrown away as a timeout, so
-      # the feature would always fall back and every branch creation would cost ten seconds. Measured
-      # here at 1.2s with the polling version, so it did not reproduce on this bash; `wait` removes the
-      # question rather than leaving it to the platform, and returns the instant the query finishes.
-      # stdout detached deliberately. This function runs inside a command substitution, and a command
-      # substitution does not return until EVERY process holding the write end of its pipe is gone —
-      # so a watchdog inheriting that pipe kept it open for the full deadline even after the query had
-      # answered and the watchdog itself was killed, because the `sleep` it spawned still held the fd.
-      # Measured: the success path took 10.2s that way, worse than the polling it replaced.
-      (
-        sleep "$GH_TIMEOUT"
-        kill -TERM "$pid" 2>/dev/null || true
-      ) >/dev/null 2>&1 &
-      watcher=$!
-
-      if wait "$pid"; then rc=0; else rc=1; fi
-      kill -TERM "$watcher" 2>/dev/null || true
-      wait "$watcher" 2>/dev/null || true
-
-      if [[ "$rc" -eq 0 ]]; then
-        cat "$out"
-        rm -f "$out"
-        return 0
-      fi
-      rm -f "$out"
-      return 1
-    }
-
-    if command -v gh >/dev/null 2>&1; then
-      if MERGED_REFS=$(bounded_merged_refs); then
-        MERGED_REFS_READ=true
-      fi
+    if MERGED_REFS=$(bounded_gh pr list --state merged --limit "$MERGED_LIMIT" \
+      --json headRefName,headRefOid --jq '.[] | "\(.headRefName) \(.headRefOid)"'); then
+      MERGED_REFS_READ=true
     fi
 
     # A full page may mean the list was truncated, so older merged branches would be missing and the

--- a/.claude/hooks/lib/bounded-gh.sh
+++ b/.claude/hooks/lib/bounded-gh.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# bounded-gh.sh — one deadline for every network call a hook makes while deciding.
+#
+# A hook runs in front of a command the operator is waiting on. A SLOW answer is not a failed one:
+# without a bound, a stalled or half-open connection holds the command open for as long as the
+# network takes to give up, and a guard that hangs is worse than one that refuses — a refusal can be
+# read and overridden, a hang can only be killed.
+#
+# WHAT A TIMEOUT MEANS, AND WHY THE ANSWER NEEDED NO DECISION. Every call site in this directory
+# already treats an unanswered lookup as a refusal: the substitution yields empty, and empty fails
+# the comparison that would have let the command through. A timeout is therefore not a new verdict,
+# it is one more way the lookup did not answer, and it lands on the behaviour each site already has.
+#
+# BUT IT MUST NOT LOOK LIKE THE OTHER ONE. "No merged pull request" and "we could not ask" both come
+# back empty, and reporting the first when the second happened costs the reader the whole debugging
+# trail — they fix what the message named, re-run, and get the same refusal. So the deadline
+# announces itself here, once, rather than being re-derived at eleven call sites. Exit codes:
+#
+#   0 — answered; stdout carries the answer
+#   1 — `gh` is absent, or it ran and failed
+#   2 — the deadline expired; a notice naming it has been written to stderr
+#
+# The bound is hand-rolled rather than delegated to `timeout`, which is absent on a stock macOS.
+# Branching on whether it exists would leave this promise true on one platform and silently false on
+# another, with the untested path being the one nobody runs. One path, everywhere.
+
+HOOK_GH_DEADLINE_SECONDS="${HOOK_GH_DEADLINE_SECONDS:-10}"
+
+# Usage: bounded_gh <gh arguments...>
+#
+# Prints what `gh` printed. `gh`'s own stderr is discarded, as it was at every call site before this
+# helper existed — the guards report their own refusals and a raw API error underneath one is noise.
+bounded_gh() {
+  command -v gh >/dev/null 2>&1 || return 1
+
+  local out expired pid watcher rc
+  out=$(mktemp) || return 1
+  # The marker records ONE fact — the deadline elapsed — written by the watchdog itself. Asking
+  # instead whether the watchdog is still alive would reintroduce the reaping question the comment
+  # below rejects for polling: a process that has exited and not yet been reaped can still answer
+  # "alive", so a deadline that HAD expired would be reported as an ordinary `gh` failure, which is
+  # the wrong-reason defect this helper is built to avoid.
+  expired=$(mktemp) || return 1
+  rm -f "$expired"
+
+  (gh "$@" >"$out" 2>/dev/null) &
+  pid=$!
+
+  # A watchdog rather than a `kill -0` polling loop. Polling asks "is the child still alive", and a
+  # child that has exited but not yet been reaped can still answer yes — on a shell where it does,
+  # every successful query would burn the whole deadline and then be thrown away as a timeout, so the
+  # bound would always fall back and every guarded command would cost the full deadline. `wait`
+  # removes the question rather than leaving it to the platform, and returns the instant the query
+  # finishes.
+  #
+  # The watchdog's stdout is detached deliberately. This function is called inside a command
+  # substitution, and a substitution does not return until EVERY process holding the write end of its
+  # pipe is gone — so a watchdog inheriting that pipe kept it open for the full deadline even after
+  # the query had answered and the watchdog itself was killed, because the `sleep` it spawned still
+  # held the descriptor. Measured on the original of this code: the SUCCESS path took 10.2s that way,
+  # worse than the polling it replaced.
+  (
+    sleep "$HOOK_GH_DEADLINE_SECONDS"
+    : >"$expired"
+    kill -TERM "$pid" 2>/dev/null || true
+  ) >/dev/null 2>&1 &
+  watcher=$!
+
+  if wait "$pid"; then rc=0; else rc=1; fi
+  kill -TERM "$watcher" 2>/dev/null || true
+  wait "$watcher" 2>/dev/null || true
+
+  if [[ "$rc" -eq 0 ]]; then
+    cat "$out"
+    rm -f "$out" "$expired"
+    return 0
+  fi
+
+  if [[ -e "$expired" ]]; then
+    rm -f "$out" "$expired"
+    echo "[hook] GitHub did not answer within ${HOOK_GH_DEADLINE_SECONDS}s (gh ${1:-} ${2:-})." >&2
+    echo "[hook] That is no answer, and no answer is a refusal — it is NOT an answer of 'none'." >&2
+    return 2
+  fi
+
+  rm -f "$out" "$expired"
+  return 1
+}

--- a/.claude/hooks/lib/bounded-gh.sh
+++ b/.claude/hooks/lib/bounded-gh.sh
@@ -14,7 +14,7 @@
 # BUT IT MUST NOT LOOK LIKE THE OTHER ONE. "No merged pull request" and "we could not ask" both come
 # back empty, and reporting the first when the second happened costs the reader the whole debugging
 # trail — they fix what the message named, re-run, and get the same refusal. So the deadline
-# announces itself here, once, rather than being re-derived at eleven call sites. Exit codes:
+# announces itself here, once, rather than being re-derived at every call site. Exit codes:
 #
 #   0 — answered; stdout carries the answer
 #   1 — `gh` is absent, or it ran and failed
@@ -40,7 +40,10 @@ bounded_gh() {
   # below rejects for polling: a process that has exited and not yet been reaped can still answer
   # "alive", so a deadline that HAD expired would be reported as an ordinary `gh` failure, which is
   # the wrong-reason defect this helper is built to avoid.
-  expired=$(mktemp) || return 1
+  if ! expired=$(mktemp); then
+    rm -f "$out"
+    return 1
+  fi
   rm -f "$expired"
 
   (gh "$@" >"$out" 2>/dev/null) &

--- a/.claude/hooks/merge-gate.sh
+++ b/.claude/hooks/merge-gate.sh
@@ -33,6 +33,8 @@ set -euo pipefail
 INPUT=$(cat)
 # shellcheck source=lib/command-scan.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/command-scan.sh"
+# shellcheck source=lib/bounded-gh.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/bounded-gh.sh"
 
 # The shared parser, for the reason it exists: the hand-rolled grep this replaces stopped at the
 # first quote inside the command, and a `gh pr merge` written after any quoted argument was never
@@ -77,7 +79,7 @@ PR=$(printf '%s' "$COMMAND_VERBS" | grep -oE 'gh[[:space:]]+pr[[:space:]]+merge[
 # same way gh does. A failure to resolve is still a refusal: not knowing which PR is being merged
 # and merging anyway are the two states this hook exists to keep apart.
 if [[ -z "$PR" ]] && command -v gh >/dev/null 2>&1; then
-  PR=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+  PR=$(bounded_gh pr view --json number --jq '.number' || true)
 fi
 
 if [[ -z "$PR" ]]; then
@@ -125,7 +127,7 @@ fi
 # The `__labels__` sentinel line is what keeps two answers apart: a PR carrying no labels still
 # answers one line, an unreadable response answers the empty string. Without it "I could not read
 # the labels" would silently mean "not withdrawn".
-LABELS=$(gh pr view "$PR" --json labels --jq '"__labels__", (.labels[].name)' 2>/dev/null || echo "")
+LABELS=$(bounded_gh pr view "$PR" --json labels --jq '"__labels__", (.labels[].name)' || echo "")
 if [[ -z "$LABELS" ]]; then
   echo "[merge-gate] Blocked: could not read the labels on #$PR, so a withdrawal cannot be ruled out." >&2
   echo "[merge-gate] Verify by hand, then override inline: MERGE_GATE_ACK=1 gh pr merge $PR --merge" >&2
@@ -162,7 +164,7 @@ if printf '%s\n' "$LABELS" | grep -qx 'disposition-containment'; then
   echo "[merge-gate] Note: #$PR carries 'disposition-containment' — it lands under a labelled hold." >&2
 fi
 
-STATE=$(gh pr view "$PR" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "")
+STATE=$(bounded_gh pr view "$PR" --json mergeStateStatus --jq '.mergeStateStatus' || echo "")
 if [[ -z "$STATE" ]]; then
   echo "[merge-gate] Blocked: could not read PR #$PR's merge state." >&2
   exit 2
@@ -173,7 +175,7 @@ fi
 # a refusal here, because "a check failed and I merged anyway" is a decision, not a default.
 if [[ "$STATE" != "CLEAN" ]]; then
   echo "[merge-gate] Blocked: PR #$PR is $STATE, not CLEAN." >&2
-  FAILING=$(gh pr checks "$PR" 2>/dev/null | grep -E "$(printf '\t')fail$(printf '\t')" | head -3 | cut -f1 | tr '\n' ' ' || true)
+  FAILING=$(bounded_gh pr checks "$PR" | grep -E "$(printf '\t')fail$(printf '\t')" | head -3 | cut -f1 | tr '\n' ' ' || true)
   [[ -n "$FAILING" ]] && echo "[merge-gate]   failing: $FAILING" >&2
   echo "[merge-gate] Wait for CI, or fix what failed. Deliberate exception: MERGE_GATE_ACK=1 inline." >&2
   exit 2
@@ -181,7 +183,7 @@ fi
 
 # --- 2. Review --------------------------------------------------------------------------------
 # A review that predates the head commit has not seen what is about to be merged.
-HEAD_AT=$(gh pr view "$PR" --json commits --jq '.commits[-1].committedDate' 2>/dev/null || echo "")
+HEAD_AT=$(bounded_gh pr view "$PR" --json commits --jq '.commits[-1].committedDate' || echo "")
 
 # The newest comment BY THE REVIEWER, not the newest comment. Reading `comments[-1]` unconditionally
 # meant anyone — including the person merging — could post a remark after the review and satisfy both
@@ -192,14 +194,14 @@ HEAD_AT=$(gh pr view "$PR" --json commits --jq '.commits[-1].committedDate' 2>/d
 # change, and a gate that silently stops recognising reviews would block every merge and teach
 # everyone to pass MERGE_GATE_ACK=1, which is the bypass it exists to prevent.
 REVIEWER_RE='^github-actions(\\[bot\\])?$'
-LAST_REVIEW=$(gh pr view "$PR" --json comments \
-  --jq "[.comments[] | select(.author.login | test(\"$REVIEWER_RE\"))] | last // {}" 2>/dev/null || echo '{}')
+LAST_REVIEW=$(bounded_gh pr view "$PR" --json comments \
+  --jq "[.comments[] | select(.author.login | test(\"$REVIEWER_RE\"))] | last // {}" || echo '{}')
 LAST_REVIEW_AT=$(printf '%s' "$LAST_REVIEW" | jq -r '.createdAt // ""' 2>/dev/null || echo "")
 
 if [[ -z "$LAST_REVIEW_AT" ]]; then
   # Distinguish "nobody reviewed" from "the reviewer is not who this gate thinks it is". Reported
   # identically, a name mismatch reads as a missing review forever and is diagnosed by nobody.
-  AUTHORS=$(gh pr view "$PR" --json comments --jq '[.comments[].author.login] | unique | join(", ")' 2>/dev/null || echo "")
+  AUTHORS=$(bounded_gh pr view "$PR" --json comments --jq '[.comments[].author.login] | unique | join(", ")' || echo "")
   if [[ -n "$AUTHORS" ]]; then
     echo "[merge-gate] Blocked: no comment on #$PR is from the reviewer this gate looks for." >&2
     echo "[merge-gate]   looked for: $REVIEWER_RE   comments are from: $AUTHORS" >&2

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -18,6 +18,8 @@ INPUT=$(cat)
 # single owner of the repository, branch and scrubbed-git facts. See lib/hook-facts.sh.
 # shellcheck source=lib/hook-facts.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+# shellcheck source=lib/bounded-gh.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/bounded-gh.sh"
 
 # Fail closed on an unreadable tool name. Left bare, a non-zero return aborts the assignment
 # under `set -e` and the hook exits 1 with nothing said — which the hook protocol treats as
@@ -283,9 +285,8 @@ if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
   # `gh pr list --head` and not `gh pr view "$CUR_BRANCH"`: `pr view` takes a number, a URL or a
   # branch and decides which by shape, so a branch named `42` would be answered with pull request
   # #42's state — a waiver granted on some other change's evidence. `--head` only ever means a branch.
-  if command -v gh >/dev/null 2>&1 &&
-    [[ "$(cd "$PROJECT_DIR" &&
-      gh pr list --head "$CUR_BRANCH" --state open --json number --jq 'length' 2>/dev/null)" =~ ^[1-9] ]]; then
+  if [[ "$(cd "$PROJECT_DIR" &&
+    bounded_gh pr list --head "$CUR_BRANCH" --state open --json number --jq 'length')" =~ ^[1-9] ]]; then
     echo "[pre-push-check] Open pull request on '$CUR_BRANCH': its review automation owns the review" >&2
     echo "[pre-push-check] of this push. Resolve what that review reports; do not review it again." >&2
     exit 0

--- a/scripts/harness/__tests__/guards-fail-closed.test.mjs
+++ b/scripts/harness/__tests__/guards-fail-closed.test.mjs
@@ -275,3 +275,90 @@ describe('a guard that must ask GitHub refuses when it cannot', () => {
     });
   }
 });
+
+describe('a guard that asks GitHub bounds how long it waits', () => {
+  // A hook runs in front of a command someone is waiting on. A SLOW answer is not a failed one, and
+  // unbounded it is worse than a refusal: a refusal can be read and overridden, a hang can only be
+  // killed. Measured on this tree with a `gh` that never returns — the push guard waited the full 61
+  // seconds and then said nothing about why, where the bounded form stops at its deadline.
+  //
+  // And the deadline must not be reported as the other answer. "No open pull request" and "we could
+  // not ask" both come back empty, and reporting the first when the second happened costs the reader
+  // the whole debugging trail: they fix what the message named, re-run, and get the same refusal.
+
+  function ghThatNeverAnswers() {
+    const dir = mkdtempSync(path.join(tmpdir(), 'slow-gh-'));
+    writeFileSync(path.join(dir, 'gh'), '#!/bin/sh\nsleep 60\n', { mode: 0o755 });
+    return `${dir}:${process.env.PATH}`;
+  }
+
+  function repo(branch) {
+    const dir = mkdtempSync(path.join(tmpdir(), 'slow-gh-repo-'));
+    const git = (...a) => spawnSync('git', ['-C', dir, ...a], { encoding: 'utf8' });
+    git('init', '--quiet', `--initial-branch=${branch}`);
+    git('config', 'user.email', 'harness@example.test');
+    git('config', 'user.name', 'Harness');
+    writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'root');
+    return dir;
+  }
+
+  // Each row is a guard whose verdict depends on a GitHub answer, and the command that makes it ask.
+  const ASKS_GITHUB = [
+    { hook: 'pre-push-check.sh', command: 'git push origin feat/probe' },
+    { hook: 'branch-guard.sh', command: 'git push origin --delete feat/probe' },
+    { hook: 'merge-gate.sh', command: 'gh pr merge 1234 --squash' },
+  ];
+
+  for (const { hook, command } of ASKS_GITHUB) {
+    it(`${hook} stops at its deadline instead of waiting on a silent GitHub`, () => {
+      const dir = repo('feat/probe');
+      const started = Date.now();
+      const { status, output } = run(
+        hook,
+        JSON.stringify({ tool_name: 'Bash', cwd: dir, tool_input: { command } }),
+        {
+          PATH: ghThatNeverAnswers(),
+          CLAUDE_PROJECT_DIR: dir,
+          HOOK_GH_DEADLINE_SECONDS: '3',
+        },
+      );
+      const elapsed = (Date.now() - started) / 1000;
+
+      // Generous against the stub's 60s so a loaded machine cannot make this flaky, and still far
+      // enough below it that only a real bound can pass.
+      expect(elapsed, `it waited ${elapsed}s on a GitHub that never answers`).toBeLessThan(30);
+      expect(status, `it let the command through: ${output}`).toBe(2);
+      expect(output, 'the deadline was not named, so the refusal states the wrong reason').toMatch(
+        /did not answer within 3s/,
+      );
+    });
+  }
+
+  it('says nothing about a deadline when GitHub simply has no such pull request', () => {
+    // The other half. A guard that announced a timeout on every ordinary empty answer would train
+    // its reader to ignore the line that matters.
+    const dir = mkdtempSync(path.join(tmpdir(), 'fast-gh-'));
+    writeFileSync(path.join(dir, 'gh'), '#!/bin/sh\nprintf "0\\n"\n', { mode: 0o755 });
+    const work = repo('feat/probe');
+
+    const { output } = run(
+      'pre-push-check.sh',
+      JSON.stringify({
+        tool_name: 'Bash',
+        cwd: work,
+        tool_input: { command: 'git push origin feat/probe' },
+      }),
+      {
+        PATH: `${dir}:${process.env.PATH}`,
+        CLAUDE_PROJECT_DIR: work,
+        HOOK_GH_DEADLINE_SECONDS: '3',
+      },
+    );
+
+    expect(output, 'an ordinary empty answer was reported as a timeout').not.toMatch(
+      /did not answer within/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #1622.

A hook runs in front of a command someone is waiting on, and a **slow** answer is not a failed one. Unbounded it is worse than a refusal: a refusal can be read and overridden, a hang can only be killed.

**Measured** with a `gh` that never returns — the push guard waited **61 seconds and then said nothing about why**.

## The item's design question dissolved when the call sites were counted

The task asked which way "closed" should point for each hook, and warned they might want opposite answers. All **eleven** call sites already treat an unanswered lookup as a refusal: the substitution yields empty, and empty fails the comparison that would have let the command through. A timeout is not a new verdict — it is one more way the lookup did not answer, and it lands on the behaviour each site already has. Nothing had to be decided per hook.

## The item named two hooks; there were three

`merge-gate.sh` holds **seven of the eleven** calls and blocks a merge on every one. Scope widened rather than filed again — one hook is a habit, two is a convention, three is the convention already being general.

## The deadline was not a new idea here — it was an existing one applied once

`branch-guard.sh` already carried a hand-rolled watchdog, with its hard-won details in comments:

- no `timeout` on a stock macOS, so branching on its presence would leave the promise true on one platform and silently false on another;
- `wait` rather than `kill -0` polling, because a child that has exited and not been reaped answers "alive" — which would burn the whole deadline on every **success**;
- the watchdog's stdout detached, because a command substitution does not return while any process still holds its pipe (the original of that bug made the success path take 10.2s).

That function guarded **one** of eleven queries. It is now `lib/bounded-gh.sh`, and all eleven go through it.

## A timeout must not be reported as the other empty answer

"No open pull request" and "we could not ask" both come back empty. Reporting the first when the second happened costs the reader the whole debugging trail — they fix what the message named, re-run, and get the same refusal. The helper returns **0 answered / 1 failed / 2 expired** and announces the expiry itself, once.

Whether it expired is read from a **marker the watchdog writes**, not from whether the watchdog is still alive — that would reintroduce the exact reaping question the polling comment rejects, and would report an expired deadline as an ordinary failure.

## Verification

- **Red-proved on all three hooks**: 60.0s / 60.0s / 60.0s before the change, against an assertion of under 30s.
- The other half is pinned too: an ordinary empty answer must **not** be announced as a timeout, or the line that matters becomes the line its reader ignores.
- `pnpm harness:test` — 2572 passed. `pnpm harness:scan` — 95/96; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

## One correction worth recording

An intermediate check of "are any bare `gh` calls left" reported none while one remained: the pattern required the call to open its own command substitution, and `pre-push-check`'s sits inside `$(cd … && \n gh …)`. A method that cannot see a shape reports the absence of that shape as a clean bill. Recorded in the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso