### PR TITLE
fix(session): a crashed tool, a denial and a success are three different things

### DIFF
--- a/packages/agent-core/src/executors/local-executor.test.ts
+++ b/packages/agent-core/src/executors/local-executor.test.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { LocalExecutor } from './local-executor';
 import type { IAIProviderInstance } from './local-executor';
 import type { TUniversalMessage, IAssistantMessage } from '../interfaces/messages';

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-streaming.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-streaming.test.ts
@@ -138,3 +138,38 @@ describe('interactive-session-streaming edit diffs', () => {
     });
   });
 });
+
+describe('an `end` with no matching `start` (CORE-027)', () => {
+  // CORE-027 made a crashed tool announce an `end` event, which it never did before. Review asked
+  // the right question: `toolName` is set partway through the wrapper's try block, so a throw BEFORE
+  // that point emits an `end` with no `start`, and a consumer that assumes strict pairing — an
+  // in-flight counter, say — could go negative.
+  //
+  // It cannot here, and this pins why rather than leaving it to a reading: the lookup requires a
+  // RUNNING tool of that name, and finding none it returns null and mutates nothing. The caller
+  // (`handleToolExecution`) emits `tool_end` only when this returns a value.
+  it('changes nothing and reports nothing finished', () => {
+    const state = createState();
+
+    const finished = applyToolEnd(state, {
+      type: 'end',
+      toolName: 'never-started',
+      success: false,
+    });
+
+    expect(finished).toBeNull();
+    expect(state.activeTools).toEqual([]);
+  });
+
+  it('leaves a DIFFERENT running tool untouched', () => {
+    // The lookup matches on name, so the case above would also pass against an implementation that
+    // closed whatever happened to be running first. This one would not.
+    const state = createState();
+    applyToolStart(state, { toolName: 'still-running', toolArgs: {} });
+
+    expect(
+      applyToolEnd(state, { type: 'end', toolName: 'never-started', success: false }),
+    ).toBeNull();
+    expect(state.activeTools[0]?.isRunning).toBe(true);
+  });
+});

--- a/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
+++ b/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
@@ -21,8 +21,10 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { PermissionEnforcer } from '../permission-enforcer.js';
 
+import { toolFailure } from '../permission-types.js';
+
 import type { IPermissionEnforcerOptions } from '../permission-types.js';
-import type { ITerminalOutput, TToolArgs } from '@robota-sdk/agent-core';
+import type { ITerminalOutput } from '@robota-sdk/agent-core';
 
 function makeNoopTerminal(): ITerminalOutput {
   return {
@@ -69,8 +71,6 @@ function makeTool(name: string, execute: () => Promise<unknown>) {
   } as never;
 }
 
-const ARGS: TToolArgs = {};
-
 describe('CORE-027: a crashed tool is not a success', () => {
   it('does not report a thrown tool as `success: true`', async () => {
     const enforcer = makeEnforcer();
@@ -106,6 +106,41 @@ describe('CORE-027: a crashed tool is not a success', () => {
     const ended = onToolExecution.mock.calls.map(([e]) => e).filter((e) => e.type === 'end');
     expect(ended, 'no end event was emitted for a crashed tool').toHaveLength(1);
     expect(ended[0].success, 'a crashed tool was announced as a successful one').toBe(false);
+  });
+});
+
+describe('CORE-027: the wrapper still never throws', () => {
+  it('survives a tool whose own name cannot be read', () => {
+    // The comment above this wrapper says it must NEVER throw: if it does, the round records the
+    // assistant tool_use with no tool_result and the conversation is corrupted. A first version of
+    // this change hoisted `tool.getName()` above the try to make the name available to the catch —
+    // putting an unguarded call above that very comment. Review caught it.
+    const enforcer = makeEnforcer();
+    const broken = {
+      getName: () => {
+        throw new Error('this tool cannot say what it is');
+      },
+      name: 'Broken',
+      description: 'a tool that cannot name itself',
+      parameters: { type: 'object' as const, properties: {} },
+      execute: (async () => ({ success: true })) as never,
+      setEventService: vi.fn(),
+    } as never;
+
+    const [wrapped] = enforcer.wrapTools([broken]);
+
+    return expect(wrapped.execute({}, undefined as never)).resolves.toMatchObject({
+      success: false,
+    });
+  });
+
+  it('names the hook block as its own outcome, not as a success', () => {
+    // The third of the three outcomes the failure type declares. It was left behind by the first
+    // pass: the type promised the distinction while `tool-hook-helpers` still returned
+    // `success: true` — the type asserting a property the code did not have, in the change whose
+    // subject is exactly that.
+    expect(toolFailure('hook-blocked', 'nope').success).toBe(false);
+    expect(toolFailure('hook-blocked', 'nope').outcome).toBe('hook-blocked');
   });
 });
 

--- a/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
+++ b/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
@@ -1,0 +1,152 @@
+/**
+ * CORE-027 — a tool result must be able to say that the tool failed.
+ *
+ * Three distinct outcomes are currently indistinguishable from success at the wrapper's return
+ * value, because failure is smuggled into a success-shaped value as a nested JSON string:
+ *
+ *   a tool that THREW      -> { success: true, data: '{"success":false,…}' }
+ *   a user DENIAL          -> { success: true, data: '{"success":false,…}' }
+ *   a hook BLOCK           -> the same shape again
+ *
+ * Every consumer above has to parse prose out of `data` and guess, and the guess is the same one
+ * three times. The framing to keep is the one the audit stated: **"never throw" is correct and
+ * "encode the failure as success" is not — they are independent decisions.** The fix is not to
+ * start throwing.
+ *
+ * These cases assert the DISTINCTION, not a particular envelope: whatever shape the result takes, a
+ * caller must be able to tell a crash from a denial from a success without reading English out of a
+ * string.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { PermissionEnforcer } from '../permission-enforcer.js';
+
+import type { IPermissionEnforcerOptions } from '../permission-types.js';
+import type { ITerminalOutput, TToolArgs } from '@robota-sdk/agent-core';
+
+function makeNoopTerminal(): ITerminalOutput {
+  return {
+    write: vi.fn(),
+    writeLine: vi.fn(),
+    writeMarkdown: vi.fn(),
+    writeError: vi.fn(),
+    prompt: vi.fn().mockResolvedValue(''),
+    select: vi.fn().mockResolvedValue(0),
+    spinner: vi.fn().mockReturnValue({ stop: vi.fn(), update: vi.fn() }),
+  };
+}
+
+function makeEnforcer(overrides: Partial<IPermissionEnforcerOptions> = {}): PermissionEnforcer {
+  return new PermissionEnforcer({
+    sessionId: 'test-session',
+    cwd: '/tmp',
+    // `bypassPermissions` so the tool actually RUNS: a crash case must be about the crash, and the
+    // first version was denied instead, which made the listener case pass on the denial's own end
+    // event — green for a reason unrelated to what it asserts.
+    getPermissionMode: () => 'bypassPermissions',
+    config: { permissions: { allow: [], deny: [] } },
+    terminal: makeNoopTerminal(),
+    // The tool must actually RUN for a crash case to be about the crash. With the default config it
+    // was denied instead, and the listener case then passed on the denial's own end event — green
+    // for a reason that has nothing to do with what it asserts.
+    permissionHandler: async () => 'allow',
+    ...overrides,
+  });
+}
+
+/** A tool whose `execute` does whatever the case needs. */
+function makeTool(name: string, execute: () => Promise<unknown>) {
+  return {
+    // `getName()` is what the wrapper calls. Supplying only `name` made the WRAPPER throw, so the
+    // first run of these cases was red for the fixture rather than for the defect — a red that
+    // proves nothing, which is the accidental-green's mirror image.
+    getName: () => name,
+    name,
+    description: `${name} for a test`,
+    parameters: { type: 'object' as const, properties: {} },
+    execute: execute as never,
+    setEventService: vi.fn(),
+  } as never;
+}
+
+const ARGS: TToolArgs = {};
+
+describe('CORE-027: a crashed tool is not a success', () => {
+  it('does not report a thrown tool as `success: true`', async () => {
+    const enforcer = makeEnforcer();
+    const [wrapped] = enforcer.wrapTools([
+      makeTool('Explode', async () => {
+        throw new Error('the tool blew up');
+      }),
+    ]);
+
+    const result = (await wrapped.execute({}, undefined as never)) as {
+      success: boolean;
+      data: unknown;
+    };
+
+    // The whole defect in one assertion: today this is `true`, and `data` carries the failure as a
+    // JSON string nobody above is obliged to parse.
+    expect(result.success, `crash reported as success, data=${JSON.stringify(result.data)}`).toBe(
+      false,
+    );
+  });
+
+  it('reports the crash to the execution listener as a failure', async () => {
+    const onToolExecution = vi.fn();
+    const enforcer = makeEnforcer({ onToolExecution });
+    const [wrapped] = enforcer.wrapTools([
+      makeTool('Explode', async () => {
+        throw new Error('the tool blew up');
+      }),
+    ]);
+
+    await wrapped.execute({}, undefined as never);
+
+    const ended = onToolExecution.mock.calls.map(([e]) => e).filter((e) => e.type === 'end');
+    expect(ended, 'no end event was emitted for a crashed tool').toHaveLength(1);
+    expect(ended[0].success, 'a crashed tool was announced as a successful one').toBe(false);
+  });
+});
+
+describe('CORE-027: a denial, a crash and a success are three different things', () => {
+  it('tells a denial apart from a crash without reading prose', async () => {
+    const denying = makeEnforcer({
+      getPermissionMode: () => 'default',
+      permissionHandler: async () => 'deny',
+    });
+    const [deniedTool] = denying.wrapTools([makeTool('Blocked', async () => ({ success: true }))]);
+
+    const crashing = makeEnforcer();
+    const [crashedTool] = crashing.wrapTools([
+      makeTool('Explode', async () => {
+        throw new Error('the tool blew up');
+      }),
+    ]);
+
+    const denied = (await deniedTool.execute({}, undefined as never)) as Record<string, unknown>;
+    const crashed = (await crashedTool.execute({}, undefined as never)) as Record<string, unknown>;
+
+    // Not "they have different English in a string" — a caller must be able to branch on this.
+    expect(
+      denied['reason'] ?? denied['outcome'] ?? denied['error'],
+      'a denial carries no machine-readable reason',
+    ).toBeDefined();
+    expect(
+      String(denied['reason'] ?? denied['outcome'] ?? ''),
+      'a denial and a crash are the same value',
+    ).not.toBe(String(crashed['reason'] ?? crashed['outcome'] ?? ''));
+  });
+
+  it('leaves an ordinary success alone', async () => {
+    // The other half of every guard: the change must not make a working tool look broken.
+    const enforcer = makeEnforcer();
+    const [wrapped] = enforcer.wrapTools([
+      makeTool('Fine', async () => ({ success: true, data: 'ok' })),
+    ]);
+
+    const result = (await wrapped.execute({}, undefined as never)) as { success: boolean };
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
+++ b/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
@@ -144,6 +144,28 @@ describe('CORE-027: the wrapper still never throws', () => {
   });
 });
 
+describe('CORE-027: what the model is told about a failure', () => {
+  it('carries the reason in `error`, which is what the history writer renders', () => {
+    // Review corrected a false claim here, and the correction is worth a case rather than a comment.
+    // Before this change a blocked call was `success: true`, so the JSON payload reached the model
+    // untouched. Now `success: false` reaches `ToolManager.executeTool`, which throws;
+    // `ToolExecutionService` catches and returns `{ success: false, error }`; and the history writer
+    // renders that as `Error: <message>`.
+    //
+    // So the model reads one error line instead of a JSON envelope — INTENDED, and the point of the
+    // item: a blocked call is a failure, and being told so plainly beats being handed a
+    // success-shaped value to introspect. The reason must therefore travel in `error`, not only in
+    // `data`, or the correction loses the thing the model needs.
+    const blocked = toolFailure('hook-blocked', 'Access denied by policy');
+
+    expect(blocked.error).toBe('Access denied by policy');
+    expect(
+      blocked.error.length,
+      'the history writer throws on a failed result with no error',
+    ).toBeGreaterThan(0);
+  });
+});
+
 describe('CORE-027: a denial, a crash and a success are three different things', () => {
   it('tells a denial apart from a crash without reading prose', async () => {
     const denying = makeEnforcer({

--- a/packages/agent-session/src/__tests__/tool-hook-helpers.test.ts
+++ b/packages/agent-session/src/__tests__/tool-hook-helpers.test.ts
@@ -97,14 +97,29 @@ describe('runPreToolHook — HOOK-003 blocked format', () => {
     expect(result).toBeNull();
   });
 
-  it('returned IToolResult has success: true so PermissionEnforcer records the result in history', async () => {
-    // Option B design: tool result IS added to history (AI sees the block signal)
+  it('returns a result that is recorded in history AND says the call was blocked', async () => {
+    // The Option B design this case protects is "the tool result IS added to history, so the model
+    // sees the block signal" — and that is what it must keep protecting. `success: true` was one way
+    // to get there and not the property itself: `execution-round-tool-results.ts` records a
+    // `success: false` result too, requiring only that it carry an `error`.
+    //
+    // CORE-027: a block is not a success. The result now says so, and still reaches history.
     const executor = makeMockExecutor(2, 'Access denied');
     const input = makeHookInput('bash');
 
-    const result = await runPreToolHook(baseConfig, input, [executor]);
+    const result = (await runPreToolHook(baseConfig, input, [executor])) as unknown as {
+      success: boolean;
+      outcome: string;
+      error: string;
+      data: string;
+    };
+
     expect(result).not.toBeNull();
-    expect(result!.success).toBe(true);
+    expect(result.success, 'a hook block was reported as a successful call').toBe(false);
+    expect(result.outcome).toBe('hook-blocked');
+    // The history path throws when a failed result carries no error message; this is what keeps the
+    // block visible to the model rather than becoming an exception one layer up.
+    expect(result.error.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/agent-session/src/permission-enforcer.ts
+++ b/packages/agent-session/src/permission-enforcer.ts
@@ -9,12 +9,6 @@
 import { evaluatePermission, resolvePermissionByPolicy, runHooks } from '@robota-sdk/agent-core';
 
 import { decideApproval } from './abortable-approval.js';
-import {
-  truncateToolResult,
-  buildHookInput,
-  runPreToolHook,
-  firePostToolHook,
-} from './tool-hook-helpers.js';
 import { wrapToolWithPermission } from './tool-permission-wrapper.js';
 
 import type {
@@ -26,14 +20,7 @@ import type {
 } from './permission-types.js';
 import type { ISessionLogger, TSessionLogData } from './session-logger.js';
 import type { IToolWrapperDeps } from './tool-permission-wrapper.js';
-import type {
-  IToolWithEventService,
-  IToolResult,
-  TToolParameters,
-  IToolExecutionContext,
-  TToolArgs,
-  THooksConfig,
-} from '@robota-sdk/agent-core';
+import type { IToolWithEventService, TToolArgs, THooksConfig } from '@robota-sdk/agent-core';
 
 export type { TPermissionHandler, TPermissionResult, ITerminalOutput, ISpinner };
 export type { IPermissionEnforcerOptions };
@@ -104,12 +91,6 @@ export class PermissionEnforcer {
   clearSessionAllowedTools(): void {
     this.sessionAllowedTools.clear();
   }
-
-  /**
-   * Wrap a tool with permission checking.
-   * The wrapper intercepts execute() and runs permission evaluation before delegating.
-   * If denied, returns a tool result indicating the action was blocked.
-   */
 
   /** Evaluate permission for a tool call. `signal` — RUNTIME-005; see `decideApproval` for why a
    * cancelled approval denies. */

--- a/packages/agent-session/src/permission-enforcer.ts
+++ b/packages/agent-session/src/permission-enforcer.ts
@@ -9,13 +9,13 @@
 import { evaluatePermission, resolvePermissionByPolicy, runHooks } from '@robota-sdk/agent-core';
 
 import { decideApproval } from './abortable-approval.js';
-import { PERMISSION_DENIED_RESULT, reportToolCrash } from './permission-types.js';
 import {
   truncateToolResult,
   buildHookInput,
   runPreToolHook,
   firePostToolHook,
 } from './tool-hook-helpers.js';
+import { wrapToolWithPermission } from './tool-permission-wrapper.js';
 
 import type {
   IPermissionEnforcerOptions,
@@ -25,6 +25,7 @@ import type {
   ISpinner,
 } from './permission-types.js';
 import type { ISessionLogger, TSessionLogData } from './session-logger.js';
+import type { IToolWrapperDeps } from './tool-permission-wrapper.js';
 import type {
   IToolWithEventService,
   IToolResult,
@@ -73,7 +74,7 @@ export class PermissionEnforcer {
 
   /** Wrap all tools with permission checking */
   wrapTools(tools: IToolWithEventService[]): IToolWithEventService[] {
-    return tools.map((tool) => this.wrapToolWithPermission(tool));
+    return tools.map((tool) => wrapToolWithPermission(tool, this as unknown as IToolWrapperDeps));
   }
 
   /** Get tools that have been session-approved (via "Allow always" choice). */
@@ -91,129 +92,6 @@ export class PermissionEnforcer {
    * The wrapper intercepts execute() and runs permission evaluation before delegating.
    * If denied, returns a tool result indicating the action was blocked.
    */
-  private wrapToolWithPermission(tool: IToolWithEventService): IToolWithEventService {
-    const enforcer = this;
-    const originalExecute = tool.execute.bind(tool);
-
-    const wrappedTool = Object.create(tool) as IToolWithEventService;
-    wrappedTool.execute = async (
-      parameters: TToolParameters,
-      context?: IToolExecutionContext,
-    ): Promise<IToolResult> => {
-      // Must NEVER throw — if this throws, the execution round records the
-      // assistant tool_use in history but never adds a tool_result, which
-      // corrupts the conversation and causes a 400 error on the next API call.
-      // OUTSIDE the try: the catch announces which tool crashed (CORE-027).
-      const toolName = tool.getName();
-
-      try {
-        enforcer.log('tool_call', {
-          tool: toolName,
-          args: parameters as Record<string, string | number | boolean | object>,
-        });
-
-        const hookInput = buildHookInput(
-          enforcer.sessionId,
-          enforcer.cwd,
-          toolName,
-          parameters,
-          enforcer.getPermissionMode(),
-          enforcer.transcriptPath,
-        );
-
-        const preResult = await runPreToolHook(
-          enforcer.config.hooks,
-          hookInput,
-          enforcer.hookTypeExecutors,
-        );
-        if (preResult) {
-          enforcer.log('tool_blocked', { tool: toolName, reason: 'hook' });
-          return preResult;
-        }
-
-        // RUNTIME-005: the turn's signal reaches this wrapper (CORE-018) and stopped here.
-        const allowed = await enforcer.checkPermission(
-          toolName,
-          parameters as TToolArgs,
-          context?.signal,
-        );
-        if (!allowed) {
-          enforcer.log('tool_denied', { tool: toolName, reason: 'permission' });
-          enforcer.onToolExecution?.({
-            type: 'end',
-            toolName,
-            toolArgs: parameters as TToolArgs,
-            success: false,
-            denied: true,
-            executionId: context?.executionId,
-          });
-          return PERMISSION_DENIED_RESULT;
-        }
-
-        enforcer.onToolExecution?.({
-          type: 'start',
-          toolName,
-          toolArgs: parameters as TToolArgs,
-          executionId: context?.executionId,
-        });
-
-        const result = await originalExecute(parameters, context as IToolExecutionContext);
-
-        // Truncate oversized tool output (matches 30K char limit)
-        const truncatedResult = truncateToolResult(result);
-
-        if (truncatedResult !== result && typeof result.data === 'string') {
-          enforcer.terminal.writeLine(
-            `  ⚠  Output truncated: ${result.data.length.toLocaleString()} chars total — model sees first and last 15,000 chars`,
-          );
-        }
-
-        enforcer.onToolExecution?.({
-          type: 'end',
-          toolName,
-          toolArgs: parameters as TToolArgs,
-          success: truncatedResult.success,
-          toolResultData:
-            typeof truncatedResult.data === 'string'
-              ? truncatedResult.data
-              : JSON.stringify(truncatedResult.data),
-          executionId: context?.executionId,
-        });
-
-        const dataSize =
-          typeof truncatedResult.data === 'string'
-            ? truncatedResult.data.length
-            : JSON.stringify(truncatedResult.data).length;
-        enforcer.log('tool_result', {
-          tool: toolName,
-          success: truncatedResult.success,
-          dataChars: dataSize,
-          truncated: truncatedResult !== result,
-        });
-        firePostToolHook(
-          enforcer.config.hooks,
-          hookInput,
-          truncatedResult,
-          enforcer.hookTypeExecutors,
-        );
-        return truncatedResult;
-      } catch (err) {
-        // CORE-027 — beside the envelope it returns, in `permission-types.ts`.
-        const where = { toolName, toolArgs: parameters, executionId: context?.executionId };
-        return reportToolCrash(err, enforcer.onToolExecution as never, where);
-      }
-    };
-
-    // SELFHOST-004: the wrapper runs `originalExecute` (bound to the ORIGINAL tool), which reads the
-    // ORIGINAL tool's `eventService` (e.g. the `FunctionTool` span-completion emit). Because
-    // `Object.create(tool)` would shadow a `setEventService` call onto the wrapper instance, forward it
-    // to the original tool — otherwise an injected event bus never reaches the tool and spans never fire.
-    wrappedTool.setEventService = (eventService) => {
-      tool.setEventService(eventService);
-    };
-
-    return wrappedTool;
-  }
 
   /** Evaluate permission for a tool call. `signal` — RUNTIME-005; see `decideApproval` for why a
    * cancelled approval denies. */

--- a/packages/agent-session/src/permission-enforcer.ts
+++ b/packages/agent-session/src/permission-enforcer.ts
@@ -9,7 +9,7 @@
 import { evaluatePermission, resolvePermissionByPolicy, runHooks } from '@robota-sdk/agent-core';
 
 import { decideApproval } from './abortable-approval.js';
-import { PERMISSION_DENIED_RESULT } from './permission-types.js';
+import { PERMISSION_DENIED_RESULT, reportToolCrash } from './permission-types.js';
 import {
   truncateToolResult,
   buildHookInput,
@@ -103,8 +103,10 @@ export class PermissionEnforcer {
       // Must NEVER throw — if this throws, the execution round records the
       // assistant tool_use in history but never adds a tool_result, which
       // corrupts the conversation and causes a 400 error on the next API call.
+      // OUTSIDE the try: the catch announces which tool crashed (CORE-027).
+      const toolName = tool.getName();
+
       try {
-        const toolName = tool.getName();
         enforcer.log('tool_call', {
           tool: toolName,
           args: parameters as Record<string, string | number | boolean | object>,
@@ -196,12 +198,9 @@ export class PermissionEnforcer {
         );
         return truncatedResult;
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return {
-          success: true,
-          data: JSON.stringify({ success: false, output: '', error: message }),
-          metadata: {},
-        };
+        // CORE-027 — beside the envelope it returns, in `permission-types.ts`.
+        const where = { toolName, toolArgs: parameters, executionId: context?.executionId };
+        return reportToolCrash(err, enforcer.onToolExecution as never, where);
       }
     };
 

--- a/packages/agent-session/src/permission-enforcer.ts
+++ b/packages/agent-session/src/permission-enforcer.ts
@@ -74,7 +74,25 @@ export class PermissionEnforcer {
 
   /** Wrap all tools with permission checking */
   wrapTools(tools: IToolWithEventService[]): IToolWithEventService[] {
-    return tools.map((tool) => wrapToolWithPermission(tool, this as unknown as IToolWrapperDeps));
+    // Built explicitly rather than cast. A blind assertion here would compile only by silencing the
+    // private-member mismatch, and this repository counts and ratchets those. Naming the ten members
+    // is what makes the extraction a boundary: if the wrapper starts reading an eleventh, this stops
+    // compiling instead of quietly widening.
+    const deps: IToolWrapperDeps = {
+      sessionId: this.sessionId,
+      cwd: this.cwd,
+      config: this.config,
+      terminal: this.terminal,
+      transcriptPath: this.transcriptPath,
+      onToolExecution: this.onToolExecution,
+      hookTypeExecutors: this.hookTypeExecutors,
+      getPermissionMode: this.getPermissionMode,
+      log: (event, detail) => this.log(event, detail),
+      checkPermission: (toolName, toolArgs, signal) =>
+        this.checkPermission(toolName, toolArgs, signal),
+    };
+
+    return tools.map((tool) => wrapToolWithPermission(tool, deps));
   }
 
   /** Get tools that have been session-approved (via "Allow always" choice). */

--- a/packages/agent-session/src/permission-types.ts
+++ b/packages/agent-session/src/permission-types.ts
@@ -96,12 +96,23 @@ export type TToolFailureOutcome = 'threw' | 'denied' | 'hook-blocked';
  * `data` keeps the JSON string it always carried, because the model is shown that text and changing
  * what it sees is a separate decision from making the envelope honest.
  */
-function toolFailure(outcome: TToolFailureOutcome, error: string) {
+export function toolFailure(
+  outcome: TToolFailureOutcome,
+  error: string,
+  /**
+   * What the MODEL is shown, when it differs from the default.
+   *
+   * A hook block has said `{ blocked: true, reason }` since HOOK-003, and the model reads that text.
+   * Changing the envelope is this item's subject; changing what the model sees is a different
+   * decision with a different blast radius, so the payload stays exactly as it was.
+   */
+  data?: unknown,
+) {
   return {
     success: false as const,
     outcome,
     error,
-    data: JSON.stringify({ success: false, output: '', error }),
+    data: JSON.stringify(data ?? { success: false, output: '', error }),
     metadata: {},
   };
 }
@@ -114,10 +125,26 @@ function toolFailure(outcome: TToolFailureOutcome, error: string) {
  * and both are the point: before CORE-027 the catch returned `success: true` AND emitted no end
  * event at all, so a crash was invisible to the caller and to anything watching.
  */
+/**
+ * What a crash announcement looks like, named rather than widened.
+ *
+ * The first version typed `announce` as taking a `Record<string, unknown>`, which the real
+ * `onToolExecution` cannot be assigned to — parameter positions are contravariant — so the call site
+ * reached for `as never`. A cast at a boundary is the boundary's type being wrong; this is the
+ * subset of the event this function actually emits.
+ */
+export interface IToolCrashAnnouncement {
+  type: 'end';
+  toolName: string;
+  toolArgs: TToolArgs;
+  success: false;
+  executionId?: string;
+}
+
 export function reportToolCrash(
   error: unknown,
-  announce: ((event: Record<string, unknown>) => void) | undefined,
-  where: { toolName: string; toolArgs: unknown; executionId?: string },
+  announce: ((event: IToolCrashAnnouncement) => void) | undefined,
+  where: { toolName: string; toolArgs: TToolArgs; executionId?: string },
 ) {
   const message = error instanceof Error ? error.message : String(error);
   announce?.({

--- a/packages/agent-session/src/permission-types.ts
+++ b/packages/agent-session/src/permission-types.ts
@@ -100,11 +100,19 @@ export function toolFailure(
   outcome: TToolFailureOutcome,
   error: string,
   /**
-   * What the MODEL is shown, when it differs from the default.
+   * The payload, kept in the shape callers already parse.
    *
-   * A hook block has said `{ blocked: true, reason }` since HOOK-003, and the model reads that text.
-   * Changing the envelope is this item's subject; changing what the model sees is a different
-   * decision with a different blast radius, so the payload stays exactly as it was.
+   * A CORRECTION, because the first version of this comment claimed something false and review
+   * caught it. It said the model still sees `{ blocked: true, reason }` because `data` was
+   * unchanged. It does not. `success: false` now reaches `ToolManager.executeTool`, which throws
+   * `ToolExecutionError`; `ToolExecutionService` catches that and returns `{ success: false, error }`,
+   * and the history writer renders a failed result as `Error: <message>`. So what the model reads
+   * changed from the JSON payload to one error line.
+   *
+   * That change is INTENDED and is the point of the item: a blocked call is a failure, and the model
+   * being told `Error: Blocked by hook — <reason>` is more honest than being handed a success-shaped
+   * envelope it has to introspect. What was wrong was the claim that nothing changed, not the change.
+   * The reason travels in `error`, so nothing is lost.
    */
   data?: unknown,
 ) {

--- a/packages/agent-session/src/permission-types.ts
+++ b/packages/agent-session/src/permission-types.ts
@@ -76,16 +76,65 @@ export interface IPermissionEnforcerOptions {
   taskPermissions?: { allow?: readonly string[]; deny?: readonly string[] };
 }
 
-/** Returned when the user denies a permission prompt. success:true prevents ToolExecutionError. */
-export const PERMISSION_DENIED_RESULT = {
-  success: true,
-  data: JSON.stringify({
+/**
+ * How a tool call ended, when it did not simply succeed (CORE-027).
+ *
+ * Three outcomes used to be indistinguishable from success at this type — a tool that THREW, a user
+ * DENIAL, and a hook BLOCK — because each was returned as `{ success: true, data: '{"success":
+ * false,…}' }`. Every consumer above had to parse English out of a string and guess, and all three
+ * guesses were the same one.
+ *
+ * The framing the audit stated is the one kept here: **"never throw" is correct and "encode the
+ * failure as success" is not — they are independent decisions.** Nothing below starts throwing.
+ */
+export type TToolFailureOutcome = 'threw' | 'denied' | 'hook-blocked';
+
+/**
+ * The failure envelope. `success: false` is the part consumers branch on; `outcome` is the part they
+ * branch on when they need to know WHICH failure, and neither requires reading `data`.
+ *
+ * `data` keeps the JSON string it always carried, because the model is shown that text and changing
+ * what it sees is a separate decision from making the envelope honest.
+ */
+function toolFailure(outcome: TToolFailureOutcome, error: string) {
+  return {
+    success: false as const,
+    outcome,
+    error,
+    data: JSON.stringify({ success: false, output: '', error }),
+    metadata: {},
+  };
+}
+
+/**
+ * The crash path, as one call: announce the failure to the listener and return an honest envelope.
+ *
+ * It lives beside the envelope rather than in the enforcer because the enforcer is at its size
+ * ceiling and this is the same subject — what a failed tool call looks like. Two things happen here
+ * and both are the point: before CORE-027 the catch returned `success: true` AND emitted no end
+ * event at all, so a crash was invisible to the caller and to anything watching.
+ */
+export function reportToolCrash(
+  error: unknown,
+  announce: ((event: Record<string, unknown>) => void) | undefined,
+  where: { toolName: string; toolArgs: unknown; executionId?: string },
+) {
+  const message = error instanceof Error ? error.message : String(error);
+  announce?.({
+    type: 'end',
+    toolName: where.toolName,
+    toolArgs: where.toolArgs,
     success: false,
-    output: '',
-    error: 'Permission denied. The user did not approve this action.',
-  }),
-  metadata: {},
-} as const;
+    executionId: where.executionId,
+  });
+  return toolFailure('threw', message);
+}
+
+/** Returned when the user denies a permission prompt. */
+export const PERMISSION_DENIED_RESULT = toolFailure(
+  'denied',
+  'Permission denied. The user did not approve this action.',
+);
 
 /** Maximum chars for any single tool output. Matches Claude Code's 30K limit. */
 export const MAX_TOOL_OUTPUT_CHARS = 30_000;

--- a/packages/agent-session/src/permission-types.ts
+++ b/packages/agent-session/src/permission-types.ts
@@ -126,14 +126,6 @@ export function toolFailure(
 }
 
 /**
- * The crash path, as one call: announce the failure to the listener and return an honest envelope.
- *
- * It lives beside the envelope rather than in the enforcer because the enforcer is at its size
- * ceiling and this is the same subject — what a failed tool call looks like. Two things happen here
- * and both are the point: before CORE-027 the catch returned `success: true` AND emitted no end
- * event at all, so a crash was invisible to the caller and to anything watching.
- */
-/**
  * What a crash announcement looks like, named rather than widened.
  *
  * The first version typed `announce` as taking a `Record<string, unknown>`, which the real
@@ -149,6 +141,14 @@ export interface IToolCrashAnnouncement {
   executionId?: string;
 }
 
+/**
+ * The crash path, as one call: announce the failure to the listener and return an honest envelope.
+ *
+ * It lives beside the envelope rather than in the enforcer because the enforcer is at its size
+ * ceiling and this is the same subject — what a failed tool call looks like. Two things happen here
+ * and both are the point: before CORE-027 the catch returned `success: true` AND emitted no end
+ * event at all, so a crash was invisible to the caller and to anything watching.
+ */
 export function reportToolCrash(
   error: unknown,
   announce: ((event: IToolCrashAnnouncement) => void) | undefined,

--- a/packages/agent-session/src/tool-hook-helpers.ts
+++ b/packages/agent-session/src/tool-hook-helpers.ts
@@ -5,7 +5,7 @@
 
 import { runHooks, createLogger } from '@robota-sdk/agent-core';
 
-import { MAX_TOOL_OUTPUT_CHARS } from './permission-types.js';
+import { MAX_TOOL_OUTPUT_CHARS, toolFailure } from './permission-types.js';
 
 import type {
   IToolResult,
@@ -67,14 +67,12 @@ export async function runPreToolHook(
     hookTypeExecutors,
   );
   if (hookResult.blocked) {
-    return {
-      success: true,
-      data: JSON.stringify({
-        blocked: true,
-        reason: hookResult.reason ?? 'Blocked by hook',
-      }),
-      metadata: {},
-    };
+    // CORE-027, the third of the three outcomes the failure type names. This path was left behind by
+    // the first pass: `permission-types.ts` declared `hook-blocked` while this still returned
+    // `success: true`, so the type promised a distinction the code did not make — in the file that
+    // exists to end exactly that.
+    const reason = hookResult.reason ?? 'Blocked by hook';
+    return toolFailure('hook-blocked', reason, { blocked: true, reason });
   }
   return null;
 }

--- a/packages/agent-session/src/tool-permission-wrapper.ts
+++ b/packages/agent-session/src/tool-permission-wrapper.ts
@@ -1,0 +1,173 @@
+import { PERMISSION_DENIED_RESULT, reportToolCrash } from './permission-types.js';
+import {
+  buildHookInput,
+  firePostToolHook,
+  runPreToolHook,
+  truncateToolResult,
+} from './tool-hook-helpers.js';
+
+import type { IPermissionEnforcerOptions } from './permission-types.js';
+import type {
+  IToolExecutionContext,
+  IToolResult,
+  IToolWithEventService,
+  ITerminalOutput,
+  TToolArgs,
+  TToolParameters,
+} from '@robota-sdk/agent-core';
+
+/** Exactly what the wrapper reads from the enforcer — no more, and named so it cannot quietly grow. */
+export interface IToolWrapperDeps {
+  readonly sessionId: string;
+  readonly cwd: string;
+  readonly config: IPermissionEnforcerOptions['config'];
+  readonly terminal: ITerminalOutput;
+  readonly transcriptPath?: string;
+  readonly onToolExecution?: IPermissionEnforcerOptions['onToolExecution'];
+  readonly hookTypeExecutors?: IPermissionEnforcerOptions['hookTypeExecutors'];
+  getPermissionMode: IPermissionEnforcerOptions['getPermissionMode'];
+  log(event: string, detail: Record<string, unknown>): void;
+  checkPermission(toolName: string, toolArgs: TToolArgs, signal?: AbortSignal): Promise<boolean>;
+}
+
+/**
+ * Wrap one tool so every call passes the permission gate, the hooks and the truncation limit.
+ *
+ * Extracted from `PermissionEnforcer` because the file-size ratchet refused to let it grow further,
+ * and a ratchet that says "split instead of extending" is asking for exactly this. It takes what it
+ * needs as `deps` rather than the enforcer itself: the ten members it reads are the honest surface
+ * of this function, and naming them is what makes the extraction a boundary rather than a move.
+ */
+export function wrapToolWithPermission(
+  tool: IToolWithEventService,
+  enforcer: IToolWrapperDeps,
+): IToolWithEventService {
+  const originalExecute = tool.execute.bind(tool);
+
+  const wrappedTool = Object.create(tool) as IToolWithEventService;
+  wrappedTool.execute = async (
+    parameters: TToolParameters,
+    context?: IToolExecutionContext,
+  ): Promise<IToolResult> => {
+    // Must NEVER throw — if this throws, the execution round records the
+    // assistant tool_use in history but never adds a tool_result, which
+    // corrupts the conversation and causes a 400 error on the next API call.
+    // Read INSIDE the try, and held for the catch. Hoisting it out put an unguarded call above
+    // the comment that says this function must never throw — a tool whose `getName` is missing or
+    // throws would have propagated, which is the corruption that comment exists to prevent. The
+    // catch needs the name only to announce the failure, and a call that has not reached it yet
+    // has nothing to announce.
+    let toolName = '(unknown)';
+
+    try {
+      toolName = tool.getName();
+      enforcer.log('tool_call', {
+        tool: toolName,
+        args: parameters as Record<string, string | number | boolean | object>,
+      });
+
+      const hookInput = buildHookInput(
+        enforcer.sessionId,
+        enforcer.cwd,
+        toolName,
+        parameters,
+        enforcer.getPermissionMode(),
+        enforcer.transcriptPath,
+      );
+
+      const preResult = await runPreToolHook(
+        enforcer.config.hooks,
+        hookInput,
+        enforcer.hookTypeExecutors,
+      );
+      if (preResult) {
+        enforcer.log('tool_blocked', { tool: toolName, reason: 'hook' });
+        return preResult;
+      }
+
+      // RUNTIME-005: the turn's signal reaches this wrapper (CORE-018) and stopped here.
+      const allowed = await enforcer.checkPermission(
+        toolName,
+        parameters as TToolArgs,
+        context?.signal,
+      );
+      if (!allowed) {
+        enforcer.log('tool_denied', { tool: toolName, reason: 'permission' });
+        enforcer.onToolExecution?.({
+          type: 'end',
+          toolName,
+          toolArgs: parameters as TToolArgs,
+          success: false,
+          denied: true,
+          executionId: context?.executionId,
+        });
+        return PERMISSION_DENIED_RESULT;
+      }
+
+      enforcer.onToolExecution?.({
+        type: 'start',
+        toolName,
+        toolArgs: parameters as TToolArgs,
+        executionId: context?.executionId,
+      });
+
+      const result = await originalExecute(parameters, context as IToolExecutionContext);
+
+      // Truncate oversized tool output (matches 30K char limit)
+      const truncatedResult = truncateToolResult(result);
+
+      if (truncatedResult !== result && typeof result.data === 'string') {
+        enforcer.terminal.writeLine(
+          `  ⚠  Output truncated: ${result.data.length.toLocaleString()} chars total — model sees first and last 15,000 chars`,
+        );
+      }
+
+      enforcer.onToolExecution?.({
+        type: 'end',
+        toolName,
+        toolArgs: parameters as TToolArgs,
+        success: truncatedResult.success,
+        toolResultData:
+          typeof truncatedResult.data === 'string'
+            ? truncatedResult.data
+            : JSON.stringify(truncatedResult.data),
+        executionId: context?.executionId,
+      });
+
+      const dataSize =
+        typeof truncatedResult.data === 'string'
+          ? truncatedResult.data.length
+          : JSON.stringify(truncatedResult.data).length;
+      enforcer.log('tool_result', {
+        tool: toolName,
+        success: truncatedResult.success,
+        dataChars: dataSize,
+        truncated: truncatedResult !== result,
+      });
+      firePostToolHook(
+        enforcer.config.hooks,
+        hookInput,
+        truncatedResult,
+        enforcer.hookTypeExecutors,
+      );
+      return truncatedResult;
+    } catch (err) {
+      // CORE-027 — beside the envelope it returns, in `permission-types.ts`.
+      return reportToolCrash(err, enforcer.onToolExecution, {
+        toolName,
+        toolArgs: parameters as TToolArgs,
+        executionId: context?.executionId,
+      });
+    }
+  };
+
+  // SELFHOST-004: the wrapper runs `originalExecute` (bound to the ORIGINAL tool), which reads the
+  // ORIGINAL tool's `eventService` (e.g. the `FunctionTool` span-completion emit). Because
+  // `Object.create(tool)` would shadow a `setEventService` call onto the wrapper instance, forward it
+  // to the original tool — otherwise an injected event bus never reaches the tool and spans never fire.
+  wrappedTool.setEventService = (eventService) => {
+    tool.setEventService(eventService);
+  };
+
+  return wrappedTool;
+}

--- a/packages/agent-session/src/tool-permission-wrapper.ts
+++ b/packages/agent-session/src/tool-permission-wrapper.ts
@@ -7,6 +7,7 @@ import {
 } from './tool-hook-helpers.js';
 
 import type { IPermissionEnforcerOptions } from './permission-types.js';
+import type { TSessionLogData } from './session-logger.js';
 import type {
   IToolExecutionContext,
   IToolResult,
@@ -26,7 +27,7 @@ export interface IToolWrapperDeps {
   readonly onToolExecution?: IPermissionEnforcerOptions['onToolExecution'];
   readonly hookTypeExecutors?: IPermissionEnforcerOptions['hookTypeExecutors'];
   getPermissionMode: IPermissionEnforcerOptions['getPermissionMode'];
-  log(event: string, detail: Record<string, unknown>): void;
+  log(event: string, detail: TSessionLogData): void;
   checkPermission(toolName: string, toolArgs: TToolArgs, signal?: AbortSignal): Promise<boolean>;
 }
 

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -48,7 +48,6 @@
   "packages/agent-provider-openai-compatible/src/gemma/provider.ts": 312,
   "packages/agent-provider-openai-compatible/src/qwen/provider.ts": 301,
   "packages/agent-provider-openai-compatible/src/qwen/responses-parser.ts": 302,
-  "packages/agent-session/src/permission-enforcer.ts": 320,
   "packages/agent-session/src/session-run.ts": 323,
   "packages/agent-session/src/session.ts": 316,
   "packages/agent-transport-tui/src/App.tsx": 605,

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -48,7 +48,7 @@
   "packages/agent-provider-openai-compatible/src/gemma/provider.ts": 312,
   "packages/agent-provider-openai-compatible/src/qwen/provider.ts": 301,
   "packages/agent-provider-openai-compatible/src/qwen/responses-parser.ts": 302,
-  "packages/agent-session/src/permission-enforcer.ts": 321,
+  "packages/agent-session/src/permission-enforcer.ts": 320,
   "packages/agent-session/src/session-run.ts": 323,
   "packages/agent-session/src/session.ts": 316,
   "packages/agent-transport-tui/src/App.tsx": 605,

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -30,6 +30,12 @@
       "timestamp": "2026-08-05T16:41:22.739Z",
       "ratio": "47/100",
       "reason": "A fifth instance, reporting the examined-size migration as 47/100 with no percentage while telling the owner the harness work was ending. Every instance so far has been a RATIO of a migration's progress written in a summary to the owner — which is exactly where a percentage carries the meaning and the bare fraction does not."
+    },
+    {
+      "transcript": "50cb28dd-0dd1-4ca4-897a-f8d0b47191c7.jsonl",
+      "timestamp": "2026-08-06T12:41:08.495Z",
+      "ratio": "1/3",
+      "reason": "A sixth instance — '#1651 (CORE-027 1/3)', naming which third of an item a pull request carries. Six for six, every one a RATIO OF PROGRESS written in a summary to the owner. The rule is right and the habit is specific: it is not ratios in general that go unqualified, it is the sentence that reports how far along something is."
     }
   ]
 }

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -24,6 +24,12 @@
       "timestamp": "2026-08-04T06:58:15.776Z",
       "ratio": "78/97",
       "reason": "A fourth instance, committed while building the acknowledgment path for the first three — reporting 78/97 of the scans still undeclared, with no percentage. Recorded rather than argued away: it is the same violation, and the fact that it happened during the fix is the clearest evidence that the rule needs a mechanism and not an intention."
+    },
+    {
+      "transcript": "50cb28dd-0dd1-4ca4-897a-f8d0b47191c7.jsonl",
+      "timestamp": "2026-08-05T16:41:22.739Z",
+      "ratio": "47/100",
+      "reason": "A fifth instance, reporting the examined-size migration as 47/100 with no percentage while telling the owner the harness work was ending. Every instance so far has been a RATIO of a migration's progress written in a summary to the owner — which is exactly where a percentage carries the meaning and the bare fraction does not."
     }
   ]
 }


### PR DESCRIPTION
## What

CORE-027, the `IToolResult` half. Three outcomes were **indistinguishable from success** at the permission wrapper's return value, because failure was smuggled into a success-shaped value as a nested JSON string:

```
a tool that THREW  ->  { success: true, data: '{"success":false,…}' }
a user DENIAL      ->  { success: true, data: '{"success":false,…}' }
a hook BLOCK       ->  the same shape again
```

Every consumer above had to parse English out of `data` and guess, and all three guesses were the same one.

## The framing kept from the audit

> **"never throw" is correct and "encode the failure as success" is not — they are independent decisions.**

Nothing starts throwing. The envelope gains `success: false` and an `outcome` naming *which* failure it was; `data` keeps the JSON string it always carried, because what the model is shown is a separate decision from whether the envelope is honest.

## A second defect the case surfaced

The catch emitted **no end event at all**, so a crash was invisible to anything watching the execution as well as to the caller. It announces the failure now.

## Red-proved against the unfixed code

```
× does not report a thrown tool as `success: true`
  → crash reported as success, data="{…\"error\":\"the tool blew up\"}"
× reports the crash to the execution listener as a failure
  → no end event was emitted for a crashed tool
× tells a denial apart from a crash without reading prose
  → a denial carries no machine-readable reason
```

**Two earlier attempts at that red were red for the FIXTURE, not the defect** — a missing `getName()` made the wrapper itself throw, then the tool was denied instead of running, so the listener case passed on the denial's own event. Both were corrected until the failure named the real thing. A red for the wrong reason proves as little as a green for the wrong reason.

## Two adjacent defects fixed rather than left

- The **file-size ratchet refused the extension**, so the crash path moved beside the envelope it returns rather than growing the enforcer. The gain below baseline is locked in the same change, as the ratchet requires.
- ~~`local-executor.test.ts` imported only `vi`, so **fifteen cases had never run at all**.~~
  **Corrected — this claim was wrong, and review caught it.** `packages/agent-core/vitest.config.ts`
  sets `globals: true`, so `describe`/`it`/`expect` were available without the import and all fifteen
  ran. Measured both ways: from the package directory the pre-change file reports `15 passed`; the
  `ReferenceError: describe is not defined` I originally took as proof only appears when the file is
  run from the repo root, where the package config does not apply — I measured with the wrong
  invocation and read the result as a property of the code. The explicit imports are still worth
  having (they do not depend on a config flag), but nothing was unreached.

## Verification

- `pnpm harness:scan` → 99 passed, 1 skipped
- 1165 tests across `agent-session` and `agent-core`
- one consumer of `wrapTools`, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMWfpbNjWYbdzAG3L1HQso
