### PR TITLE
fix(ci): the review-gate red is transient — CodeQL re-runs the gate it starved

### DIFF
--- a/.agents/tasks/HARNESS-082-job-level-permissions-invisible-to-the-scan.md
+++ b/.agents/tasks/HARNESS-082-job-level-permissions-invisible-to-the-scan.md
@@ -27,9 +27,10 @@ the exact "excused-but-unchecked" drift the scan exists to prevent.
 
 Measured 2026-08-09, during #1669 review:
 
-- `codeql.yml` had to be REMOVED from the scan's checked list entirely, because the scan cannot
-  see that the workflow-level grant stayed read-only while one job adds `actions: write` — the
-  parser reads only the top-level block and would have judged the whole file by it.
+- `codeql.yml` STAYS in the scan's checked list, but only its workflow-level grant
+  (`security-events`) is what the scan actually judges — the recovery job's `actions: write`
+  is structurally invisible to `parsePermissions`, and the PR could record that fact only as a
+  comment beside the entry, not as anything the scan enforces.
 - `review-gate.yml` precedent: `disarm-auto-merge`'s `pull-requests: write` is documented in a
   comment, verified by nobody.
 - The #1669 review round named the pattern: "the second job-level `write` grant now excused only
@@ -40,8 +41,9 @@ Measured 2026-08-09, during #1669 review:
 Extend `parsePermissions` to walk `jobs.<id>.permissions` blocks and judge each job's effective
 grant (job block overrides workflow block; absence inherits). Then:
 
-- restore `codeql.yml` to the checked list, with the recovery job's `actions: write` carried as
-  a structured allowlist entry (file + job + permission + reason), not a prose comment;
+- carry the recovery job's `actions: write` as a structured allowlist entry
+  (file + job + permission + reason) in `codeql.yml`'s existing entry, replacing the prose
+  comment;
 - convert `review-gate.yml`'s `disarm-auto-merge` excuse to the same structured entry;
 - fail on any job-level write grant not in the allowlist, so the category stops growing
   silently.

--- a/.agents/tasks/HARNESS-082-job-level-permissions-invisible-to-the-scan.md
+++ b/.agents/tasks/HARNESS-082-job-level-permissions-invisible-to-the-scan.md
@@ -1,0 +1,58 @@
+---
+title: 'HARNESS-082: job-level workflow permissions are invisible to the permissions scan'
+status: todo
+created: 2026-08-09
+priority: high
+urgency: next
+area: scripts/harness
+depends_on: []
+issue: https://github.com/woojubb/robota/issues/1675
+---
+
+# HARNESS-082: job-level workflow permissions are invisible to the permissions scan
+
+## Problem
+
+`scripts/harness/scan-workflow-permissions.mjs` parses only the WORKFLOW-level `permissions:`
+block. A job-level block — the form GitHub itself recommends for scoping a single job's grant —
+is invisible to `parsePermissions`, so any write permission granted at job level is excused only
+in prose (a comment in the scan's registry entry) and checked by nothing.
+
+The category is growing: `review-gate.yml`'s `disarm-auto-merge` job was the first job-level
+write grant carried on a comment, and `codeql.yml`'s `recover-review-gate` job
+(`actions: write`, #1669) is the second. Each addition widens the unchecked surface silently —
+the exact "excused-but-unchecked" drift the scan exists to prevent.
+
+## Evidence
+
+Measured 2026-08-09, during #1669 review:
+
+- `codeql.yml` had to be REMOVED from the scan's checked list entirely, because the scan cannot
+  see that the workflow-level grant stayed read-only while one job adds `actions: write` — the
+  parser reads only the top-level block and would have judged the whole file by it.
+- `review-gate.yml` precedent: `disarm-auto-merge`'s `pull-requests: write` is documented in a
+  comment, verified by nobody.
+- The #1669 review round named the pattern: "the second job-level `write` grant now excused only
+  in prose and invisible to this scan … worth a filed backlog item."
+
+## Direction
+
+Extend `parsePermissions` to walk `jobs.<id>.permissions` blocks and judge each job's effective
+grant (job block overrides workflow block; absence inherits). Then:
+
+- restore `codeql.yml` to the checked list, with the recovery job's `actions: write` carried as
+  a structured allowlist entry (file + job + permission + reason), not a prose comment;
+- convert `review-gate.yml`'s `disarm-auto-merge` excuse to the same structured entry;
+- fail on any job-level write grant not in the allowlist, so the category stops growing
+  silently.
+
+## Acceptance
+
+- [ ] `parsePermissions` resolves the EFFECTIVE permissions per job (job-level override,
+      workflow-level inheritance).
+- [ ] Job-level write grants require a structured allowlist entry; a reason-less entry fails
+      (anti-rot, same shape as scan-no-fallback).
+- [ ] `codeql.yml` and `review-gate.yml` are both back under the scan with their two job-level
+      grants allowlisted.
+- [ ] Red-proof: a fixture (or temporary mutation) with an unlisted job-level `write` makes the
+      scan fail before the fix to the allowlist, pass after.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,9 +87,12 @@ jobs:
       # Accepted costs, recorded rather than discovered:
       #   - `actions: write` widens this job's blast radius to rerunning/cancelling runs
       #     (justified in scan-workflow-permissions.mjs). JS/TS autobuild is a no-op, so PR code
-      #     does not execute in the analysis steps; the recovery step below runs only what this
-      #     workflow file states — and a FORK pull request receives a read-only GITHUB_TOKEN
-      #     regardless of this block, so the widened scope never reaches untrusted code.
+      #     does not execute in the analysis steps. A FORK pull request receives a read-only
+      #     GITHUB_TOKEN regardless of this block, so the widened scope never reaches untrusted
+      #     code. A SAME-REPO branch does run its own edit of this file — and gains nothing by
+      #     it: pushing a branch here requires repo write access, which already carries the
+      #     Actions re-run/cancel rights this token grants. The scope widens what this WORKFLOW
+      #     may do, not what any contributor may.
       #   - The head_sha query can pick up a same-SHA run from another PR — a rerun is
       #     idempotent, so the cost of that rarity is a wasted rerun, not a wrong verdict.
       #   - The rerun restores the REQUIRED CHECK, not auto-merge: a first failure has already
@@ -101,6 +104,10 @@ jobs:
       #     stays-red watcher, the pre-#1660 state.
       - name: Re-run a review-gate that read this analysis too early (#1660)
         if: github.event_name == 'pull_request'
+        # Non-fatal MECHANICALLY, not by convention: every branch of the script exits 0 on
+        # purpose, but a future edit or a `set -u` unbound variable would flip the SAST job red —
+        # the exact outcome the header forswears. The runner enforces what the comment promised.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -100,6 +100,8 @@ jobs:
           # into the empty answer the may-not-have-started notice narrates, which is the exact
           # wrong-reason silence this step's own header forswears — so the two are separated:
           # an unreadable listing warns as itself and stops. (#1669 review)
+          # allow-unpaginated: one head SHA accumulates Review Gate runs only by rerun; a page of
+          # 100 outlives any plausible rerun count, and missing a run past it costs one manual rerun.
           if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>&1); then
             echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} (${runs_json}). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
             exit 0
@@ -109,6 +111,7 @@ jobs:
             echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
             exit 0
           fi
+          # allow-unpaginated: a single-record read by id — there is no collection to truncate.
           if ! status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
             --jq '"\(.status) \(.conclusion // "")"' 2>&1); then
             echo "::warning::#1660 recovery: could not READ Review Gate run ${run_id} (${status_conclusion}). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -104,42 +104,34 @@ jobs:
           # jq parse (empty run_id, benign narrative) or ride into the conclusion word, which is
           # the same wrong-reason silence through a side door. (#1669 review, both rounds)
           err_file=$(mktemp)
-          # A single check races: the gate run may still be mid-flight HERE while its
-          # read-the-analysis step has already read an absent analysis, and once it concludes
-          # failure nothing else re-checks. A short bounded poll closes most of that window at the
-          # cost of at most ~1 minute inside an already-running job; a run still in flight after
-          # the last look is narrated with the residual risk named. (#1669 review)
-          attempt=0
-          while :; do
-            attempt=$((attempt + 1))
-            # allow-unpaginated: one head SHA accumulates Review Gate runs only by rerun; a page of
-            # 100 outlives any plausible rerun count, and a miss past it costs one manual rerun.
-            if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>"${err_file}"); then
-              echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
-              exit 0
-            fi
-            run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty')
-            if [ -z "${run_id}" ]; then
-              echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
-              exit 0
-            fi
-            # allow-unpaginated: a single-record read by id — there is no collection to truncate.
-            if ! status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-              --jq '"\(.status) \(.conclusion // "")"' 2>"${err_file}"); then
-              echo "::warning::#1660 recovery: could not READ Review Gate run ${run_id} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
-              exit 0
-            fi
-            status=${status_conclusion%% *}
-            conclusion=${status_conclusion#* }
-            if [ "${status}" = "completed" ]; then
-              break
-            fi
-            if [ "${attempt}" -ge 4 ]; then
-              echo "::notice::#1660 recovery: Review Gate run ${run_id} is still ${status} after ${attempt} looks. If it read this analysis before it existed AND concludes failure after this job ends, nothing re-checks it — that residual window falls back to the stays-red watcher."
-              exit 0
-            fi
-            sleep 15
-          done
+          # allow-unpaginated: one head SHA accumulates Review Gate runs only by rerun; a page of
+          # 100 outlives any plausible rerun count, and a miss past it costs one manual rerun.
+          if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>"${err_file}"); then
+            echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+            exit 0
+          fi
+          run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty')
+          if [ -z "${run_id}" ]; then
+            echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
+            exit 0
+          fi
+          # allow-unpaginated: a single-record read by id — there is no collection to truncate.
+          if ! status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+            --jq '"\(.status) \(.conclusion // "")"' 2>"${err_file}"); then
+            echo "::warning::#1660 recovery: could not READ Review Gate run ${run_id} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+            exit 0
+          fi
+          status=${status_conclusion%% *}
+          conclusion=${status_conclusion#* }
+          if [ "${status}" != "completed" ]; then
+            # DELIBERATELY one look, no poll: a wait held here is billed runner time on every PR
+            # (scan-runner-wait owns that cost class), spent against a narrow race. The residual
+            # window is real and named: a gate run still in flight HERE that already read the
+            # absent analysis and concludes failure after this job ends is re-checked by nothing —
+            # that case falls back to the stays-red watcher, the pre-#1660 state.
+            echo "::notice::#1660 recovery: Review Gate run ${run_id} is ${status}. If it started after this analysis it will read it completed; if it read too early and later concludes failure, nothing re-checks it — re-run it by hand if it stays red."
+            exit 0
+          fi
           if [ "${conclusion}" != "failure" ]; then
             echo "::notice::#1660 recovery: Review Gate run ${run_id} concluded ${conclusion} — nothing to recover."
             exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,12 +68,19 @@ jobs:
   recover-review-gate:
     name: Re-run a review-gate that read this analysis too early
     needs: analyze
-    if: github.event_name == 'pull_request'
+    # An explicit success(): a custom `if:` REPLACES the implicit success() gate `needs` carries,
+    # so without it this job would also run when analyze failed or was cancelled — and there is
+    # no completed analysis to recover with there. (#1669 review)
+    if: success() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       # #1660: re-running a workflow run needs actions: write; the token is same-repo, and a fork
-      # pull request receives a read-only token regardless of this block.
+      # pull request receives a read-only token regardless of this block. A job-level block
+      # ZEROES every unlisted scope, so the head-moved check's PR read is granted explicitly —
+      # without it, `gh api pulls/<n>` 403s on every run and the recovery never reruns anything,
+      # silently restoring the stays-red state this job exists to end. (#1669 review)
+      pull-requests: read
       actions: write
     steps:
       # ── #1660: recovery for the review-gate ordering artefact ─────────────────────────────────

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -142,6 +142,7 @@ jobs:
           # jq parse (empty run_id, benign narrative) or ride into the conclusion word, which is
           # the same wrong-reason silence through a side door. (#1669 review, both rounds)
           err_file=$(mktemp)
+          trap 'rm -f "${err_file}"' EXIT
           # allow-unpaginated: the listing returns EVERY pull_request-triggered run for this head
           # SHA — all ~6 workflows per push, plus reruns — so the page holds roughly fifteen
           # pushes' worth of runs for one SHA, which does not recur; a miss past it costs one

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,9 +36,6 @@ on:
 permissions:
   contents: read
   security-events: write
-  # #1660: the last step re-runs a review-gate that went red only because it read this analysis
-  # before it finished. Re-running a workflow run needs actions: write; the token is same-repo.
-  actions: write
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -63,6 +60,22 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: '/language:javascript-typescript'
+
+  # ── #1660: recovery in its OWN job — the analyze job must not hold the write token ────────────
+  # review-gate.yml sets the pattern for this exact class (its disarm-auto-merge job): a job that
+  # checks out and analyzes PR-controlled content never shares a token that writes. This job
+  # checks nothing out and runs only the script below, with the workflow's only actions: write.
+  recover-review-gate:
+    name: Re-run a review-gate that read this analysis too early
+    needs: analyze
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # #1660: re-running a workflow run needs actions: write; the token is same-repo, and a fork
+      # pull request receives a read-only token regardless of this block.
+      actions: write
+    steps:
       # ── #1660: recovery for the review-gate ordering artefact ─────────────────────────────────
       # `review-gate` reads this analysis ONCE, with no wait — the wait was moved off the billed
       # runner deliberately, and that part stays. What was never paid for was the recovery: both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -83,6 +83,12 @@ jobs:
       # NON-FATAL by decision, not by silence: a failed redispatch must not turn the SAST job red
       # (the analysis it reports on succeeded), but it says what went wrong — recovery falling back
       # to the watcher is the pre-#1660 state, and the log names it.
+      #
+      # Two accepted costs, recorded rather than discovered: `actions: write` widens this job's
+      # blast radius to rerunning/cancelling runs (justified in scan-workflow-permissions.mjs;
+      # JS/TS autobuild is a no-op, so PR code does not execute in this job), and the head_sha
+      # query can pick up a same-SHA run from another PR — a rerun is idempotent, so the cost of
+      # that rarity is a wasted rerun, not a wrong verdict.
       - name: Re-run a review-gate that read this analysis too early (#1660)
         if: github.event_name == 'pull_request'
         env:
@@ -90,14 +96,24 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -u
-          run_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" \
-            --jq '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty' || true)
+          # An API failure is not "no run yet". `|| true` folded rate limits and network errors
+          # into the empty answer the may-not-have-started notice narrates, which is the exact
+          # wrong-reason silence this step's own header forswears — so the two are separated:
+          # an unreadable listing warns as itself and stops. (#1669 review)
+          if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>&1); then
+            echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} (${runs_json}). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+            exit 0
+          fi
+          run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty')
           if [ -z "${run_id}" ]; then
             echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
             exit 0
           fi
-          status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-            --jq '"\(.status) \(.conclusion // "")"' || echo "unreadable")
+          if ! status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+            --jq '"\(.status) \(.conclusion // "")"' 2>&1); then
+            echo "::warning::#1660 recovery: could not READ Review Gate run ${run_id} (${status_conclusion}). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+            exit 0
+          fi
           status=${status_conclusion%% *}
           conclusion=${status_conclusion#* }
           if [ "${status}" != "completed" ]; then

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,9 @@ on:
 permissions:
   contents: read
   security-events: write
+  # #1660: the last step re-runs a review-gate that went red only because it read this analysis
+  # before it finished. Re-running a workflow run needs actions: write; the token is same-repo.
+  actions: write
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -60,3 +63,53 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: '/language:javascript-typescript'
+      # ── #1660: recovery for the review-gate ordering artefact ─────────────────────────────────
+      # `review-gate` reads this analysis ONCE, with no wait — the wait was moved off the billed
+      # runner deliberately, and that part stays. What was never paid for was the recovery: both
+      # workflows fire on the same pull_request event, so the gate's read almost always lands while
+      # this analysis is still running, goes red with `verdict-unavailable`, and STAYS red until a
+      # human re-runs it. Measured on 2026-08-08: all eight open code PRs red simultaneously on a
+      # gate that had found nothing, each turned green by a bare re-run.
+      #
+      # This step is the alternative the gate's own comment names as removing the watcher without
+      # re-introducing the wait: the moment the analysis completes, re-run the same-SHA gate run if
+      # it failed. It keys the gate to the analysis completing WITHOUT changing the gate's own
+      # trigger — the workflow_run route would report against the default branch's workflow file
+      # and its ability to satisfy the required context name is unverified (#1660 discusses why).
+      #
+      # A rerun of a gate that failed on a REAL finding is harmless: it re-reads and goes red with
+      # the same verdict. There is no loop — rerunning review-gate triggers nothing here.
+      #
+      # NON-FATAL by decision, not by silence: a failed redispatch must not turn the SAST job red
+      # (the analysis it reports on succeeded), but it says what went wrong — recovery falling back
+      # to the watcher is the pre-#1660 state, and the log names it.
+      - name: Re-run a review-gate that read this analysis too early (#1660)
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -u
+          run_id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" \
+            --jq '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty' || true)
+          if [ -z "${run_id}" ]; then
+            echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
+            exit 0
+          fi
+          status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+            --jq '"\(.status) \(.conclusion // "")"' || echo "unreadable")
+          status=${status_conclusion%% *}
+          conclusion=${status_conclusion#* }
+          if [ "${status}" != "completed" ]; then
+            echo "::notice::#1660 recovery: Review Gate run ${run_id} is ${status} — it started after this analysis and will read it completed."
+            exit 0
+          fi
+          if [ "${conclusion}" != "failure" ]; then
+            echo "::notice::#1660 recovery: Review Gate run ${run_id} concluded ${conclusion} — nothing to recover."
+            exit 0
+          fi
+          if gh run rerun "${run_id}" --failed --repo "${GITHUB_REPOSITORY}"; then
+            echo "::notice::#1660 recovery: re-ran Review Gate run ${run_id} — it now reads a completed analysis."
+          else
+            echo "::warning::#1660 recovery FAILED to re-run Review Gate run ${run_id}. The gate stays red until re-run by hand — the pre-#1660 state. Check the actions: write permission and the run id."
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -u
           # An API failure is not "no run yet". `|| true` folded rate limits and network errors
@@ -134,8 +135,11 @@ jobs:
           # jq parse (empty run_id, benign narrative) or ride into the conclusion word, which is
           # the same wrong-reason silence through a side door. (#1669 review, both rounds)
           err_file=$(mktemp)
-          # allow-unpaginated: one head SHA accumulates Review Gate runs only by rerun; a page of
-          # 100 outlives any plausible rerun count, and a miss past it costs one manual rerun.
+          # allow-unpaginated: the listing returns EVERY pull_request-triggered run for this head
+          # SHA — all ~6 workflows per push, plus reruns — so the page holds roughly fifteen
+          # pushes' worth of runs for one SHA, which does not recur; a miss past it costs one
+          # manual rerun. (#1669 review corrected the earlier phrasing, which read as Review
+          # Gate-only.)
           if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>"${err_file}"); then
             echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
             exit 0
@@ -170,6 +174,20 @@ jobs:
           fi
           if [ "${conclusion}" != "failure" ]; then
             echo "::notice::#1660 recovery: Review Gate run ${run_id} concluded ${conclusion} — nothing to recover."
+            exit 0
+          fi
+          # SUPERSEDED analyses do not rerun the gate. review-gate's concurrency group is keyed
+          # by PR number with cancel-in-progress, so a rerun issued for an old SHA after a new
+          # push would CANCEL the new push's in-flight gate — trading a stale red for a missing
+          # check on the SHA that matters. If the PR's head has moved on, this analysis's rerun
+          # right has lapsed. (#1669 review)
+          # allow-unpaginated: a single-record read of one pull request by number.
+          if ! current_head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>"${err_file}"); then
+            echo "::warning::#1660 recovery: could not read the PR's current head ($(cat "${err_file}")). Not rerunning against an unverifiable head — the stays-red watcher covers it."
+            exit 0
+          fi
+          if [ "${current_head}" != "${HEAD_SHA}" ]; then
+            echo "::notice::#1660 recovery: the PR's head moved on (${current_head} != ${HEAD_SHA}) — the newer push's own analysis owns the recovery now."
             exit 0
           fi
           if gh run rerun "${run_id}" --failed --repo "${GITHUB_REPOSITORY}"; then

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,11 +84,21 @@ jobs:
       # (the analysis it reports on succeeded), but it says what went wrong — recovery falling back
       # to the watcher is the pre-#1660 state, and the log names it.
       #
-      # Two accepted costs, recorded rather than discovered: `actions: write` widens this job's
-      # blast radius to rerunning/cancelling runs (justified in scan-workflow-permissions.mjs;
-      # JS/TS autobuild is a no-op, so PR code does not execute in this job), and the head_sha
-      # query can pick up a same-SHA run from another PR — a rerun is idempotent, so the cost of
-      # that rarity is a wasted rerun, not a wrong verdict.
+      # Accepted costs, recorded rather than discovered:
+      #   - `actions: write` widens this job's blast radius to rerunning/cancelling runs
+      #     (justified in scan-workflow-permissions.mjs). JS/TS autobuild is a no-op, so PR code
+      #     does not execute in the analysis steps; the recovery step below runs only what this
+      #     workflow file states — and a FORK pull request receives a read-only GITHUB_TOKEN
+      #     regardless of this block, so the widened scope never reaches untrusted code.
+      #   - The head_sha query can pick up a same-SHA run from another PR — a rerun is
+      #     idempotent, so the cost of that rarity is a wasted rerun, not a wrong verdict.
+      #   - The rerun restores the REQUIRED CHECK, not auto-merge: a first failure has already
+      #     disarmed auto-merge (review-gate.yml's disarm job), and re-arming stays a human
+      #     decision by design — the disarm exists to force a look, and this step must not
+      #     un-force it.
+      #   - SARIF upload completing and the code-scanning API serving the alerts are not the
+      #     same instant; a rerun racing that propagation re-fails and falls back to the
+      #     stays-red watcher, the pre-#1660 state.
       - name: Re-run a review-gate that read this analysis too early (#1660)
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -120,7 +120,13 @@ jobs:
             echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
             exit 0
           fi
-          run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty')
+          # The PARSE is checked like the calls around it: gh can exit 0 with a body that has no
+          # .workflow_runs (rate-limit payload on a 200, schema drift), and an unchecked pipe let
+          # that fall into the benign no-run narrative. (#1669 review)
+          if ! run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty' 2>"${err_file}"); then
+            echo "::warning::#1660 recovery: the run listing for ${HEAD_SHA} did not parse as expected ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+            exit 0
+          fi
           if [ -z "${run_id}" ]; then
             echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
             exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -193,5 +193,5 @@ jobs:
           if gh run rerun "${run_id}" --failed --repo "${GITHUB_REPOSITORY}"; then
             echo "::notice::#1660 recovery: re-ran Review Gate run ${run_id} — it now reads a completed analysis."
           else
-            echo "::warning::#1660 recovery FAILED to re-run Review Gate run ${run_id}. The gate stays red until re-run by hand — the pre-#1660 state. Check the actions: write permission and the run id."
+            echo "::warning::#1660 recovery FAILED to re-run Review Gate run ${run_id}. The gate stays red until re-run by hand — the pre-#1660 state. On a FORK pull request this is expected: the token is read-only regardless of this workflow's permissions. Same-repo: check the actions: write permission and the run id."
           fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -99,30 +99,47 @@ jobs:
           # An API failure is not "no run yet". `|| true` folded rate limits and network errors
           # into the empty answer the may-not-have-started notice narrates, which is the exact
           # wrong-reason silence this step's own header forswears — so the two are separated:
-          # an unreadable listing warns as itself and stops. (#1669 review)
-          # allow-unpaginated: one head SHA accumulates Review Gate runs only by rerun; a page of
-          # 100 outlives any plausible rerun count, and missing a run past it costs one manual rerun.
-          if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>&1); then
-            echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} (${runs_json}). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
-            exit 0
-          fi
-          run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty')
-          if [ -z "${run_id}" ]; then
-            echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
-            exit 0
-          fi
-          # allow-unpaginated: a single-record read by id — there is no collection to truncate.
-          if ! status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-            --jq '"\(.status) \(.conclusion // "")"' 2>&1); then
-            echo "::warning::#1660 recovery: could not READ Review Gate run ${run_id} (${status_conclusion}). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
-            exit 0
-          fi
-          status=${status_conclusion%% *}
-          conclusion=${status_conclusion#* }
-          if [ "${status}" != "completed" ]; then
-            echo "::notice::#1660 recovery: Review Gate run ${run_id} is ${status} — it started after this analysis and will read it completed."
-            exit 0
-          fi
+          # an unreadable listing warns as itself and stops. stderr is captured to a FILE, never
+          # merged into the parsed stream: an exit-0 `gh` warning on stdout+stderr would break the
+          # jq parse (empty run_id, benign narrative) or ride into the conclusion word, which is
+          # the same wrong-reason silence through a side door. (#1669 review, both rounds)
+          err_file=$(mktemp)
+          # A single check races: the gate run may still be mid-flight HERE while its
+          # read-the-analysis step has already read an absent analysis, and once it concludes
+          # failure nothing else re-checks. A short bounded poll closes most of that window at the
+          # cost of at most ~1 minute inside an already-running job; a run still in flight after
+          # the last look is narrated with the residual risk named. (#1669 review)
+          attempt=0
+          while :; do
+            attempt=$((attempt + 1))
+            # allow-unpaginated: one head SHA accumulates Review Gate runs only by rerun; a page of
+            # 100 outlives any plausible rerun count, and a miss past it costs one manual rerun.
+            if ! runs_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=100" 2>"${err_file}"); then
+              echo "::warning::#1660 recovery: could not LIST workflow runs for ${HEAD_SHA} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+              exit 0
+            fi
+            run_id=$(printf '%s' "${runs_json}" | jq -r '[.workflow_runs[] | select(.name == "Review Gate")] | sort_by(.created_at) | last | .id // empty')
+            if [ -z "${run_id}" ]; then
+              echo "::notice::#1660 recovery: no Review Gate run found for ${HEAD_SHA} — nothing to recover (it may not have started yet; when it starts it will read a completed analysis)."
+              exit 0
+            fi
+            # allow-unpaginated: a single-record read by id — there is no collection to truncate.
+            if ! status_conclusion=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+              --jq '"\(.status) \(.conclusion // "")"' 2>"${err_file}"); then
+              echo "::warning::#1660 recovery: could not READ Review Gate run ${run_id} ($(cat "${err_file}")). Recovery falls back to the stays-red watcher — re-run the Review Gate by hand if it stays red."
+              exit 0
+            fi
+            status=${status_conclusion%% *}
+            conclusion=${status_conclusion#* }
+            if [ "${status}" = "completed" ]; then
+              break
+            fi
+            if [ "${attempt}" -ge 4 ]; then
+              echo "::notice::#1660 recovery: Review Gate run ${run_id} is still ${status} after ${attempt} looks. If it read this analysis before it existed AND concludes failure after this job ends, nothing re-checks it — that residual window falls back to the stays-red watcher."
+              exit 0
+            fi
+            sleep 15
+          done
           if [ "${conclusion}" != "failure" ]; then
             echo "::notice::#1660 recovery: Review Gate run ${run_id} concluded ${conclusion} — nothing to recover."
             exit 0

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -283,12 +283,14 @@ jobs:
           # refusal: the #1660 recovery reruns this gate the moment the analysis completes, which
           # makes the transient BLOCKED comment routine — and a reader scanning comments would
           # keep meeting a verdict the checks page no longer agrees with. Only posted when a
-          # BLOCKED comment exists, so an ordinarily green PR gains no noise. (#1669 review)
+          # BLOCKED comment exists AND this pass actually read an analysis: on the docs-only
+          # path nothing was re-read, and the supersession sentence would claim a read that
+          # never happened. (#1669 review, both rounds)
           # allow-unpaginated: reads the newest page of this gate's own comments — an older
           # BLOCKED beyond it means at worst a skipped courtesy note, never a wrong verdict.
           last_gate_comment=$(gh pr view "$PR_NUMBER" --json comments \
             --jq '[.comments[] | select(.body | startswith("**Review gate:"))] | last | .body // ""' || echo "")
-          if printf '%s' "$last_gate_comment" | grep -q 'BLOCKED'; then
+          if [ "${CODE_CHANGED}" = "true" ] && printf '%s' "$last_gate_comment" | grep -q 'BLOCKED'; then
             gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
           **Review gate: PASS** — the earlier BLOCKED verdict above is superseded (the gate re-read a completed analysis).
           EOF

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -298,9 +298,21 @@ jobs:
           # Matched on the comment's HEADER, not a substring: the supersession text below quotes
           # the word BLOCKED, so a substring test would match the supersession itself and every
           # later green run would re-post it — a self-feeding loop. (#1669 review, two rounds)
-          last_gate_comment=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq '[.[] | select(.body | startswith("**Review gate:"))] | last | (.body // "" | split("\n")[0])' \
-            | grep -v '^$' | tail -1 || echo "")
+          # The read fails LOUDLY: `|| echo ""` would turn "could not read the comments" into
+          # "there is no BLOCKED comment", the exact silence INFRA-077 forbids and every other
+          # gh api read in this step already avoids. On failure we warn and skip the courtesy
+          # note (its absence is harmless — the gate verdict is on the checks page regardless).
+          # A pipe would mask gh's exit under the trailing grep/tail, so gh's output is captured
+          # first and the line-pick runs only after gh succeeded. (#1669 review)
+          gate_comments_err=$(mktemp)
+          if gate_comments_json=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("**Review gate:"))] | last | (.body // "" | split("\n")[0])' 2>"${gate_comments_err}"); then
+            last_gate_comment=$(printf '%s' "${gate_comments_json}" | grep -v '^$' | tail -1 || echo "")
+          else
+            echo "::warning::review-gate supersession: could not read PR comments ($(cat "${gate_comments_err}")). Skipping the superseded-note; the checks page still carries the verdict."
+            last_gate_comment=""
+          fi
+          rm -f "${gate_comments_err}"
           if [ "${CODE_CHANGED}" = "true" ] && printf '%s' "$last_gate_comment" | head -1 | grep -q '^\*\*Review gate: BLOCKED'; then
             gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
           **Review gate: PASS** — the BLOCKED verdict above is superseded; the checks page carries the current verdict and the run log says why this pass passed.

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -149,14 +149,15 @@ jobs:
           # WHAT THIS COSTS, stated because it is a real trade and not a free win. The poll used to be
           # self-recovering: most pull requests resolved inside a single run without anyone acting.
           # Now the first read almost always finds the analysis still running — the two workflows are
-          # triggered by the same event — so this check goes red and STAYS red until it is re-run.
-          # Nothing in this repository re-runs it automatically; recovery is the watcher's job, and on
-          # a pull request nobody is watching, a required check sits red until a human notices.
+          # triggered by the same event — so this check goes red until it is re-run. The RECOVERY is
+          # codeql.yml's last step (#1660): when the analysis completes, it re-runs a same-SHA gate
+          # run that failed, so the red is transient without anyone watching and without changing
+          # this workflow's trigger or holding a runner. Measured before that step existed: all
+          # eight open code PRs red simultaneously on a gate that had found nothing.
           #
-          # That is the accepted shape, not an oversight. The alternative that removes both the wait
-          # and the dependency on a watcher is a `workflow_run` trigger keyed to the analysis
-          # completing, which is a larger change to a required check than this one and is not made
-          # here.
+          # The `workflow_run` alternative is deliberately NOT taken: such a run reports against the
+          # default branch's workflow file, and whether it can satisfy branch protection as the same
+          # required context name is unverified — #1660 records the constraint.
           runs="$(node scripts/harness/github-api.mjs \
                     "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" \
                     --jq '[.[] | select(.name | startswith("Analyze"))]' 2>/dev/null || echo '[]')"

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -279,6 +279,20 @@ jobs:
             echo "::error::review-gate blocked this PR. See the job summary."
             exit 1
           fi
+          # A PASS after a BLOCKED comment says so, or the last word on the PR stays a stale
+          # refusal: the #1660 recovery reruns this gate the moment the analysis completes, which
+          # makes the transient BLOCKED comment routine — and a reader scanning comments would
+          # keep meeting a verdict the checks page no longer agrees with. Only posted when a
+          # BLOCKED comment exists, so an ordinarily green PR gains no noise. (#1669 review)
+          # allow-unpaginated: reads the newest page of this gate's own comments — an older
+          # BLOCKED beyond it means at worst a skipped courtesy note, never a wrong verdict.
+          last_gate_comment=$(gh pr view "$PR_NUMBER" --json comments \
+            --jq '[.comments[] | select(.body | startswith("**Review gate:"))] | last | .body // ""' || echo "")
+          if printf '%s' "$last_gate_comment" | grep -q 'BLOCKED'; then
+            gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
+          **Review gate: PASS** — the earlier BLOCKED verdict above is superseded (the gate re-read a completed analysis).
+          EOF
+          fi
 
   # INFRA-057. Disarming an armed auto-merge is INFRA-048's stated lever for the #1409 hole: a red
   # NON-REQUIRED check does not stop an auto-merge by itself. It had never once worked. Measured on

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -290,9 +290,12 @@ jobs:
           # (#1669 review, three rounds)
           # allow-unpaginated: reads the newest page of this gate's own comments — an older
           # BLOCKED beyond it means at worst a skipped courtesy note, never a wrong verdict.
+          # Matched on the comment's HEADER, not a substring: the supersession text below quotes
+          # the word BLOCKED, so a substring test would match the supersession itself and every
+          # later green run would re-post it — a self-feeding loop. (#1669 review)
           last_gate_comment=$(gh pr view "$PR_NUMBER" --json comments \
             --jq '[.comments[] | select(.body | startswith("**Review gate:"))] | last | .body // ""' || echo "")
-          if [ "${CODE_CHANGED}" = "true" ] && printf '%s' "$last_gate_comment" | grep -q 'BLOCKED'; then
+          if [ "${CODE_CHANGED}" = "true" ] && printf '%s' "$last_gate_comment" | head -1 | grep -q '^\*\*Review gate: BLOCKED'; then
             gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
           **Review gate: PASS** — the BLOCKED verdict above is superseded; the checks page carries the current verdict and the run log says why this pass passed.
           EOF

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -283,16 +283,18 @@ jobs:
           # refusal: the #1660 recovery reruns this gate the moment the analysis completes, which
           # makes the transient BLOCKED comment routine — and a reader scanning comments would
           # keep meeting a verdict the checks page no longer agrees with. Only posted when a
-          # BLOCKED comment exists AND this pass actually read an analysis: on the docs-only
-          # path nothing was re-read, and the supersession sentence would claim a read that
-          # never happened. (#1669 review, both rounds)
+          # BLOCKED comment exists AND this pass actually judged code: on the docs-only path
+          # nothing was re-read. The sentence claims only the supersession — a pass can arrive
+          # by re-reading a completed analysis OR by the acknowledge label (a human override
+          # with findings still real), and naming the wrong one would misreport the second.
+          # (#1669 review, three rounds)
           # allow-unpaginated: reads the newest page of this gate's own comments — an older
           # BLOCKED beyond it means at worst a skipped courtesy note, never a wrong verdict.
           last_gate_comment=$(gh pr view "$PR_NUMBER" --json comments \
             --jq '[.comments[] | select(.body | startswith("**Review gate:"))] | last | .body // ""' || echo "")
           if [ "${CODE_CHANGED}" = "true" ] && printf '%s' "$last_gate_comment" | grep -q 'BLOCKED'; then
             gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
-          **Review gate: PASS** — the earlier BLOCKED verdict above is superseded (the gate re-read a completed analysis).
+          **Review gate: PASS** — the BLOCKED verdict above is superseded; the checks page carries the current verdict and the run log says why this pass passed.
           EOF
           fi
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -288,13 +288,19 @@ jobs:
           # by re-reading a completed analysis OR by the acknowledge label (a human override
           # with findings still real), and naming the wrong one would misreport the second.
           # (#1669 review, three rounds)
-          # allow-unpaginated: reads the newest page of this gate's own comments — an older
-          # BLOCKED beyond it means at worst a skipped courtesy note, never a wrong verdict.
+          # Read PAGINATED, oldest→newest, because whether `gh pr view --json comments` returns
+          # the newest or the oldest page on a >100-comment PR is not documented and could not
+          # be measured here (no PR in this repository has crossed 100 yet) — and this repo's
+          # review process is exactly the kind that will cross it. Per REST page, jq keeps the
+          # FIRST LINE of the last matching gate comment (the header is all the test below
+          # reads, and one line per page keeps multiline bodies from breaking the line-based
+          # tail); the last non-empty line across pages is therefore the newest gate header.
           # Matched on the comment's HEADER, not a substring: the supersession text below quotes
           # the word BLOCKED, so a substring test would match the supersession itself and every
-          # later green run would re-post it — a self-feeding loop. (#1669 review)
-          last_gate_comment=$(gh pr view "$PR_NUMBER" --json comments \
-            --jq '[.comments[] | select(.body | startswith("**Review gate:"))] | last | .body // ""' || echo "")
+          # later green run would re-post it — a self-feeding loop. (#1669 review, two rounds)
+          last_gate_comment=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("**Review gate:"))] | last | (.body // "" | split("\n")[0])' \
+            | grep -v '^$' | tail -1 || echo "")
           if [ "${CODE_CHANGED}" = "true" ] && printf '%s' "$last_gate_comment" | head -1 | grep -q '^\*\*Review gate: BLOCKED'; then
             gh pr comment "$PR_NUMBER" --body-file - <<EOF || true
           **Review gate: PASS** — the BLOCKED verdict above is superseded; the checks page carries the current verdict and the run log says why this pass passed.

--- a/scripts/harness/ci-footprint-baseline.json
+++ b/scripts/harness/ci-footprint-baseline.json
@@ -1,9 +1,9 @@
 {
-  "jobs": 21,
+  "jobs": 22,
   "perWorkflow": {
     "ci.yml": 15,
     "claude-code-review.yml": 1,
-    "codeql.yml": 1,
+    "codeql.yml": 2,
     "dependency-review.yml": 1,
     "gitleaks.yml": 1,
     "review-gate.yml": 2

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -24,6 +24,11 @@
  *      write scope appearing in a workflow is a finding; so is a justification for a scope no
  *      workflow actually asks for any more (anti-rot — a stale excuse outlives what it excused).
  *
+ * Deliberately NOT checked: JOB-level `permissions:` blocks. `parsePermissions` reads only the
+ * top-level block, so a job-scoped grant (review-gate.yml's disarm job, codeql.yml's recovery
+ * job) is structurally invisible here — those grants are justified in prose beside themselves,
+ * and widening this scan to job scopes is its own change, not a side effect.
+ *
  * Deliberately NOT checked: that every workflow declares a block. That would fire on every
  * read-only workflow in the repository — noise, and a noisy guard gets suppressed, which costs more
  * than it catches. The same reasoning `review-gate`'s severity split rests on.

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -53,6 +53,8 @@ export const JUSTIFIED_WRITE_SCOPES = {
   },
   'codeql.yml': {
     'security-events': 'uploads the SARIF analysis that becomes the code-scanning alerts',
+    actions:
+      're-runs a same-SHA Review Gate that read this analysis before it existed (#1660 recovery)',
   },
   'dependency-review.yml': {
     'pull-requests': 'comments the dependency-review summary on failure (comment-summary-in-pr)',

--- a/scripts/harness/scan-workflow-permissions.mjs
+++ b/scripts/harness/scan-workflow-permissions.mjs
@@ -53,8 +53,9 @@ export const JUSTIFIED_WRITE_SCOPES = {
   },
   'codeql.yml': {
     'security-events': 'uploads the SARIF analysis that becomes the code-scanning alerts',
-    actions:
-      're-runs a same-SHA Review Gate that read this analysis before it existed (#1660 recovery)',
+    // The #1660 recovery's `actions: write` is JOB-level (recover-review-gate), like
+    // review-gate.yml's disarm job — outside this scan's workflow-level vision, justified in the
+    // workflow beside the grant.
   },
   'dependency-review.yml': {
     'pull-requests': 'comments the dependency-review summary on failure (comment-summary-in-pr)',


### PR DESCRIPTION
Fixes #1660.

`review-gate` reads the CodeQL analysis once, with no wait — deliberately, and that stays: the 15-minute poll on a billed runner was this workflow's entire runtime. What was never paid for was the recovery. Both workflows fire on the same `pull_request` event, so the gate's read almost always lands mid-analysis, goes red with `verdict-unavailable`, and stays red until a human re-runs it. Measured on 2026-08-08: **all eight open code PRs red simultaneously** on a gate that had found nothing; each turned green by a bare re-run (10–17s).

This takes the alternative the gate's own comment names as removing the watcher without re-introducing the wait: `codeql.yml`'s last step re-runs the same-SHA `Review Gate` run **if it completed as failure**, the moment the analysis completes. It keys the gate to the analysis without touching the gate's own trigger — the `workflow_run` route reports against the default branch's workflow file and its ability to satisfy the required context name is unverified (the issue records that constraint; this PR does not take that risk).

Properties, each stated in the step:
- a gate still running started after the analysis and will read it completed → skip;
- a gate that failed on a REAL finding re-runs harmlessly to the same verdict; no loop exists (re-running review-gate triggers nothing here);
- the step is non-fatal **by decision, not by silence**: a failed redispatch must not turn the SAST job red, but it prints a warning naming the fallback (the pre-#1660 watcher state).

`codeql.yml` gains `actions: write` (same-repo token) for the rerun; `review-gate.yml`'s stays-red trade note now names its recovery instead of naming a watcher.

Verification note: this is workflow behavior only CI can exercise — the observable is this PR's own review-gate turning green without a manual re-run once CodeQL finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbMB4MGdHAg6fgzzspSjqp