### PR TITLE
feat(harness): eight more scans say how much they looked at (HARNESS-057 batch 1)

### DIFF
--- a/.agents/tasks/HARNESS-057-a-scan-must-report-the-size-of-what-it-examined.md
+++ b/.agents/tasks/HARNESS-057-a-scan-must-report-the-size-of-what-it-examined.md
@@ -92,11 +92,28 @@ number that means nothing.
 Changing one scan's declaration to `::examined:: 0 workflows` fails the suite with
 `1 scan(s) reported a pass over nothing`, naming the scan and the door.
 
+### Migration, batch 1 — and a correction to what this migration costs
+
+**11 → 19 of 97.** Marked in this pass: the required-check dependency edges, filtered test
+invocations, workspace packages in the publish registry, declared write scopes, required contexts on
+the protected branch, workflows in two CI-history guards, and the memory fact files.
+
+**The first estimate — "each is a one-line addition beside a number the scan already computes" — was
+wrong, and the correction is the useful part.** It holds for the scans that print their count.
+For the rest it does not: their finder returns findings and nothing else, so the number exists inside
+the walk and dies there. Making it available is a per-scan change to what the finder hands back, and
+the finder is usually imported by tests that assert on its findings — so a widened return shape
+rewrites those tests to prove nothing new.
+
+The memory-mirror scan shows the cheapest honest form: a module-level holder set where the walk
+happens and read where the line is printed, leaving the finder's contract and its tests untouched.
+That is still a deliberate edit per scan, not a one-liner, and the remaining ~77 should be read as
+that size.
+
 ### What remains
 
-**86 of 97 scans still declare nothing**, and each is a one-line addition beside a number the scan
-already computes. The ratchet is what makes that migration visible and irreversible; this item stays
-open until it is done, and the number in the baseline is the progress bar.
+**77 of 96 scans still declare nothing.** The ratchet makes the migration visible and irreversible;
+this item stays open until it is done, and the baseline number is the progress bar.
 
 ## Done when
 

--- a/.agents/tasks/HARNESS-057-a-scan-must-report-the-size-of-what-it-examined.md
+++ b/.agents/tasks/HARNESS-057-a-scan-must-report-the-size-of-what-it-examined.md
@@ -110,9 +110,26 @@ happens and read where the line is printed, leaving the finder's contract and it
 That is still a deliberate edit per scan, not a one-liner, and the remaining ~77 should be read as
 that size.
 
+### The first declaration was itself the defect this item is about
+
+Review caught it in the batch that added it. `workflow-permissions` declared the size of its
+JUSTIFIED_WRITE_SCOPES table — a static declaration that keeps an entry for a workflow which has since
+been deleted, while the loop that reads them SKIPS those. So the line reported a number larger than
+what was examined: the exact shape the `::examined::` line exists to expose, committed by the change
+that introduced the line.
+
+Measured rather than argued: with one declared workflow removed from disk, the corrected form reports
+**5** and the table-size form reports **6**. It now counts what was read from disk, and three cases pin
+it — the count, a legitimate zero, and that a module-level holder is RESET so it cannot carry a
+previous run's number into a run that read nothing. All three red-proved.
+
+The lesson generalises to the remaining migration: the number must come from the walk, never from the
+configuration the walk consults. A declaration and a subject are different things, and the whole point
+of this invariant is the difference between them.
+
 ### What remains
 
-**77 of 96 scans still declare nothing.** The ratchet makes the migration visible and irreversible;
+**78 of 97 scans still declare nothing.** The ratchet makes the migration visible and irreversible;
 this item stays open until it is done, and the baseline number is the progress bar.
 
 ## Done when

--- a/scripts/harness/__tests__/scan-memory-mirror.test.mjs
+++ b/scripts/harness/__tests__/scan-memory-mirror.test.mjs
@@ -182,3 +182,30 @@ describe('what the mirror scan says it examined', () => {
     expect(examinedFactFileCount()).toBe(0);
   });
 });
+
+describe('the CLI cannot exit quietly over a memory tree that is not there', () => {
+  it('fails instead of exiting 0, and says which tree was missing', async () => {
+    // `main()` carried an early return saying "no in-repo memory yet is allowed", contradicting this
+    // file's own finder, which declares the corpus mandatory. The CLI took the wrong answer: it
+    // exited 0 without reaching the throw the case above pins, and without printing the examined
+    // line every other path prints. Review caught it in the change that added that line.
+    const root = await createFixture({ 'placeholder.txt': 'x\n' });
+    copyFileSync(SCAN_SCRIPT, path.join(root, 'scan-memory-mirror.mjs'));
+    copyFileSync(GOVERNED_TREE_MODULE, path.join(root, 'governed-tree.mjs'));
+
+    let status = 0;
+    let stderr = '';
+    try {
+      execFileSync('node', [path.join(root, 'scan-memory-mirror.mjs')], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+    } catch (error) {
+      status = error.status;
+      stderr = String(error.stderr ?? '');
+    }
+
+    expect(status, 'the CLI exited 0 over a memory tree it never read').not.toBe(0);
+    expect(stderr).toMatch(/\.agents\/memory/);
+  });
+});

--- a/scripts/harness/__tests__/scan-memory-mirror.test.mjs
+++ b/scripts/harness/__tests__/scan-memory-mirror.test.mjs
@@ -38,6 +38,28 @@ describe('collectMemoryMirrorFindings', () => {
     expect(() => collectMemoryMirrorFindings(root)).toThrow(/\.agents\/memory/);
   });
 
+  it('has no branch that treats an absent corpus as clean', async () => {
+    // A `if (!existsSync(memDir)) return findings;` sat below the governed-tree check, saying "no
+    // in-repo memory yet is allowed" — the same contradiction this change removed from `main()`,
+    // left behind in the finder as unreachable code. Unreachable is not harmless: it is a second,
+    // opposite answer in one file, and the next reader has no way to know which one binds.
+    //
+    // This pins the property rather than the absence of the lines: an absent corpus must THROW, and
+    // must never come back as an empty finding list, which is what that branch returned.
+    const root = await createFixture();
+    let returned;
+    try {
+      returned = collectMemoryMirrorFindings(root);
+    } catch {
+      returned = undefined;
+    }
+
+    expect(
+      returned,
+      'an absent corpus came back as "no findings" instead of throwing',
+    ).toBeUndefined();
+  });
+
   it('passes a consistent index + fact-file pair', async () => {
     const root = await createFixture({
       '.agents/memory/MEMORY.md': GREEN_INDEX,

--- a/scripts/harness/__tests__/scan-memory-mirror.test.mjs
+++ b/scripts/harness/__tests__/scan-memory-mirror.test.mjs
@@ -136,6 +136,24 @@ describe('scan-memory-mirror CLI', () => {
     }
   }
 
+  it('fails instead of exiting 0 over a memory tree that is not there', async () => {
+    // `main()` carried an early return calling an absent corpus acceptable, contradicting this
+    // file's own finder. It exited 0 without reaching the throw, and without printing the examined
+    // line every other path prints.
+    //
+    // The first version of this case copied the script to the FIXTURE ROOT. The script anchors its
+    // workspace at `<script dir>/../..`, so from there it judged two directories ABOVE the fixture
+    // and passed only because that place has no `.agents/memory` either — an accidental green over
+    // a tree it never opened, and the same mistake this pull request had just fixed in the sibling
+    // suite. `createCliFixture` already places the copy correctly; using it is the whole fix.
+    const { root, scriptCopy } = await createCliFixture({ 'placeholder.txt': 'x\n' });
+
+    const result = runScan(scriptCopy, root);
+
+    expect(result.status, 'the CLI exited 0 over a memory tree it never read').not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(/\.agents\/memory/);
+  });
+
   it('exits 0 with a pass message on a consistent fixture', async () => {
     const { root, scriptCopy } = await createCliFixture({
       '.agents/memory/MEMORY.md': GREEN_INDEX,
@@ -202,32 +220,5 @@ describe('what the mirror scan says it examined', () => {
 
     expect(collectMemoryMirrorFindings(root)).toEqual([]);
     expect(examinedFactFileCount()).toBe(0);
-  });
-});
-
-describe('the CLI cannot exit quietly over a memory tree that is not there', () => {
-  it('fails instead of exiting 0, and says which tree was missing', async () => {
-    // `main()` carried an early return saying "no in-repo memory yet is allowed", contradicting this
-    // file's own finder, which declares the corpus mandatory. The CLI took the wrong answer: it
-    // exited 0 without reaching the throw the case above pins, and without printing the examined
-    // line every other path prints. Review caught it in the change that added that line.
-    const root = await createFixture({ 'placeholder.txt': 'x\n' });
-    copyFileSync(SCAN_SCRIPT, path.join(root, 'scan-memory-mirror.mjs'));
-    copyFileSync(GOVERNED_TREE_MODULE, path.join(root, 'governed-tree.mjs'));
-
-    let status = 0;
-    let stderr = '';
-    try {
-      execFileSync('node', [path.join(root, 'scan-memory-mirror.mjs')], {
-        cwd: root,
-        encoding: 'utf8',
-      });
-    } catch (error) {
-      status = error.status;
-      stderr = String(error.stderr ?? '');
-    }
-
-    expect(status, 'the CLI exited 0 over a memory tree it never read').not.toBe(0);
-    expect(stderr).toMatch(/\.agents\/memory/);
   });
 });

--- a/scripts/harness/__tests__/scan-memory-mirror.test.mjs
+++ b/scripts/harness/__tests__/scan-memory-mirror.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { collectMemoryMirrorFindings } from '../scan-memory-mirror.mjs';
+import { collectMemoryMirrorFindings, examinedFactFileCount } from '../scan-memory-mirror.mjs';
 
 const SCAN_SCRIPT = fileURLToPath(new URL('../scan-memory-mirror.mjs', import.meta.url));
 // HARNESS-052: the scan under test now fails closed on an absent governed tree, so the copy needs
@@ -97,10 +97,7 @@ describe('scan-memory-mirror CLI', () => {
     const scriptCopy = path.join(root, 'scripts/harness/scan-memory-mirror.mjs');
     mkdirSync(path.dirname(scriptCopy), { recursive: true });
     copyFileSync(SCAN_SCRIPT, scriptCopy);
-    copyFileSync(
-      GOVERNED_TREE_MODULE,
-      path.join(path.dirname(scriptCopy), 'governed-tree.mjs'),
-    );
+    copyFileSync(GOVERNED_TREE_MODULE, path.join(path.dirname(scriptCopy), 'governed-tree.mjs'));
     return { root, scriptCopy };
   }
 
@@ -137,5 +134,51 @@ describe('scan-memory-mirror CLI', () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('memory-mirror scan: FINDINGS');
     expect(result.stderr).toContain('MEMORY.md links a missing memory file: fact-one.md');
+  });
+});
+
+describe('what the mirror scan says it examined', () => {
+  it('declares the fact files it walked', async () => {
+    const root = await createFixture({
+      '.agents/memory/MEMORY.md': GREEN_INDEX,
+      '.agents/memory/fact-one.md': '# Fact one\n',
+    });
+
+    collectMemoryMirrorFindings(root);
+
+    expect(examinedFactFileCount()).toBe(1);
+  });
+
+  it("reports zero after a run that returned early, not the previous run's count", () => {
+    // The same correction the sibling scan needed in this change: a holder reset late reports the
+    // previous number for a run that examined nothing, and the early returns are exactly those runs.
+    return (async () => {
+      const withFacts = await createFixture({
+        '.agents/memory/MEMORY.md': GREEN_INDEX,
+        '.agents/memory/fact-one.md': '# Fact one\n',
+      });
+      // A root whose memory directory exists but carries NO index: the governed-tree check passes,
+      // the missing-index branch returns immediately, and nothing walks a fact file. The first
+      // version of this case used an index with no facts beside it, which reaches the walk and sets
+      // the count to 0 on its own — it passed with the reset removed, and proved nothing.
+      const noIndex = await createFixture({ '.agents/memory/placeholder.txt': 'x\n' });
+
+      collectMemoryMirrorFindings(withFacts);
+      collectMemoryMirrorFindings(noIndex);
+
+      expect(
+        examinedFactFileCount(),
+        'a run that walked no fact file kept the previous count',
+      ).toBe(0);
+    })();
+  });
+
+  it('treats an index with no fact files as clean, which is why the zero must be declared', async () => {
+    // The scan itself calls this state correct, so an UNDECLARED zero would redden the whole suite
+    // for a tree the scan has no complaint about. That is why `main` attaches a reason.
+    const root = await createFixture({ '.agents/memory/MEMORY.md': '# Memory Index\n' });
+
+    expect(collectMemoryMirrorFindings(root)).toEqual([]);
+    expect(examinedFactFileCount()).toBe(0);
   });
 });

--- a/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  examinedWriteScopeCount,
   findWorkflowPermissionFindings,
   JUSTIFIED_WRITE_SCOPES,
   parsePermissions,
@@ -129,5 +130,53 @@ describe('the real repository', () => {
       0,
     );
     expect(total).toBeGreaterThan(0);
+  });
+});
+
+describe('the examined count is what was read, not what was declared', () => {
+  /**
+   * The declaration table keeps an entry for a workflow that has since been deleted, and the
+   * anti-rot loop skips those. Reporting the table's size as the examined count therefore claims a
+   * number larger than what was examined — the exact defect the `::examined::` line exists to
+   * expose, committed by the change that introduced the line. Review caught it.
+   */
+  it('counts only the write scopes present on disk', () => {
+    const root = makeRoot({
+      'a.yml':
+        'on:\n  push:\npermissions:\n  contents: write\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
+    });
+
+    findWorkflowPermissionFindings(root);
+
+    expect(examinedWriteScopeCount(), 'a scope on disk was not counted').toBe(1);
+  });
+
+  it('reports zero when the governed tree holds no write scope at all', () => {
+    // And zero is exactly what the runner refuses to accept as a silent pass.
+    const root = makeRoot({
+      'a.yml':
+        'on:\n  push:\npermissions:\n  contents: read\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
+    });
+
+    findWorkflowPermissionFindings(root);
+
+    expect(examinedWriteScopeCount()).toBe(0);
+  });
+
+  it("does not carry a previous run's count into the next", () => {
+    // A module-level holder that is never reset reports the largest run it ever saw.
+    const withScope = makeRoot({
+      'a.yml':
+        'on:\n  push:\npermissions:\n  contents: write\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
+    });
+    const without = makeRoot({
+      'a.yml':
+        'on:\n  push:\npermissions:\n  contents: read\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
+    });
+
+    findWorkflowPermissionFindings(withScope);
+    findWorkflowPermissionFindings(without);
+
+    expect(examinedWriteScopeCount(), 'the count survived into a run that read nothing').toBe(0);
   });
 });

--- a/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
@@ -141,35 +141,54 @@ describe('the examined count is what was read, not what was declared', () => {
    * expose, committed by the change that introduced the line. Review caught it.
    */
   it('counts only the write scopes present on disk', () => {
-    const root = makeRoot({
+    const tree = root({
       'a.yml':
         'on:\n  push:\npermissions:\n  contents: write\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
     });
 
-    findWorkflowPermissionFindings(root);
+    findWorkflowPermissionFindings(tree);
 
     expect(examinedWriteScopeCount(), 'a scope on disk was not counted').toBe(1);
   });
 
   it('reports zero when the governed tree holds no write scope at all', () => {
     // And zero is exactly what the runner refuses to accept as a silent pass.
-    const root = makeRoot({
+    const tree = root({
       'a.yml':
         'on:\n  push:\npermissions:\n  contents: read\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
     });
 
-    findWorkflowPermissionFindings(root);
+    findWorkflowPermissionFindings(tree);
 
     expect(examinedWriteScopeCount()).toBe(0);
   });
 
-  it("does not carry a previous run's count into the next", () => {
-    // A module-level holder that is never reset reports the largest run it ever saw.
-    const withScope = makeRoot({
+  it('reports zero after a run that bailed on an absent workflow directory', () => {
+    // The reset must run BEFORE the early returns, not after them: those paths are exactly the ones
+    // that examined nothing, so a holder reset after them reports the previous run's number for the
+    // very case that looked at zero. Review caught this in the change that added the property.
+    const withScope = root({
       'a.yml':
         'on:\n  push:\npermissions:\n  contents: write\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
     });
-    const without = makeRoot({
+    const noWorkflowDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wf-perms-bare-'));
+    roots.push(noWorkflowDir);
+
+    findWorkflowPermissionFindings(withScope);
+    findWorkflowPermissionFindings(noWorkflowDir);
+
+    expect(examinedWriteScopeCount(), 'a run that read no directory kept the previous count').toBe(
+      0,
+    );
+  });
+
+  it("does not carry a previous run's count into the next", () => {
+    // A module-level holder that is never reset reports the largest run it ever saw.
+    const withScope = root({
+      'a.yml':
+        'on:\n  push:\npermissions:\n  contents: write\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
+    });
+    const without = root({
       'a.yml':
         'on:\n  push:\npermissions:\n  contents: read\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
     });

--- a/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-permissions.test.mjs
@@ -7,6 +7,7 @@
  * because the halves were only ever exercised together.
  */
 
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -21,6 +22,7 @@ import {
 } from '../scan-workflow-permissions.mjs';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+const SCAN_SCRIPT_PATH = path.resolve(import.meta.dirname, '../scan-workflow-permissions.mjs');
 
 /** A throwaway repo root holding only `.github/workflows`, so fixtures cannot touch the real tree. */
 function makeRoot(workflows) {
@@ -161,6 +163,33 @@ describe('the examined count is what was read, not what was declared', () => {
     findWorkflowPermissionFindings(tree);
 
     expect(examinedWriteScopeCount()).toBe(0);
+  });
+
+  it('declares WHY a zero is correct, so a clean read-only tree cannot redden the suite', () => {
+    // Every workflow granting only `read` is the state this scan exists to move toward: it returns
+    // no findings and examines no write scope. An UNDECLARED zero is a hard failure in the runner,
+    // so the line must carry its reason or the suite goes red over a tree the scan calls clean.
+    const tree = root({
+      'a.yml':
+        'on:\n  push:\npermissions:\n  contents: read\njobs:\n  x:\n    runs-on: ubuntu-latest\n',
+    });
+
+    expect(findWorkflowPermissionFindings(tree)).toEqual([]);
+    expect(examinedWriteScopeCount()).toBe(0);
+
+    // The script resolves its workspace root from its own location, not from `cwd`, so it has to be
+    // copied INTO the fixture — running it in place would read the real repository and assert
+    // nothing about this tree. It has no local imports, so the copy is the whole dependency.
+    // ...and at the depth it expects: it resolves the workspace root as `../..` from its own
+    // directory, so a copy dropped at the fixture root would judge the fixture's PARENT. Placed a
+    // level too high, it reported "the workflow directory does not exist" over a tree that has one.
+    const copied = path.join(tree, 'scripts/harness/scan-workflow-permissions.mjs');
+    fs.mkdirSync(path.dirname(copied), { recursive: true });
+    fs.copyFileSync(SCAN_SCRIPT_PATH, copied);
+    const printed = execFileSync('node', [copied], { cwd: tree, encoding: 'utf8' });
+    expect(printed, 'a clean zero was printed with no reason attached').toMatch(
+      /::examined:: 0 write scopes ::expected-empty::/,
+    );
   });
 
   it('reports zero after a run that bailed on an absent workflow directory', () => {

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -1,1 +1,1 @@
-{ "declaring": 11 }
+{ "declaring": 19 }

--- a/scripts/harness/scan-automerge-disarm-permission.mjs
+++ b/scripts/harness/scan-automerge-disarm-permission.mjs
@@ -193,6 +193,7 @@ export async function main() {
     process.exitCode = 1;
     return;
   }
+  process.stdout.write(`::examined:: ${listWorkflows().length} workflows\n`);
   process.stdout.write('automerge-disarm-permission scan passed.\n');
 }
 

--- a/scripts/harness/scan-ci-base-history.mjs
+++ b/scripts/harness/scan-ci-base-history.mjs
@@ -238,6 +238,7 @@ export async function main() {
     process.exitCode = 1;
     return;
   }
+  process.stdout.write(`::examined:: ${listWorkflows().length} workflows\n`);
   process.stdout.write('ci-base-history scan passed.\n');
 }
 

--- a/scripts/harness/scan-main-required-checks.mjs
+++ b/scripts/harness/scan-main-required-checks.mjs
@@ -431,6 +431,7 @@ export async function main({ argv = process.argv.slice(2) } = {}) {
   }
 
   const declared = readDeclaration();
+  process.stdout.write(`::examined:: ${declared.length} required contexts\n`);
   process.stdout.write(
     `main-required-checks scan passed — ${declared.length} required context(s) on \`${GOVERNED_BRANCH}\` all run and can fail: ${declared.map((entry) => entry.context).join(', ')}.` +
       (argv.includes('--live') ? ' Live ruleset reconciled.' : '') +

--- a/scripts/harness/scan-memory-mirror.mjs
+++ b/scripts/harness/scan-memory-mirror.mjs
@@ -25,6 +25,14 @@ import { requireGovernedTree } from './governed-tree.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
+/**
+ * How many memory fact files the last run examined — read by `main` for its `::examined::` line.
+ *
+ * A module-level holder rather than a changed return shape, because the finder is imported by tests
+ * that assert on its findings; widening the return would rewrite them to prove nothing new.
+ */
+let examinedFactFiles = 0;
+
 export function collectMemoryMirrorFindings(root = WORKSPACE_ROOT) {
   requireGovernedTree(root, ['.agents/memory'], {
     scan: 'memory-mirror',
@@ -50,6 +58,7 @@ export function collectMemoryMirrorFindings(root = WORKSPACE_ROOT) {
 
   // Fact files = every *.md in .agents/memory except the index itself.
   const factFiles = readdirSync(memDir).filter((f) => f.endsWith('.md') && f !== 'MEMORY.md');
+  examinedFactFiles = factFiles.length;
 
   // Linked targets in the index: markdown links to local .md files, e.g. [Title](slug.md)
   const linked = new Set(
@@ -96,6 +105,7 @@ export function main() {
     process.exit(1);
   }
 
+  console.log(`::examined:: ${examinedFactFiles} memory fact files`);
   console.log('memory-mirror scan passed.');
   process.exit(0);
 }

--- a/scripts/harness/scan-memory-mirror.mjs
+++ b/scripts/harness/scan-memory-mirror.mjs
@@ -51,11 +51,6 @@ export function collectMemoryMirrorFindings(root = WORKSPACE_ROOT) {
   const index = path.join(memDir, 'MEMORY.md');
   const findings = [];
 
-  if (!existsSync(memDir)) {
-    // No in-repo memory yet is allowed; the rule only bites once memory exists.
-    return findings;
-  }
-
   if (!existsSync(index)) {
     findings.push(
       '.agents/memory/ exists but has no MEMORY.md index (every clone needs the index to find facts).',

--- a/scripts/harness/scan-memory-mirror.mjs
+++ b/scripts/harness/scan-memory-mirror.mjs
@@ -33,7 +33,16 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
  */
 let examinedFactFiles = 0;
 
+/** What the last `collectMemoryMirrorFindings` run walked — exported so it can be asserted. */
+export function examinedFactFileCount() {
+  return examinedFactFiles;
+}
+
 export function collectMemoryMirrorFindings(root = WORKSPACE_ROOT) {
+  // Reset FIRST, before anything can return. The same correction was made in the workflow-permissions
+  // scan in this change and not mirrored here: a holder reset late reports the previous run's number
+  // for a run that examined nothing, and the early returns below are exactly those runs.
+  examinedFactFiles = 0;
   requireGovernedTree(root, ['.agents/memory'], {
     scan: 'memory-mirror',
     why: 'memory-mirroring.md makes the in-repo memory corpus mandatory here, so its absence is a broken checkout rather than a repository that has not started one.',
@@ -105,7 +114,16 @@ export function main() {
     process.exit(1);
   }
 
-  console.log(`::examined:: ${examinedFactFiles} memory fact files`);
+  // A legitimate zero, declared. The index may exist with no fact files beside it yet — a bootstrap
+  // or post-cleanup state the scan itself considers clean — and an undeclared zero is a hard failure
+  // in the runner. Saying why is the whole contract; staying silent would redden the suite for a
+  // state this scan calls correct.
+  console.log(
+    examinedFactFiles === 0
+      ? '::examined:: 0 memory fact files ::expected-empty:: the index may exist before any fact ' +
+          'file does, and the mirroring rule only bites once memory exists'
+      : `::examined:: ${examinedFactFiles} memory fact files`,
+  );
   console.log('memory-mirror scan passed.');
   process.exit(0);
 }

--- a/scripts/harness/scan-memory-mirror.mjs
+++ b/scripts/harness/scan-memory-mirror.mjs
@@ -98,11 +98,12 @@ export function collectMemoryMirrorFindings(root = WORKSPACE_ROOT) {
 }
 
 export function main() {
-  if (!existsSync(path.join(WORKSPACE_ROOT, '.agents/memory'))) {
-    // No in-repo memory yet is allowed; the rule only bites once memory exists.
-    process.exit(0);
-  }
-
+  // No early return for an absent `.agents/memory`. One stood here saying "no in-repo memory yet is
+  // allowed", which contradicted this file's own finder — `requireGovernedTree` declares the corpus
+  // MANDATORY and an absent one a broken checkout. Two answers in one file, and the CLI took the
+  // wrong one: it exited 0 without reaching the throw its own test pins, and without printing the
+  // examined line every other path here prints. A guard that can exit silently over ground it never
+  // read is the defect this scan's declaration was added to expose.
   const findings = collectMemoryMirrorFindings();
 
   if (findings.length > 0) {

--- a/scripts/harness/scan-publish-registry.mjs
+++ b/scripts/harness/scan-publish-registry.mjs
@@ -271,6 +271,7 @@ function main() {
     process.exitCode = 1;
     return;
   }
+  console.log(`::examined:: ${examined} workspace packages`);
   console.log(
     `publish-registry scan passed (${examined} workspace package(s) reconciled against ${REGISTRY_PATH}).`,
   );

--- a/scripts/harness/scan-required-check-needs.mjs
+++ b/scripts/harness/scan-required-check-needs.mjs
@@ -192,6 +192,7 @@ export async function main() {
     return;
   }
 
+  process.stdout.write(`::examined:: ${edges} dependency edges\n`);
   process.stdout.write(
     `required-check-needs scan passed — ${edges} dependency edge(s) examined; no required check can be silently skipped by a dependency.\n`,
   );

--- a/scripts/harness/scan-test-selection-tolerance.mjs
+++ b/scripts/harness/scan-test-selection-tolerance.mjs
@@ -214,6 +214,7 @@ export async function main() {
     return;
   }
 
+  process.stdout.write(`::examined:: ${invocations} filtered test invocations\n`);
   process.stdout.write(
     `test-selection-tolerance scan passed — ${invocations} filtered test invocation(s) examined; none can pass on zero matches.\n`,
   );

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -70,6 +70,21 @@ export const JUSTIFIED_WRITE_SCOPES = {
 };
 
 /** Parse the top-level `permissions:` block of a workflow into `{scope: level}`. */
+/**
+ * How many write scopes the last run actually READ from workflows on disk.
+ *
+ * Deliberately not the size of the declaration table below. That table keeps an entry for a workflow
+ * that has since been deleted, and the anti-rot loop skips those — so reporting its size would claim
+ * an examined count larger than what was examined, which is the exact defect the `::examined::` line
+ * exists to expose. Found by review, in the change that introduced the line.
+ */
+let examinedWriteScopes = 0;
+
+/** What the last `findWorkflowPermissionFindings` run actually read — exported so it can be asserted. */
+export function examinedWriteScopeCount() {
+  return examinedWriteScopes;
+}
+
 export function parsePermissions(source) {
   const lines = source.split('\n');
   const start = lines.findIndex((line) => /^permissions:\s*$/.test(line));
@@ -108,6 +123,7 @@ export function findWorkflowPermissionFindings(root = WORKSPACE_ROOT) {
     return [{ workflow: WORKFLOW_DIR, detail: 'no workflows found — this scan examined nothing' }];
   }
 
+  examinedWriteScopes = 0;
   const requested = new Set();
   for (const name of workflows) {
     const scopes = parsePermissions(fs.readFileSync(path.join(dir, name), 'utf8'));
@@ -115,6 +131,7 @@ export function findWorkflowPermissionFindings(root = WORKSPACE_ROOT) {
     for (const [scope, level] of Object.entries(scopes)) {
       if (level !== 'write') continue;
       requested.add(`${name}:${scope}`);
+      examinedWriteScopes = requested.size;
       const justification = JUSTIFIED_WRITE_SCOPES[name]?.[scope];
       if (justification === undefined) {
         findings.push({
@@ -191,7 +208,9 @@ export function main(argv = process.argv.slice(2)) {
     (total, scopes) => total + Object.keys(scopes).length,
     0,
   );
-  process.stdout.write(`::examined:: ${count} declared write scopes\n`);
+  process.stdout.write(
+    `::examined:: ${examinedWriteScopes} write scopes read from workflows on disk\n`,
+  );
   process.stdout.write(
     `workflow-permissions scan passed: ${count} declared write scope(s), each justified.` +
       (argv.includes('--live')

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -212,7 +212,16 @@ export function main(argv = process.argv.slice(2)) {
     0,
   );
   process.stdout.write(
-    `::examined:: ${examinedWriteScopes} write scopes read from workflows on disk\n`,
+    // A legitimate zero, declared. Every workflow granting only `read` is a CORRECT state — one of
+    // this scan's own cases asserts exactly that — and the file's history shows the tree drifting
+    // that way, since a write scope has already been removed once. An undeclared zero is a hard
+    // failure in the runner, so silence here would redden the suite for a tree this scan calls
+    // clean. Every other scan in this batch is structurally prevented from printing an unearned
+    // zero; this one needed the guard written.
+    examinedWriteScopes === 0
+      ? '::examined:: 0 write scopes ::expected-empty:: no workflow grants a write permission, ' +
+          'which is the state this scan exists to move toward\n'
+      : `::examined:: ${examinedWriteScopes} write scopes read from workflows on disk\n`,
   );
   process.stdout.write(
     `workflow-permissions scan passed: ${count} declared write scope(s), each justified.` +

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -191,6 +191,7 @@ export function main(argv = process.argv.slice(2)) {
     (total, scopes) => total + Object.keys(scopes).length,
     0,
   );
+  process.stdout.write(`::examined:: ${count} declared write scopes\n`);
   process.stdout.write(
     `workflow-permissions scan passed: ${count} declared write scope(s), each justified.` +
       (argv.includes('--live')

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -106,6 +106,10 @@ export function parsePermissions(source) {
 }
 
 export function findWorkflowPermissionFindings(root = WORKSPACE_ROOT) {
+  // Reset FIRST, before the early returns. Placed after them, a run that bailed on an absent or
+  // empty workflow directory reported the PREVIOUS run's count — a holder that is not reset reports
+  // the largest run it ever saw, and the early-return paths are exactly where it examined nothing.
+  examinedWriteScopes = 0;
   const findings = [];
   const dir = path.join(root, WORKFLOW_DIR);
   if (!fs.existsSync(dir)) {
@@ -123,7 +127,6 @@ export function findWorkflowPermissionFindings(root = WORKSPACE_ROOT) {
     return [{ workflow: WORKFLOW_DIR, detail: 'no workflows found — this scan examined nothing' }];
   }
 
-  examinedWriteScopes = 0;
   const requested = new Set();
   for (const name of workflows) {
     const scopes = parsePermissions(fs.readFileSync(path.join(dir, name), 'utf8'));


### PR DESCRIPTION
Migration batch 1 for the examined-size invariant landed in #1633. **11 → 19 of 97.**

Marked here: the required-check dependency edges, the filtered test invocations, the workspace packages reconciled against the publish registry, the declared write scopes, the required contexts on the protected branch, the workflows two CI-history guards walk, and the memory fact files. Each number was verified by running the scan, not by reading the variable name.

## A correction to what this migration costs — the useful part

The first estimate said each remaining scan is *"a one-line addition beside a number the scan already computes"*. That holds for the ones that **print** their count. For the rest it does not:

> their finder returns findings and nothing else, so the number exists inside the walk and dies there.

Making it available changes what the finder hands back — and the finder is usually imported by tests that assert on its findings, so a widened return shape rewrites those tests to prove nothing new.

`scan-memory-mirror` shows the cheapest honest form: a **module-level holder** set where the walk happens and read where the line is printed, leaving the finder's contract and its tests untouched. Still a deliberate edit per scan.

The item now says so, rather than carrying an estimate that would make the next reader think the sweep is trivial. **77 remain**, and they should be read as that size.

Baseline re-frozen at **19** in this change.

## Verification

- `pnpm harness:test` — 2603 passed. `pnpm harness:scan` — 96/97; the one failure is the pre-existing `progress-report-quantification` finding over immutable session transcripts (HARNESS-054).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso