### PR TITLE
fix(hooks): the push is judged against the repository it acts on

### DIFF
--- a/.agents/tasks/HARNESS-083-per-statement-walk-retokenizes-the-whole-command.md
+++ b/.agents/tasks/HARNESS-083-per-statement-walk-retokenizes-the-whole-command.md
@@ -1,0 +1,48 @@
+---
+title: 'HARNESS-083: the pre-push per-statement walk re-tokenizes the whole command O(N) times'
+status: todo
+created: 2026-08-09
+priority: medium
+urgency: later
+area: scripts/harness, .claude/hooks
+depends_on: []
+issue: https://github.com/woojubb/robota/issues/1677
+---
+
+# HARNESS-083: the pre-push per-statement walk re-tokenizes the whole command O(N) times
+
+## Problem
+
+`.claude/hooks/pre-push-check.sh`'s per-statement walk calls `hook_verb_scan`,
+`hook_git_c_path`, and `hook_statement_words` once PER statement. Each of those functions forks a
+fresh `awk` that tokenizes the ENTIRE command from the start — `WSTART`/`WLEN` only slice the
+OUTPUT, they do not narrow the parse. For a command of N statements that is ~2N awk forks and
+O(N²) tokenization work, in a SYNCHRONOUS hook that runs on every push.
+
+Agents routinely write long `;`/`&&`-chained commands (tens to hundreds of statements), so the
+cost is real and user-visible on exactly the shape the hook must handle.
+
+## Evidence
+
+Raised 2026-08-09 in #1667 review (SHOULD): "statement 수가 N개면 대략 O(N²) 스캔 비용 +
+약 2N번의 awk 프로세스 fork … 이 동기 훅이 push마다 눈에 띄게 느려질 수 있습니다."
+
+## Direction
+
+Tokenize ONCE and reuse the token stream across statements, rather than re-parsing per statement:
+
+- have the tokenizer emit the full token/statement structure a single time, and let the walk
+  index into it, OR
+- pass the already-masked whole-command scan into the per-statement readers so they slice a
+  cached parse instead of re-forking `awk`.
+
+Keep the current correctness (heredoc/quote/substitution masking, the worktree-aware resolution,
+the `||`-guard from #1667) — this is a performance refactor, not a behavior change, so it must be
+covered by the existing `pre-push-repo-resolution` / `pre-push-sequence` suites staying green.
+
+## Acceptance
+
+- [ ] The whole command is tokenized a bounded number of times (ideally once), independent of the
+      statement count.
+- [ ] All existing pre-push resolution/sequence tests stay green (behavior unchanged).
+- [ ] A micro-benchmark (or a large-N fixture) shows the walk no longer scales O(N²) in awk forks.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -92,9 +92,9 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # because this line is the whole file's entry point, the branch-hygiene check, the lockfile-sync
 # check and the local-review record were all skipped for that shape. Two guards reading one command
 # must reach one reading of it.
-# ONE spelling of "this statement is a push", shared with the per-statement walk below — a second
-# copy of the pattern is a second answer waiting to disagree (#1667 review; lib/command-scan.sh
-# carries this file's history of exactly that).
+# ONE spelling of "this statement is a push", reused by the per-statement walk AND by the
+# override/ACK counting below (PUSH_RE) — a second copy of the pattern is a second answer waiting
+# to disagree (#1667 review; lib/command-scan.sh carries this file's history of exactly that).
 RE_PUSH_STMT='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)'
 printf '%s' "$COMMAND_VERBS" | grep -qE "$RE_PUSH_STMT" || exit 0
 
@@ -203,7 +203,15 @@ while read -r PS_START PS_LEN; do
       [[ -n "$LAST_CD" ]] && PS_DIR_EXPLICIT=true
       PS_DIR="${LAST_CD:-$HOOK_CWD}"
     fi
-    if [[ "$PUSH_SEEN" == "true" && "$PS_DIR" != "$PUSH_DIR" ]]; then
+    # Compare on a trailing-slash-normalized form so `-C /repo` and `-C /repo/` are not read as two
+    # different repositories (fail-closed over-refusal). STATED LIMIT: this is a string compare, so
+    # two spellings that only a filesystem could equate — a relative `-C ../repo` vs a cd-absolutized
+    # path, or a symlink — can still over-refuse. Canonicalizing would mean a rev-parse per push on a
+    # directory that may not exist yet (the mkdir case), so the cheap normalization covers the common
+    # spelling and the rest stays a documented fail-closed edge. (#1667 review)
+    _PS_DIR_NORM="$PS_DIR"; while [[ "$_PS_DIR_NORM" == */ && "$_PS_DIR_NORM" != "/" ]]; do _PS_DIR_NORM="${_PS_DIR_NORM%/}"; done
+    _PUSH_DIR_NORM="$PUSH_DIR"; while [[ "$_PUSH_DIR_NORM" == */ && "$_PUSH_DIR_NORM" != "/" ]]; do _PUSH_DIR_NORM="${_PUSH_DIR_NORM%/}"; done
+    if [[ "$PUSH_SEEN" == "true" && "$_PS_DIR_NORM" != "$_PUSH_DIR_NORM" ]]; then
       PUSH_DIR_CONFLICT=true
     fi
     PUSH_SEEN=true
@@ -560,8 +568,13 @@ esac
 # whole command through would grant an unearned bypass to the second — the one direction this file
 # never trades in. When some pushes are unprefixed the override does not apply and the record check
 # below decides for all of them.
-PUSH_RE='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push\b'
-ACK_RE='(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push\b'
+# The push detector IS RE_PUSH_STMT — the same spelling the per-statement walk uses, so the two
+# cannot disagree. The earlier `push\b` copy differed from RE_PUSH_STMT's `push([^-[:alnum:]_]|$)`
+# on `git push-x`: `\b` treats the `-` as a word boundary and matched, the explicit class does not.
+# ACK_RE carries the `PRE_PUSH_ALLOW_UNREVIEWED=1` prefix so it cannot simply be RE_PUSH_STMT, but
+# its push token uses the SAME boundary class now, not `\b`. (#1667 review)
+PUSH_RE="$RE_PUSH_STMT"
+ACK_RE='(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push([^-[:alnum:]_]|$)'
 PUSH_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$PUSH_RE" | grep -c . || true)
 ACK_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$ACK_RE" | grep -c . || true)
 

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -244,6 +244,15 @@ while read -r PS_START PS_LEN; do
       if [[ "$RAW_TGT" == *'$'* || "$RAW_TGT" == *'`'* ]]; then
         TARGET_HIDDEN=true
       fi
+      # NO raw occurrence at all is its own refusal: words-mode said this statement is a cd,
+      # so a raw slice in which `cd `-followed-by-a-target cannot be found (`"cd" /x` — the
+      # quoted builtin name breaks the adjacency the pattern needs) is a shape this reader
+      # does not understand, and the target it failed to find is exactly the one it exists
+      # to inspect. Measured: `"cd" /repo\`evil\`/path && git push` walked through with a
+      # clean-looking PS_SECOND and a silently wrong LAST_CD. (#1667 review)
+      if [[ -z "$RAW_TGT" ]]; then
+        TARGET_HIDDEN=true
+      fi
       # A target this hook cannot resolve, decided BEFORE the stack is touched: empty (quoted
       # away), `-`/flags, a variable or substitution (`$DIR`, or one EMBEDDED in the token —
       # TARGET_HIDDEN above), `~` (the hook does not expand another process's home), a `pushd`

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -169,6 +169,14 @@ while read -r PS_START PS_LEN; do
     # an unstripped paren made the whole idiom invisible to this tracking: the push was judged
     # against the declared cwd, the exact wrong-repository answer this walk exists to end.
     PS_FIRST="${PS_FIRST#"${PS_FIRST%%[!({]*}"}"
+    # A BRACE group is different: `{` must be its own space-delimited word (`{ cd dir; …`), so the
+    # stripped first word comes back empty and the `cd` sits one word later — shift, or the walk
+    # silently falls back to the declared cwd for a form bash itself accepts. (#1667 review)
+    if [[ -z "$PS_FIRST" ]]; then
+      PS_FIRST="$PS_SECOND"
+      PS_SECOND="$PS_THIRD"
+      PS_THIRD=""
+    fi
     if [[ "$PS_FIRST" == "popd" ]]; then
       # `popd` returns to the top of the stack this walk has been keeping. A stack this walk did
       # not see filled (no prior pushd), a rotation (`+N`), or a poisoned entry is a base only the

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -122,6 +122,7 @@ PUSH_DIR=""
 PUSH_DIR_CONFLICT=false
 LAST_CD=""
 LAST_CD_UNREADABLE=false
+PUSHD_STACK=()
 STATEMENT_RANGES=$(hook_statement_ranges "$COMMAND" || printf '')
 if [[ -z "${STATEMENT_RANGES//[[:space:]]/}" ]]; then
   echo "[pre-push-check] Blocked: the command could not be split into statements, so which" >&2
@@ -164,13 +165,43 @@ while read -r PS_START PS_LEN; do
       [[ "$PS_INDEX" -eq 3 ]] && PS_THIRD="$PS_W"
       [[ "$PS_INDEX" -ge 4 ]] && break
     done <<< "$PS_WORDS"
-    if [[ "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" ]]; then
+    # A subshell opener glues to the first word — `(cd <dir> && git push)` reads as `(cd` — and
+    # an unstripped paren made the whole idiom invisible to this tracking: the push was judged
+    # against the declared cwd, the exact wrong-repository answer this walk exists to end.
+    PS_FIRST="${PS_FIRST#"${PS_FIRST%%[!({]*}"}"
+    if [[ "$PS_FIRST" == "popd" ]]; then
+      # `popd` returns to the top of the stack this walk has been keeping. A stack this walk did
+      # not see filled (no prior pushd), a rotation (`+N`), or a poisoned entry is a base only the
+      # real shell knows — unreadable, the same answer every other unknowable target gets.
+      if [[ -n "$PS_SECOND" ]] || [[ ${#PUSHD_STACK[@]} -eq 0 ]]; then
+        LAST_CD_UNREADABLE=true
+      else
+        LAST_CD="${PUSHD_STACK[-1]}"
+        unset 'PUSHD_STACK[-1]'
+        if [[ "$LAST_CD" == "?" ]]; then
+          LAST_CD=""
+          LAST_CD_UNREADABLE=true
+        else
+          LAST_CD_UNREADABLE=false
+        fi
+      fi
+    elif [[ "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" ]]; then
       # `cd -- <path>`: the end-of-options marker is not the target — the next word is.
       [[ "$PS_SECOND" == "--" && -n "$PS_THIRD" ]] && PS_SECOND="$PS_THIRD"
+      # `pushd` remembers where the shell stood, or that it could not tell (`?`), so a later
+      # `popd` restores exactly what this walk knew at the push.
+      if [[ "$PS_FIRST" == "pushd" ]]; then
+        if [[ "$LAST_CD_UNREADABLE" == "true" ]]; then
+          PUSHD_STACK+=("?")
+        else
+          PUSHD_STACK+=("${LAST_CD:-${HOOK_CWD:-.}}")
+        fi
+      fi
       # A target this hook cannot resolve: empty (quoted away), `-`/flags, a variable or
-      # substitution (`$DIR`), `~` (the hook does not expand another process's home), or a
-      # `pushd` stack rotation (`+N`/`-N`), which lands on a directory only the shell's stack knows.
-      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* ]] \
+      # substitution (`$DIR`), `~` (the hook does not expand another process's home), a `pushd`
+      # stack rotation (`+N`/`-N`), or a word still carrying a subshell paren — `(cd x) && push`
+      # changes no directory the push will see, and guessing would judge the wrong repository.
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* ]] \
         || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
         LAST_CD_UNREADABLE=true
       else

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -125,6 +125,7 @@ PUSH_DIR=""
 # read that empty first push as "no push yet", so a second push to a DIFFERENT repo overwrote it
 # with no conflict and the first push went unverified. (#1667 review)
 PUSH_SEEN=false
+PUSH_DIR_EXPLICIT=false
 PUSH_DIR_CONFLICT=false
 LAST_CD=""
 LAST_CD_UNREADABLE=false
@@ -164,8 +165,13 @@ while read -r PS_START PS_LEN; do
   esac
   PS_MASK=$(hook_verb_scan "$COMMAND" "$PS_START" "$PS_LEN")
   if printf '%s' "$PS_MASK" | grep -qE "$RE_PUSH_STMT"; then
+    # Whether this push's directory was named EXPLICITLY — a `-C` or a tracked `cd` — as opposed
+    # to the HOOK_CWD fallback (the bare-`git push`-in-session case). Only an explicit target that
+    # turns out not to be a work tree is refused below; the fallback keeps its existing handling.
+    PS_DIR_EXPLICIT=false
     # 1. This statement's own `git -C`.
     PS_DIR=$(hook_git_c_path "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null || printf '')
+    [[ -n "$PS_DIR" ]] && PS_DIR_EXPLICIT=true
     # A `||`-guarded push with no `-C` of its own runs only when the prior command FAILED — so
     # the directory the walk tracked (from the branch that succeeded) is not where this push
     # lands. Its base is unknowable; refuse rather than judge the wrong repository. (#1667 review)
@@ -183,6 +189,9 @@ while read -r PS_START PS_LEN; do
         echo "[pre-push-check] push acts on is unknown. Name it: git -C <path> push …" >&2
         exit 2
       fi
+      # A tracked `cd` named this directory (explicit); an empty LAST_CD means the HOOK_CWD
+      # fallback (bare push in session), which is NOT explicit.
+      [[ -n "$LAST_CD" ]] && PS_DIR_EXPLICIT=true
       PS_DIR="${LAST_CD:-$HOOK_CWD}"
     fi
     if [[ "$PUSH_SEEN" == "true" && "$PS_DIR" != "$PUSH_DIR" ]]; then
@@ -190,6 +199,7 @@ while read -r PS_START PS_LEN; do
     fi
     PUSH_SEEN=true
     PUSH_DIR="$PS_DIR"
+    PUSH_DIR_EXPLICIT="$PS_DIR_EXPLICIT"
   else
     # Track directory changes so a later push statement is judged where it runs. Words-mode hides
     # quoted content and substitutions, so an unreadable target is DETECTED rather than guessed at.
@@ -397,6 +407,21 @@ done <<< "$STATEMENT_RANGES"
 if [[ "$PUSH_DIR_CONFLICT" == "true" ]]; then
   echo "[pre-push-check] Blocked: this command pushes from two different repositories, and one" >&2
   echo "[pre-push-check] verdict cannot be about both. Split the pushes into separate commands." >&2
+  exit 2
+fi
+# A push whose directory was named EXPLICITLY — a `-C` or a tracked `cd` — but which is not a git
+# work tree at hook time is refused, not silently retargeted at the session checkout. `mkdir /x &&
+# cd /x && git init && git push` names /x; `validated` mode, finding /x is not (yet) a repository,
+# would fall back to CLAUDE_PROJECT_DIR and judge the MAIN checkout's branch and record — a false
+# pass for a push that lands in an unreviewed new repo, the #1662 direction this hook exists to
+# close. Every other unresolvable case here refuses; this one must too. Gated on PUSH_DIR_EXPLICIT
+# so the bare-`git push`-in-session case (PUSH_DIR is only the HOOK_CWD fallback) keeps the
+# existing "no git repository" handling at the PROJECT_DIR check below. (#1667 review)
+if [[ "$PUSH_DIR_EXPLICIT" == "true" ]] && ! hook_is_work_tree "$PUSH_DIR"; then
+  echo "[pre-push-check] Blocked: this push targets '$PUSH_DIR', which is not a git repository the" >&2
+  echo "[pre-push-check] hook can read now (it may be created later in the same command). Its branch" >&2
+  echo "[pre-push-check] and review record cannot be verified, and falling back to the session" >&2
+  echo "[pre-push-check] checkout would judge the wrong repository. Push from an existing checkout." >&2
   exit 2
 fi
 # `validated` still applies its work-tree test to what the statement walk produced; the project dir

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -163,7 +163,16 @@ while read -r PS_START PS_LEN; do
     '||'* | '&&'*) : ;;
     '|'* | '&'*) PS_SUBSHELLED=true ;;
   esac
-  PS_MASK=$(hook_verb_scan "$COMMAND" "$PS_START" "$PS_LEN")
+  # Guarded like its siblings below: a bare `PS_MASK=$(…)` aborts the whole hook under set -e if
+  # hook_verb_scan returns non-zero on a statement slice, exiting 1 with nothing said — which the
+  # protocol reads as non-blocking (fail-OPEN, a push-review gate silently skipped). An unreadable
+  # statement is refused: whether it is a push, and which repository it targets, is unknown. (#1667)
+  if ! PS_MASK=$(hook_verb_scan "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null); then
+    echo "[pre-push-check] Blocked: a statement in this command could not be read, so whether it" >&2
+    echo "[pre-push-check] is a push — and which repository it would act on — is unknown. This is" >&2
+    echo "[pre-push-check] not a pass." >&2
+    exit 2
+  fi
   if printf '%s' "$PS_MASK" | grep -qE "$RE_PUSH_STMT"; then
     # Whether this push's directory was named EXPLICITLY — a `-C` or a tracked `cd` — as opposed
     # to the HOOK_CWD fallback (the bare-`git push`-in-session case). Only an explicit target that

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -245,8 +245,17 @@ while read -r PS_START PS_LEN; do
       # stack rotation (`+N`/`-N`), a word still carrying a subshell paren — `(cd x) && push`
       # changes no directory the push will see — or a quote character, the tokenizer's mark of
       # hidden content (a quoted target with inner spaces words as bare quote marks).
+      #
+      # The closing paren need not glue to the target: `( cd x ) && push` tokenizes the `)` as
+      # its own word, so the slice AFTER the target is tested too — a `)` there means the
+      # subshell closed before the push, and the outer directory is not what this walk just
+      # read. Only the tail is tested, because a paren BEFORE the target is a different fact:
+      # an env-prefix substitution (`V=$(x) cd /repo`) closes ITS paren before `cd`, and the
+      # target is still literal. The residue is a `)` in a trailing comment, which refuses —
+      # fail-closed, and the shape is not one an agent writes. (#1667 review)
+      PS_TAIL="${PS_RAW##*"$PS_SECOND"}"
       UNREADABLE_TARGET="$TARGET_HIDDEN"
-      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* ]] \
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* || "$PS_TAIL" == *')'* ]] \
         || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
         UNREADABLE_TARGET=true
       fi

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -92,7 +92,11 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # because this line is the whole file's entry point, the branch-hygiene check, the lockfile-sync
 # check and the local-review record were all skipped for that shape. Two guards reading one command
 # must reach one reading of it.
-printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)' || exit 0
+# ONE spelling of "this statement is a push", shared with the per-statement walk below — a second
+# copy of the pattern is a second answer waiting to disagree (#1667 review; lib/command-scan.sh
+# carries this file's history of exactly that).
+RE_PUSH_STMT='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)'
+printf '%s' "$COMMAND_VERBS" | grep -qE "$RE_PUSH_STMT" || exit 0
 
 # Worktree-aware context resolution — the repository the push will ACTUALLY act on (#1662).
 #
@@ -114,7 +118,6 @@ printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:
 # repository is being pushed has not verified anything about it. Two push statements resolving to
 # different repositories refuse for the same reason.
 HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
-RE_PUSH_STMT='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)'
 PUSH_DIR=""
 PUSH_DIR_CONFLICT=false
 LAST_CD=""
@@ -150,6 +153,7 @@ while read -r PS_START PS_LEN; do
     PS_WORDS=$(hook_statement_words "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null || printf '')
     PS_FIRST=""
     PS_SECOND=""
+    PS_THIRD=""
     PS_INDEX=0
     while IFS= read -r PS_W; do
       [[ -n "$PS_W" || "$PS_INDEX" -gt 0 ]] || continue
@@ -157,19 +161,35 @@ while read -r PS_START PS_LEN; do
       PS_INDEX=$((PS_INDEX + 1))
       [[ "$PS_INDEX" -eq 1 ]] && PS_FIRST="$PS_W"
       [[ "$PS_INDEX" -eq 2 ]] && PS_SECOND="$PS_W"
-      [[ "$PS_INDEX" -ge 3 ]] && break
+      [[ "$PS_INDEX" -eq 3 ]] && PS_THIRD="$PS_W"
+      [[ "$PS_INDEX" -ge 4 ]] && break
     done <<< "$PS_WORDS"
     if [[ "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" ]]; then
+      # `cd -- <path>`: the end-of-options marker is not the target — the next word is.
+      [[ "$PS_SECOND" == "--" && -n "$PS_THIRD" ]] && PS_SECOND="$PS_THIRD"
       # A target this hook cannot resolve: empty (quoted away), `-`/flags, a variable or
-      # substitution (`$DIR`), or `~` (the hook does not expand another process's home).
-      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* ]]; then
+      # substitution (`$DIR`), `~` (the hook does not expand another process's home), or a
+      # `pushd` stack rotation (`+N`/`-N`), which lands on a directory only the shell's stack knows.
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* ]] \
+        || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
         LAST_CD_UNREADABLE=true
       else
         case "$PS_SECOND" in
-          /*) LAST_CD="$PS_SECOND" ;;
-          *) LAST_CD="${HOOK_CWD:-.}/$PS_SECOND" ;;
+          /*)
+            LAST_CD="$PS_SECOND"
+            LAST_CD_UNREADABLE=false
+            ;;
+          *)
+            # A RELATIVE hop resolves against where the shell already stands: the last tracked
+            # `cd`, or the declared cwd when none. Resolving every hop against the declared cwd
+            # sent the second hop of `cd .. && cd sibling && git push` to the wrong path — and
+            # the fallback then judged the main clone, the exact pre-#1662 resolution, silently.
+            # After an UNREADABLE cd the base is unknown, so a relative hop stays unreadable.
+            if [[ "$LAST_CD_UNREADABLE" != "true" ]]; then
+              LAST_CD="${LAST_CD:-${HOOK_CWD:-.}}/$PS_SECOND"
+            fi
+            ;;
         esac
-        LAST_CD_UNREADABLE=false
       fi
     fi
   fi

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -144,9 +144,24 @@ while read -r PS_START PS_LEN; do
   # judging the wrong repository — the #1662 defect in its more dangerous under-refusing form. A
   # `||`-guarded directory change is therefore UNCERTAIN, not a definite base. (#1667 review)
   PS_CONNECTOR="${COMMAND:$PREV_STMT_END:$((PS_START - 1 - PREV_STMT_END))}"
-  PREV_STMT_END=$((PS_START - 1 + PS_LEN))
+  PS_STMT_END=$((PS_START - 1 + PS_LEN))
+  PREV_STMT_END="$PS_STMT_END"
   PS_OR_GUARDED=false
   [[ "$PS_CONNECTOR" == *'||'* ]] && PS_OR_GUARDED=true
+  # A `cd` that runs in a SUBSHELL never propagates its directory to a later statement, so its
+  # effect must be IGNORED, not carried forward. Both sides of a pipe run in subshells, and a
+  # backgrounded (`&`) command does too. The connector AFTER a statement is the operator that
+  # applies to IT — a background `&` and a pipe `|` bind to the command on their LEFT — while a
+  # pipe on the connector BEFORE binds to the command on its right. `||`/`&&` are two-char and
+  # must not be mistaken for the single `|`/`&`. (#1667 review)
+  PS_AFTER="${COMMAND:$PS_STMT_END}"
+  PS_AFTER="${PS_AFTER#"${PS_AFTER%%[![:space:]]*}"}"
+  PS_SUBSHELLED=false
+  [[ "$PS_CONNECTOR" != *'||'* && "$PS_CONNECTOR" == *'|'* ]] && PS_SUBSHELLED=true
+  case "$PS_AFTER" in
+    '||'* | '&&'*) : ;;
+    '|'* | '&'*) PS_SUBSHELLED=true ;;
+  esac
   PS_MASK=$(hook_verb_scan "$COMMAND" "$PS_START" "$PS_LEN")
   if printf '%s' "$PS_MASK" | grep -qE "$RE_PUSH_STMT"; then
     # 1. This statement's own `git -C`.
@@ -238,6 +253,13 @@ while read -r PS_START PS_LEN; do
       LAST_CD_UNREADABLE=true
       continue
     fi
+    # A subshell'd cd/pushd/popd (either side of a `|`, or backgrounded with `&`) changed a
+    # directory the parent shell never saw, so it is IGNORED — the base stays what it was, and a
+    # later push resolves to that, not to this phantom. Distinct from `||` above, which is
+    # UNCERTAIN (refuse): this one is certainly-no-effect. (#1667 review)
+    if [[ "$PS_SUBSHELLED" == "true" && ( "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" || "$PS_FIRST" == "popd" ) ]]; then
+      continue
+    fi
     if [[ "$PS_FIRST" == "popd" ]]; then
       # `popd` returns to the top of the stack this walk has been keeping. A stack this walk did
       # not see filled (no prior pushd), a rotation (`+N`), or a poisoned entry is a base only the
@@ -324,8 +346,14 @@ while read -r PS_START PS_LEN; do
       # read. Only the tail is tested, because a paren BEFORE the target is a different fact:
       # an env-prefix substitution (`V=$(x) cd /repo`) closes ITS paren before `cd`, and the
       # target is still literal. The residue is a `)` in a trailing comment, which refuses —
-      # fail-closed, and the shape is not one an agent writes. (#1667 review)
-      PS_TAIL="${PS_RAW##*"$PS_SECOND"}"
+      # fail-closed, and the shape is not one an agent writes.
+      #
+      # Cut at the FIRST occurrence of the target (`#`, not `##`): the target text can repeat
+      # later in the statement — most plausibly a redirection to the same path, `( cd /r ) 2>/r`
+      # — and cutting at the LAST occurrence put the real subshell-closing `)` (right after the
+      # cd arg) BEFORE the cut, leaving an empty tail that hid the close. The cd arg is the first
+      # occurrence. (#1667 review)
+      PS_TAIL="${PS_RAW#*"$PS_SECOND"}"
       UNREADABLE_TARGET="$TARGET_HIDDEN"
       if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* || "$PS_TAIL" == *')'* ]] \
         || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -177,6 +177,15 @@ while read -r PS_START PS_LEN; do
       PS_SECOND="$PS_THIRD"
       PS_THIRD=""
     fi
+    # `builtin cd`, `command cd` and `\cd` are the cd builtin wearing a bypass prefix — valid
+    # ways to skip a shell function or alias, and each left the walk blind to a real directory
+    # change: the push after one was judged where the shell no longer stood. (#1667 review)
+    if [[ "$PS_FIRST" == "builtin" || "$PS_FIRST" == "command" ]]; then
+      PS_FIRST="$PS_SECOND"
+      PS_SECOND="$PS_THIRD"
+      PS_THIRD=""
+    fi
+    PS_FIRST="${PS_FIRST#\\}"
     if [[ "$PS_FIRST" == "popd" ]]; then
       # `popd` returns to the top of the stack this walk has been keeping. A stack this walk did
       # not see filled (no prior pushd), a rotation (`+N`), or a poisoned entry is a base only the

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -156,6 +156,7 @@ while read -r PS_START PS_LEN; do
     PS_SECOND=""
     PS_THIRD=""
     PS_FOURTH=""
+    PS_FIFTH=""
     PS_INDEX=0
     while IFS= read -r PS_W; do
       [[ -n "$PS_W" || "$PS_INDEX" -gt 0 ]] || continue
@@ -165,7 +166,8 @@ while read -r PS_START PS_LEN; do
       [[ "$PS_INDEX" -eq 2 ]] && PS_SECOND="$PS_W"
       [[ "$PS_INDEX" -eq 3 ]] && PS_THIRD="$PS_W"
       [[ "$PS_INDEX" -eq 4 ]] && PS_FOURTH="$PS_W"
-      [[ "$PS_INDEX" -ge 5 ]] && break
+      [[ "$PS_INDEX" -eq 5 ]] && PS_FIFTH="$PS_W"
+      [[ "$PS_INDEX" -ge 6 ]] && break
     done <<< "$PS_WORDS"
     # A subshell opener glues to the first word — `(cd <dir> && git push)` reads as `(cd` — and
     # an unstripped paren made the whole idiom invisible to this tracking: the push was judged
@@ -178,7 +180,8 @@ while read -r PS_START PS_LEN; do
       PS_FIRST="$PS_SECOND"
       PS_SECOND="$PS_THIRD"
       PS_THIRD="$PS_FOURTH"
-      PS_FOURTH=""
+      PS_FOURTH="$PS_FIFTH"
+      PS_FIFTH=""
     fi
     # `builtin cd`, `command cd` and `\cd` are the cd builtin wearing a bypass prefix — valid
     # ways to skip a shell function or alias, and each left the walk blind to a real directory
@@ -189,7 +192,8 @@ while read -r PS_START PS_LEN; do
       PS_FIRST="$PS_SECOND"
       PS_SECOND="$PS_THIRD"
       PS_THIRD="$PS_FOURTH"
-      PS_FOURTH=""
+      PS_FOURTH="$PS_FIFTH"
+      PS_FIFTH=""
     done
     PS_FIRST="${PS_FIRST#\\}"
     if [[ "$PS_FIRST" == "popd" ]]; then
@@ -239,7 +243,10 @@ while read -r PS_START PS_LEN; do
       # substitution (`$DIR`), `~` (the hook does not expand another process's home), a `pushd`
       # stack rotation (`+N`/`-N`), or a word still carrying a subshell paren — `(cd x) && push`
       # changes no directory the push will see, and guessing would judge the wrong repository.
-      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* ]] \
+      # A quoted target with INNER SPACES words as bare quote characters (`""`), the tokenizer
+      # hiding the content — resolving that literally would judge a path of quote marks. Any
+      # quote character in the word means the real target is partly hidden. (#1667 review)
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* ]] \
         || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
         LAST_CD_UNREADABLE=true
       else

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -306,12 +306,19 @@ while read -r PS_START PS_LEN; do
     # matters here: a `||`-guarded NON-directory command (`foo || bar`) changes no directory, so
     # the base is unaffected and must not be poisoned. (#1667 review)
     if [[ "$PS_OR_GUARDED" == "true" && ( "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" || "$PS_FIRST" == "popd" ) ]]; then
-      # A `||`-guarded pushd MIGHT have run and pushed a frame, or might not — unlike a subshell'd
-      # pushd, which certainly did not. Leaving the stack untouched let a later popd pop an EARLIER
-      # real frame with false confidence: `pushd /A; false || pushd /B; popd; git push` would popd
-      # back to /A's saved dir as if certain. A `?` poison frame carries the uncertainty forward so
-      # that popd inherits it. (#1667 review)
-      [[ "$PS_FIRST" == "pushd" ]] && PUSHD_STACK+=("?")
+      # A `||`-guarded pushd/popd MIGHT have run, or might not — unlike a subshell'd one, which
+      # certainly did not. Leaving the stack untouched let a later UNCONDITIONAL popd resolve a
+      # frame with false confidence:
+      #   `pushd /A; false || pushd /B; popd; git push`  — the pushd may have pushed a frame, and
+      #   `pushd /A; pushd /B; false || popd; popd; git push` — the popd may have consumed one.
+      # A `?` poison carries the uncertainty forward: a guarded pushd APPENDS one (the frame it may
+      # have added), a guarded popd REPLACES the top (the frame it may have consumed), and either
+      # way the next popd inherits the `?` and reads unreadable. (#1667 review)
+      if [[ "$PS_FIRST" == "pushd" ]]; then
+        PUSHD_STACK+=("?")
+      elif [[ "$PS_FIRST" == "popd" && ${#PUSHD_STACK[@]} -gt 0 ]]; then
+        PUSHD_STACK[$(( ${#PUSHD_STACK[@]} - 1 ))]="?"
+      fi
       LAST_CD_UNREADABLE=true
       continue
     fi

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -135,11 +135,31 @@ if [[ -z "${STATEMENT_RANGES//[[:space:]]/}" ]]; then
   echo "[pre-push-check] repository this push acts on was never read. This is not a pass." >&2
   exit 2
 fi
+PREV_STMT_END=0
 while read -r PS_START PS_LEN; do
+  # The connector JOINING this statement to the previous one — the text in the gap the ranges
+  # discard. `A || B` runs B only when A FAILED, so the linear walk (every statement runs, in
+  # order) is wrong for a `||`-guarded statement: `cd /a || cd /b && git push` lands the push in
+  # /a when /a exists (|| short-circuits, cd /b never runs) but the walk would carry /b forward,
+  # judging the wrong repository — the #1662 defect in its more dangerous under-refusing form. A
+  # `||`-guarded directory change is therefore UNCERTAIN, not a definite base. (#1667 review)
+  PS_CONNECTOR="${COMMAND:$PREV_STMT_END:$((PS_START - 1 - PREV_STMT_END))}"
+  PREV_STMT_END=$((PS_START - 1 + PS_LEN))
+  PS_OR_GUARDED=false
+  [[ "$PS_CONNECTOR" == *'||'* ]] && PS_OR_GUARDED=true
   PS_MASK=$(hook_verb_scan "$COMMAND" "$PS_START" "$PS_LEN")
   if printf '%s' "$PS_MASK" | grep -qE "$RE_PUSH_STMT"; then
     # 1. This statement's own `git -C`.
     PS_DIR=$(hook_git_c_path "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null || printf '')
+    # A `||`-guarded push with no `-C` of its own runs only when the prior command FAILED — so
+    # the directory the walk tracked (from the branch that succeeded) is not where this push
+    # lands. Its base is unknowable; refuse rather than judge the wrong repository. (#1667 review)
+    if [[ -z "$PS_DIR" && "$PS_OR_GUARDED" == "true" ]]; then
+      echo "[pre-push-check] Blocked: this push runs only if a preceding command failed (\`||\`)," >&2
+      echo "[pre-push-check] so which directory it lands in depends on that failure and cannot be" >&2
+      echo "[pre-push-check] read here. Name the repository explicitly: git -C <path> push …" >&2
+      exit 2
+    fi
     if [[ -z "$PS_DIR" ]]; then
       # 2. The last `cd` seen before this statement.
       if [[ "$LAST_CD_UNREADABLE" == "true" ]]; then
@@ -161,6 +181,7 @@ while read -r PS_START PS_LEN; do
     # A statement whose words cannot be READ is a statement whose directory changes cannot be
     # seen — the same answer every other unknowable gets, not a silent skip that leaves a later
     # push trusting a stale base. (#1667 review)
+    #
     if ! PS_WORDS=$(hook_statement_words "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null); then
       LAST_CD_UNREADABLE=true
       continue
@@ -209,6 +230,14 @@ while read -r PS_START PS_LEN; do
       PS_FIFTH=""
     done
     PS_FIRST="${PS_FIRST#\\}"
+    # A `||`-guarded directory change runs only if the prior command failed, so whether it took
+    # effect is unknowable — the base is uncertain, not the value it names. Only a cd/pushd/popd
+    # matters here: a `||`-guarded NON-directory command (`foo || bar`) changes no directory, so
+    # the base is unaffected and must not be poisoned. (#1667 review)
+    if [[ "$PS_OR_GUARDED" == "true" && ( "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" || "$PS_FIRST" == "popd" ) ]]; then
+      LAST_CD_UNREADABLE=true
+      continue
+    fi
     if [[ "$PS_FIRST" == "popd" ]]; then
       # `popd` returns to the top of the stack this walk has been keeping. A stack this walk did
       # not see filled (no prior pushd), a rotation (`+N`), or a poisoned entry is a base only the

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -290,9 +290,19 @@ while read -r PS_START PS_LEN; do
     if [[ "$PUSH_SEEN" == "true" && "$_PS_DIR_NORM" != "$_PUSH_DIR_NORM" ]]; then
       PUSH_DIR_CONFLICT=true
     fi
+    # OR-latch the "was any push to this dir EXPLICIT?" invariant rather than overwriting it with
+    # the last statement's value. Two pushes to the same normalized dir where one is explicit
+    # (`cd`/`-C`) and one is the HOOK_CWD fallback would otherwise let the fallback's `false` flip
+    # it off, skipping the not-a-work-tree refusal below. No current bypass (the shapes converge on
+    # the already-permitted bare-push-in-session path), but the invariant should not hinge on
+    # statement order. (#1667 review)
+    if [[ "$PUSH_SEEN" == "true" ]]; then
+      if [[ "$PS_DIR_EXPLICIT" == "true" ]]; then PUSH_DIR_EXPLICIT=true; fi
+    else
+      PUSH_DIR_EXPLICIT="$PS_DIR_EXPLICIT"
+    fi
     PUSH_SEEN=true
     PUSH_DIR="$PS_DIR"
-    PUSH_DIR_EXPLICIT="$PS_DIR_EXPLICIT"
   else
     # Track directory changes so a later push statement is judged where it runs. Words-mode hides
     # quoted content and substitutions, so an unreadable target is DETECTED rather than guessed at.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -224,6 +224,28 @@ while read -r PS_START PS_LEN; do
           LAST_CD_UNREADABLE=false
         fi
       fi
+    elif [[ "$PS_FIRST" == "pushd" && -z "$PS_SECOND" ]]; then
+      # A bare `pushd` (no argument) does NOT go somewhere unknowable: bash swaps the top two
+      # directory-stack entries and cd's to the new top — a directory this walk already knows.
+      # Its model holds LAST_CD (the current dir) and PUSHD_STACK (the saved pre-pushd dirs),
+      # so the swap exchanges LAST_CD with the stack top. Bash errors on a bare pushd with fewer
+      # than two dirs on the stack (no prior pushd here), and a poisoned top or an unreadable
+      # LAST_CD leaves the destination unknown — those refuse. Otherwise this is the ordinary
+      # `pushd /a && pushd && git push` idiom that lands back where it began, and refusing it
+      # was an over-refusal not covered by any earlier case. (#1667 review)
+      if [[ ${#PUSHD_STACK[@]} -eq 0 || "$LAST_CD_UNREADABLE" == "true" ]]; then
+        LAST_CD_UNREADABLE=true
+      else
+        _PUSHD_TOP=$(( ${#PUSHD_STACK[@]} - 1 ))
+        _PUSHD_SWAP="${PUSHD_STACK[$_PUSHD_TOP]}"
+        if [[ "$_PUSHD_SWAP" == "?" ]]; then
+          LAST_CD_UNREADABLE=true
+        else
+          PUSHD_STACK[$_PUSHD_TOP]="${LAST_CD:-${HOOK_CWD:-.}}"
+          LAST_CD="$_PUSHD_SWAP"
+          LAST_CD_UNREADABLE=false
+        fi
+      fi
     elif [[ "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" ]]; then
       # `cd -- <path>`: the end-of-options marker is not the target — the next word is.
       [[ "$PS_SECOND" == "--" && -n "$PS_THIRD" ]] && PS_SECOND="$PS_THIRD"

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -151,7 +151,13 @@ while read -r PS_START PS_LEN; do
   else
     # Track directory changes so a later push statement is judged where it runs. Words-mode hides
     # quoted content and substitutions, so an unreadable target is DETECTED rather than guessed at.
-    PS_WORDS=$(hook_statement_words "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null || printf '')
+    # A statement whose words cannot be READ is a statement whose directory changes cannot be
+    # seen — the same answer every other unknowable gets, not a silent skip that leaves a later
+    # push trusting a stale base. (#1667 review)
+    if ! PS_WORDS=$(hook_statement_words "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null); then
+      LAST_CD_UNREADABLE=true
+      continue
+    fi
     PS_FIRST=""
     PS_SECOND=""
     PS_THIRD=""

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -223,31 +223,40 @@ while read -r PS_START PS_LEN; do
       [[ "$PS_SECOND" == "--" && -n "$PS_THIRD" ]] && PS_SECOND="$PS_THIRD"
       # A substitution EMBEDDED in the target is invisible to words-mode: `cd /pre$(x)post`
       # yields the word `/prepost`, the inner content AND its delimiters dropped — a clean-looking
-      # literal that is not where the shell will land. The raw statement text still carries the
-      # `$`/backtick, so the raw slice is what says this target cannot be read. (#1667 review)
+      # literal that is not where the shell will land. The raw TARGET TOKEN still carries the
+      # `$`/backtick — and it is the token that is scanned, not the whole statement, or an
+      # env-var prefix (`V=$(x) cd ../sibling`) would refuse a perfectly literal target.
+      # (#1667 review, both rounds)
       PS_RAW="${COMMAND:$((PS_START - 1)):$PS_LEN}"
-      if [[ "$PS_RAW" == *'$'* || "$PS_RAW" == *'`'* ]]; then
-        LAST_CD_UNREADABLE=true
-        continue
+      RAW_TGT=$(printf '%s' "$PS_RAW" | grep -oE "(^|[^[:alnum:]_-])${PS_FIRST}[[:space:]]+(--[[:space:]]+)?[^[:space:]]+" | head -1 | awk '{print $NF}') || RAW_TGT=""
+      TARGET_HIDDEN=false
+      if [[ "$RAW_TGT" == *'$'* || "$RAW_TGT" == *'`'* ]]; then
+        TARGET_HIDDEN=true
+      fi
+      # A target this hook cannot resolve, decided BEFORE the stack is touched: empty (quoted
+      # away), `-`/flags, a variable or substitution (`$DIR`, or one EMBEDDED in the token —
+      # TARGET_HIDDEN above), `~` (the hook does not expand another process's home), a `pushd`
+      # stack rotation (`+N`/`-N`), a word still carrying a subshell paren — `(cd x) && push`
+      # changes no directory the push will see — or a quote character, the tokenizer's mark of
+      # hidden content (a quoted target with inner spaces words as bare quote marks).
+      UNREADABLE_TARGET="$TARGET_HIDDEN"
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* ]] \
+        || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
+        UNREADABLE_TARGET=true
       fi
       # `pushd` remembers where the shell stood, or that it could not tell (`?`), so a later
-      # `popd` restores exactly what this walk knew at the push.
+      # `popd` restores exactly what this walk knew at the push. The frame is pushed for EVERY
+      # pushd, poisoned when the target is unreadable: the real pushd moved the stack one frame
+      # (or failed and moved it none — unknowable), and a stack one frame short handed popd the
+      # wrong directory with full confidence. (#1667 review)
       if [[ "$PS_FIRST" == "pushd" ]]; then
-        if [[ "$LAST_CD_UNREADABLE" == "true" ]]; then
+        if [[ "$LAST_CD_UNREADABLE" == "true" || "$UNREADABLE_TARGET" == "true" ]]; then
           PUSHD_STACK+=("?")
         else
           PUSHD_STACK+=("${LAST_CD:-${HOOK_CWD:-.}}")
         fi
       fi
-      # A target this hook cannot resolve: empty (quoted away), `-`/flags, a variable or
-      # substitution (`$DIR`), `~` (the hook does not expand another process's home), a `pushd`
-      # stack rotation (`+N`/`-N`), or a word still carrying a subshell paren — `(cd x) && push`
-      # changes no directory the push will see, and guessing would judge the wrong repository.
-      # A quoted target with INNER SPACES words as bare quote characters (`""`), the tokenizer
-      # hiding the content — resolving that literally would judge a path of quote marks. Any
-      # quote character in the word means the real target is partly hidden. (#1667 review)
-      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* ]] \
-        || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
+      if [[ "$UNREADABLE_TARGET" == "true" ]]; then
         LAST_CD_UNREADABLE=true
       else
         case "$PS_SECOND" in

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -133,6 +133,18 @@ LAST_CD_UNREADABLE=false
 # only if the push is `&&`-chained back to it. (#1667 review)
 LAST_CD_CONDITIONAL=false
 PUSHD_STACK=()
+# Subshell scope. A `cd` inside `( … )` applies to commands WITHIN that subshell but NEVER to the
+# parent shell after the `)` — `(cd /w && npm ci); git push` runs the push in the ORIGINAL dir, not
+# /w. A single-statement `PS_TAIL` check saw only a `)` in the same statement as the cd; a subshell
+# spanning statements (`(cd /w`, then `npm ci)`) leaked its cd past the close entirely. So the dir
+# state is SAVED at every `(` and RESTORED at every `)`: a cd done inside is visible until the close
+# and discarded after. Closes are applied at the TOP of the NEXT statement (and after the loop), so
+# a push in the SAME statement as its own closing `)` — `(cd /w && git push)` — still resolves
+# against the in-subshell dir before the restore. (#1667 review)
+SUBSHELL_STACK_CD=()
+SUBSHELL_STACK_UNREAD=()
+SUBSHELL_STACK_COND=()
+PENDING_CLOSES=0
 STATEMENT_RANGES=$(hook_statement_ranges "$COMMAND" || printf '')
 if [[ -z "${STATEMENT_RANGES//[[:space:]]/}" ]]; then
   echo "[pre-push-check] Blocked: the command could not be split into statements, so which" >&2
@@ -184,6 +196,47 @@ while read -r PS_START PS_LEN; do
     echo "[pre-push-check] not a pass." >&2
     exit 2
   fi
+  # Subshell CLOSES pending from the previous statement are applied HERE, before this statement runs
+  # — restoring the dir state saved at the matching `(`. Deferring to the next statement's top (not
+  # the end of the closing statement) means a push sharing a statement with its own `)` has already
+  # resolved against the in-subshell dir. (#1667 review)
+  while (( PENDING_CLOSES > 0 )); do
+    if (( ${#SUBSHELL_STACK_CD[@]} > 0 )); then
+      _SS_TOP=$(( ${#SUBSHELL_STACK_CD[@]} - 1 ))
+      LAST_CD="${SUBSHELL_STACK_CD[$_SS_TOP]}"
+      LAST_CD_UNREADABLE="${SUBSHELL_STACK_UNREAD[$_SS_TOP]}"
+      LAST_CD_CONDITIONAL="${SUBSHELL_STACK_COND[$_SS_TOP]}"
+      unset "SUBSHELL_STACK_CD[$_SS_TOP]" "SUBSHELL_STACK_UNREAD[$_SS_TOP]" "SUBSHELL_STACK_COND[$_SS_TOP]"
+    fi
+    PENDING_CLOSES=$((PENDING_CLOSES - 1))
+  done
+  # This statement's own SUBSHELL-GROUP parens, counted on the MASK (quoted parens are fill). A
+  # command/process substitution — `$( … )`, `<( … )`, `>( … )` — is NOT a subshell that scopes the
+  # surrounding cd: `cd /pre$(x)post` runs the cd in the CURRENT shell, the `$( )` only produces
+  # part of the argument. Its parens are balanced within the one statement, so they are subtracted
+  # from both the open and close counts and never trigger a save/restore (which would erase the
+  # target-is-unreadable verdict the `$` earns). STATED LIMIT: arithmetic `$(( … ))` / `(( … ))` is
+  # not special-cased — rare on a push command line, and its extra paren fails toward a refusal, not
+  # a bypass. (#1667 review)
+  _SS_ALLOPEN="${PS_MASK//[^(]/}"
+  _SS_ALLCLOSE="${PS_MASK//[^)]/}"
+  _SS_CMDSUB=0
+  for _SS_PAT in '$(' '<(' '>('; do
+    _SS_STRIPPED="${PS_MASK//"$_SS_PAT"/}"
+    _SS_CMDSUB=$(( _SS_CMDSUB + (${#PS_MASK} - ${#_SS_STRIPPED}) / 2 ))
+  done
+  _SS_OPENS_N=$(( ${#_SS_ALLOPEN} - _SS_CMDSUB ))
+  _SS_CLOSES_N=$(( ${#_SS_ALLCLOSE} - _SS_CMDSUB ))
+  if (( _SS_OPENS_N < 0 )); then _SS_OPENS_N=0; fi
+  if (( _SS_CLOSES_N < 0 )); then _SS_CLOSES_N=0; fi
+  _SS_I=0
+  while (( _SS_I < _SS_OPENS_N )); do
+    SUBSHELL_STACK_CD+=("$LAST_CD")
+    SUBSHELL_STACK_UNREAD+=("$LAST_CD_UNREADABLE")
+    SUBSHELL_STACK_COND+=("$LAST_CD_CONDITIONAL")
+    _SS_I=$((_SS_I + 1))
+  done
+  PENDING_CLOSES=$_SS_CLOSES_N
   if printf '%s' "$PS_MASK" | grep -qE "$RE_PUSH_STMT"; then
     # Whether this push's directory was named EXPLICITLY — a `-C` or a tracked `cd` — as opposed
     # to the HOOK_CWD fallback (the bare-`git push`-in-session case). Only an explicit target that
@@ -412,22 +465,12 @@ while read -r PS_START PS_LEN; do
       # changes no directory the push will see — or a quote character, the tokenizer's mark of
       # hidden content (a quoted target with inner spaces words as bare quote marks).
       #
-      # The closing paren need not glue to the target: `( cd x ) && push` tokenizes the `)` as
-      # its own word, so the slice AFTER the target is tested too — a `)` there means the
-      # subshell closed before the push, and the outer directory is not what this walk just
-      # read. Only the tail is tested, because a paren BEFORE the target is a different fact:
-      # an env-prefix substitution (`V=$(x) cd /repo`) closes ITS paren before `cd`, and the
-      # target is still literal. The residue is a `)` in a trailing comment, which refuses —
-      # fail-closed, and the shape is not one an agent writes.
-      #
-      # Cut at the FIRST occurrence of the target (`#`, not `##`): the target text can repeat
-      # later in the statement — most plausibly a redirection to the same path, `( cd /r ) 2>/r`
-      # — and cutting at the LAST occurrence put the real subshell-closing `)` (right after the
-      # cd arg) BEFORE the cut, leaving an empty tail that hid the close. The cd arg is the first
-      # occurrence. (#1667 review)
-      PS_TAIL="${PS_RAW#*"$PS_SECOND"}"
+      # Closing a subshell is handled globally by the SUBSHELL_STACK save/restore above — a cd
+      # inside `( … )`, however many statements the group spans, is discarded at its `)`. So the
+      # per-target `)` tail check that used to live here is gone; what remains is the target itself
+      # carrying a `(`/`)`, which is hidden content in the token, not a subshell boundary. (#1667)
       UNREADABLE_TARGET="$TARGET_HIDDEN"
-      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* || "$PS_TAIL" == *')'* ]] \
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* || "$PS_SECOND" == *'('* || "$PS_SECOND" == *')'* || "$PS_SECOND" == *'"'* || "$PS_SECOND" == *"'"* ]] \
         || [[ "$PS_FIRST" == "pushd" && "$PS_SECOND" == +* ]]; then
         UNREADABLE_TARGET=true
       fi

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -176,8 +176,14 @@ while read -r PS_START PS_LEN; do
       if [[ -n "$PS_SECOND" ]] || [[ ${#PUSHD_STACK[@]} -eq 0 ]]; then
         LAST_CD_UNREADABLE=true
       else
-        LAST_CD="${PUSHD_STACK[-1]}"
-        unset 'PUSHD_STACK[-1]'
+        # Indexed from the length, not a negative subscript: bash gained negative array indices
+        # in 4.3, and macOS ships /bin/bash at 3.2 — where the negative form is a fatal expansion
+        # error that, under set -e, kills the hook with a non-2 exit the protocol reads as PASS.
+        # A guard whose newest line fail-opens an entire platform is the exact silence it exists
+        # to refuse. (#1667 review)
+        _PUSHD_TOP=$(( ${#PUSHD_STACK[@]} - 1 ))
+        LAST_CD="${PUSHD_STACK[$_PUSHD_TOP]}"
+        unset "PUSHD_STACK[$_PUSHD_TOP]"
         if [[ "$LAST_CD" == "?" ]]; then
           LAST_CD=""
           LAST_CD_UNREADABLE=true

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -119,6 +119,12 @@ printf '%s' "$COMMAND_VERBS" | grep -qE "$RE_PUSH_STMT" || exit 0
 # different repositories refuse for the same reason.
 HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
 PUSH_DIR=""
+# A SEEN flag, not `-n "$PUSH_DIR"`, decides whether a prior push exists: the first push can
+# legitimately resolve to the EMPTY string (no cwd in the payload — "Absence is normal" — no `cd`,
+# no `-C`, the bare-push-in-session case that falls back to the project dir). Testing `-n` then
+# read that empty first push as "no push yet", so a second push to a DIFFERENT repo overwrote it
+# with no conflict and the first push went unverified. (#1667 review)
+PUSH_SEEN=false
 PUSH_DIR_CONFLICT=false
 LAST_CD=""
 LAST_CD_UNREADABLE=false
@@ -144,9 +150,10 @@ while read -r PS_START PS_LEN; do
       fi
       PS_DIR="${LAST_CD:-$HOOK_CWD}"
     fi
-    if [[ -n "$PUSH_DIR" && "$PS_DIR" != "$PUSH_DIR" ]]; then
+    if [[ "$PUSH_SEEN" == "true" && "$PS_DIR" != "$PUSH_DIR" ]]; then
       PUSH_DIR_CONFLICT=true
     fi
+    PUSH_SEEN=true
     PUSH_DIR="$PS_DIR"
   else
     # Track directory changes so a later push statement is judged where it runs. Words-mode hides

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -234,7 +234,12 @@ while read -r PS_START PS_LEN; do
       # env-var prefix (`V=$(x) cd ../sibling`) would refuse a perfectly literal target.
       # (#1667 review, both rounds)
       PS_RAW="${COMMAND:$((PS_START - 1)):$PS_LEN}"
-      RAW_TGT=$(printf '%s' "$PS_RAW" | grep -oE "(^|[^[:alnum:]_-])${PS_FIRST}[[:space:]]+(--[[:space:]]+)?[^[:space:]]+" | head -1 | awk '{print $NF}') || RAW_TGT=""
+      # EVERY raw occurrence is tested, not the first: `head -1` locked onto a decoy `cd `
+      # inside an env-prefix substitution (`V=$(cd /tmp) cd /repo$(echo evil)path`), and the
+      # real, substitution-bearing target was never inspected. The walk cannot know which
+      # occurrence is the live command word, so a `$`/backtick in ANY of them refuses —
+      # a decoy can only add a refusal, never launder a hidden target past one. (#1667 review)
+      RAW_TGT=$(printf '%s' "$PS_RAW" | grep -oE "(^|[^[:alnum:]_-])${PS_FIRST}[[:space:]]+(--[[:space:]]+)?[^[:space:]]+") || RAW_TGT=""
       TARGET_HIDDEN=false
       if [[ "$RAW_TGT" == *'$'* || "$RAW_TGT" == *'`'* ]]; then
         TARGET_HIDDEN=true

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -94,20 +94,95 @@ COMMAND_VERBS=$(hook_verb_scan "$COMMAND")
 # must reach one reading of it.
 printf '%s' "$COMMAND_VERBS" | grep -qE '(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)' || exit 0
 
-# Worktree-aware context resolution (parallel-wave lesson): judge the repo the command actually runs
-# in — `git -C <path>` in the command > hook-input `cwd` > project dir — never blindly the main clone.
+# Worktree-aware context resolution — the repository the push will ACTUALLY act on (#1662).
+#
+# The previous resolution took `git -C` from the whole command, then the DECLARED tool cwd, then the
+# project dir. For the shape pushes are actually written in here — `cd <worktree> && git push` —
+# that is exactly wrong: the `cd` runs after the hook has read the payload, there is no `-C`, and
+# the declared cwd is the MAIN clone. Measured (issue #1662): five worktree pushes, each with a
+# fresh 0-finding review recorded IN the worktree, all refused against the record of a sixth,
+# already-merged branch the main checkout happened to be parked on. And the mirror direction is the
+# one this hook exists for: a main checkout parked on a branch with a CURRENT record would wave an
+# unreviewed worktree push straight through.
+#
+# So the resolution follows the PUSH STATEMENT:
+#   1. that statement's own `git -C <path>`;
+#   2. else the LAST `cd <path>` in a statement BEFORE it, resolved against the declared cwd;
+#   3. else the declared cwd.
+# A `cd` whose target cannot be read (quoted away, a variable, `cd -`) REFUSES: the hook then knows
+# the push runs somewhere other than anywhere it can name, and a guard that cannot tell which
+# repository is being pushed has not verified anything about it. Two push statements resolving to
+# different repositories refuse for the same reason.
 HOOK_CWD=$(hook_cwd_of "$INPUT" || true)
-# One extractor, matched against a masked command so a quoted mention of `git -C` cannot
-# redirect this guard at another repository. The RAW command goes in: `hook_git_c_path` masks it
-# itself, by the grammar, and handing it a string a second reader had already mangled was the
-# bypass above. See lib/command-scan.sh.
-GIT_C_PATH=$(hook_git_c_path "$COMMAND" || true)
-# One resolution, four callers, three NAMED modes — see lib/hook-facts.sh. This caller takes
-# `validated`: it must name SOME repository, because its verdict is about the branch that
-# repository is on. The mode is named rather than inlined so the two DELIBERATE divergences beside
-# it (worktree-cwd-guard's first-nonempty fail-safe, and this hook's own `session` base check) stay
-# decisions with a reason instead of four copies that drift apart.
-PROJECT_DIR=$(hook_effective_repo validated "$GIT_C_PATH" "$HOOK_CWD" "${CLAUDE_PROJECT_DIR:-}")
+RE_PUSH_STMT='(^|[;&|({"'"'"'`]|[[:space:]])[[:space:]]*(\S+=\S+[[:space:]]+)*git[[:space:]]+((-C|-c)[[:space:]]+\S+[[:space:]]+)*push([^-[:alnum:]_]|$)'
+PUSH_DIR=""
+PUSH_DIR_CONFLICT=false
+LAST_CD=""
+LAST_CD_UNREADABLE=false
+STATEMENT_RANGES=$(hook_statement_ranges "$COMMAND" || printf '')
+if [[ -z "${STATEMENT_RANGES//[[:space:]]/}" ]]; then
+  echo "[pre-push-check] Blocked: the command could not be split into statements, so which" >&2
+  echo "[pre-push-check] repository this push acts on was never read. This is not a pass." >&2
+  exit 2
+fi
+while read -r PS_START PS_LEN; do
+  PS_MASK=$(hook_verb_scan "$COMMAND" "$PS_START" "$PS_LEN")
+  if printf '%s' "$PS_MASK" | grep -qE "$RE_PUSH_STMT"; then
+    # 1. This statement's own `git -C`.
+    PS_DIR=$(hook_git_c_path "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null || printf '')
+    if [[ -z "$PS_DIR" ]]; then
+      # 2. The last `cd` seen before this statement.
+      if [[ "$LAST_CD_UNREADABLE" == "true" ]]; then
+        echo "[pre-push-check] Blocked: a \`cd\` earlier in this command has a target this hook" >&2
+        echo "[pre-push-check] cannot read (quoted, a variable, or bare), so which repository the" >&2
+        echo "[pre-push-check] push acts on is unknown. Name it: git -C <path> push …" >&2
+        exit 2
+      fi
+      PS_DIR="${LAST_CD:-$HOOK_CWD}"
+    fi
+    if [[ -n "$PUSH_DIR" && "$PS_DIR" != "$PUSH_DIR" ]]; then
+      PUSH_DIR_CONFLICT=true
+    fi
+    PUSH_DIR="$PS_DIR"
+  else
+    # Track directory changes so a later push statement is judged where it runs. Words-mode hides
+    # quoted content and substitutions, so an unreadable target is DETECTED rather than guessed at.
+    PS_WORDS=$(hook_statement_words "$COMMAND" "$PS_START" "$PS_LEN" 2>/dev/null || printf '')
+    PS_FIRST=""
+    PS_SECOND=""
+    PS_INDEX=0
+    while IFS= read -r PS_W; do
+      [[ -n "$PS_W" || "$PS_INDEX" -gt 0 ]] || continue
+      case "$PS_W" in *=*) [[ "$PS_INDEX" -eq 0 ]] && continue ;; esac
+      PS_INDEX=$((PS_INDEX + 1))
+      [[ "$PS_INDEX" -eq 1 ]] && PS_FIRST="$PS_W"
+      [[ "$PS_INDEX" -eq 2 ]] && PS_SECOND="$PS_W"
+      [[ "$PS_INDEX" -ge 3 ]] && break
+    done <<< "$PS_WORDS"
+    if [[ "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" ]]; then
+      # A target this hook cannot resolve: empty (quoted away), `-`/flags, a variable or
+      # substitution (`$DIR`), or `~` (the hook does not expand another process's home).
+      if [[ -z "$PS_SECOND" || "$PS_SECOND" == "-" || "$PS_SECOND" == -* || "$PS_SECOND" == *'$'* || "$PS_SECOND" == *'`'* || "$PS_SECOND" == '~'* ]]; then
+        LAST_CD_UNREADABLE=true
+      else
+        case "$PS_SECOND" in
+          /*) LAST_CD="$PS_SECOND" ;;
+          *) LAST_CD="${HOOK_CWD:-.}/$PS_SECOND" ;;
+        esac
+        LAST_CD_UNREADABLE=false
+      fi
+    fi
+  fi
+done <<< "$STATEMENT_RANGES"
+if [[ "$PUSH_DIR_CONFLICT" == "true" ]]; then
+  echo "[pre-push-check] Blocked: this command pushes from two different repositories, and one" >&2
+  echo "[pre-push-check] verdict cannot be about both. Split the pushes into separate commands." >&2
+  exit 2
+fi
+# `validated` still applies its work-tree test to what the statement walk produced; the project dir
+# stays as the final fallback ONLY when neither a `-C`, a `cd`, nor the declared cwd named a work
+# tree — the bare-`git push`-in-the-session case, which is the one that fallback was for.
+PROJECT_DIR=$(hook_effective_repo validated "" "$PUSH_DIR" "${CLAUDE_PROJECT_DIR:-}")
 
 # A guard fails CLOSED, and two guards taking the same resolution must answer this the same way.
 # branch-guard refuses when nothing resolvable is a repository; this hook took the identical

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -155,6 +155,7 @@ while read -r PS_START PS_LEN; do
     PS_FIRST=""
     PS_SECOND=""
     PS_THIRD=""
+    PS_FOURTH=""
     PS_INDEX=0
     while IFS= read -r PS_W; do
       [[ -n "$PS_W" || "$PS_INDEX" -gt 0 ]] || continue
@@ -163,7 +164,8 @@ while read -r PS_START PS_LEN; do
       [[ "$PS_INDEX" -eq 1 ]] && PS_FIRST="$PS_W"
       [[ "$PS_INDEX" -eq 2 ]] && PS_SECOND="$PS_W"
       [[ "$PS_INDEX" -eq 3 ]] && PS_THIRD="$PS_W"
-      [[ "$PS_INDEX" -ge 4 ]] && break
+      [[ "$PS_INDEX" -eq 4 ]] && PS_FOURTH="$PS_W"
+      [[ "$PS_INDEX" -ge 5 ]] && break
     done <<< "$PS_WORDS"
     # A subshell opener glues to the first word — `(cd <dir> && git push)` reads as `(cd` — and
     # an unstripped paren made the whole idiom invisible to this tracking: the push was judged
@@ -175,16 +177,20 @@ while read -r PS_START PS_LEN; do
     if [[ -z "$PS_FIRST" ]]; then
       PS_FIRST="$PS_SECOND"
       PS_SECOND="$PS_THIRD"
-      PS_THIRD=""
+      PS_THIRD="$PS_FOURTH"
+      PS_FOURTH=""
     fi
     # `builtin cd`, `command cd` and `\cd` are the cd builtin wearing a bypass prefix — valid
     # ways to skip a shell function or alias, and each left the walk blind to a real directory
-    # change: the push after one was judged where the shell no longer stood. (#1667 review)
-    if [[ "$PS_FIRST" == "builtin" || "$PS_FIRST" == "command" ]]; then
+    # change: the push after one was judged where the shell no longer stood. STACKED prefixes
+    # (`command builtin cd`) unwrap one per loop turn, or the second prefix re-blinded the walk
+    # one word later. (#1667 review)
+    while [[ "$PS_FIRST" == "builtin" || "$PS_FIRST" == "command" ]]; do
       PS_FIRST="$PS_SECOND"
       PS_SECOND="$PS_THIRD"
-      PS_THIRD=""
-    fi
+      PS_THIRD="$PS_FOURTH"
+      PS_FOURTH=""
+    done
     PS_FIRST="${PS_FIRST#\\}"
     if [[ "$PS_FIRST" == "popd" ]]; then
       # `popd` returns to the top of the stack this walk has been keeping. A stack this walk did
@@ -211,6 +217,15 @@ while read -r PS_START PS_LEN; do
     elif [[ "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" ]]; then
       # `cd -- <path>`: the end-of-options marker is not the target — the next word is.
       [[ "$PS_SECOND" == "--" && -n "$PS_THIRD" ]] && PS_SECOND="$PS_THIRD"
+      # A substitution EMBEDDED in the target is invisible to words-mode: `cd /pre$(x)post`
+      # yields the word `/prepost`, the inner content AND its delimiters dropped — a clean-looking
+      # literal that is not where the shell will land. The raw statement text still carries the
+      # `$`/backtick, so the raw slice is what says this target cannot be read. (#1667 review)
+      PS_RAW="${COMMAND:$((PS_START - 1)):$PS_LEN}"
+      if [[ "$PS_RAW" == *'$'* || "$PS_RAW" == *'`'* ]]; then
+        LAST_CD_UNREADABLE=true
+        continue
+      fi
       # `pushd` remembers where the shell stood, or that it could not tell (`?`), so a later
       # `popd` restores exactly what this walk knew at the push.
       if [[ "$PS_FIRST" == "pushd" ]]; then

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -129,6 +129,9 @@ PUSH_DIR_EXPLICIT=false
 PUSH_DIR_CONFLICT=false
 LAST_CD=""
 LAST_CD_UNREADABLE=false
+# Whether the cd that set LAST_CD was itself CONDITIONAL (`&&`-guarded) — its effect is certain
+# only if the push is `&&`-chained back to it. (#1667 review)
+LAST_CD_CONDITIONAL=false
 PUSHD_STACK=()
 STATEMENT_RANGES=$(hook_statement_ranges "$COMMAND" || printf '')
 if [[ -z "${STATEMENT_RANGES//[[:space:]]/}" ]]; then
@@ -149,6 +152,14 @@ while read -r PS_START PS_LEN; do
   PREV_STMT_END="$PS_STMT_END"
   PS_OR_GUARDED=false
   [[ "$PS_CONNECTOR" == *'||'* ]] && PS_OR_GUARDED=true
+  # `&&` before a statement means it runs only if the PRIOR command succeeded — conditional, just
+  # like `||`, but in the other direction. A cd so guarded is CERTAIN to have taken effect only
+  # when the push is itself reached through an unbroken `&&` chain from it (push runs ⟹ every
+  # `&&`-linked command before it, including the cd, succeeded). If a `;` or `||` breaks that chain
+  # between the cd and the push, the cd may not have run while the push still does. Tracked here and
+  # resolved at the push. (#1667 review)
+  PS_AND_GUARDED=false
+  [[ "$PS_CONNECTOR" == *'&&'* ]] && PS_AND_GUARDED=true
   # A `cd` that runs in a SUBSHELL never propagates its directory to a later statement, so its
   # effect must be IGNORED, not carried forward. Both sides of a pipe run in subshells, and a
   # backgrounded (`&`) command does too. The connector AFTER a statement is the operator that
@@ -198,6 +209,18 @@ while read -r PS_START PS_LEN; do
         echo "[pre-push-check] push acts on is unknown. Name it: git -C <path> push …" >&2
         exit 2
       fi
+      # The tracked `cd` was CONDITIONAL (`&&`-guarded) and this push is not `&&`-chained back to
+      # it — a `;` or `||` sits between, so the push runs even if that cd never did, landing
+      # somewhere other than the dir the walk carried. `cd /A && git push` (push `&&`-chained) is
+      # certain and passes; `false && cd /A ; git push` (push `;`-separated) is not. Refuse the
+      # uncertain shape rather than judge the wrong repository. (#1667 review)
+      if [[ -n "$LAST_CD" && "$LAST_CD_CONDITIONAL" == "true" && "$PS_CONNECTOR" != *'&&'* ]]; then
+        echo "[pre-push-check] Blocked: a \`cd\` this push relies on runs only if a preceding" >&2
+        echo "[pre-push-check] command succeeded (\`&&\`), but this push is not chained to that" >&2
+        echo "[pre-push-check] success — it would run even where the cd did not. Which repository" >&2
+        echo "[pre-push-check] it lands in is unknown; name it: git -C <path> push …" >&2
+        exit 2
+      fi
       # A tracked `cd` named this directory (explicit); an empty LAST_CD means the HOOK_CWD
       # fallback (bare push in session), which is NOT explicit.
       [[ -n "$LAST_CD" ]] && PS_DIR_EXPLICIT=true
@@ -245,14 +268,20 @@ while read -r PS_START PS_LEN; do
       [[ "$PS_INDEX" -eq 5 ]] && PS_FIFTH="$PS_W"
       [[ "$PS_INDEX" -ge 6 ]] && break
     done <<< "$PS_WORDS"
-    # A subshell opener glues to the first word — `(cd <dir> && git push)` reads as `(cd` — and
+    # A subshell opener `(` glues to the first word — `(cd <dir> && git push)` reads as `(cd` — and
     # an unstripped paren made the whole idiom invisible to this tracking: the push was judged
-    # against the declared cwd, the exact wrong-repository answer this walk exists to end.
-    PS_FIRST="${PS_FIRST#"${PS_FIRST%%[!({]*}"}"
-    # A BRACE group is different: `{` must be its own space-delimited word (`{ cd dir; …`), so the
-    # stripped first word comes back empty and the `cd` sits one word later — shift, or the walk
-    # silently falls back to the declared cwd for a form bash itself accepts. (#1667 review)
-    if [[ -z "$PS_FIRST" ]]; then
+    # against the declared cwd, the exact wrong-repository answer this walk exists to end. Only `(`
+    # is stripped here: it is a shell metacharacter that always tokenizes on its own, so `(cd` is
+    # genuinely a cd.
+    PS_FIRST="${PS_FIRST#"${PS_FIRST%%[!(]*}"}"
+    # A BRACE group is different: `{` opens a group ONLY as its own space-delimited word (`{ cd
+    # dir; …`), where the first word is bare `{` and the cd sits one word later — shift. A GLUED
+    # `{cd` is NOT a group: bash runs it as the command `{cd`, which fails and changes no
+    # directory, so it must stay a non-cd token, not be stripped to `cd`. Stripping `{` in the
+    # same class as `(` read `{cd /reviewed-repo; git push` as a valid brace-group cd and judged
+    # /reviewed-repo while the real push ran in the unreviewed cwd (fail-open). The empty case is
+    # a bare `(` that stripped to nothing (`( cd dir …`). (#1667 review)
+    if [[ -z "$PS_FIRST" || "$PS_FIRST" == "{" ]]; then
       PS_FIRST="$PS_SECOND"
       PS_SECOND="$PS_THIRD"
       PS_THIRD="$PS_FOURTH"
@@ -277,6 +306,12 @@ while read -r PS_START PS_LEN; do
     # matters here: a `||`-guarded NON-directory command (`foo || bar`) changes no directory, so
     # the base is unaffected and must not be poisoned. (#1667 review)
     if [[ "$PS_OR_GUARDED" == "true" && ( "$PS_FIRST" == "cd" || "$PS_FIRST" == "pushd" || "$PS_FIRST" == "popd" ) ]]; then
+      # A `||`-guarded pushd MIGHT have run and pushed a frame, or might not — unlike a subshell'd
+      # pushd, which certainly did not. Leaving the stack untouched let a later popd pop an EARLIER
+      # real frame with false confidence: `pushd /A; false || pushd /B; popd; git push` would popd
+      # back to /A's saved dir as if certain. A `?` poison frame carries the uncertainty forward so
+      # that popd inherits it. (#1667 review)
+      [[ "$PS_FIRST" == "pushd" ]] && PUSHD_STACK+=("?")
       LAST_CD_UNREADABLE=true
       continue
     fi
@@ -306,6 +341,8 @@ while read -r PS_START PS_LEN; do
           LAST_CD=""
           LAST_CD_UNREADABLE=true
         else
+          # A `&&`-guarded popd is conditional like a `&&`-guarded cd. (#1667 review)
+          LAST_CD_CONDITIONAL="$PS_AND_GUARDED"
           LAST_CD_UNREADABLE=false
         fi
       fi
@@ -328,6 +365,7 @@ while read -r PS_START PS_LEN; do
         else
           PUSHD_STACK[$_PUSHD_TOP]="${LAST_CD:-${HOOK_CWD:-.}}"
           LAST_CD="$_PUSHD_SWAP"
+          LAST_CD_CONDITIONAL="$PS_AND_GUARDED"
           LAST_CD_UNREADABLE=false
         fi
       fi
@@ -405,6 +443,9 @@ while read -r PS_START PS_LEN; do
           /*)
             LAST_CD="$PS_SECOND"
             LAST_CD_UNREADABLE=false
+            # An ABSOLUTE cd does not depend on the base, so its conditionality is its OWN
+            # connector alone — reset, not inherited. (#1667 review)
+            LAST_CD_CONDITIONAL="$PS_AND_GUARDED"
             ;;
           *)
             # A RELATIVE hop resolves against where the shell already stands: the last tracked
@@ -414,6 +455,9 @@ while read -r PS_START PS_LEN; do
             # After an UNREADABLE cd the base is unknown, so a relative hop stays unreadable.
             if [[ "$LAST_CD_UNREADABLE" != "true" ]]; then
               LAST_CD="${LAST_CD:-${HOOK_CWD:-.}}/$PS_SECOND"
+              # A relative hop INHERITS the base's conditionality — if the base cd may not have
+              # run, neither did this hop off it — and adds its own. Never resets to certain.
+              [[ "$PS_AND_GUARDED" == "true" ]] && LAST_CD_CONDITIONAL=true
             fi
             ;;
         esac

--- a/scripts/harness/__tests__/hook-command-reachability.test.mjs
+++ b/scripts/harness/__tests__/hook-command-reachability.test.mjs
@@ -28,8 +28,12 @@ const COMPOUND_FORMS = [
   // no fixture here contained one, which is how that gap stayed invisible (HARNESS-061).
   (verb) => `echo "starting" && ${verb}`,
   (verb) => verb,
-  (verb) => `cd ${WORKSPACE_ROOT}\n${verb}`,
-  (verb) => `cd ${WORKSPACE_ROOT} && ${verb}`,
+  // The cd forms target the SCRATCH project, not the real workspace. pre-push-check now follows a
+  // `cd` to decide WHICH repository it judges (#1662/#1667), so a cd into the real tree made the
+  // probe's verdict depend on the real tree's review-record state — exactly the dependence this
+  // file's header forswears, surfaced the day the walk started honouring the cd.
+  (verb, dir) => `cd ${dir}\n${verb}`,
+  (verb, dir) => `cd ${dir} && ${verb}`,
   (verb) => `git status; ${verb}`,
 ];
 
@@ -119,7 +123,8 @@ describe('hooks are reachable from the command forms actually used', () => {
     // which is the whole question.
     it(`${hook} recognises its verb in every compound form`, { timeout: 120_000 }, () => {
       const reactions = COMPOUND_FORMS.map((shape) => {
-        const result = runHook(hook, shape(verb));
+        const projectDir = scratchProject();
+        const result = runHook(hook, shape(verb, projectDir), projectDir);
         // "Reacted" = said something or refused. Silence with status 0 is the bypass being measured.
         return result.output.trim().length > 0 || result.status !== 0;
       });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -237,6 +237,25 @@ describe('which repository the push verdict is about', () => {
     expect(status, `popd did not restore the tracked base:\n${output}`).toBe(0);
   });
 
+  it('detects a two-repo conflict even when the FIRST push resolves to the empty base', () => {
+    // No payload cwd (absence is normal), so the first `git push` resolves to the empty string —
+    // the bare-push-in-session case. A `-n "$PUSH_DIR"` conflict test read that as "no push yet",
+    // so a second push to a DIFFERENT repo overwrote it silently and the first went unverified. A
+    // SEEN flag distinguishes "no push" from "a push whose dir is empty". (#1667 review)
+    const other = repoOn('feat/other', { recorded: true });
+
+    const { status, output } = runHook(
+      `git push origin main && git -C ${other} push origin feat/other`,
+      undefined,
+    );
+
+    expect(
+      status,
+      `the first empty-resolved push was overwritten with no conflict:\n${output}`,
+    ).toBe(2);
+    expect(output).toMatch(/two different repositories/);
+  });
+
   it('follows a bare `pushd` swap back to the directory the shell began in', () => {
     // `cd <pushed> && pushd <other> && pushd && git push`: real bash's bare pushd swaps the top
     // two stack entries and cd's back to <pushed>. Treating an argument-less pushd as unreadable

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -120,6 +120,20 @@ describe('which repository the push verdict is about', () => {
     expect(status, `the ordinary case broke:\n${output}`).toBe(0);
   });
 
+  it('does not flag a trailing-slash spelling of the same repo as two repositories', () => {
+    // `git -C <A> push; git -C <A>/ push`: the same repo, two spellings. A raw string compare read
+    // them as a two-repo conflict and over-refused. The comparison normalizes trailing slashes.
+    // (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+
+    const { status, output } = runHook(
+      `git -C ${a} push origin feat/a; git -C ${a}/ push origin feat/a`,
+      a,
+    );
+
+    expect(status, `a trailing-slash spelling was read as a second repo:\n${output}`).toBe(0);
+  });
+
   it('resolves a SECOND relative cd against the first, not the declared cwd', () => {
     // `cd .. && cd <sibling> && git push` — every hop used to resolve against the declared cwd,
     // so the second landed on a path that does not exist and the fallback judged the main clone:

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -312,6 +312,24 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/cannot read/);
   });
 
+  it('poisons the stack for a `||`-guarded popd so a later popd inherits the uncertainty', () => {
+    // `pushd <A>; pushd <B>; false || popd; popd; git push`: the `||`-guarded popd MIGHT have
+    // consumed a frame. Leaving the stack untouched let the unconditional popd confidently pop
+    // <B>'s saved dir and judge it, while the real cwd was one level further out. The guarded popd
+    // now replaces the top with `?`, so the next popd reads unreadable → refuse. (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+    const b = repoOn('feat/b', { recorded: true });
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(
+      `pushd ${a}; pushd ${b}; false || popd; popd; git push origin x`,
+      parked,
+    );
+
+    expect(status, `a ||-guarded popd let a later popd resolve confidently:\n${output}`).toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('does not carry a PIPED cd forward — it ran in a subshell', () => {
     // `cd <A> | cat; git push`: the cd is the left of a pipe, so bash runs it in a subshell and
     // the parent cwd never changes — the push lands in the ORIGINAL dir, not <A>. The walk used

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -179,6 +179,24 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/cannot read/);
   });
 
+  it('a decoy cd in an env-prefix substitution does not launder the real hidden target', () => {
+    // The first `cd `-shaped substring is the harmless decoy inside the env prefix's
+    // substitution; locking onto it (`head -1`) left the real target's substitution
+    // uninspected, and LAST_CD silently became a path bash never resolves. Every occurrence is
+    // tested now, so the hidden one refuses. The backtick spelling is the one that leaked:
+    // a `$( )` decoy carries `)`, which the closed-subshell tail test already refuses, and a
+    // plain `$VAR` target survives words-mode into PS_SECOND's own `$` check. (#1667 review)
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(
+      'V=`cd /tmp ` cd /repo`evil`/path && git push origin x',
+      parked,
+    );
+
+    expect(status, 'the decoy cd laundered the substitution-bearing target').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('does not let a SPACED closed subshell cd leak either — `( cd x ) && push`', () => {
     // With spaces the closing paren tokenizes as its own word, which no per-word test sees.
     // The raw-slice test catches it: a `)` in a cd statement whose target read clean means

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -213,6 +213,21 @@ describe('which repository the push verdict is about', () => {
     expect(status, `the brace-group cd was invisible to the walk:\n${output}`).toBe(0);
   });
 
+  it('follows the cd behind a BYPASS prefix — `builtin cd`, `command cd`, `\\cd`', () => {
+    // Each is the cd builtin skipping a function or alias; each left the walk blind, so the
+    // push was judged where the shell no longer stood.
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    for (const spelling of ['builtin cd', 'command cd', '\\cd']) {
+      const { status, output } = runHook(
+        `${spelling} ${pushed} && git push origin feat/target`,
+        parked,
+      );
+      expect(status, `'${spelling}' was invisible to the walk:\n${output}`).toBe(0);
+    }
+  });
+
   it('treats a pushd stack rotation as a target it cannot read', () => {
     // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -275,6 +275,35 @@ describe('which repository the push verdict is about', () => {
     expect(status, `the fifth word (the path) was dropped:\n${output}`).toBe(0);
   });
 
+  it('an unreadable pushd still costs a stack frame — popd after it is unreadable', () => {
+    // Real bash moved the stack one frame (or failed and moved none — unknowable); a model one
+    // frame short handed popd the PREVIOUS directory with full confidence.
+    const parked = repoOn('feat/parked');
+    const known = repoOn('feat/known', { recorded: true });
+
+    const { status, output } = runHook(
+      `pushd ${known} && pushd "$UNKNOWN" && popd && git push origin x`,
+      parked,
+    );
+
+    expect(status, 'popd after an unreadable pushd resolved with confidence').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('an env-var prefix does not make a literal cd target unreadable', () => {
+    // The raw check is scoped to the TARGET TOKEN: `V=$(x) cd <literal>` carries its $ in the
+    // prefix, not the target.
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(
+      `SOME_VAR=$(echo hi) cd ${pushed} && git push origin feat/target`,
+      parked,
+    );
+
+    expect(status, `a prefix substitution refused a literal target:\n${output}`).toBe(0);
+  });
+
   it('treats a pushd stack rotation as a target it cannot read', () => {
     // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -228,6 +228,29 @@ describe('which repository the push verdict is about', () => {
     }
   });
 
+  it('treats a target with an EMBEDDED substitution as unreadable', () => {
+    // `cd /pre$(x)post` words as the clean-looking literal `/prepost` — the substitution and its
+    // delimiters are dropped by words-mode — which is not where the shell will land.
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('cd /pre$(x)post && git push origin x', parked);
+
+    expect(status, 'an embedded substitution resolved as a literal path').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('unwraps STACKED bypass prefixes — `command builtin cd`', () => {
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(
+      `command builtin cd ${pushed} && git push origin feat/target`,
+      parked,
+    );
+
+    expect(status, `the stacked prefixes re-blinded the walk:\n${output}`).toBe(0);
+  });
+
   it('treats a pushd stack rotation as a target it cannot read', () => {
     // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -237,6 +237,43 @@ describe('which repository the push verdict is about', () => {
     expect(status, `popd did not restore the tracked base:\n${output}`).toBe(0);
   });
 
+  it('does not carry a PIPED cd forward — it ran in a subshell', () => {
+    // `cd <A> | cat; git push`: the cd is the left of a pipe, so bash runs it in a subshell and
+    // the parent cwd never changes — the push lands in the ORIGINAL dir, not <A>. The walk used
+    // to record <A> and validate the wrong repo. A subshell'd cd is ignored, so the push
+    // resolves to the declared cwd (here a repo with no record → refuse). (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`cd ${a} | cat; git push origin x`, parked);
+
+    expect(status, `a piped cd was carried forward as the base:\n${output}`).toBe(2);
+  });
+
+  it('does not carry a BACKGROUNDED cd forward — it ran in a subshell', () => {
+    // `cd <A> & git push`: the `&` backgrounds the cd in a subshell; the push runs in the parent
+    // cwd, not <A>. (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`cd ${a} & git push origin x`, parked);
+
+    expect(status, `a backgrounded cd was carried forward as the base:\n${output}`).toBe(2);
+  });
+
+  it('sees a subshell close even when the target path repeats in a redirection', () => {
+    // `( cd <A> ) 2><A> && git push`: the target text repeats in the redirection, so cutting the
+    // tail at the LAST occurrence hid the real closing `)` right after the cd arg. Cutting at the
+    // FIRST occurrence sees it — the closed subshell's cd must not leak. (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(`( cd ${a} ) 2>${a} && git push origin x`, parked);
+
+    expect(status, `a repeated path hid the subshell close:\n${output}`).toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('does not carry a `||`-guarded cd forward as a definite base', () => {
     // `cd <A> || cd <B> && git push`: bash runs `cd <B>` only if `cd <A>` FAILED, so with <A>
     // present the push lands in <A> — but the linear walk carried <B> forward and judged the

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -119,4 +119,49 @@ describe('which repository the push verdict is about', () => {
 
     expect(status, `the ordinary case broke:\n${output}`).toBe(0);
   });
+
+  it('resolves a SECOND relative cd against the first, not the declared cwd', () => {
+    // `cd .. && cd <sibling> && git push` — every hop used to resolve against the declared cwd,
+    // so the second landed on a path that does not exist and the fallback judged the main clone:
+    // the pre-#1662 resolution, silently, for exactly this shape. (#1667 review)
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(
+      `cd .. && cd ${path.basename(pushed)} && git push origin feat/target`,
+      parked,
+    );
+
+    expect(status, `the chained relative cd was judged against the wrong repo:\n${output}`).toBe(0);
+  });
+
+  it('keeps a relative cd AFTER an unreadable one unreadable', () => {
+    // The base of the hop is unknown, so the hop is too — resolving it against the declared cwd
+    // would be the same silent regression one directory later.
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('cd "$SOMEWHERE" && cd sub && git push origin x', parked);
+
+    expect(status, 'a relative cd laundered the unreadable base').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('reads the target after a `--` end-of-options marker', () => {
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`cd -- ${pushed} && git push origin feat/target`, parked);
+
+    expect(status, `cd -- <path> was treated as unreadable:\n${output}`).toBe(0);
+  });
+
+  it('treats a pushd stack rotation as a target it cannot read', () => {
+    // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('pushd +1 && git push origin x', parked);
+
+    expect(status, 'a stack rotation was concatenated onto the cwd as a directory name').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
 });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -251,6 +251,30 @@ describe('which repository the push verdict is about', () => {
     expect(status, `the stacked prefixes re-blinded the walk:\n${output}`).toBe(0);
   });
 
+  it('treats a quoted target with inner spaces as unreadable', () => {
+    // Words-mode hides quoted content with spaces, leaving bare quote marks — resolving that
+    // literally would judge a path of quote characters.
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('cd "/path with space" && git push origin x', parked);
+
+    expect(status, 'a space-bearing quoted target resolved as quote marks').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('keeps the target through prefixes AND the end-of-options marker together', () => {
+    // `command builtin cd -- <path>` needs five words; a four-word capture dropped the path.
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(
+      `command builtin cd -- ${pushed} && git push origin feat/target`,
+      parked,
+    );
+
+    expect(status, `the fifth word (the path) was dropped:\n${output}`).toBe(0);
+  });
+
   it('treats a pushd stack rotation as a target it cannot read', () => {
     // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -237,6 +237,23 @@ describe('which repository the push verdict is about', () => {
     expect(status, `popd did not restore the tracked base:\n${output}`).toBe(0);
   });
 
+  it('refuses a cd to a readable path that is not (yet) a git work tree', () => {
+    // `mkdir <x> && cd <x> && git init && git push`: the hook runs before the command, so <x> is
+    // readable but not a repo at hook time. `validated` mode would fall back to the declared cwd
+    // (the main checkout) and judge ITS record — a false pass for a push into an unreviewed new
+    // repo. The resolved-but-not-a-work-tree case now refuses. (#1667 review)
+    const parked = repoOn('feat/parked', { recorded: true });
+    const notARepo = mkdtempSync(path.join(tmpdir(), 'pre-push-notrepo-'));
+    scratch.push(notARepo);
+
+    const { status, output } = runHook(`cd ${notARepo} && git push origin x`, parked);
+
+    expect(status, `a non-work-tree cd target fell back to the session checkout:\n${output}`).toBe(
+      2,
+    );
+    expect(output).toMatch(/not a git repository/);
+  });
+
   it('does not carry a PIPED cd forward — it ran in a subshell', () => {
     // `cd <A> | cat; git push`: the cd is the left of a pipe, so bash runs it in a subshell and
     // the parent cwd never changes — the push lands in the ORIGINAL dir, not <A>. The walk used

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -237,6 +237,32 @@ describe('which repository the push verdict is about', () => {
     expect(status, `popd did not restore the tracked base:\n${output}`).toBe(0);
   });
 
+  it('follows a bare `pushd` swap back to the directory the shell began in', () => {
+    // `cd <pushed> && pushd <other> && pushd && git push`: real bash's bare pushd swaps the top
+    // two stack entries and cd's back to <pushed>. Treating an argument-less pushd as unreadable
+    // refused this ordinary idiom; the swap now lands where bash does. (#1667 review)
+    const pushed = repoOn('feat/target', { recorded: true });
+    const other = repoOn('feat/other');
+
+    const { status, output } = runHook(
+      `cd ${pushed} && pushd ${other} && pushd && git push origin feat/target`,
+      pushed,
+    );
+
+    expect(status, `the bare pushd swap was treated as unreadable:\n${output}`).toBe(0);
+  });
+
+  it('treats a bare `pushd` with no tracked pushd as a base it cannot read', () => {
+    // Bash errors on a bare pushd with fewer than two stack entries; this walk has nothing to
+    // swap, so the destination is unknown and refuses. (#1667 review)
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('pushd && git push origin x', parked);
+
+    expect(status, 'a bare pushd with no prior pushd was not refused').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('treats a popd with no tracked pushd as a base it cannot read', () => {
     // The real shell may have a directory stack this walk never saw filled.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -237,6 +237,31 @@ describe('which repository the push verdict is about', () => {
     expect(status, `popd did not restore the tracked base:\n${output}`).toBe(0);
   });
 
+  it('does not carry a `||`-guarded cd forward as a definite base', () => {
+    // `cd <A> || cd <B> && git push`: bash runs `cd <B>` only if `cd <A>` FAILED, so with <A>
+    // present the push lands in <A> — but the linear walk carried <B> forward and judged the
+    // wrong repo (the #1662 defect, under-refusing). A `||`-guarded cd is now uncertain. (#1667)
+    const a = repoOn('feat/a', { recorded: true });
+    const b = repoOn('feat/b', { recorded: true });
+
+    const { status, output } = runHook(`cd ${a} || cd ${b} && git push origin feat/a`, a);
+
+    expect(status, `a ||-guarded cd was carried forward as certain:\n${output}`).toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('refuses a `||`-guarded push whose landing directory depends on a failure', () => {
+    // `cd <A> || git push`: the push runs only if `cd <A>` failed, so it lands in the ORIGINAL
+    // dir, not <A>. The walk tracked <A>; judging against it is the wrong repo. No own -C, so the
+    // base is unknowable and refuses. (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+
+    const { status, output } = runHook(`cd ${a} || git push origin x`, a);
+
+    expect(status, 'a ||-guarded push was judged against the succeeded-branch dir').toBe(2);
+    expect(output).toMatch(/preceding command failed/);
+  });
+
   it('detects a two-repo conflict even when the FIRST push resolves to the empty base', () => {
     // No payload cwd (absence is normal), so the first `git push` resolves to the empty string —
     // the bare-push-in-session case. A `-n "$PUSH_DIR"` conflict test read that as "no push yet",

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -155,6 +155,53 @@ describe('which repository the push verdict is about', () => {
     expect(status, `cd -- <path> was treated as unreadable:\n${output}`).toBe(0);
   });
 
+  it('follows the cd INSIDE a subshell — `(cd <dir> && git push)`', () => {
+    // The parenthesis glues to the first word, so `(cd` was not `cd` and the whole idiom — the
+    // usual way to push without moving the parent shell — fell back to the declared cwd: the
+    // pre-#1662 resolution, for the shape people actually write. (#1667 review)
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`(cd ${pushed} && git push origin feat/target)`, parked);
+
+    expect(status, `the subshell cd was invisible to the walk:\n${output}`).toBe(0);
+  });
+
+  it('does not let a CLOSED subshell cd leak into a later push', () => {
+    // `(cd x) && git push` changes no directory the push will see. The still-parenthesised
+    // target reads as unreadable rather than as a base the push never had.
+    const parked = repoOn('feat/parked', { recorded: true });
+    const other = repoOn('feat/other');
+
+    const { status, output } = runHook(`(cd ${other}) && git push origin x`, parked);
+
+    expect(status, 'a closed subshell cd was carried into the push').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('returns to where the shell stood when a pushd is popd-ed', () => {
+    // pushd/popd bracketing an errand elsewhere: the push after popd runs where the shell began.
+    const pushed = repoOn('feat/target', { recorded: true });
+    const other = repoOn('feat/other');
+
+    const { status, output } = runHook(
+      `cd ${pushed} && pushd ${other} && ls && popd && git push origin feat/target`,
+      pushed,
+    );
+
+    expect(status, `popd did not restore the tracked base:\n${output}`).toBe(0);
+  });
+
+  it('treats a popd with no tracked pushd as a base it cannot read', () => {
+    // The real shell may have a directory stack this walk never saw filled.
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('popd && git push origin x', parked);
+
+    expect(status, "an unseen stack's popd was guessed at").toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('treats a pushd stack rotation as a target it cannot read', () => {
     // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * #1662 — the push is judged against the repository it will actually act on.
+ *
+ * `cd <worktree> && git push` was judged against the DECLARED tool cwd — the main clone — because
+ * the `cd` runs after the hook reads the payload and there is no `git -C`. Measured: five worktree
+ * pushes, each with a fresh 0-finding review recorded in its own worktree, all refused against a
+ * stale record for a sixth, already-merged branch the main checkout was parked on. The mirror
+ * direction is the one the hook exists for: a current record on the parked branch would wave an
+ * UNREVIEWED worktree push through.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/pre-push-check.sh');
+
+const scratch = [];
+afterAll(() => {
+  while (scratch.length > 0) rmSync(scratch.pop(), { recursive: true, force: true });
+});
+
+/** A repo whose review-record state the case controls: recorded = run the real recorder in it. */
+function repoOn(branch, { recorded = false } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'pre-push-repo-'));
+  scratch.push(dir);
+  const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  execFileSync('git', ['init', '--quiet', `--initial-branch=${branch}`, dir]);
+  git('config', 'user.email', 'h@e.test');
+  git('config', 'user.name', 'H');
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git('add', '.');
+  git('commit', '--quiet', '-m', 'init');
+  if (recorded) {
+    execFileSync(
+      'node',
+      [path.join(WORKSPACE_ROOT, 'scripts/harness/record-local-review.mjs'), '--findings', '0'],
+      { cwd: dir, encoding: 'utf8' },
+    );
+  }
+  return dir;
+}
+
+function runHook(command, declaredCwd) {
+  const payload = JSON.stringify({ tool_name: 'Bash', cwd: declaredCwd, tool_input: { command } });
+  const result = spawnSync('bash', [HOOK], {
+    input: payload,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: declaredCwd },
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('which repository the push verdict is about', () => {
+  it('judges `cd <worktree> && git push` against the WORKTREE, not the declared cwd', () => {
+    // The false-refusal half of #1662: the pushed repo has a fresh 0-finding record, the declared
+    // cwd (standing in for the parked main clone) has NONE — so a verdict about the wrong repo is
+    // a refusal, and a verdict about the right one is a pass.
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`cd ${pushed} && git push origin feat/target`, parked);
+
+    expect(status, `judged the parked repo, not the pushed one:\n${output}`).toBe(0);
+  });
+
+  it('judges the FALSE-PASS mirror: a recorded parked branch must not excuse an unreviewed push', () => {
+    // The direction the hook exists for. Declared cwd has a CURRENT record; the pushed worktree has
+    // none. The old resolution read the parked record and waved the push through.
+    const pushed = repoOn('feat/unreviewed');
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status } = runHook(`cd ${pushed} && git push origin feat/unreviewed`, parked);
+
+    expect(status, "the parked repo's record excused an unreviewed push").toBe(2);
+  });
+
+  it('still follows a per-statement `git -C`', () => {
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status } = runHook(`git -C ${pushed} push origin feat/target`, parked);
+
+    expect(status).toBe(0);
+  });
+
+  it('REFUSES when the cd target cannot be read', () => {
+    // `cd "$DIR" && git push` — the target is a variable the hook cannot resolve. Judging the
+    // declared cwd anyway is the wrong-repository answer; the hook says why and names the fix.
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('cd "$SOMEWHERE" && git push origin x', parked);
+
+    expect(status, 'an unreadable cd was judged against the declared cwd').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
+  it('REFUSES one command pushing from two repositories', () => {
+    const a = repoOn('feat/a', { recorded: true });
+    const b = repoOn('feat/b', { recorded: true });
+
+    const { status, output } = runHook(
+      `git -C ${a} push origin feat/a; git -C ${b} push origin feat/b`,
+      a,
+    );
+
+    expect(status, 'two-repo push got one verdict').toBe(2);
+    expect(output).toMatch(/two different repositories/);
+  });
+
+  it('keeps the plain in-session push working', () => {
+    const repo = repoOn('feat/plain', { recorded: true });
+
+    const { status, output } = runHook('git push origin feat/plain', repo);
+
+    expect(status, `the ordinary case broke:\n${output}`).toBe(0);
+  });
+});

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -181,16 +181,31 @@ describe('which repository the push verdict is about', () => {
     expect(status, `the subshell cd was invisible to the walk:\n${output}`).toBe(0);
   });
 
+  it('does not let a MULTI-command subshell leak its cd past the close', () => {
+    // `(cd <A> && npm ci); git push`: the subshell spans two statement ranges — `(cd <A>` opens
+    // it, `npm ci)` closes it — so a single-statement `)` check never saw the close and the cd
+    // leaked to the push. The subshell-scope save/restore discards it at the `)` in the later
+    // statement; the push runs in the session dir (recorded → pass), not the unrecorded <A> the
+    // subshell cd'd to. This is the finding that motivated the depth model. (#1667 review)
+    const a = repoOn('feat/a');
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(`(cd ${a} && npm ci); git push origin x`, parked);
+
+    expect(status, `a multi-command subshell leaked its cd:\n${output}`).toBe(0);
+  });
+
   it('does not let a CLOSED subshell cd leak into a later push', () => {
-    // `(cd x) && git push` changes no directory the push will see. The still-parenthesised
-    // target reads as unreadable rather than as a base the push never had.
+    // `(cd <other>) && git push` changes no directory the push will see — the subshell cd is
+    // discarded at its `)`, so the push runs in the ORIGINAL (session) dir. The subshell-scope
+    // save/restore judges the session repo (recorded → pass); it does NOT judge <other>, which is
+    // unrecorded and would refuse if the cd had leaked. (#1667 review)
     const parked = repoOn('feat/parked', { recorded: true });
     const other = repoOn('feat/other');
 
     const { status, output } = runHook(`(cd ${other}) && git push origin x`, parked);
 
-    expect(status, 'a closed subshell cd was carried into the push').toBe(2);
-    expect(output).toMatch(/cannot read/);
+    expect(status, `a closed subshell cd was carried into the push:\n${output}`).toBe(0);
   });
 
   it('a decoy cd in an env-prefix substitution does not launder the real hidden target', () => {
@@ -212,16 +227,14 @@ describe('which repository the push verdict is about', () => {
   });
 
   it('does not let a SPACED closed subshell cd leak either — `( cd x ) && push`', () => {
-    // With spaces the closing paren tokenizes as its own word, which no per-word test sees.
-    // The raw-slice test catches it: a `)` in a cd statement whose target read clean means
-    // the subshell closed before the push. (#1667 review)
+    // Same as above with spaces: the subshell-scope save/restore discards the cd at the `)`, so
+    // the push runs in the session dir (recorded → pass), never in the unrecorded <other>. (#1667)
     const parked = repoOn('feat/parked', { recorded: true });
     const other = repoOn('feat/other');
 
     const { status, output } = runHook(`( cd ${other} ) && git push origin x`, parked);
 
-    expect(status, 'a spaced closed subshell cd was carried into the push').toBe(2);
-    expect(output).toMatch(/cannot read/);
+    expect(status, `a spaced closed subshell cd was carried into the push:\n${output}`).toBe(0);
   });
 
   it('a QUOTED builtin name cannot slip a hidden target past the raw inspection', () => {
@@ -354,17 +367,17 @@ describe('which repository the push verdict is about', () => {
     expect(status, `a backgrounded cd was carried forward as the base:\n${output}`).toBe(2);
   });
 
-  it('sees a subshell close even when the target path repeats in a redirection', () => {
-    // `( cd <A> ) 2><A> && git push`: the target text repeats in the redirection, so cutting the
-    // tail at the LAST occurrence hid the real closing `)` right after the cd arg. Cutting at the
-    // FIRST occurrence sees it — the closed subshell's cd must not leak. (#1667 review)
-    const a = repoOn('feat/a', { recorded: true });
+  it('closes the subshell even when the target path repeats in a redirection', () => {
+    // `( cd <A> ) 2><A> && git push`: the target text repeats in the redirection, but the
+    // subshell-scope save/restore counts the `(`/`)` on the mask and discards the cd at the `)`
+    // regardless of where the path text repeats. The push runs in the session dir (recorded →
+    // pass), never in the unrecorded <A> the subshell cd'd to. (#1667 review)
+    const a = repoOn('feat/a');
     const parked = repoOn('feat/parked', { recorded: true });
 
     const { status, output } = runHook(`( cd ${a} ) 2>${a} && git push origin x`, parked);
 
-    expect(status, `a repeated path hid the subshell close:\n${output}`).toBe(2);
-    expect(output).toMatch(/cannot read/);
+    expect(status, `a repeated path leaked the subshell cd:\n${output}`).toBe(0);
   });
 
   it('does not carry a `||`-guarded cd forward as a definite base', () => {

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -202,6 +202,17 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/cannot read/);
   });
 
+  it('follows the cd inside a BRACE group — `{ cd <dir>; git push; }`', () => {
+    // Unlike `(`, a brace opener must be its own word, so the cd sits one word later and an
+    // unshifted read fell back to the declared cwd for a form bash itself accepts.
+    const pushed = repoOn('feat/target', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`{ cd ${pushed}; git push origin feat/target; }`, parked);
+
+    expect(status, `the brace-group cd was invisible to the walk:\n${output}`).toBe(0);
+  });
+
   it('treats a pushd stack rotation as a target it cannot read', () => {
     // `pushd +1` lands wherever the shell's directory stack says — a place only that shell knows.
     const parked = repoOn('feat/parked', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -210,6 +210,20 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/cannot read/);
   });
 
+  it('a QUOTED builtin name cannot slip a hidden target past the raw inspection', () => {
+    // `"cd" /repo\`evil\`/path && git push` — words-mode resolves PS_FIRST to cd, but the raw
+    // pattern needs `cd ` followed by a target, and the quote glued to the builtin name breaks
+    // that adjacency: RAW_TGT came back empty and the hidden-target test never ran. An empty
+    // RAW_TGT on a cd statement now refuses — the target it failed to find is the one it
+    // exists to inspect. (#1667 review)
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook('"cd" /repo`evil`/path && git push origin x', parked);
+
+    expect(status, 'the quoted builtin name laundered the hidden target').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('returns to where the shell stood when a pushd is popd-ed', () => {
     // pushd/popd bracketing an errand elsewhere: the push after popd runs where the shell began.
     const pushed = repoOn('feat/target', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -268,6 +268,50 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/not a git repository/);
   });
 
+  it('does not read a GLUED `{cd` as a brace-group cd', () => {
+    // `{cd <A>; git push; }`: `{` opens a group ONLY as its own word; glued `{cd` is the command
+    // `{cd`, which bash fails, leaving cwd unchanged so the push runs in the session dir. Stripping
+    // `{` like `(` read it as a valid cd and judged <A> (fail-open). The glued form is ignored, so
+    // the push resolves to the declared cwd (here unrecorded → refuse). (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`{cd ${a}; git push origin x; }`, parked);
+
+    expect(status, `a glued {cd was read as a brace-group cd:\n${output}`).toBe(2);
+  });
+
+  it('does not trust a `&&`-guarded cd that the push is not `&&`-chained to', () => {
+    // `false && cd <A> ; git push`: cd <A> runs only if `false` succeeded (it never does), so the
+    // push runs in the session dir — but the walk treated cd <A> as definite and judged <A>
+    // (fail-open). The push is `;`-separated, not `&&`-chained to the cd, so the cd is uncertain.
+    // (#1667 review)
+    const a = repoOn('feat/a', { recorded: true });
+    const parked = repoOn('feat/parked');
+
+    const { status, output } = runHook(`false && cd ${a} ; git push origin x`, parked);
+
+    expect(status, `a &&-guarded cd was trusted for a ;-separated push:\n${output}`).toBe(2);
+    expect(output).toMatch(/only if a preceding/);
+  });
+
+  it('poisons the stack for a `||`-guarded pushd so a later popd inherits the uncertainty', () => {
+    // `pushd <B>; false || pushd <C>; popd; git push`: the `||`-guarded pushd MIGHT have run.
+    // Leaving the stack untouched let the popd confidently pop pushd <B>'s saved dir and judge it.
+    // A `?` poison frame makes the popd unreadable → refuse. (#1667 review)
+    const b = repoOn('feat/b', { recorded: true });
+    const c = repoOn('feat/c', { recorded: true });
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(
+      `pushd ${b}; false || pushd ${c}; popd; git push origin x`,
+      parked,
+    );
+
+    expect(status, `a ||-guarded pushd let a later popd resolve confidently:\n${output}`).toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('does not carry a PIPED cd forward — it ran in a subshell', () => {
     // `cd <A> | cat; git push`: the cd is the left of a pipe, so bash runs it in a subshell and
     // the parent cwd never changes — the push lands in the ORIGINAL dir, not <A>. The walk used

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -179,6 +179,19 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/cannot read/);
   });
 
+  it('does not let a SPACED closed subshell cd leak either — `( cd x ) && push`', () => {
+    // With spaces the closing paren tokenizes as its own word, which no per-word test sees.
+    // The raw-slice test catches it: a `)` in a cd statement whose target read clean means
+    // the subshell closed before the push. (#1667 review)
+    const parked = repoOn('feat/parked', { recorded: true });
+    const other = repoOn('feat/other');
+
+    const { status, output } = runHook(`( cd ${other} ) && git push origin x`, parked);
+
+    expect(status, 'a spaced closed subshell cd was carried into the push').toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('returns to where the shell stood when a pushd is popd-ed', () => {
     // pushd/popd bracketing an errand elsewhere: the push after popd runs where the shell began.
     const pushed = repoOn('feat/target', { recorded: true });

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -304,6 +304,20 @@ describe('which repository the push verdict is about', () => {
     expect(output).toMatch(/cannot read/);
   });
 
+  it('refuses a cd that is BOTH `||`-guarded and pipe-subshelled (the safe superset)', () => {
+    // `foo || cd <A> | cat; git push`: the cd is conditional (runs only if foo failed) AND in a
+    // pipe subshell (never propagates). Taken alone the subshell fact says "ignore"; the `||`
+    // fact says "uncertain, refuse". They are checked `||`-first, so this refuses — the
+    // fail-closed superset. Pinned so that intended priority is explicit, not accidental. (#1667)
+    const a = repoOn('feat/a', { recorded: true });
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(`false || cd ${a} | cat; git push origin x`, parked);
+
+    expect(status, `a ||-guarded + subshelled cd was not refused:\n${output}`).toBe(2);
+    expect(output).toMatch(/cannot read/);
+  });
+
   it('refuses a `||`-guarded push whose landing directory depends on a failure', () => {
     // `cd <A> || git push`: the push runs only if `cd <A>` failed, so it lands in the ORIGINAL
     // dir, not <A>. The walk tracked <A>; judging against it is the wrong repo. No own -C, so the

--- a/scripts/harness/scan-legacy-typescript.mjs
+++ b/scripts/harness/scan-legacy-typescript.mjs
@@ -99,6 +99,7 @@ import path from 'node:path';
 
 import * as ts from './lib/ts-ast.mjs';
 import { ADVISORY_MARKER } from './run-all-scans.mjs';
+import { envWithoutGitVars } from './shared.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const BASELINE_PATH = path.join(WORKSPACE_ROOT, 'scripts/harness/legacy-typescript-baseline.json');
@@ -445,10 +446,17 @@ export function findLegacyDependencies(manifest) {
  * than it was asked to is the vacuity this suite is elsewhere measuring.
  */
 export function gitTrackedFiles(root, notices = []) {
+  // Ambient git context is scrubbed, or the reading is not about `root` at all. A git hook exports
+  // GIT_DIR into everything it launches, so under `git push` from a linked worktree this listing
+  // answered from THAT repository while `cwd` pointed at a probe directory — every listed path was
+  // then absent from disk, the finder returned an empty, noticed result over a tree it never read,
+  // and the fail-closed ledger measured it `vacuous`. The same redirection, aimed at a real
+  // repository, is how fixture commits have overwritten a shared branch (git-ambient-env.json).
   const listed = execFileSync('git', ['ls-files'], {
     cwd: root,
     encoding: 'utf8',
     maxBuffer: 1 << 28,
+    env: envWithoutGitVars(),
   })
     .split('\n')
     .filter(Boolean);


### PR DESCRIPTION
Fixes #1662.

`pre-push-check.sh` resolved its repository from whole-command `git -C` → declared tool cwd → project dir. For the shape pushes are actually written in — `cd <worktree> && git push` — that is exactly wrong: the `cd` runs after the hook reads the payload, there is no `-C`, and the declared cwd is the main clone. The issue measured both directions: five reviewed worktree pushes refused against a stale record for a branch none of them were on, and the mirror — a parked branch with a current record waving an **unreviewed** worktree push through — is the case the hook exists to prevent.

The resolution now follows the PUSH STATEMENT:
1. that statement's own `git -C`;
2. else the last `cd <path>` in a statement before it, resolved against the declared cwd;
3. else the declared cwd.

A `cd` whose target the tokenizer cannot read (quoted away, `$VAR`, backtick, `~`, `-`) **refuses** — the hook then knows the push runs somewhere it cannot name, and a guard that cannot tell which repository is being pushed has not verified anything about it. Two push statements resolving to different repositories refuse for the same reason. The reader/writer split the issue diagnosed closes with this: the record is read via `--show` in the resolved repository, which is the same worktree `record-local-review.mjs` writes into.

Six cases; four red against the previous hook, including both of the issue's measured directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbMB4MGdHAg6fgzzspSjqp