### PR TITLE
chore(backlog): archive eight items whose work had landed, and fix an ID collision

### DIFF
--- a/.agents/tasks/completed/HARNESS-062-five-copies-of-one-path-rule.md
+++ b/.agents/tasks/completed/HARNESS-062-five-copies-of-one-path-rule.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-062: five implementations of "a cited repo path must resolve", giving three verdicts on one sentence'
-status: in-progress
+status: done
+completed: 2026-07-31
 priority: medium
 urgency: soon
 type: HARNESS
@@ -135,3 +136,10 @@ recorded at the function.
 
 Not applicable — a harness-internal refactor with no runnable user-facing behavior. The verification
 is the scan suite in the Test Plan.
+
+## Completion (2026-07-31)
+
+Resolved by PR #1564. `scripts/harness/cited-paths.mjs` owns the one cited-path rule and `listSourceFiles` owns the one exclusion set; six walkers route through it with a measured 0-finding delta on every one. What was deliberately NOT flattened is recorded on the issue.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.

--- a/.agents/tasks/completed/INFRA-073-one-verdict-for-an-aggregate.md
+++ b/.agents/tasks/completed/INFRA-073-one-verdict-for-an-aggregate.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-073: the red-proof gate reports one verdict for an aggregate, so a pass hides inside a fail'
-status: in-progress
+status: done
+completed: 2026-07-31
 priority: high
 urgency: soon
 type: INFRA
@@ -96,3 +97,10 @@ because at that point an aggregate verdict starts deciding merges.
   `ACCIDENTAL_GREEN`, proven by replaying `2ac10f251..b1f46acf3`.~~ **Retracted on measurement — that
   range has no accidental-green source.** Replaced by a fixture that fails on the unfixed gate.
 - Decided jointly with INFRA-072, or with a written reason for deciding them apart.
+
+## Completion (2026-07-31)
+
+Resolved on `develop`: `check-regression-red-proof.mjs` judges per source pair (`decidePairVerdict`, `qualifyingPairs`, both exported and unit-tested) instead of reporting one verdict for the aggregate, so a pass no longer hides inside a fail.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.

--- a/.agents/tasks/completed/INFRA-075-substitution-span-restores-its-own-quotes.md
+++ b/.agents/tasks/completed/INFRA-075-substitution-span-restores-its-own-quotes.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-075: restoring a command-substitution span un-masks the quotes inside it'
-status: in-progress
+status: done
+completed: 2026-07-31
 priority: high
 urgency: now
 type: INFRA
@@ -109,3 +110,10 @@ That needs the tokenizer this item asks for; masking cannot reach it. The corpus
   string is still ignored.
 - The differential corpus runs in `pnpm harness:scan` or the harness suite, so the next spelling is
   found by the machine rather than by someone being blocked.
+
+## Completion (2026-07-31)
+
+Resolved by PR #1565. The two-pass mask/restore is replaced by a stack-based tokenizer over explicit contexts (SQ / ANSI / TOK / HD / PARAM / ARITH / DQ / CMD), with a differential corpus executed against real bash as the oracle.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.

--- a/.agents/tasks/completed/INFRA-076-loose-override-tokens.md
+++ b/.agents/tasks/completed/INFRA-076-loose-override-tokens.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-076: branch-guard honours an override token wherever it appears, not where it is given'
-status: todo
+status: done
+completed: 2026-07-31
 priority: high
 urgency: soon
 type: INFRA
@@ -57,3 +58,10 @@ should be taken deliberately rather than as a side effect of fixing a sibling.
 
 - One convention is chosen for override tokens across `.claude/hooks/`, and every hook follows it.
 - A case per hook proves a bare mention does NOT disarm it, and the real prefix still does.
+
+## Completion (2026-07-31)
+
+Resolved by PR #1559 — with one half deliberately held and filed as #1563 (INFRA-079, since resolved by #1583). An override token is no longer honoured wherever it appears: it must prefix a statement, and that statement must carry the action it excuses. `branch-guard.sh` reads all four through `stmt_override`.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.

--- a/.agents/tasks/completed/INFRA-077-one-owner-for-what-a-hook-computes.md
+++ b/.agents/tasks/completed/INFRA-077-one-owner-for-what-a-hook-computes.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-077: five facts computed separately in four hooks, and the copies disagree'
-status: in-progress
+status: done
+completed: 2026-07-31
 priority: high
 urgency: now
 type: INFRA
@@ -141,3 +142,10 @@ Not applicable — this changes agent-harness hooks only. The hooks are invoked 
 around the agent's own tool calls and deliver no runnable user-facing behaviour, so there is no
 product surface to execute. Verification lives in `## Test Plan`, where every case runs the real
 hook against a scratch repository rather than inspecting its source.
+
+## Completion (2026-07-31)
+
+Resolved by PR #1566. Five facts have one owner in `.claude/hooks/lib/hook-facts.sh` — file path, payload JSON, effective repository (three NAMED modes), current branch, and the scrubbed command.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.

--- a/.agents/tasks/completed/INFRA-078-nothing-checks-hook-registration.md
+++ b/.agents/tasks/completed/INFRA-078-nothing-checks-hook-registration.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-078: a hook can be wired to no event, or a matcher can name a deleted file, and everything stays green'
-status: in-progress
+status: done
+completed: 2026-07-31
 priority: high
 urgency: now
 type: INFRA
@@ -63,3 +64,10 @@ the verified declaration to `revert-detect.sh` turned it green.
   `registers \`deleted.sh\` for PreToolUse, but .claude/hooks/deleted.sh does not exist`.
 - Neither is accidentally green: reverse-applying rule A fails 4 tests, rule B fails its own test,
   and the correctly-registered fixture plus the real tree pass with an empty findings list.
+
+## Completion (2026-07-31)
+
+Resolved by PR #1560. `scan-hook-registration.mjs` is registered in `run-all-scans.mjs` and was red-proved on the real tree — `revert-detect.sh` was genuinely unregistered when the scan first ran. Verified today: 12 hook files, 6 matchers, 12 registrations, every hook reached.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.

--- a/.agents/tasks/completed/INFRA-087-a-hook-waits-on-the-network-without-a-deadline.md
+++ b/.agents/tasks/completed/INFRA-087-a-hook-waits-on-the-network-without-a-deadline.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-079: two hooks block a command on a network call with no deadline'
+title: 'INFRA-087: two hooks block a command on a network call with no deadline'
 status: done
 created: 2026-08-03
 completed: 2026-08-03
@@ -9,7 +9,7 @@ area: .claude/hooks
 depends_on: []
 ---
 
-# INFRA-079: a gate that can hang instead of refusing
+# INFRA-087: a gate that can hang instead of refusing
 
 ## Problem
 
@@ -24,7 +24,14 @@ the property that removal was about, arriving through a different door.
 
 ## Evidence
 
-Registered as [#1622](https://github.com/woojubb/robota/issues/1622). Raised as a CONSIDER on PR #1621, and correct on both counts: the call is unbounded, and it matches
+Registered as [#1622](https://github.com/woojubb/robota/issues/1622).
+
+**Filed first as INFRA-079, which was already taken.** Issue [#1563](https://github.com/woojubb/robota/issues/1563)
+claimed that ID on 2026-07-31 for a different item, and `branch-guard.sh` and `command-scan.sh` cite it
+by that number in five places. The ID was picked here by reading the task tree, where the earlier
+item left no file — so the tree said 079 was next and GitHub said otherwise. Renumbered to 087, above
+every ID used in either place, and the lesson is that the ID space spans BOTH: a new ID has to be
+checked against the issue titles as well as the files. Raised as a CONSIDER on PR #1621, and correct on both counts: the call is unbounded, and it matches
 what `branch-guard.sh` already does rather than introducing a new pattern. That is what makes it a
 shared property rather than a defect in the change that surfaced it — one hook is a habit, two is a
 convention, and a convention is fixed in one place or not at all.

--- a/.agents/tasks/completed/PROC-004-github-issues-as-tracker.md
+++ b/.agents/tasks/completed/PROC-004-github-issues-as-tracker.md
@@ -1,6 +1,7 @@
 ---
 title: 'PROC-004: GitHub Issues as the tracker, backlog files as the implementation document'
-status: todo
+status: wontfix
+completed: 2026-08-01
 priority: high
 urgency: soon
 type: PROC
@@ -62,3 +63,26 @@ without committing to the migration. First three: INFRA-073 (#1536), INFRA-072 (
   the choice spelled out.
 - If migrating: every floor that reads backlog frontmatter has a named new subject, and no field
   exists in two places without one of them being generated.
+
+## Closed by owner decision (2026-08-01) — NOT done, decided otherwise
+
+This item asked whether GitHub Issues should become the tracker, with the in-repo tree demoted to an
+implementation-detail document. The owner decided otherwise, and more precisely:
+
+> 이제부터는 이슈와 백로그를 구별하겠습니다. 이슈는 좀더 간단하고 이슈를 기반으로 백로그를 만들수 있습니다.
+> 이슈가 꼭 있어야 백로그를 만들수 있는건 아닙니다. 지금처럼 백로그부터 만들수도 있습니다. 이슈는 그 앞단에
+> 새로 생기는 옵셔널한 절차입니다.
+
+So the shape is settled, and it is not this item's proposal:
+
+- **An Issue is an OPTIONAL front stage.** Simpler, and a Task may be created from one.
+- **A Task does not require an Issue.** Creating the Task directly stays valid.
+- **The in-repo record stays.** It is not demoted to an implementation detail.
+
+Recorded as `wontfix` rather than `done`, because nothing was built — a decision was taken. Marking it
+done would claim a change that never happened, which is the class this repository measures most.
+
+The sequencing warning it raised is discharged: state is not moving out of the repository, so there is
+no second migration pending, and [PROC-006](completed/PROC-006-one-document-kind-for-a-unit-of-work.md)
+was safe to perform. Reconciled 2026-08-04, when the Task file was found still open behind a closed
+issue ([#1538](https://github.com/woojubb/robota/issues/1538)).

--- a/.agents/tasks/completed/PROC-006-one-document-kind-for-a-unit-of-work.md
+++ b/.agents/tasks/completed/PROC-006-one-document-kind-for-a-unit-of-work.md
@@ -1,6 +1,7 @@
 ---
 title: 'PROC-006: two tracking systems, two lifecycles, one job — unify them and name the result for what it is'
-status: todo
+status: done
+completed: 2026-08-01
 priority: high
 urgency: soon
 type: PROC
@@ -81,3 +82,10 @@ in-repo systems and then moving state out of them would be two migrations where 
   `check-task-archival` reads a tree that is no longer empty.
 - The chosen name appears in AGENTS.md's document tree, and no document calls the same thing by the
   old name.
+
+## Completion (2026-08-01)
+
+Resolved by PR #1586. `.agents/backlog/` is gone, `.agents/tasks/` holds the open Tasks and the archive, and nothing in the repository resolves the old path. What was NOT done, and why, is recorded on the issue.
+
+Reconciled 2026-08-04: the work had landed and the issue was closed with its evidence, but the Task
+file was never moved. Verified against the tree before moving, not taken from the closed issue.


### PR DESCRIPTION
The tree said **87 open items**; eight of them were finished. Each carried a link to a GitHub issue closed with its evidence, and the Task file was simply never moved — the half of the done gate a machine does not check.

## Verified against the tree, not taken from the closed issue

A closed issue is not proof of work, so each was checked:

| Item | Evidence found |
|---|---|
| HARNESS-062 | `cited-paths.mjs` owns the rule; six walkers route through it |
| INFRA-073 | `decidePairVerdict` / `qualifyingPairs` exported and unit-tested — per-pair, not aggregate |
| INFRA-075 | stack-based tokenizer replaced the mask/restore pass |
| INFRA-076 | `stmt_override` reads all four branch-guard overrides as statement prefixes |
| INFRA-077 | five hook facts have one owner in `lib/hook-facts.sh` |
| INFRA-078 | `scan-hook-registration` registered; reports 12 hooks, 6 matchers, 12 registrations |
| PROC-006 | `.agents/backlog/` gone, nothing resolves the old path |

## PROC-004 is archived as `wontfix`, not as done

The owner decided **against** its proposal: an Issue is an optional front stage, a Task does not require one, and the in-repo record stays. Nothing was built, so marking it done would claim a change that never happened — the class this repository measures most. The decision and its quotation are in the file.

## An ID collision this session created

The deadline item was filed as **INFRA-079**, which issue #1563 had already claimed on 2026-07-31 — and `branch-guard.sh` and `command-scan.sh` cite it by that number in five places.

The ID was picked by reading the task tree, where that earlier item left no file. **The tree said 079 was next; GitHub said otherwise.** Renumbered to **INFRA-087**, above every ID used in either place, its issue retitled, and the lesson written into the file: the ID space spans both, so a new ID must be checked against issue titles as well as files.

## Verification

- `pnpm harness:test` — 2595 passed. `pnpm harness:scan` — 96/97; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso