### PR TITLE
feat(harness): a finding in append-only history can be acknowledged (HARNESS-054)

### DIFF
--- a/.agents/tasks/completed/HARNESS-054-progress-quantification-scan-cannot-be-cleared.md
+++ b/.agents/tasks/completed/HARNESS-054-progress-quantification-scan-cannot-be-cleared.md
@@ -1,7 +1,8 @@
 ---
 id: HARNESS-054
 title: 'HARNESS-054: the progress-quantification scan skips in CI and its local red can never be cleared'
-status: todo
+status: done
+completed: 2026-08-04
 priority: medium
 urgency: soon
 type: INFRA
@@ -65,3 +66,42 @@ sound; what is missing is a clearing mechanism.
   flagged — stated deliberately rather than falling out of a lookbehind width.
 - The CI-vacuity is stated in the scan's own header, so a reader of `run-all-scans` output is not
   led to believe this scan gates anything in CI.
+
+## Implementation (2026-08-04)
+
+**The suite is green for the first time in this session.** `pnpm harness:scan` reported
+`1 of 97 scans failed` on every run for days, and this was the one — a guard that fires and cannot be
+cleared, which the memory file it cites names as the shape that gets suppressed.
+
+**A per-finding acknowledgment ledger**, `scripts/harness/progress-report-acknowledgments.json`. A
+finding is identified by transcript basename + timestamp + ratio — deliberately NOT the excerpt, which
+is prose a later reader may requote, and an identity that changes when the quotation is reformatted
+goes stale for the wrong reason. An entry with no reason is refused: a waiver nobody had to justify is
+the shape this repository rejects wherever it allows one at all.
+
+**Anti-rot, scoped to what was actually read.** An entry whose finding no longer appears FAILS — but
+only when this run read the transcript the entry names. On a host without it (CI, a fresh checkout,
+another developer's machine) the entry is not judged, because an anti-rot firing over ground it never
+covered is the vacuity this harness spends its time removing. That trap has been sprung twice before
+in this repository and is pinned by a case here.
+
+**One defect on the first run, and it was the identity.** A finding calls the field `file` and a ledger
+entry calls it `transcript`, so every entry read as STALE — two keys for one thing. The key reads both
+now, with a case pinning that they agree.
+
+**Four findings acknowledged, all of them mine.** Three from 2026-08-01/02, and a FOURTH committed
+while building this very path — a report of the migration progress written as a bare ratio. It is
+recorded rather than argued away: that it happened during the fix is the clearest possible evidence
+that the rule needs a mechanism rather than an intention.
+
+**The version-migration verdict, stated rather than inherited.** `X → Y/Z` with a NUMBER before the
+arrow is already suppressed as a version transition, and that suppression is deliberate and
+documented; a WORD before the arrow stays a violation. The prose form `from v5 to 6/7` remains
+FLAGGED, and the item's proposal to widen the version-noun suppression to sentence scope is REFUSED on
+evidence: a case here shows it would drop a genuine finding from `작업 4/6 완료. 버전 5도 확인했습니다.`
+A false positive with two cheap escapes — the arrow form, or the percentage the rule asks for — is a
+better trade than a class of false negatives with none.
+
+**The CI vacuity is in the scan's own header**, so a reader of the suite summary is not led to believe
+this scan gates anything on a pull request. It also declares `::examined::` now, which brought the
+adoption ratchet from 19 to 20.

--- a/.agents/tasks/completed/HARNESS-054-progress-quantification-scan-cannot-be-cleared.md
+++ b/.agents/tasks/completed/HARNESS-054-progress-quantification-scan-cannot-be-cleared.md
@@ -102,6 +102,16 @@ evidence: a case here shows it would drop a genuine finding from `작업 4/6 완
 A false positive with two cheap escapes — the arrow form, or the percentage the rule asks for — is a
 better trade than a class of false negatives with none.
 
+**The declaration must not depend on the host — review found it did.** The SKIP branch printed no
+`::examined::` line, so this was the one scan in the suite whose declaration appeared on a machine that
+had run agent sessions and vanished on a fresh checkout. The adoption ratchet counts that line, and
+the promotion-to-`main` gate runs the suite UNSKIPPED on a fresh runner, so a baseline that was correct
+on this laptop would have turned that required check red. The local `all 97 scans passed` could not
+have shown it. Verified by recomputing the count with no transcript directory: 20, the same number.
+
+That is also the invariant working as intended one level up — a skip reporting nothing is exactly the
+shape the declaration exists to make visible.
+
 **The CI vacuity is in the scan's own header**, so a reader of the suite summary is not led to believe
 this scan gates anything on a pull request. It also declares `::examined::` now, which brought the
 adoption ratchet from 19 to 20.

--- a/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
+++ b/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
@@ -418,16 +418,47 @@ describe('a finding in append-only history can be acknowledged, and the ledger c
     );
   });
 
+  it('refuses an UNREADABLE ledger, which is a different claim from an absent one', () => {
+    // A permission error or a corrupt read would otherwise become "no acknowledgments" — the same
+    // file, a different claim. Absent is a valid state; unreadable is not.
+    expect(() =>
+      loadAcknowledgments(() => {
+        throw Object.assign(new Error('denied'), { code: 'EACCES' });
+      }),
+    ).toThrow(/could not be read/);
+  });
+
   it('treats a missing ledger as an empty one, not as an error', () => {
     // The ledger is optional: a repository with nothing to acknowledge should not have to carry a file.
     expect(
       loadAcknowledgments(() => {
-        throw new Error('ENOENT');
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' });
       }),
     ).toEqual([]);
   });
 
   it('reads the SHIPPED ledger, so a malformed one fails here rather than in CI', () => {
     expect(() => loadAcknowledgments()).not.toThrow();
+  });
+});
+
+describe('what it declares does not depend on the host it runs on', () => {
+  it('declares a zero WITH its reason when there is no transcript at all', async () => {
+    // The skip branch printed no declaration, so this was the one scan in the suite whose
+    // `::examined::` line appeared on a machine that had run agent sessions and vanished on a fresh
+    // checkout. The adoption ratchet counts that line, and the promotion-to-main gate runs the suite
+    // unskipped on a fresh runner — so a count that was correct on the author's laptop would have
+    // turned that gate red. Review traced it; the local green could not have shown it.
+    const lines = [];
+    const code = await main((line) => lines.push(line), {
+      root: '/home/dev/repo',
+      home: makeTempDir(),
+    });
+
+    const printed = lines.join('\n');
+    expect(code, 'a host without transcripts must still skip cleanly').toBe(0);
+    expect(printed, 'the skip declared nothing, so its adoption depends on the host').toMatch(
+      /::examined:: 0 transcripts ::expected-empty::/,
+    );
   });
 });

--- a/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
+++ b/scripts/harness/__tests__/scan-progress-report-quantification.test.mjs
@@ -7,8 +7,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { loadHarnessConfig } from '../harness-config.mjs';
 import { ADVISORY_MARKER } from '../run-all-scans.mjs';
 import {
+  applyAcknowledgments,
   extractNarrativeText,
   findBareRatioProgressStatements,
+  findingKey,
+  loadAcknowledgments,
   main,
   resolveTranscriptFiles,
   scanTranscriptFile,
@@ -311,5 +314,120 @@ describe('main', () => {
     const output = lines.join('\n');
     expect(output).toContain('3/7');
     expect(output).toContain('agent-conduct.md');
+  });
+});
+
+describe('the version-migration form, judged deliberately', () => {
+  /**
+   * HARNESS-054 asked for this verdict to be STATED rather than left to fall out of a lookbehind
+   * width. It is two verdicts, and they differ on what sits before the arrow.
+   */
+  it('suppresses a version transition and flags a progress statement wearing an arrow', () => {
+    // A NUMBER before the arrow is a version or state transition: `5 → 6/7` is one version to
+    // another, not six sevenths of a task finished.
+    expect(findBareRatioProgressStatements('**5 → 6/7 병행 전환 완료.**', POLICY)).toEqual([]);
+    expect(
+      findBareRatioProgressStatements('TypeScript 5 → 6/7 migration complete.', POLICY),
+    ).toEqual([]);
+
+    // A WORD before it is not. The arrow does not make a count into a version.
+    expect(findBareRatioProgressStatements('마이그레이션 작업 → 6/7 완료.', POLICY)).toHaveLength(
+      1,
+    );
+  });
+
+  it('still flags the prose form, and that is the deliberate answer', () => {
+    // `from v5 to 6/7` reads as a version pair to someone who knows the domain, and the version noun
+    // is not adjacent to the ratio. The item proposed widening the suppression to SENTENCE scope for
+    // the version nouns; that is refused here, on this evidence: it would suppress a real finding in
+    // any sentence that happens to mention a version, and the next case is exactly that sentence.
+    //
+    // The writer has two ways to say it without tripping the rule — the arrow form above, or the
+    // percentage the rule asks for. A false positive with two cheap escapes is a better trade than a
+    // class of false negatives with none.
+    expect(findBareRatioProgressStatements('Migrated from v5 to 6/7 — done.', POLICY)).toHaveLength(
+      1,
+    );
+  });
+
+  it('would have lost a real finding under sentence-scope suppression', () => {
+    // The sentence that decides it: a genuine mid-work ratio, in a message that also mentions a
+    // version. Sentence scope would have read the version noun and dropped the violation.
+    expect(
+      findBareRatioProgressStatements('작업 4/6 완료. 버전 5도 확인했습니다.', POLICY),
+    ).toHaveLength(1);
+  });
+});
+
+describe('a finding in append-only history can be acknowledged, and the ledger cannot rot', () => {
+  /**
+   * A transcript cannot be edited, so a finding here is permanent: without a clearing path the scan
+   * is red on that host forever, for every unrelated change. A guard that fires and cannot be
+   * cleared is one that gets suppressed, and a suppressed guard costs more than what it catches.
+   */
+  const FINDING = {
+    file: '/somewhere/session.jsonl',
+    timestamp: '2026-08-01T00:00:00.000Z',
+    ratio: '4/6',
+  };
+  const ENTRY = {
+    transcript: 'session.jsonl',
+    timestamp: '2026-08-01T00:00:00.000Z',
+    ratio: '4/6',
+    reason: 'why',
+  };
+
+  it('identifies a finding the same way from either side', () => {
+    // A finding calls it `file`, a ledger entry calls it `transcript`. Two keys for one thing means
+    // every entry reads stale — measured on the first run of this ledger, where all of them did.
+    expect(findingKey(FINDING)).toBe(findingKey(ENTRY));
+  });
+
+  it('does not key on the excerpt', () => {
+    // The excerpt is prose a later reader may requote. An identity that changes when the quotation
+    // is reformatted goes stale for the wrong reason.
+    expect(findingKey({ ...FINDING, excerpt: 'one wording' })).toBe(
+      findingKey({ ...FINDING, excerpt: 'another wording entirely' }),
+    );
+  });
+
+  it('clears a finding it covers, and leaves the rest open', () => {
+    const other = { ...FINDING, ratio: '5/6' };
+    const result = applyAcknowledgments([FINDING, other], [ENTRY], [FINDING.file]);
+
+    expect(result.cleared).toBe(1);
+    expect(result.open).toEqual([other]);
+    expect(result.stale).toEqual([]);
+  });
+
+  it('fails an entry whose finding no longer appears', () => {
+    expect(applyAcknowledgments([], [ENTRY], [FINDING.file]).stale).toEqual([ENTRY]);
+  });
+
+  it('does NOT judge an entry for a transcript this run never read', () => {
+    // The anti-rot must be scoped to the real subject. On a host without that transcript — CI, a
+    // fresh checkout, another developer's machine — every entry would read stale, and a check that
+    // fires over ground it never covered is the vacuity this harness spends its time removing.
+    expect(applyAcknowledgments([], [ENTRY], []).stale).toEqual([]);
+  });
+
+  it('refuses an acknowledgment with no reason', () => {
+    // A waiver nobody had to justify is the shape this repository refuses wherever it allows one.
+    expect(() => loadAcknowledgments(() => JSON.stringify([{ ...ENTRY, reason: '   ' }]))).toThrow(
+      /carries no reason/,
+    );
+  });
+
+  it('treats a missing ledger as an empty one, not as an error', () => {
+    // The ledger is optional: a repository with nothing to acknowledge should not have to carry a file.
+    expect(
+      loadAcknowledgments(() => {
+        throw new Error('ENOENT');
+      }),
+    ).toEqual([]);
+  });
+
+  it('reads the SHIPPED ledger, so a malformed one fails here rather than in CI', () => {
+    expect(() => loadAcknowledgments()).not.toThrow();
   });
 });

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -1,1 +1,1 @@
-{ "declaring": 19 }
+{ "declaring": 20 }

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -1,0 +1,29 @@
+{
+  "why": "A transcript is append-only history: a finding here cannot be fixed, only recorded. Each entry names a real violation of the quantified-progress rule that has already happened, so the scan can return to green without being disarmed. An entry whose finding no longer appears in a transcript this run READ fails the scan — see the header of scan-progress-report-quantification.mjs.",
+  "acknowledgments": [
+    {
+      "transcript": "50cb28dd-0dd1-4ca4-897a-f8d0b47191c7.jsonl",
+      "timestamp": "2026-08-01T19:39:25.576Z",
+      "ratio": "4/6",
+      "reason": "A real violation, committed by me: a mid-work audit status reported 4/6 with no percentage. History cannot be edited, so it is recorded rather than fixed."
+    },
+    {
+      "transcript": "50cb28dd-0dd1-4ca4-897a-f8d0b47191c7.jsonl",
+      "timestamp": "2026-08-01T19:39:52.985Z",
+      "ratio": "5/6",
+      "reason": "The same violation seventeen seconds later in the same session — which is the argument for a mechanism rather than an intention, and why the rule is enforced by a scan at all."
+    },
+    {
+      "transcript": "50cb28dd-0dd1-4ca4-897a-f8d0b47191c7.jsonl",
+      "timestamp": "2026-08-02T12:42:07.310Z",
+      "ratio": "13/16",
+      "reason": "A third instance the next day, reporting 13/16 without the percentage. Recorded for the same reason: the transcript is immutable and the alternative is a permanently red scan that gets suppressed."
+    },
+    {
+      "transcript": "50cb28dd-0dd1-4ca4-897a-f8d0b47191c7.jsonl",
+      "timestamp": "2026-08-04T06:58:15.776Z",
+      "ratio": "78/97",
+      "reason": "A fourth instance, committed while building the acknowledgment path for the first three — reporting 78/97 of the scans still undeclared, with no percentage. Recorded rather than argued away: it is the same violation, and the fact that it happened during the fix is the clearest evidence that the rule needs a mechanism and not an intention."
+    }
+  ]
+}

--- a/scripts/harness/scan-progress-report-quantification.mjs
+++ b/scripts/harness/scan-progress-report-quantification.mjs
@@ -97,7 +97,16 @@ export function loadAcknowledgments(readFile = () => readFileSync(ACKNOWLEDGMENT
   let raw;
   try {
     raw = readFile();
-  } catch {
+  } catch (error) {
+    // ABSENT is a valid state — a repository with nothing to acknowledge should not have to carry
+    // the file. UNREADABLE is not: a permission error or a corrupt read would otherwise become "no
+    // acknowledgments", which is a different claim about the same file.
+    if (error?.code && error.code !== 'ENOENT') {
+      throw new Error(
+        `progress-report acknowledgments: ${ACKNOWLEDGMENTS_PATH} could not be read (${error.code}). ` +
+          'An unreadable ledger is not an empty one.',
+      );
+    }
     return [];
   }
   const parsed = JSON.parse(raw);
@@ -316,6 +325,16 @@ export async function main(write = (line) => process.stdout.write(`${line}\n`), 
       `${ADVISORY_MARKER} progress-report quantification examined 0 transcript(s) — no session ` +
         `transcript for this workspace at ${dir}; the agent-narrative channel does not exist on ` +
         'this host (e.g. CI or a fresh checkout), so nothing was judged.',
+    );
+    // The SKIP declares its zero too, with the reason. Without this the scan is the only one in the
+    // suite whose declaration depends on the HOST: present on a machine that has run agent sessions,
+    // absent on a fresh checkout — so the adoption count fell by one wherever it actually matters,
+    // and the promotion-to-main gate, which runs the suite unskipped on a fresh runner, would have
+    // gone red for a count that was correct on the author's laptop. A skip reporting nothing is
+    // precisely the shape this declaration exists to make visible.
+    write(
+      '::examined:: 0 transcripts ::expected-empty:: no session transcript exists on this host, ' +
+        'which is every CI runner and every fresh checkout — this scan gates nothing there',
     );
     write(
       `progress-report quantification scan skipped (0 transcript(s), 0 narrative message(s) examined): ` +

--- a/scripts/harness/scan-progress-report-quantification.mjs
+++ b/scripts/harness/scan-progress-report-quantification.mjs
@@ -43,10 +43,29 @@
  * Policy DATA (transcript root, cutoff, keyword/suppression vocabulary) lives under the
  * `progressReportQuantification` key of `.agents/harness.config.json`; this file is the engine.
  *
- * Exit code 0 = clean or skipped, 1 = violations found.
+ * ## It gates nothing in CI, and says so
+ *
+ * No CI runner has a session transcript, so this scan SKIPS on every CI run. A reader of the suite
+ * summary must not take its tick as evidence about a pull request: the only host where it can fail is
+ * a developer's own machine. That is stated here rather than left to be rediscovered.
+ *
+ * ## Why a finding can be acknowledged
+ *
+ * A transcript is append-only history. A finding cannot be edited away, so without a clearing path
+ * the scan is red on that host FOREVER, for every unrelated change — and a guard that fires and
+ * cannot be cleared is one that gets suppressed, which costs more than what it catches. So a finding
+ * may be acknowledged, with a reason, in a checked-in ledger beside this file.
+ *
+ * The acknowledgment is anti-rotted: an entry naming a finding that no longer appears FAILS. But
+ * only for a transcript this run actually READ — on a host without that transcript the entry is not
+ * judged at all, because an anti-rot that fires over ground it never covered is the vacuity this
+ * harness spends its time removing.
+ *
+ * Exit code 0 = clean, skipped, or wholly acknowledged; 1 = unacknowledged violations or a stale
+ * acknowledgment.
  */
 
-import { createReadStream, existsSync, readdirSync, statSync } from 'node:fs';
+import { createReadStream, existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
@@ -55,6 +74,67 @@ import { loadHarnessConfig } from './harness-config.mjs';
 import { ADVISORY_MARKER } from './run-all-scans.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const ACKNOWLEDGMENTS_PATH = path.join(
+  WORKSPACE_ROOT,
+  'scripts/harness/progress-report-acknowledgments.json',
+);
+
+/**
+ * A finding's identity: which transcript, when, and which ratio.
+ *
+ * Not the excerpt. The excerpt is prose that a later reader may want to quote differently, and an
+ * identity that changes when the quotation is reformatted is an identity that goes stale for the
+ * wrong reason.
+ */
+export function findingKey({ file, transcript, timestamp, ratio }) {
+  // A finding calls it `file`, a ledger entry calls it `transcript`. One key reads both, so the two
+  // sides cannot drift into producing different identities for the same thing — which they did on
+  // first run: every entry read as stale because the key saw an empty filename on one side.
+  return `${path.basename(String(file ?? transcript ?? ''))}|${timestamp ?? ''}|${ratio ?? ''}`;
+}
+
+export function loadAcknowledgments(readFile = () => readFileSync(ACKNOWLEDGMENTS_PATH, 'utf8')) {
+  let raw;
+  try {
+    raw = readFile();
+  } catch {
+    return [];
+  }
+  const parsed = JSON.parse(raw);
+  const entries = Array.isArray(parsed) ? parsed : (parsed.acknowledgments ?? []);
+  for (const entry of entries) {
+    // A waiver with no reason is a waiver nobody had to justify — the shape this repository refuses
+    // wherever it allows a suppression at all.
+    if (!entry.reason || String(entry.reason).trim().length === 0) {
+      throw new Error(
+        `progress-report acknowledgments: ${findingKey(entry)} carries no reason. An acknowledgment ` +
+          'without one is a silent waiver.',
+      );
+    }
+  }
+  return entries;
+}
+
+/**
+ * Split findings into those an acknowledgment covers and those it does not, and report entries that
+ * no longer match anything — but only for transcripts this run actually read.
+ */
+export function applyAcknowledgments(findings, acknowledgments, transcriptsRead) {
+  const acknowledged = new Map(acknowledgments.map((entry) => [findingKey(entry), entry]));
+  const matched = new Set();
+  const open = [];
+  for (const finding of findings) {
+    const key = findingKey(finding);
+    if (acknowledged.has(key)) matched.add(key);
+    else open.push(finding);
+  }
+  const readable = new Set(transcriptsRead.map((file) => path.basename(file)));
+  const stale = acknowledgments.filter(
+    (entry) =>
+      !matched.has(findingKey(entry)) && readable.has(path.basename(entry.transcript ?? '')),
+  );
+  return { open, stale, cleared: matched.size };
+}
 
 /** Fenced code blocks and inline code spans are quoted material, not narrative prose. */
 function stripCode(text) {
@@ -252,6 +332,33 @@ export async function main(write = (line) => process.stdout.write(`${line}\n`), 
     findings.push(...(await scanTranscriptFile(file, policy, sinceMs, stats)));
   }
   const subject = `${files.length} transcript(s), ${stats.messages} narrative message(s) examined`;
+  write(
+    stats.messages === 0
+      ? `::examined:: 0 narrative messages ::expected-empty:: ${files.length} transcript(s) were read ` +
+          'and every record fell outside the enforcement ratchet or carried no assistant narrative'
+      : `::examined:: ${stats.messages} narrative messages`,
+  );
+
+  const { open, stale, cleared } = applyAcknowledgments(findings, loadAcknowledgments(), files);
+  if (stale.length > 0) {
+    write('progress-report quantification scan failed — stale acknowledgment(s):');
+    for (const entry of stale) {
+      write(`  ${findingKey(entry)} no longer matches any finding in a transcript this run read.`);
+    }
+    write(
+      '\nRemove the entry. An acknowledgment that outlives its finding is a waiver nobody is using, ' +
+        'and a ledger that only grows stops being read.',
+    );
+    return 1;
+  }
+  findings.length = 0;
+  findings.push(...open);
+  if (cleared > 0) {
+    write(
+      `${ADVISORY_MARKER} progress-report quantification: ${cleared} finding(s) acknowledged in ` +
+        `${path.relative(WORKSPACE_ROOT, ACKNOWLEDGMENTS_PATH)} — recorded, not cleared by editing history.`,
+    );
+  }
 
   if (findings.length === 0) {
     if (stats.messages === 0) {


### PR DESCRIPTION
**`all 97 scans passed`** — the suite is green for the first time in this session. It reported `1 of 97 scans failed` on every run for days, and this was the one.

## The defect was structural, not a false positive

A transcript is append-only. A finding here can never be edited away, so once the scan fired it was red **on that host forever, for every unrelated change**. That is the shape this repository's own memory names as the one that gets suppressed — and a suppressed guard costs more than what it catches.

## A per-finding acknowledgment ledger

A finding is identified by **transcript + timestamp + ratio** — deliberately *not* the excerpt, which is prose a later reader may requote, and an identity that changes when the quotation is reformatted goes stale for the wrong reason. An entry with no reason is refused: a waiver nobody had to justify is the shape this repo rejects wherever it allows one at all.

**Anti-rot scoped to what was actually READ.** An entry whose finding no longer appears fails — but only when this run read the transcript it names. On a host without it (CI, a fresh checkout, another developer's machine) the entry is not judged, because an anti-rot firing over ground it never covered is the vacuity this harness spends its time removing. That trap has been sprung twice here already; it is pinned by a case.

### One defect on the first run, and it was the identity

A finding calls the field `file`; a ledger entry calls it `transcript`. **Every entry read as stale** — two keys for one thing. The key reads both now, with a case pinning that they agree.

## Four findings acknowledged, all of them mine

Three from 08-01 and 08-02 — and a **fourth committed while building this very path**, reporting the migration progress as a bare ratio. Recorded rather than argued away: that it happened *during the fix* is the clearest evidence the rule needs a mechanism and not an intention.

## The version-migration verdict, stated rather than inherited

- An arrow with a **number** before it is a version transition → suppressed (already deliberate and documented).
- A **word** before the arrow → still a violation.
- The prose form `from v5 to 6/7` → **flagged**, and the item's proposal to widen the version-noun suppression to *sentence scope* is **refused on evidence**: a case shows it would drop a genuine finding from `작업 4/6 완료. 버전 5도 확인했습니다.` A false positive with two cheap escapes — the arrow form, or the percentage the rule asks for — beats a class of false negatives with none.

## All four "Done when" criteria met

- ✅ a finding can be acknowledged with a recorded reason, and the scan exits 0
- ✅ an acknowledgment whose finding no longer exists fails the scan
- ✅ the `X → Y/Z` form is covered by fixtures with the verdict stated deliberately
- ✅ the CI vacuity is in the scan's own header

## Verification

- `pnpm harness:scan` — **all 97 passed** (20 declared what they examined; adoption re-frozen 19 → 20).
- `pnpm harness:test` — 2624 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso