### PR TITLE
fix(ci): the Windows job stops re-running a pure function, for the right reason

### DIFF
--- a/.agents/memory/a-wait-is-not-idle-time.md
+++ b/.agents/memory/a-wait-is-not-idle-time.md
@@ -41,3 +41,24 @@ adoption ratchet, edit the same registry, or touch the same rule document are ON
 collide at the baseline even when their subjects are unrelated. See
 [`check-validity-two-axes.md`](check-validity-two-axes.md) for the neighbouring lesson about harness
 changes overlapping more than they appear to.
+
+## Two frictions the first parallel run actually hit
+
+Recorded because both are silent, both cost a CI round trip, and neither is visible until the work is
+already in a worktree.
+
+**1. Committing from inside the worktree is refused; committing with `git -C` skips the hooks.**
+`branch-guard` resolves the repository from `git -C <path>` before the project dir — but it reads the
+command as TEXT, so `git -C "$WT" commit` hands it an unexpanded variable, falls back to the project
+dir, and refuses the commit for being on whatever branch the MAIN checkout sits on. Passing the
+literal path works. But a `git -C` commit run from outside the worktree does not fire the repository's
+`lint-staged` pre-commit, so `prettier` never runs and the required `format-check` job goes red on
+files the local flow would have fixed silently.
+
+Until the shell-aware extraction lands (HARNESS-061), the working combination is: **literal path in
+`git -C`, and run `prettier --write` over the changed files yourself before committing.**
+
+**2. A fresh worktree has no `node_modules`.** Every scan and test fails in ways that look like real
+findings — eleven scans "failed" on the first run purely for that. `pnpm install --frozen-lockfile
+--ignore-scripts` first, in the background while something else proceeds, and remember that the
+`dist`-dependent scans still need a build (CI's own `scans` job skips them for the same reason).

--- a/.agents/tasks/completed/INFRA-064-windows-runner-reruns-a-pure-function.md
+++ b/.agents/tasks/completed/INFRA-064-windows-runner-reruns-a-pure-function.md
@@ -1,7 +1,8 @@
 ---
 id: INFRA-064
 title: 'INFRA-064: the windows-shell job pays for the most expensive runner to re-run a pure function'
-status: todo
+status: done
+completed: 2026-08-05
 priority: low
 urgency: later
 type: INFRA
@@ -50,3 +51,46 @@ does the test take the platform as an argument, or read it from the process?
   by the argument above.
 - No coverage is lost: the removed test still runs somewhere on every PR, proven by pointing at the
   job that runs it.
+
+## Resolution — and the item's own cost argument does not survive its measurement
+
+The `platform-shell` step is gone from `windows-shell`. `resolvePlatformShell(env, platform)` takes
+the platform as an ARGUMENT, reads no `process.platform` and spawns nothing, so its verdict on
+`windows-latest` is identical to its verdict anywhere else.
+
+**The number the done-gate demanded refutes the reason the item gave.** Measured on a real run of the
+job:
+
+| Step | Time |
+| --- | --- |
+| Set up job, checkout | 9 s |
+| Install pnpm, Node | 9 s |
+| `pnpm install --frozen-lockfile` | **42 s** |
+| Build agent-core + agent-process | 7 s |
+| **`platform-shell` (removed)** | **2 s** |
+| `shell-tool` (kept — genuinely win32) | 3 s |
+| Teardown | 20 s |
+| **Total** | **~103 s** |
+
+The item said it "buys the matrix's most expensive runner to re-run something `quality` already
+covers". The runner is bought by the step that stays; this one was **2 % of one job**, about two
+seconds, on a public repository where standard runners are not billed by the minute. As a cost
+argument it is worth nothing, and the done-gate asking for the number is what surfaced that.
+
+**Removed for what it CLAIMED, not for what it cost.** A step on a Windows runner asserts, by being
+there, that something about it needs Windows — and the job's own stated reason said so in those
+words. It did not. A job whose stated coverage is wider than its real coverage is the defect,
+independent of runtime; the same comment-asserted-invariant class this session kept finding
+elsewhere.
+
+**No coverage lost, and the argument is stronger than "it runs somewhere else too."** A pure
+function's verdict cannot change unless its subject or its test changes; both live in `agent-core`,
+and a change to `agent-core` is exactly what puts it in scope. Measured, not assumed: a content
+change to `platform-shell.ts` makes `plan-change` select
+`packages/agent-core: build, test, lint, typecheck`, which the REQUIRED `quality` job runs. When
+`agent-core` is untouched, the test could not have changed its answer — so running it bought nothing
+on those PRs either.
+
+Both remaining halves of the job now state their platform-dependence in the workflow, which is the
+first done-gate criterion: the `shell-tool` step spawns a real shell and asserts PowerShell answers,
+which no Linux or macOS runner can execute.

--- a/.agents/tasks/completed/INFRA-064-windows-runner-reruns-a-pure-function.md
+++ b/.agents/tasks/completed/INFRA-064-windows-runner-reruns-a-pure-function.md
@@ -61,16 +61,16 @@ the platform as an ARGUMENT, reads no `process.platform` and spawns nothing, so 
 **The number the done-gate demanded refutes the reason the item gave.** Measured on a real run of the
 job:
 
-| Step | Time |
-| --- | --- |
-| Set up job, checkout | 9 s |
-| Install pnpm, Node | 9 s |
-| `pnpm install --frozen-lockfile` | **42 s** |
-| Build agent-core + agent-process | 7 s |
-| **`platform-shell` (removed)** | **2 s** |
-| `shell-tool` (kept — genuinely win32) | 3 s |
-| Teardown | 20 s |
-| **Total** | **~103 s** |
+| Step                                  | Time       |
+| ------------------------------------- | ---------- |
+| Set up job, checkout                  | 9 s        |
+| Install pnpm, Node                    | 9 s        |
+| `pnpm install --frozen-lockfile`      | **42 s**   |
+| Build agent-core + agent-process      | 7 s        |
+| **`platform-shell` (removed)**        | **2 s**    |
+| `shell-tool` (kept — genuinely win32) | 3 s        |
+| Teardown                              | 20 s       |
+| **Total**                             | **~103 s** |
 
 The item said it "buys the matrix's most expensive runner to re-run something `quality` already
 covers". The runner is bought by the step that stays; this one was **2 % of one job**, about two

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,10 +768,26 @@ jobs:
       # value ... received [true, false]"), so the script indirection is bypassed instead. Invoking
       # vitest directly resolves the same per-package config and exits 1 when the filter matches
       # nothing — the whole point of selecting tests by name here.
-      - name: Verify the cross-platform shell resolver on Windows
-        run: pnpm --filter @robota-sdk/agent-core exec vitest run platform-shell
-
+      # INFRA-064: the `platform-shell` step is GONE, and the reason is what it claimed rather than
+      # what it cost. `resolvePlatformShell(env, platform)` takes the platform as an ARGUMENT — it
+      # reads no `process.platform` and spawns nothing — so its verdict on windows-latest is
+      # identical to its verdict anywhere else. A step on this runner asserts, by being here, that
+      # something about it needs Windows. That one did not, and a job whose stated coverage is wider
+      # than its real coverage is the defect, independent of runtime.
+      #
+      # THE COST ARGUMENT IN THE ITEM DOES NOT HOLD, and the measurement is why this comment says so:
+      # the step took 2s of a ~103s job (checkout 8s, pnpm install 42s, build 7s, teardown 20s). The
+      # expensive part is standing the runner up, and the step below still needs it. Removing this
+      # saves about 2% of one job — worth doing for the claim it was making, not for the seconds.
+      #
+      # NO COVERAGE IS LOST, and the argument is stronger than "it runs somewhere else too". A pure
+      # function's verdict cannot change unless its subject or its test changes; both live in
+      # `agent-core`, and a change to `agent-core` is exactly what puts it in `harness:verify`'s
+      # scope. Measured: touching `platform-shell.ts` selects `packages/agent-core: build, test,
+      # lint, typecheck`, which the REQUIRED `quality` job runs.
       - name: Verify the Shell tool actually spawns PowerShell on Windows
+        # The genuinely win32-only half: it SPAWNS a real shell and asserts PowerShell answers. No
+        # Linux or macOS runner can execute this, which is what buys the runner the job runs on.
         run: pnpm --filter @robota-sdk/agent-tools exec vitest run shell-tool
 
   # TEST-010: run the TUI PTY E2E suite (`*.ptytest.ts`) against the BUILT robota binary on every PR,


### PR DESCRIPTION
## What

INFRA-064. `windows-shell` step 1 ran `platform-shell.test.ts` on `windows-latest`. `resolvePlatformShell(env, platform)` takes the platform as an **argument**, reads no `process.platform` and spawns nothing — its verdict there is identical to its verdict anywhere. A step on that runner asserts, by being there, that something about it needs Windows, and the job's stated reason said so in those words. It did not.

## The done-gate asked for a number, and the number refutes the item's own argument

| Step | Time |
| --- | --- |
| Set up job, checkout | 9 s |
| Install pnpm, Node | 9 s |
| `pnpm install --frozen-lockfile` | **42 s** |
| Build agent-core + agent-process | 7 s |
| **`platform-shell` (removed)** | **2 s** |
| `shell-tool` (kept) | 3 s |
| Teardown | 20 s |
| **Total** | **~103 s** |

The item said this step "buys the matrix's most expensive runner". It does not — the runner is bought by the step that stays. This was **2 % of one job**, on a public repository where standard runners are not billed by the minute.

So it is removed **for what it claimed, not for what it cost**. A job whose stated coverage is wider than its real coverage is the defect, independent of runtime. The commit and the item both say the cost argument failed rather than quietly keeping it.

## No coverage lost — and the argument is stronger than "it runs elsewhere too"

A pure function's verdict cannot change unless its subject or its test changes. Both live in `agent-core`, and a change to `agent-core` is exactly what puts it in scope. **Measured, not assumed:** a content change to `platform-shell.ts` makes `plan-change` select

```
- packages/agent-core: build, test, lint, typecheck
```

which the REQUIRED `quality` job runs. When `agent-core` is untouched the test could not have changed its answer, so running it bought nothing on those PRs either.

## Remaining step states its platform-dependence

`shell-tool` spawns a real shell and asserts PowerShell answers — no Linux or macOS runner can execute it. That is what buys the runner, and it is now written where the step is.

## Verification

- `pnpm harness:scan -- --skip dist --skip build-contracts` → 96 passed, 2 skipped
- `pnpm harness:test` → 2687 passed
- `ci-mirror-map` declares the CONTEXT `windows-shell`, not its steps, so no registry drift

Worked in a worktree in parallel with #1644, under the rule #1643's branch added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso