### PR TITLE
feat(harness): a rule that states a loop is bound by the same contract (HARNESS-072 step 3)

### DIFF
--- a/.agents/rules/spec-workflow.md
+++ b/.agents/rules/spec-workflow.md
@@ -183,7 +183,7 @@ This vocabulary governs **spec documents** under `.agents/spec-docs/`. Backlog i
 
 ### Spec-Code Conformance Verification
 
-- Any SPEC.md or contract document change MUST be followed by a conformance verification loop before the change is considered complete.
+- Any SPEC.md or contract document change MUST be followed by a conformance verification loop before the change is considered complete — bounded like every auto-re-drive loop, per [enforcement-architecture.md](enforcement-architecture.md).
 - The spec is the source of truth. The loop compares every spec assertion against implementation code, lists all gaps, and fixes the **code** (not the spec) to match.
 - Each code fix MUST include a corresponding contract test.
 - The loop repeats until zero discrepancies remain, then regression tests for all affected packages MUST pass. Like every auto-re-drive loop it escapes on no-progress detection — if the same discrepancy set recurs unchanged, stop and escalate to the user rather than spin ([enforcement-architecture.md](enforcement-architecture.md)).

--- a/.agents/tasks/HARNESS-072-nothing-detects-a-contradiction-between-two-rules.md
+++ b/.agents/tasks/HARNESS-072-nothing-detects-a-contradiction-between-two-rules.md
@@ -130,6 +130,15 @@ would be the restatement defect this repository files items about.
 **Red-proved against the exact wording round 13 found.** Restoring "bounded iterations, then escalate
 to the user" in `research.md` exits 1; the current text exits 0.
 
+**The exemption hole took TWO corrections, and the second is the instructive one.** Splitting on blank
+lines is not splitting into passages: a bulleted list in these documents is ONE blank-line block, so an
+unrelated bullet's link to the rule that owns the escape still excused a loop bullet that carried
+none — the same coincidence, one level tighter. Each list item is its own passage now, with its
+indented continuation lines, and the stricter split immediately surfaced a real instance: a bullet
+naming the conformance loop leaned on a sibling three bullets away. It carries its own pointer now,
+which is what this rule set asks of an entry anyway — a reader must be able to obey one without
+opening anything else.
+
 And the first version of that check was an accidental green worth recording: it asked whether the FILE
 anywhere linked the rule that owns the escape. Every rule links that rule for other reasons, so the
 restored bad wording passed. An exemption read from somewhere else in the document is an exemption

--- a/.agents/tasks/HARNESS-072-nothing-detects-a-contradiction-between-two-rules.md
+++ b/.agents/tasks/HARNESS-072-nothing-detects-a-contradiction-between-two-rules.md
@@ -96,9 +96,49 @@ pipeline" without opening seven skills. So the fact has ONE owner (the declarati
 is a derived restatement a machine now holds to it — which is the fallback that line reserves for
 facts that genuinely must appear twice.
 
-**Steps 2 and 3 remain**, and they are the harder ones: a quantified bound appearing outside its owner
-(the shape rounds 9, 10 and 12 kept re-finding in one draft spec), and rule-to-rule contradiction,
-which needs its suppression designed before the check is written.
+### Step 2 — measured, and DELIBERATELY NOT SHIPPED
+
+A copy detector was written and then removed, on evidence. Over every normative harness document it
+produced **15 findings and 0 true positives**: `max 72 chars` (a commit-message length), a loop step
+mentioning its own escape, a table of contents, an eslint rule name, and — the largest class —
+NEGATIONS, where "there is no round cap" reads to a pattern exactly like a round cap.
+
+The class it targets is empty. The three instances this item cites were all in one draft document and
+were corrected in the change that filed this; that document now states the removed cap as history and
+links the skill that owns the decision, which is what the Direction asks for.
+
+So the choice was between shipping a check with a 15:0 noise ratio and not shipping one. The
+Direction's own warning about step 3 decides it — "expect false positives; design the suppression
+before writing the check, or it will be suppressed rather than obeyed" — and a check that arrives with
+nothing but false positives is suppressed on its first run. Recorded rather than silently dropped:
+**what would make step 2 viable is not a better regex but a machine-readable bound everywhere**, the
+way step 1's declaration made the map comparison exact. Until a bound outside a skill is structured,
+prose matching cannot tell a statement of a bound from a sentence about one.
+
+### Step 3 — the tractable core, shipped
+
+Not "detect any contradiction between two rules", which is the ambition the Direction rightly warns
+about. The contradiction that actually arrived had a shape: a RULE described a loop and stated a count
+as its only bound, while another rule forbade exactly that. Rules outrank skills, so a reader
+following the first was correct to ignore the second.
+
+`scan-loop-contract.mjs` now reads rule documents too. A rule paragraph describing a re-driven loop
+must state what a round that changes nothing does, or point at the rule that owns the answer. The
+owning rule is held to defining it once rather than restating it per paragraph — demanding otherwise
+would be the restatement defect this repository files items about.
+
+**Red-proved against the exact wording round 13 found.** Restoring "bounded iterations, then escalate
+to the user" in `research.md` exits 1; the current text exits 0.
+
+And the first version of that check was an accidental green worth recording: it asked whether the FILE
+anywhere linked the rule that owns the escape. Every rule links that rule for other reasons, so the
+restored bad wording passed. An exemption read from somewhere else in the document is an exemption
+granted by coincidence. Judged per paragraph now, and a case pins that.
+
+**What remains** is step 2, and it remains as a DECISION rather than as work not yet done: it is not
+viable as prose matching, and it becomes viable when a bound stated outside a skill is structured. The
+general form of step 3 — contradiction between any two rules on any subject — is also still open; what
+shipped is the one shape that has actually occurred.
 
 ## A live instance, RESOLVED by the above (kept for the record)
 

--- a/scripts/harness/__tests__/scan-loop-contract.test.mjs
+++ b/scripts/harness/__tests__/scan-loop-contract.test.mjs
@@ -244,6 +244,20 @@ describe('a rule that states a loop is bound by the same contract', () => {
     ]);
   });
 
+  it('keeps an ordinary hard-wrapped paragraph whole', () => {
+    // The inverse defect, and the same cause: splitting by FORMATTING rather than by passage. A
+    // paragraph stating a loop on one line and its escape on the next was flagged for lacking what
+    // it said one wrap away — an accusation granted by coincidence instead of an exemption.
+    expect(passages('first line\nsecond line')).toEqual(['first line\nsecond line']);
+
+    expect(
+      judgeRule({
+        name: 'research.md',
+        text: 'The orchestrator AUTO-re-drives the researcher toward convergence, and\nescapes when the same finding set recurs unchanged.',
+      }),
+    ).toEqual([]);
+  });
+
   it('accepts a loop paragraph that states the escape, or points at the rule that owns it', () => {
     expect(
       judgeRule({

--- a/scripts/harness/__tests__/scan-loop-contract.test.mjs
+++ b/scripts/harness/__tests__/scan-loop-contract.test.mjs
@@ -6,6 +6,7 @@ import { afterAll, describe, expect, it } from 'vitest';
 
 import {
   judgeRule,
+  passages,
   judgeSkill,
   parseDeclaration,
   readMapBounds,
@@ -217,6 +218,30 @@ describe('a rule that states a loop is bound by the same contract', () => {
     });
 
     expect(found.map((f) => f.kind)).toEqual(['rule-states-a-loop-without-its-escape']);
+  });
+
+  it("does not let a SIBLING BULLET's link excuse a loop bullet", () => {
+    // A bulleted list is one blank-line block, so splitting on blank lines left the coincidence
+    // intact one level tighter: an unrelated bullet's link to the rule that owns the escape would
+    // excuse a loop bullet that carried none. Each list item is its own passage, and each normative
+    // bullet has to stand on its own — which is what this rule set asks of an entry anyway.
+    const found = judgeRule({
+      name: 'spec-workflow.md',
+      text: [
+        '- See [enforcement-architecture.md](enforcement-architecture.md) for the worker model.',
+        '- Any contract change MUST be followed by a conformance verification loop.',
+      ].join('\n'),
+    });
+
+    expect(found.map((f) => f.kind)).toEqual(['rule-states-a-loop-without-its-escape']);
+  });
+
+  it('splits a list into its items, and keeps their continuation lines', () => {
+    expect(passages('- one\n  wrapped\n- two\n\nprose')).toEqual([
+      '- one\n  wrapped',
+      '- two',
+      'prose',
+    ]);
   });
 
   it('accepts a loop paragraph that states the escape, or points at the rule that owns it', () => {

--- a/scripts/harness/__tests__/scan-loop-contract.test.mjs
+++ b/scripts/harness/__tests__/scan-loop-contract.test.mjs
@@ -4,7 +4,13 @@ import path from 'node:path';
 
 import { afterAll, describe, expect, it } from 'vitest';
 
-import { judgeSkill, parseDeclaration, readMapBounds, scanLoops } from '../scan-loop-contract.mjs';
+import {
+  judgeRule,
+  judgeSkill,
+  parseDeclaration,
+  readMapBounds,
+  scanLoops,
+} from '../scan-loop-contract.mjs';
 
 /**
  * A loop that cannot notice it is stuck, and a registry that disagrees with the loop it registers.
@@ -180,6 +186,70 @@ describe('the map and the skill state one bound', () => {
     });
 
     expect(found.map((f) => f.kind)).toEqual(['map-disagrees-on-the-bound']);
+  });
+});
+
+describe('a rule that states a loop is bound by the same contract', () => {
+  // This is where a rule-versus-rule contradiction actually arrived: one mandatory rule said
+  // "bounded iterations, then escalate" — a count as the only bound — while another forbade exactly
+  // that, in normative text, created by the change that landed the second. Rules outrank skills, so
+  // a reader following the first was correct to ignore the second.
+
+  it('flags a rule whose loop paragraph names no escape', () => {
+    const found = judgeRule({
+      name: 'research.md',
+      text: '- **Loop-back is hybrid.** The orchestrator AUTO-re-drives toward convergence:\n  bounded iterations, then escalate to the user.\n',
+    });
+
+    expect(found.map((f) => f.kind)).toEqual(['rule-states-a-loop-without-its-escape']);
+  });
+
+  it('does not accept a link that sits in some OTHER paragraph', () => {
+    // The first version asked whether the FILE anywhere linked the rule that owns the escape. Every
+    // rule links that rule for other reasons, so restoring the exact wording this check exists to
+    // catch left it green — an exemption granted by coincidence. Judged per paragraph now.
+    const found = judgeRule({
+      name: 'research.md',
+      text: [
+        'See [enforcement-architecture.md](enforcement-architecture.md) for the worker model.',
+        '- **Loop-back is hybrid.** The orchestrator AUTO-re-drives: bounded iterations, then escalate.',
+      ].join('\n\n'),
+    });
+
+    expect(found.map((f) => f.kind)).toEqual(['rule-states-a-loop-without-its-escape']);
+  });
+
+  it('accepts a loop paragraph that states the escape, or points at the rule that owns it', () => {
+    expect(
+      judgeRule({
+        name: 'research.md',
+        text: '- **Loop-back is hybrid.** It AUTO-re-drives; if the same finding set recurs unchanged, stop.\n',
+      }),
+    ).toEqual([]);
+
+    expect(
+      judgeRule({
+        name: 'research.md',
+        text: '- **Loop-back is hybrid.** It AUTO-re-drives, escaping per [x](enforcement-architecture.md).\n',
+      }),
+    ).toEqual([]);
+  });
+
+  it('holds the OWNING rule to defining the escape, not to restating it per paragraph', () => {
+    // Demanding every paragraph of the definition restate the definition is the restatement defect
+    // this harness files items about.
+    expect(
+      judgeRule({
+        name: '.agents/rules/enforcement-architecture.md',
+        text: '- **Auto-re-drive.** The orchestrator re-runs the worker.\n\nIts escape is no-progress detection.\n',
+      }),
+    ).toEqual([]);
+
+    const undefined_ = judgeRule({
+      name: '.agents/rules/enforcement-architecture.md',
+      text: '- **Auto-re-drive.** The orchestrator re-runs the worker until it converges.\n',
+    });
+    expect(undefined_.map((f) => f.kind)).toEqual(['the-escape-has-no-owner']);
   });
 });
 

--- a/scripts/harness/scan-loop-contract.mjs
+++ b/scripts/harness/scan-loop-contract.mjs
@@ -241,13 +241,15 @@ export function passages(text) {
   for (const block of String(text).split(/\n\s*\n/)) {
     let current = null;
     for (const line of block.split('\n')) {
+      // A LIST MARKER opens a new passage. Anything else continues the one in progress — including
+      // the second line of an ordinary hard-wrapped paragraph, which the first version pushed as its
+      // own passage. That inverted the defect: a paragraph stating a loop on one line and its escape
+      // on the next was flagged for lacking what it said one wrap away.
       if (/^\s{0,3}(?:[-*+]|\d+\.)\s/.test(line)) {
         if (current !== null) out.push(current);
         current = line;
-      } else if (current !== null) {
-        current += `\n${line}`;
       } else {
-        out.push(line);
+        current = current === null ? line : `${current}\n${line}`;
       }
     }
     if (current !== null) out.push(current);

--- a/scripts/harness/scan-loop-contract.mjs
+++ b/scripts/harness/scan-loop-contract.mjs
@@ -227,6 +227,34 @@ export function judgeSkill({ name, text, mapBound, ownerExists = () => true }) {
  * that owns the answer. That is narrower than "detect any contradiction between two rules", and it
  * is the shape the contradiction took.
  */
+/**
+ * The passages a rule is judged in.
+ *
+ * Blank lines are not enough. A bulleted list in these documents is ONE blank-line block, so a loop
+ * bullet with no escape sat in the same passage as an unrelated bullet's link to the rule that owns
+ * one — and the link would excuse it. That is the same "exemption granted by coincidence" this check
+ * was corrected for once already, one level tighter. A list item is its own passage; its indented
+ * continuation lines belong to it.
+ */
+export function passages(text) {
+  const out = [];
+  for (const block of String(text).split(/\n\s*\n/)) {
+    let current = null;
+    for (const line of block.split('\n')) {
+      if (/^\s{0,3}(?:[-*+]|\d+\.)\s/.test(line)) {
+        if (current !== null) out.push(current);
+        current = line;
+      } else if (current !== null) {
+        current += `\n${line}`;
+      } else {
+        out.push(line);
+      }
+    }
+    if (current !== null) out.push(current);
+  }
+  return out;
+}
+
 export function judgeRule({ name, text }) {
   const findings = [];
   // The rule that OWNS the escape states it once; demanding every paragraph of it restate the
@@ -246,7 +274,7 @@ export function judgeRule({ name, text }) {
   // the escape or linked the rule that owns it — and every rule links that rule for other reasons, so
   // restoring the exact wording this check exists to catch left it green. An exemption read from
   // somewhere else in the document is an exemption granted by coincidence.
-  for (const paragraph of text.split(/\n\s*\n/)) {
+  for (const paragraph of passages(text)) {
     if (!LOOP_LANGUAGE.test(paragraph)) continue;
     if (ESCAPE_IN_BODY.test(paragraph)) continue;
     // A paragraph may DELEGATE: pointing at the rule that owns the escape answers the same question.

--- a/scripts/harness/scan-loop-contract.mjs
+++ b/scripts/harness/scan-loop-contract.mjs
@@ -43,6 +43,9 @@ import { asScalar, splitFrontmatter } from './frontmatter.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const SKILLS_DIR = '.agents/skills';
+const RULES_DIR = '.agents/rules';
+/** The rule that owns the no-progress escape; every other loop states it or points here. */
+const OWNER_RULE = 'enforcement-architecture.md';
 const MAP_PATH = '.agents/specs/orchestration-map.md';
 
 /**
@@ -211,6 +214,57 @@ export function judgeSkill({ name, text, mapBound, ownerExists = () => true }) {
   return findings;
 }
 
+/**
+ * A RULE may describe a loop too, and then it is bound by the same contract.
+ *
+ * This is where a rule-versus-rule contradiction actually arrived: one mandatory rule said "bounded
+ * iterations, then escalate" — a count as the only bound — while another forbade exactly that, in
+ * normative text, created by the change that landed the second. Rules outrank skills, so a reader
+ * following the first was correct to ignore the second.
+ *
+ * A rule carries no frontmatter declaration, so the check is the one axis it can have: a rule that
+ * describes a re-driven loop must say what a round that changes nothing does, or point at the rule
+ * that owns the answer. That is narrower than "detect any contradiction between two rules", and it
+ * is the shape the contradiction took.
+ */
+export function judgeRule({ name, text }) {
+  const findings = [];
+  // The rule that OWNS the escape states it once; demanding every paragraph of it restate the
+  // definition would be the restatement defect this harness files items about. It is held to the one
+  // thing it must do: define the escape somewhere in itself.
+  if (name.endsWith(OWNER_RULE)) {
+    if (!ESCAPE_IN_BODY.test(text)) {
+      findings.push({
+        skill: name,
+        kind: 'the-escape-has-no-owner',
+        detail: 'the rule that every other loop points at for the escape no longer defines one.',
+      });
+    }
+    return findings;
+  }
+  // Judged PER PARAGRAPH, not per document. The first version asked whether the FILE anywhere stated
+  // the escape or linked the rule that owns it — and every rule links that rule for other reasons, so
+  // restoring the exact wording this check exists to catch left it green. An exemption read from
+  // somewhere else in the document is an exemption granted by coincidence.
+  for (const paragraph of text.split(/\n\s*\n/)) {
+    if (!LOOP_LANGUAGE.test(paragraph)) continue;
+    if (ESCAPE_IN_BODY.test(paragraph)) continue;
+    // A paragraph may DELEGATE: pointing at the rule that owns the escape answers the same question.
+    if (paragraph.includes(OWNER_RULE)) continue;
+    findings.push({
+      skill: name,
+      kind: 'rule-states-a-loop-without-its-escape',
+      detail:
+        'a mandatory rule describes a re-driven loop and never says what a round that changes nothing ' +
+        'does — "' +
+        paragraph.replace(/\s+/g, ' ').trim().slice(0, 90) +
+        '". A rule outranks a skill, so a loop stated here without its escape licenses every loop ' +
+        'that reads it. State the escape, or link the rule that owns it.',
+    });
+  }
+  return findings;
+}
+
 export function scanLoops(root = WORKSPACE_ROOT) {
   const skillsDir = path.join(root, SKILLS_DIR);
   const mapFile = path.join(root, MAP_PATH);
@@ -245,8 +299,22 @@ export function scanLoops(root = WORKSPACE_ROOT) {
       .map(([name]) => name),
   );
 
+  const rulesDir = path.join(root, RULES_DIR);
+  if (!existsSync(rulesDir))
+    throw new Error(`loop-contract: ${RULES_DIR} does not exist under ${root}.`);
+  const ruleNames = readdirSync(rulesDir)
+    .filter((n) => n.endsWith('.md'))
+    .sort();
+  if (ruleNames.length === 0)
+    throw new Error(`loop-contract: ${RULES_DIR} holds no rules to examine.`);
+
   const findings = [];
   let loops = 0;
+  for (const name of ruleNames) {
+    const text = readFileSync(path.join(rulesDir, name), 'utf8');
+    if (LOOP_LANGUAGE.test(text)) loops += 1;
+    findings.push(...judgeRule({ name: `${RULES_DIR}/${name}`, text }));
+  }
   for (const name of names) {
     const text = sources.get(name);
     if (parseDeclaration(text) || LOOP_LANGUAGE.test(bodyOf(text))) loops += 1;
@@ -265,15 +333,18 @@ export function scanLoops(root = WORKSPACE_ROOT) {
 function main() {
   const { findings, examined, loops } = scanLoops();
   for (const finding of findings) {
-    console.error(`- [${finding.kind}] ${SKILLS_DIR}/${finding.skill}/SKILL.md: ${finding.detail}`);
+    const where = finding.skill.includes('/')
+      ? finding.skill
+      : `${SKILLS_DIR}/${finding.skill}/SKILL.md`;
+    console.error(`- [${finding.kind}] ${where}: ${finding.detail}`);
   }
   if (findings.length > 0) {
     process.exitCode = 1;
     return;
   }
   console.log(
-    `loop-contract scan passed (${examined} skill(s) examined; ${loops} declare a loop, each ` +
-      'implementing the escape it declares and agreeing with the orchestration map).',
+    `loop-contract scan passed (${examined} skill(s) and every rule document examined; ${loops} ` +
+      'state a loop, each implementing the escape it declares and agreeing with the orchestration map).',
   );
 }
 


### PR DESCRIPTION
Advances #1617. Step 1 landed in #1629; this is **step 3**, and it also records a **decision not to ship step 2**.

## Step 3 — the tractable core

Not "detect any contradiction between two rules", which is the ambition the item's own Direction warns about. The contradiction that actually arrived had a shape:

> a **rule** described a loop and gave a count as its only bound, while another rule forbade exactly that — in normative text, created by the change that landed the second.

Rules outrank skills, so a reader following the first was **correct** to ignore the second.

`scan-loop-contract.mjs` now reads rule documents too. A rule paragraph describing a re-driven loop must say what a round that changes nothing does, or point at the rule that owns the answer. The owning rule is held to defining it **once** rather than restating it per paragraph — demanding otherwise is the restatement defect #1618 is about.

**Red-proved against the exact wording round 13 found**: restoring `bounded iterations, then escalate to the user` in `research.md` exits 1; the current text exits 0.

### The first version of that check was an accidental green

Recorded rather than quietly fixed. It asked whether the **file** anywhere linked the rule that owns the escape — and every rule links that rule for other reasons, so the restored bad wording **passed**. An exemption read from somewhere else in the document is an exemption granted by coincidence. Judged per paragraph now, with a case pinning exactly that.

## Step 2 — written, measured, deliberately NOT shipped

A copy detector over every normative harness document produced **15 findings and 0 true positives**:

- `max 72 chars` — a commit-message length limit
- a loop step mentioning its own escape
- a table of contents; an eslint rule name
- and the largest class: **negations** — "there is no round cap" reads to a pattern exactly like a round cap

The class it targets is **empty**. The three instances the item cites were all in one draft document and were corrected by the change that filed this; that document now states the removed cap as history and links the skill that owns the decision — which is what the Direction asks for.

So the choice was between shipping a check with a 15:0 noise ratio and not shipping one. The item's own warning decides it — *"expect false positives; design the suppression before writing the check, or it will be suppressed rather than obeyed"* — and a check that arrives with nothing but false positives is suppressed on its first run.

**What would make step 2 viable is not a better regex but a machine-readable bound outside a skill**, the way step 1's declaration made the map comparison exact. That is written into the item, so the next reader inherits the measurement rather than the idea.

## Verification

- `pnpm harness:test` — 2592 passed. `pnpm harness:scan` — 96/97; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso