### PR TITLE
feat(harness): a scan that skipped stops rendering as a tick (HARNESS-056, HARNESS-064)

### DIFF
--- a/.agents/tasks/completed/HARNESS-056-a-scan-that-skipped-renders-as-a-tick.md
+++ b/.agents/tasks/completed/HARNESS-056-a-scan-that-skipped-renders-as-a-tick.md
@@ -1,7 +1,8 @@
 ---
 id: HARNESS-056
 title: 'HARNESS-056: a scan that skipped renders as ✓, so the suite total overstates what ran'
-status: todo
+status: done
+completed: 2026-08-04
 priority: medium
 urgency: soon
 type: INFRA
@@ -54,3 +55,34 @@ the `✓` mark and the count are unchanged. The channel exists; the skip is not 
 - The suite summary separates ran from skipped, proven by a run containing at least one of each.
 - A scan that exits 0 having examined nothing cannot report `✓` — proven RED by executing one
   against an empty subject, not by reading the runner.
+
+## Implementation (2026-08-04)
+
+Both halves of the proposed direction, and the mechanism came from the sibling item rather than being
+invented here.
+
+**A skip is now a machine-readable fact, not a sentence.** HARNESS-057 gave the runner an
+`::examined:: <n> <subject>` declaration and made a zero WITHOUT a reason a hard failure. A zero WITH
+a reason is exactly what a skip is: the scan ran, found no subject, and said which and why. The runner
+reads that, so no scan had to learn a second convention.
+
+**Three marks, not two.** `✗` failed, `↩` skipped, `✓` examined its subject and found it clean.
+
+**The count states what RAN.** `all 97 scans passed` became `97 scans passed`, and on a host without
+the subject:
+
+```
+↩ progress-report-quantification
+96 scans passed, 1 skipped (20 declared what they examined)
+```
+
+That is the same suite on the same commit — the difference is the host, which is the whole point: on
+every CI runner this scan has no subject, and the old summary counted it as evidence.
+
+**Two existing cases asserted the old wording** and were updated rather than worked around. They
+asserted `all N scans passed`, which is the sentence this item filed as weaker than it reads; leaving
+them would have pinned the defect.
+
+**An undeclared zero is NOT a skip.** A scan that reports zero without saying why still fails, and a
+case pins that — otherwise the skip mark would have become a way to launder the very state
+HARNESS-057 refuses.

--- a/.agents/tasks/completed/HARNESS-064-vacuity-was-measured-once.md
+++ b/.agents/tasks/completed/HARNESS-064-vacuity-was-measured-once.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-064: vacuity was measured once and never again — 30 of 76 scans could not fail, and nothing tracks whether that number moves'
-status: in-progress
+status: done
+completed: 2026-08-04
 created: 2026-08-02
 priority: critical
 urgency: now
@@ -180,3 +181,42 @@ by removing it — an argument would be the same hole spelled differently — so
 but the frozen file now DECLARES that on both the pass and the fail path, and a case pins the
 declaration. The wiring red-proof was re-run against the change: deleting the line that calls
 `ledgerCeilingFindings` from `findGuardScopeFindings` still fails the reachability case.
+
+## Closed 2026-08-04 — every part of it already holds, and each was verified by execution
+
+This item asked for three things. All three are in force, and none of them was taken on trust; the
+commands and their output are below so the next reader can recount rather than believe.
+
+**1. The measurement repeats.** `scan-guard-scope-fail-closed` is registered and runs on every
+`pnpm harness:scan`. It does not read a recorded number — it points each pinned finder at a root
+without its governed tree and observes whether the finder throws or reports a pass, and it
+RE-EXECUTES every ledger entry's recorded verdict on every run. Today: **53 guards proven fail-closed
+by execution, 4 measured vacuous, 14 that fail closed but are not pinned.**
+
+**2. The population is derived, not hand-kept.** This was the item's sharpest claim and it is wrong:
+rule 1 of that scan derives the finder set from the registration list and the source, and a scan
+registered without a table entry FAILS. A guard cannot be added without answering for its behaviour,
+and a table entry naming a scan that no longer exists is itself a finding.
+
+**3. The number is ratcheted.** `scripts/harness/guard-ledger-ceilings.json` freezes
+`{ "vacuous": 4, "unpinned": 14 }`. Exercised in all four directions:
+
+```
+at ceiling   : []
+vacuous ROSE : 4 entr(y/ies), up from a frozen 3. A new vacuous entry is a NEW live instance …
+vacuous FELL : 4 entr(y/ies), DOWN from a frozen 5. Re-freeze it in this same change …
+unfrozen     : [ 'ledger-ceiling:vacuous', 'ledger-ceiling:unpinned' ]
+```
+
+So the 30-of-76 figure this item was filed about cannot silently move: a new vacuous guard raises the
+count and fails the suite, and a repaired one lowers it and demands a re-freeze in the same change.
+
+**What this item added, since it was not merely closed as stale.** The scan now declares
+`::examined:: 53 pinned guards`, so the number it audits is visible to the runner on every run and an
+unearned zero from it would fail the suite — the invariant of
+[HARNESS-057](HARNESS-057-a-scan-must-report-the-size-of-what-it-examined.md) applied to the scan that
+measures vacuity.
+
+**The honest residue.** The 14 unpinned guards fail closed but are not proven so by execution, and
+their ceiling holds the count rather than the property. Reducing that number is ordinary debt work
+under HARNESS-052, not a gap in the mechanism this item asked for.

--- a/scripts/harness/__tests__/run-all-scans.test.mjs
+++ b/scripts/harness/__tests__/run-all-scans.test.mjs
@@ -83,7 +83,9 @@ describe('run-all-scans', () => {
       lines.push(line),
     );
     expect(exitCode).toBe(0);
-    expect(lines.join('\n')).toContain('all 2 scans passed');
+    // "all N scans passed" became "N scans passed": the word `all` covered a suite in which some
+    // scans had no subject and were counted anyway (HARNESS-056). The count now states what RAN.
+    expect(lines.join('\n')).toContain('2 scans passed');
   });
 
   it('counts multiple failures', async () => {
@@ -181,7 +183,7 @@ describe('runScans — advisory surfacing', () => {
 
     expect(exitCode).toBe(0);
     expect(out).toContain('✓ a'); // the emitting scan is still a PASS in the summary
-    expect(out).toContain('all 2 scans passed');
+    expect(out).toContain('2 scans passed');
     expect(out).toContain('NOT failures');
   });
 
@@ -191,7 +193,7 @@ describe('runScans — advisory surfacing', () => {
     ];
     const lines = [];
     await runScans(scans, (line) => lines.push(line));
-    expect(lines.filter((line) => line !== '').at(-1)).toBe('all 1 scans passed');
+    expect(lines.filter((line) => line !== '').at(-1)).toBe('1 scans passed');
   });
 
   it('prints no advisory block at all when there are none', async () => {
@@ -311,5 +313,55 @@ describe('how much did you look at', () => {
     expect(judgeExaminedAdoption(9, 97, () => 10).message).toMatch(/FELL/);
     expect(judgeExaminedAdoption(11, 97, () => 10).message).toMatch(/ROSE/);
     expect(judgeExaminedAdoption(10, 97, () => null).message).toMatch(/no frozen/);
+  });
+});
+
+describe('a scan that skipped does not render as a tick', () => {
+  /**
+   * The runner decided a scan's mark from its exit code alone, so a scan that ran nothing and exited
+   * 0 because it had no subject was indistinguishable from one that examined its whole subject and
+   * found it clean. Both printed `✓`, and both counted toward "all N scans passed" — a stronger
+   * claim than the run supports, on the line people actually read.
+   *
+   * The declaration supplies the missing signal: a zero WITH a reason is a skip.
+   */
+  const passed = { name: 'ran', run: async () => ({ code: 0, output: '::examined:: 12 files' }) };
+  const skipped = {
+    name: 'no-subject',
+    run: async () => ({
+      code: 0,
+      output: '::examined:: 0 transcripts ::expected-empty:: no transcript exists on this host',
+    }),
+  };
+
+  it('marks it ↩ and counts what RAN', async () => {
+    const lines = [];
+    const code = await runScans([passed, skipped], (l) => lines.push(l), 1);
+    const printed = lines.join('\n');
+
+    expect(code, 'a skip must not fail the suite').toBe(0);
+    expect(printed).toContain('↩ no-subject');
+    expect(printed).toContain('✓ ran');
+    expect(printed, 'the summary counted a skip as a pass').toContain('1 scans passed, 1 skipped');
+  });
+
+  it('says nothing about skips when there are none', async () => {
+    const lines = [];
+    await runScans([passed], (l) => lines.push(l), 1);
+
+    expect(lines.join('\n')).not.toMatch(/skipped/);
+  });
+
+  it('does not call an undeclared zero a skip — it fails', async () => {
+    // A skip is a scan that said WHY it had no subject. One that merely reports zero has not.
+    const lines = [];
+    const code = await runScans(
+      [{ name: 'silent', run: async () => ({ code: 0, output: '::examined:: 0 files' }) }],
+      (l) => lines.push(l),
+      1,
+    );
+
+    expect(code).toBe(1);
+    expect(lines.join('\n')).not.toContain('↩ silent');
   });
 });

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -140,6 +140,10 @@ export function extractExamined(output) {
 export function judgeExamined(name, output) {
   const declarations = extractExamined(output);
   const problems = [];
+  // A scan that declared a zero AND said why is a SKIP, not a pass. It ran, found no subject, and
+  // said so — which is a different fact from "examined the subject and found it clean", and the
+  // summary is the line people actually read.
+  const skipped = declarations.some((d) => d.size === 0 && Boolean(d.expectedEmpty));
   for (const d of declarations) {
     if (d.size === null) {
       problems.push(
@@ -154,7 +158,7 @@ export function judgeExamined(name, output) {
       );
     }
   }
-  return { declared: declarations.length > 0, problems };
+  return { declared: declarations.length > 0, skipped, problems };
 }
 
 /**
@@ -591,10 +595,21 @@ export async function runScans(
     }
   }
 
+  // Judged BEFORE the summary is printed, because the mark a scan gets depends on what it declared.
+  const examined = results.map((result) => ({
+    name: result.name,
+    ...judgeExamined(result.name, result.output),
+  }));
+  const skippedNames = new Set(examined.filter((e) => e.skipped).map((e) => e.name));
+
   write('');
   write('harness scan summary:');
   for (const result of results) {
-    write(`${result.code === 0 ? '✓' : '✗'} ${result.name}`);
+    // Three marks, not two. A skip that renders as a tick is counted in "all N scans passed" and is
+    // indistinguishable from a scan that examined its whole subject — the output above it may be
+    // honest while the summary line is not, and the summary is the line people read.
+    const mark = result.code !== 0 ? '✗' : skippedNames.has(result.name) ? '↩' : '✓';
+    write(`${mark} ${result.name}`);
   }
 
   // ADVISORIES from EVERY scan, passing or failing (HARNESS-053). Deliberately placed after the
@@ -615,10 +630,6 @@ export async function runScans(
   // HOW MUCH DID EACH ONE LOOK AT (HARNESS-057). An unearned zero fails the suite outright; the
   // ADOPTION count is a ratchet, because 79 of 97 declare nothing today and a check that is red on
   // arrival gets suppressed rather than obeyed.
-  const examined = results.map((result) => ({
-    name: result.name,
-    ...judgeExamined(result.name, result.output),
-  }));
   const unearnedZeros = examined.flatMap((e) => e.problems);
   const declaring = examined.filter((e) => e.declared).length;
   const adoption = checkAdoption
@@ -637,10 +648,14 @@ export async function runScans(
 
   const failed = results.filter((result) => result.code !== 0);
   if (failed.length === 0 && unearnedZeros.length === 0 && adoption.ok) {
+    // The count states what RAN. "all 97 scans passed" over a suite where two had no subject is a
+    // stronger claim than the run supports.
+    const ran = results.length - skippedNames.size;
+    const tail = skippedNames.size > 0 ? `, ${skippedNames.size} skipped` : '';
     write(
       checkAdoption
-        ? `all ${results.length} scans passed (${declaring} declared what they examined)`
-        : `all ${results.length} scans passed`,
+        ? `${ran} scans passed${tail} (${declaring} declared what they examined)`
+        : `${ran} scans passed${tail}`,
     );
     return 0;
   }


### PR DESCRIPTION
Closes two items on one axis.

## HARNESS-056 — the summary claimed more than the run supports

The runner decided a scan's mark from its **exit code alone**, so a scan that ran nothing and exited 0 because it had no subject was indistinguishable from one that examined its whole subject and found it clean. Both printed `✓`, and both counted toward *"all N scans passed"* — on the line people actually read.

**The mechanism came from the sibling item rather than being invented here.** A zero *with* a declared reason already means "ran, found no subject, said which and why". The runner reads that, so no scan had to learn a second convention.

- Three marks: `✗` failed, `↩` skipped, `✓` examined its subject.
- The count states what **ran**: `all 97 scans passed` → `97 scans passed`.

On a host without the subject, same suite, same commit:

```
↩ progress-report-quantification
96 scans passed, 1 skipped (20 declared what they examined)
```

The difference is the *host* — and on every CI runner that scan has no subject, which the old summary counted as evidence.

**Two existing cases asserted the old wording** and were updated rather than worked around: they pinned `all N scans passed`, the sentence this item filed as weaker than it reads. Leaving them would have pinned the defect.

**An undeclared zero is NOT a skip** — it still fails, pinned by a case, or the new mark becomes a way to launder the state the declaration refuses.

## HARNESS-064 — closed, and not as stale

It asked for three things; all three already held, each **verified by execution** rather than by reading:

1. **The measurement repeats.** The vacuity scan re-executes every pinned finder against a root without its governed tree, every run: 53 proven fail-closed, 4 vacuous, 14 unpinned.
2. **The population is derived**, not hand-kept — rule 1 derives the finder set from the registration list, so a scan cannot be added without answering for its behaviour. *(This was the item's sharpest claim, and it was wrong.)*
3. **The count is ratcheted** in `guard-ledger-ceilings.json`, exercised in all four directions — at ceiling, risen, fallen, unfrozen.

What this change adds: the scan declares what it examined, so the number it audits is visible to the runner on every run.

**Honest residue, recorded**: the 14 unpinned guards are held by a *count*, not by a proof.

## Verification

- `pnpm harness:scan` — 97 passed. `pnpm harness:test` — 2629 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso