### PR TITLE
feat(harness): two new floors, skill invocability, and the parked harness fixes

### DIFF
--- a/.agents/rules/verification.md
+++ b/.agents/rules/verification.md
@@ -14,8 +14,12 @@ Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
 ### Browser Verification Requirement
 
 - After changes to a web app or any package whose output is rendered in a browser, you MUST verify in a browser before reporting completion.
-- Use Playwright MCP to navigate to the app URL, take a screenshot, and verify the UI renders correctly.
-- Check for: page loads without error, key elements visible, no console errors.
+- Drive a real browser against the running app. Whatever driver is configured, the obligation is
+  the same and the evidence is the same: the page loaded, the elements the change concerns are
+  present, and the console is clean. Name the driver you used in the report.
+- If no browser driver is configured in this repository, that is a missing capability, not an
+  exemption. File it and say plainly that the change is unverified — an unverified change reported
+  as done is the failure this rule exists to prevent.
 - If the dev server is not running, start it and wait for it to be ready before checking.
 - This is non-negotiable — do NOT claim UI changes work without browser verification.
 

--- a/.agents/skills/architecture-refresh/SKILL.md
+++ b/.agents/skills/architecture-refresh/SKILL.md
@@ -2,6 +2,7 @@
 name: architecture-refresh
 description: Thin orchestration for the recurring architecture audit→depth→apply→re-audit loop. It holds NO architecture policy — it only sequences five predefined subagents (two auditors, the depth guardian, two appliers), reads their convergence signal, routes each finding on its depth verdict to the applier the auditor named, and re-calls them until every finding of a round is RESOLVED. Every judgement lives in the agents. Use to keep architecture and implementation in sync when a single pass won't finish it.
 loop: over=finding-set; escape=no-progress
+invocable: true
 ---
 
 # Architecture Refresh — pipeline only

--- a/.agents/skills/backlog-execution-orchestrator/SKILL.md
+++ b/.agents/skills/backlog-execution-orchestrator/SKILL.md
@@ -2,6 +2,7 @@
 name: backlog-execution-orchestrator
 description: The state machine for executing ONE backlog item or named work unit end to end. Sequences five phases — recommendation gate, scenario planning, implementation, done gate, completion — dispatching proposal-reviewer and the user-execution-scenario sub-pipeline, and routing on each outcome (advance / repeat / return to an earlier phase / terminate). It holds NO backlog policy: every gate definition, PR contract, status invariant, and stop condition is owned by the project's backlog-execution rule and is pointed at, never restated. Use when working a backlog item; for an initiative spanning several items, multi-backlog-initiative is the entry point and dispatches this once per item.
 loop: over=finding-set; escape=no-progress; bound=2 rounds
+invocable: true
 ---
 
 # Backlog Execution Orchestrator — pipeline only

--- a/.agents/skills/backlog-pipeline/SKILL.md
+++ b/.agents/skills/backlog-pipeline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: backlog-pipeline
 description: Orchestrator for the spec document gate pipeline. Reads current status from frontmatter, determines the next gate, invokes backlog-writer or backlog-gate-guard, and updates frontmatter status on PASS. Does nothing else.
+invocable: true
 ---
 
 # Backlog Pipeline

--- a/.agents/skills/backlog-writer/SKILL.md
+++ b/.agents/skills/backlog-writer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: backlog-writer
 description: Guides authoring of a new spec document. Ensures every required section is present and meets minimum quality before the item enters the gate pipeline. Does not validate gates or make approval decisions.
+invocable: true
 ---
 
 # Backlog Writer

--- a/.agents/skills/documentation-refresh/SKILL.md
+++ b/.agents/skills/documentation-refresh/SKILL.md
@@ -2,6 +2,7 @@
 name: documentation-refresh
 description: Thin orchestration for the recurring documentation audit→depth→fix→re-audit loop. It holds NO documentation policy — it only sequences three subagents (doc-auditor, finding-depth-triager, doc-fixer), routes each finding on its depth verdict, and re-calls them until every finding of a round is RESOLVED. All judgement (what to audit, what "good" means, where the defect is, how to fix) lives in the agents. Use when docs must be brought current with the code and a single pass won't finish it.
 loop: over=finding-set; escape=no-progress
+invocable: true
 ---
 
 # Documentation Refresh — pipeline only

--- a/.agents/skills/lesson-to-harness/SKILL.md
+++ b/.agents/skills/lesson-to-harness/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: lesson-to-harness
 description: Invoke when the user says "turn this session's repeated requests into rules/skills", "교훈 처리해줘", "규칙으로 박아줘", or when the agent detects EITHER a repeated user correction/preference in-session (same kind of correction 2x+, or an explicit "from now on do/don't ...") OR a recurring agent/technical failure class (the same kind of failure hit 2x+ in-session — e.g. fixing the same category of CI failure twice — even with no user correction). Mines lesson candidates from the session, proposes them for approval, and institutionalizes only the approved ones as neutral, universal principles wired into the repo harness (.agents/rules, AGENTS.md, related skills, harness scan / hooks) as a single source — never memory-only. Fixing an instance never closes a recurring mistake; only a mechanical prevention does. Operationalizes learning-loop.md.
+invocable: true
 ---
 
 # Lesson → Harness

--- a/.agents/skills/multi-backlog-initiative/SKILL.md
+++ b/.agents/skills/multi-backlog-initiative/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: multi-backlog-initiative
 description: Sub-orchestration for an initiative that spans several backlog items. Establishes an integration base branch cut from the integration branch, dispatches backlog-execution-orchestrator once per item against that base, keeps the base from drifting mid-flight, and opens the final PR that the user — never this pipeline — decides to merge. Owns only the ordering and routing between items; every branch, PR, and gate constraint is owned by the rules it points at. The entry point for multi-item work; a single item enters backlog-execution-orchestrator directly.
+invocable: true
 ---
 
 # Multi-Backlog Initiative — pipeline only

--- a/.agents/skills/post-implementation-checklist/SKILL.md
+++ b/.agents/skills/post-implementation-checklist/SKILL.md
@@ -2,6 +2,7 @@
 name: post-implementation-checklist
 description: Router for the mandatory post-implementation sequence — SPEC sync, build/test, README, commit/PR, publish, content/ docs, docs deploy. Each step's detail lives in its owning skill/rule; this file only fixes the order and the gates. Execute automatically after implementation work; do not wait for the user to request it.
 loop: over=finding-set; escape=no-progress
+invocable: true
 ---
 
 # Post-Implementation Checklist (router)

--- a/.agents/skills/pr-finding-resolution-loop/SKILL.md
+++ b/.agents/skills/pr-finding-resolution-loop/SKILL.md
@@ -2,6 +2,7 @@
 name: pr-finding-resolution-loop
 description: Drives a pull request to convergence by RESOLVING the findings its review automation produces — it does not review. Round A reviews the LOCAL diff once, before the pull request exists and while no reviewer has seen it, where a round costs a minute instead of a CI cycle; Round B reads what the pull request's automation reported, routes each finding to a verdict and a fix, pushes, and re-reads, looping until zero remain — no round cap (owner directive 2026-08-03); the only escape is progress detection. Then hands to the gated merge path. It routes only: it does not review, write, fix, or judge. Dispatching a reviewer on an OPEN pull request is the duplication this skill exists to prevent.
 loop: over=finding-set; escape=no-progress
+invocable: true
 ---
 
 # PR Finding Resolution Loop

--- a/.agents/skills/release-orchestration/SKILL.md
+++ b/.agents/skills/release-orchestration/SKILL.md
@@ -2,6 +2,7 @@
 name: release-orchestration
 description: Top-level orchestrator for a release. Sequences three phases — source-stabilization → version-bump → npm-otp-publish — maintains the release control-plane state artifact across them, and routes on each phase's outcome (advance / repeat / return to an earlier phase / terminate). It holds NO release policy: every command name, gate definition, required field, and prohibition is owned by the project's publish rule and is pointed at, never restated. Use when running a release, a release-level merge, a version bump, or a publish.
 loop: over=attempt; bound=2 re-runs
+invocable: true
 ---
 
 # Release Orchestration — pipeline only

--- a/.agents/skills/user-request-gate/SKILL.md
+++ b/.agents/skills/user-request-gate/SKILL.md
@@ -2,6 +2,7 @@
 name: user-request-gate
 description: Use immediately when the user requests any implementation, code change, feature addition, fix, or modification. Gates code writing behind a backlog draft document. Read-only exploration is always permitted.
 loop: over=finding-set; escape=no-progress
+invocable: true
 ---
 
 ## Rule Anchor

--- a/.agents/skills/worktree-parallel-orchestration/SKILL.md
+++ b/.agents/skills/worktree-parallel-orchestration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: worktree-parallel-orchestration
 description: Procedure for running multiple independent backlog items in parallel via worktree-isolated subagents with zero merge conflicts — partition file ownership before spawning, isolate each implementer in its own worktree, sequence overlapping work behind occupants, one coherent self-verified PR per agent, and serial orchestrator merge. Use when executing 2 or more independent items concurrently.
+invocable: true
 ---
 
 # Worktree-Parallel Orchestration

--- a/.agents/token-cost-report.md
+++ b/.agents/token-cost-report.md
@@ -1,0 +1,262 @@
+# Harness audit — decisions open, work done
+
+Measured 2026-08-09 from `~/.claude/projects/-home-ubuntu-dev-robota/*.jsonl` and from the tree.
+
+**This is an open action item, not a reference document.** Everything under "Decisions" needs an
+owner's answer; nothing there can be settled by reading the code. When all of them are answered and
+the checklist is clear, delete this file and its row in `AGENTS.md`.
+
+> **Counting note — read before re-measuring.** Claude Code writes **one JSONL record per content
+> block**, and every block of one response carries an **identical copy** of `message.usage`. This
+> session has 50,536 assistant records but only **26,068 distinct `message.id`** values (1.94
+> records per turn), and none disagreed on usage. Summing per record overcounts by **1.93×**.
+> Always deduplicate by `message.id`. Per-turn context is unaffected — it is a per-record field.
+
+## What was measured
+
+| Metric                    | Value       |
+| ------------------------- | ----------- |
+| Real API turns            | **26,068**  |
+| Session length            | 34.6 days   |
+| Total input tokens        | **14.1 B**  |
+| Output tokens             | 20.4 M      |
+| Mean context **per turn** | **539,612** |
+| Compaction events         | 70          |
+
+Cost per turn is flat regardless of how long a request runs — a one-line question costs the same
+per turn as a 600-turn run. With a 1 M window, compaction floors context at ~73 K and it refills to
+~999 K before the next one; the mean across that sawtooth is ~540 K. **That is arithmetic, not a
+usage habit.** Session start was 32,154 tokens, so fixed overhead is innocent.
+
+Turn count is therefore the whole multiplier. Sampling 1,211 turns found **0 that issued more than
+one tool call** — every Read, every grep, every Bash was its own full-price turn.
+
+---
+
+## Decisions
+
+Each needs a call. Recommendations are marked, but the choice is the owner's.
+
+### D1 — `AGENTS.md` is 194 % of the size its own rule sets
+
+`operational.md:58` requires `AGENTS.md`, `.agents/rules/index.md` and `.agents/project-structure.md`
+to stay under 80 lines. Measured: **155 / 103 / 370**. Three of three named documents in violation.
+`scan-file-size.mjs:26` scopes to `packages` and `apps`, so nothing can see them.
+
+This matters more than a style nit: `AGENTS.md` is one of only two files re-injected after each of
+the 70 compactions. Every line is paid on all 26,068 turns.
+
+- **(a) Enforce it.** Slim the three documents, then extend the size scan to read its own document
+  list out of `operational.md:58` so the two cannot drift. Candidates for eviction from `AGENTS.md`:
+  `:54-56` (product/self-hosting narrative → `VISION.md`), `:60-63` (toolchain versions, already in
+  `package.json`/Volta), `:77-85` (eight `pnpm harness:*` invocations, contradicting `:72-73` which
+  says commands live in `package.json`), `:145-155` (three `rg` commands the file itself says are
+  already mechanized as `conflict-markers` — and `scan-conflict-markers.mjs:31` carries an allowlist
+  entry that exists only to stop those copies tripping it).
+- **(b) Amend the rule** to the size these documents actually need, and say why routing documents
+  are exempt from their own target.
+- Leaving both as they are is the one option with no defence: `index.md:22-24` says a rule believed
+  wrong needs a filed item, and there is none.
+
+**Recommended: (a).** The eviction list above is ~2,900 bytes of content that already has an owner
+elsewhere, which is more than the 80-line gap.
+
+### D2 — `common-mistakes.md` is 82 % whitespace, and a gate enforces it
+
+187,367 bytes, of which **153,281 are prettier table-alignment padding**. Squeezed content is 34,119
+bytes. The file is not in `.prettierignore`, and `format:check` is a CI stage — so the padding is
+mechanically defended. `AGENTS.md:110-111` tells every agent to read this file before non-trivial
+work, i.e. ~18 K tokens paid to receive ~8.5 K of instruction.
+
+- **(a) Add it to `.prettierignore` and squeeze the tables.** `scan-mistake-mechanisms` reads the
+  `**Mechanism:**` token, not column geometry — verify that parser first, then it is a pure win.
+- **(b) Convert to heading-per-entry**, which removes the table geometry entirely and reads better
+  at 83 rows.
+- **(c) Accept the cost.**
+
+**Recommended: (a)** now, **(b)** if the file keeps growing.
+
+### D3 — Two rules contradict each other, six lines apart
+
+`git-branch.md:79` — "No `git commit` or `git push` without explicit user approval."
+`git-branch.md:85-92` — "Commit at appropriate logical boundaries **as work progresses**… never
+defer committing until the context is nearly exhausted… deferring reads as stalling. (Owner
+directive.)"
+
+Both cannot hold in an autonomous run. The session shows the seam being hit from the cadence side:
+the user asked why commits were deferred until the context limit. `:85` was added as the correction
+and `:79` was never reconciled. `agent-conduct.md:99-100` outranks both, which makes `:79` a dead
+letter that still reads as absolute.
+
+**Decide which survives**, and delete the other rather than qualifying it.
+
+### D4 — Build after every commit, or not
+
+`verification.md:11` — "**After every commit that modifies `packages/*/src/`**, run `pnpm build`…
+**Do NOT skip this step**."
+`verification.md:33` — "…re-running the build by hand after it is wasted minutes."
+
+Unconditional at `:11`, conditioned away at `:33`, neither citing the other, inside one document.
+`.agents/tasks/HARNESS-072-nothing-detects-a-contradiction-between-two-rules.md` is open for the
+detection problem; this instance still needs an answer.
+
+### D5 — A standing "keep going" authorization
+
+The most repeated correction in the session — five utterances, plus two Stop-hook re-drives:
+_"멈출건지 물어보지말고 계속 진행해"_, _"멈추지 말고 내가 멈추라고 할 때까지 계속 진행해"_.
+
+This is **not** a missing rule. It is an unresolved contradiction: `spec-workflow.md:109-151`,
+`backlog-execution.md:39-61` and `:398-421`, and `git-branch.md:79,302-304` all mandate stopping to
+ask; `agent-conduct.md:57-60,99-100` and `backlog-execution.md:23-37` mandate deciding and acting.
+Nothing covers a _standing_ authorization that spans many turns.
+
+- **(a) Write the exception** in `backlog-execution.md` beside the stop conditions: a user
+  instruction to proceed without further confirmation outranks the ask-gates for decisions inside
+  agent authority, stands until revoked or the session ends, and still stops for the four decisions
+  that are the user's alone (product direction, published contract, repository policy files,
+  user-authored documents). Record in the work item that it was in force and what it covered.
+- **(b) Keep asking** and accept that the correction recurs.
+
+**Recommended: (a).** It also needs one line in D6's card, or a compaction will drop it.
+
+### D6 — A hook-refusal card in `AGENTS.md`
+
+200 blocked tool calls came from three hooks enforcing rules that live in a 33 KB file which is
+never auto-loaded. The rules are correct and the hooks work; the agent simply did not have them in
+context after a compaction.
+
+Proposed: ~700 bytes in `AGENTS.md` listing the five most-blocked refusals in imperative form, with
+reasoning left in `git-branch.md`.
+
+The arithmetic: 700 bytes ≈ 180 tokens × 26,068 turns ≈ **4.7 M tokens**. One blocked turn costs
+~540 K; 200 blocked turns ≈ **108 M**, before the retry turn each one causes. **A card that
+prevents 10 % of the blocks pays for itself; at 50 % it returns 10×.**
+
+This is the only place in the audit where adding prose to an always-loaded file is defensible, and
+it only stays defensible if D1 funds it.
+
+### D7 — A hook that refuses foreground waits
+
+61 turns died to Bash timeouts, almost all foreground CI polling (`sleep 150; for n in …; do gh pr
+checks …`). The shape persisted to the final day. `Monitor` was used 36 times against 17,702 Bash
+calls. Verified: all four PreToolUse Bash guards exit 0 on the timing-out shape — nothing looks.
+
+`operational.md` already has "A Wait Is Not Idle Time" and it was violated for 34 days, which is the
+case for making it mechanical.
+
+- **(a) Add `no-foreground-wait.sh`** — refuse a foreground call whose sleep budget exceeds ~60 s or
+  that loops around `gh pr checks`/`gh run view`, naming the background/monitor path in the message,
+  with an ack env var for the deliberate case.
+- **(b) Rule only**, and accept that prose already failed once here.
+
+**Recommended: (a).** Not built yet — it needs the ack-variable name and the sleep budget decided.
+
+### D8 — Skill descriptions, and the other 41 skills
+
+12 skills are now registered (see below). Their descriptions total **5,720 bytes**, and 9 of the 12
+exceed 250 B — they carry a procedure summary and a policy statement after the trigger clause. The
+budget is currently a **ratchet pinned at today's value**: it cannot grow, and it should be lowered
+as descriptions are trimmed.
+
+Trimming is a content change only the skill owners should make: the description is what decides
+whether a skill fires, and a bad trim is the same failure in a new costume.
+
+Also open: **41 skills remain unregistered.** The reasoning for the 12 was that the rest are either
+dispatched only by a parent (registering them invites bypassing the parent's ordering), pointer
+stubs with no behaviour, or reference documents that `Read` serves better. **Confirm or revise that
+boundary.**
+
+### D9 — Stated limits that are stricter than the configured ones
+
+Small, long-standing, and each is one edit:
+
+| Rule                                                | Configuration                                                                 |
+| --------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `git-branch.md:80` — commit subject max 72 chars    | `commitlint.config.js` never sets `header-max-length`; default is 100         |
+| `code-quality.md:11` — `@ts-ignore` is "prohibited" | `.eslintrc.json:53` is `"warn"`; `package.json:24` passes no `--max-warnings` |
+
+Either tighten the configuration or amend the rule. `HARNESS-070` is filed for the second; the first
+has no filed item, which under `index.md:22-24` makes it simply mandatory and unenforced.
+
+### D10 — This file's own placement
+
+`AGENTS.md:7-10` carries an "Open action" blockquote pointing here, plus a row in the document
+table. `AGENTS.md:43` routes tasks to `.agents/tasks/README.md`, so a task with a checklist is the
+one document class `AGENTS.md` explicitly delegates — and it costs always-loaded context on every
+turn until someone deletes it.
+
+Move it to `.agents/tasks/`, or accept the cost while it is open. **Recommended: move it**, and keep
+only a one-line pointer if a pointer is wanted at all.
+
+---
+
+## Done
+
+Landed and verified in this pass. Full harness green afterwards: **159 test files, 2,751 tests.**
+
+- **Global default model moved off the 1 M context variant.** `~/.claude/settings.json` had
+  `"model": "opus[1m]"` as the default for every project; now `"opus"`. Backup kept beside it.
+  Changing nothing else, this is the largest single reduction available — a 200 K window caps
+  per-turn cost at roughly a third of a 1 M one.
+- **Skill layer repaired and locked.** `.claude/skills/` held 5 symlinks, **3 of them dangling**, and
+  the 2 that resolved were vendored Vercel/React skills unrelated to this repo. 53 project skills
+  were unreachable, so every project-skill invocation in 34.6 days failed — including
+  `lesson-to-harness` (6/6), which `learning-loop.md:8` names as _the_ procedure for turning a
+  repeated lesson into an enforced rule. Twelve are now registered, each declaring `invocable: true`
+  in its own frontmatter, cross-checked by `scan-skill-registration.mjs`.
+- **`scan-named-mechanism-resolves.mjs`** — a document that names a mechanism as required must name
+  one that exists. Found `verification.md:17` requiring Playwright MCP as "non-negotiable" with no
+  MCP server configured anywhere. That rule now states the outcome and the evidence rather than a
+  tool identity, and says plainly that a missing driver is an unverified change, not an exemption.
+- **`scan-hook-syntax.mjs`** — a hook that no longer parses exits 127, which the hook protocol
+  treats as PASS. Four outages in late July took all four PreToolUse Bash guards offline at once.
+  Covers `lib/`, which registration floors deliberately exclude and which has the widest blast
+  radius.
+- **`branch-guard.sh` no longer restates policy.** Its message contradicted `git-branch.md:162,165`
+  on both who may delete a merged branch and which flag to use — the likely reason a prohibited
+  command was retried 93 times. It now prints the corrected command and points at the single owner.
+  The second `-D` recommendation is gone; no hook recommends `-D` any more.
+- Removed the empty `.agents/rules/rules/`.
+
+Not committed: `fix/core-027-*` was unmerged, and One-Branch-At-A-Time forbids cutting another
+branch while it stands.
+
+## Checklist
+
+- [x] Default model off the 1 M context variant
+- [x] Skill registry repaired; registration, declaration, ordering and description budget enforced
+- [x] Named-mechanism floor; `verification.md` browser rule restated as an outcome
+- [x] Hook syntax floor, including `lib/`
+- [x] `branch-guard` message stops restating policy
+- [ ] D1–D10 answered
+- [ ] Behavioural rules written into `.agents/rules/operational.md` — issue independent tool calls
+      together (0 of 1,211 sampled turns used more than one); chain consecutive same-directory Bash
+      commands (73 % of adjacent pairs share a `cd` target); plan a file's edits before the first
+      one (49 edits to one document, 34 reads of one file)
+- [ ] One session per work item — do not carry a session for weeks
+- [ ] Re-measure after one week and record the new per-turn context here
+
+## Known drivers not yet addressed
+
+- **A formatter hook invalidates the agent's copy of every file it edits.** `post-tool-format.sh`
+  runs `prettier --write` on PostToolUse, so an Edit's own anchor is stale the instant it lands.
+  This is the mechanical cause of 12 × "modified since read", 13 × "string to replace not found",
+  and the defensive re-reads behind the 34-read file. The two worst-thrashed files are markdown,
+  which prettier reflows most aggressively.
+- **Editing migrated out of the Edit tool into Bash.** By the final slice, 98 of 462 Bash calls were
+  `python3` string-replace scripts and 46 were `sed -i`, while Edit and Read had fallen to 1 call
+  each. A `str.replace(a, b, 1)` that matches nothing exits 0 and rewrites the file unchanged — a
+  failed edit reported as success, and uncountable.
+- **~300 ms of hook latency on every Bash call** (four guards, each sourcing the same 52 KB
+  tokenizer) ≈ 90 minutes across 17,702 calls. A literal `grep -qF` fast-path before `source` would
+  remove most of it without changing a verdict.
+- **`revert-detect.sh` slurps the whole transcript on every Stop** (`jq -rs`, 3,005 Stops, a
+  transcript that reached 400 MB). Bounding the read to a tail window gives the same signal at
+  constant cost.
+
+## How to re-measure
+
+Parse `~/.claude/projects/-home-ubuntu-dev-robota/*.jsonl`. Each `type: "assistant"` record carries
+`message.usage` with `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`,
+`output_tokens`. Context per turn is the sum of the three input fields. **Deduplicate by
+`message.id` before summing** — see the counting note above.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -687,10 +687,20 @@ while read -r STMT_START STMT_LEN; do
     # becomes a second copy of it that drifts — this message once said the opposite of
     # git-branch.md on both who may delete a branch and which flag to use, and the prohibited
     # command was retried for weeks because the guard taught the wrong alternative.
-    FIXED_COMMAND=$(printf '%s' "$COMMAND" | sed -E 's/[[:space:]]+--delete-branch\b//g')
+    # Correct THIS STATEMENT, not the whole raw command: a sed over the full command also strips
+    # the flag's name out of quoted text — a commit message, a PR body — and the "corrected"
+    # suggestion is then a different command than the user meant. The statement slice bounds it,
+    # and a statement where the flag appears more than once (one of them necessarily quoted text)
+    # gets an instruction instead of a synthesis that would guess which one to drop.
+    STMT_RAW="${COMMAND:$STMT_START:$STMT_LEN}"
     echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
-    echo "[branch-guard] Run this instead:" >&2
-    echo "[branch-guard]   $FIXED_COMMAND" >&2
+    if [[ $(printf '%s' "$STMT_RAW" | grep -o -- '--delete-branch' | grep -c .) -eq 1 ]]; then
+      FIXED_COMMAND=$(printf '%s' "$STMT_RAW" | sed -E 's/[[:space:]]+--delete-branch\b//')
+      echo "[branch-guard] Run this instead:" >&2
+      echo "[branch-guard]   $FIXED_COMMAND" >&2
+    else
+      echo "[branch-guard] Re-run this statement without '--delete-branch'." >&2
+    fi
     echo "[branch-guard] Branch cleanup after the merge is governed by .agents/rules/git-branch.md" >&2
     echo "[branch-guard] (see 'Deleting a merged branch') — read it there, it is the only copy." >&2
     exit 2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -692,7 +692,8 @@ while read -r STMT_START STMT_LEN; do
     # suggestion is then a different command than the user meant. The statement slice bounds it,
     # and a statement where the flag appears more than once (one of them necessarily quoted text)
     # gets an instruction instead of a synthesis that would guess which one to drop.
-    STMT_RAW="${COMMAND:$STMT_START:$STMT_LEN}"
+    # Ranges are 1-based (awk substr); bash slicing is 0-based.
+    STMT_RAW="${COMMAND:$((STMT_START - 1)):$STMT_LEN}"
     echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
     if [[ $(printf '%s' "$STMT_RAW" | grep -o -- '--delete-branch' | grep -c .) -eq 1 ]]; then
       FIXED_COMMAND=$(printf '%s' "$STMT_RAW" | sed -E 's/[[:space:]]+--delete-branch\b//')

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -696,14 +696,16 @@ while read -r STMT_START STMT_LEN; do
     STMT_RAW="${COMMAND:$((STMT_START - 1)):$STMT_LEN}"
     echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
     if [[ $(printf '%s' "$STMT_RAW" | grep -o -- '--delete-branch' | grep -c .) -eq 1 ]]; then
-      FIXED_COMMAND=$(printf '%s' "$STMT_RAW" | sed -E 's/[[:space:]]+--delete-branch\b//')
+      # An explicit boundary class, not \b: `-` is not a word character, so \b matched inside
+      # `--delete-branch-like` names and the sed would strip a prefix of a different flag.
+      FIXED_COMMAND=$(printf '%s' "$STMT_RAW" | sed -E 's/[[:space:]]+--delete-branch([^-[:alnum:]_]|$)/\1/')
       echo "[branch-guard] Run this instead:" >&2
       echo "[branch-guard]   $FIXED_COMMAND" >&2
     else
       echo "[branch-guard] Re-run this statement without '--delete-branch'." >&2
     fi
     echo "[branch-guard] Branch cleanup after the merge is governed by .agents/rules/git-branch.md" >&2
-    echo "[branch-guard] (see 'Deleting a merged branch') — read it there, it is the only copy." >&2
+    echo "[branch-guard] (see 'Delete Merged Branches') — read it there, it is the only copy." >&2
     exit 2
   fi
 
@@ -892,7 +894,7 @@ while read -r STMT_START STMT_LEN; do
         echo "  - $b" >&2
       done
       echo "[branch-guard] Branch cleanup after a merge is governed by .agents/rules/git-branch.md" >&2
-      echo "[branch-guard] (see 'Deleting a merged branch') — read it there, it is the only copy." >&2
+      echo "[branch-guard] (see 'Delete Merged Branches') — read it there, it is the only copy." >&2
       if [[ "$MERGED_REFS_READ" != "true" ]]; then
         echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
         echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -697,8 +697,10 @@ while read -r STMT_START STMT_LEN; do
     echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
     if [[ $(printf '%s' "$STMT_RAW" | grep -o -- '--delete-branch' | grep -c .) -eq 1 ]]; then
       # An explicit boundary class, not \b: `-` is not a word character, so \b matched inside
-      # `--delete-branch-like` names and the sed would strip a prefix of a different flag.
-      FIXED_COMMAND=$(printf '%s' "$STMT_RAW" | sed -E 's/[[:space:]]+--delete-branch([^-[:alnum:]_]|$)/\1/')
+      # `--delete-branch-like` names and the sed would strip a prefix of a different flag. The
+      # `=value` spelling is consumed WITH the flag — keeping the boundary alone turned
+      # `--delete-branch=false` into a stray `=false` glued to the previous word. (#1672 review)
+      FIXED_COMMAND=$(printf '%s' "$STMT_RAW" | sed -E 's/[[:space:]]+--delete-branch(=[^[:space:]]*)?([^-=[:alnum:]_]|$)/\2/')
       echo "[branch-guard] Run this instead:" >&2
       echo "[branch-guard]   $FIXED_COMMAND" >&2
     else

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -683,10 +683,16 @@ while read -r STMT_START STMT_LEN; do
   fi
 
   if [[ "$IS_GH_DELETE_BRANCH" == "true" ]]; then
+    # Print the corrected command; do not paraphrase the policy. A guard that restates a rule
+    # becomes a second copy of it that drifts — this message once said the opposite of
+    # git-branch.md on both who may delete a branch and which flag to use, and the prohibited
+    # command was retried for weeks because the guard taught the wrong alternative.
+    FIXED_COMMAND=$(printf '%s' "$COMMAND" | sed -E 's/[[:space:]]+--delete-branch\b//g')
     echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
-    echo "[branch-guard] It once deleted the develop integration branch. Merge without it, then delete" >&2
-    echo "[branch-guard] only on explicit user request: git branch -D <name> (local) /" >&2
-    echo "[branch-guard] gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<name> (remote)." >&2
+    echo "[branch-guard] Run this instead:" >&2
+    echo "[branch-guard]   $FIXED_COMMAND" >&2
+    echo "[branch-guard] Branch cleanup after the merge is governed by .agents/rules/git-branch.md" >&2
+    echo "[branch-guard] (see 'Deleting a merged branch') — read it there, it is the only copy." >&2
     exit 2
   fi
 
@@ -874,7 +880,8 @@ while read -r STMT_START STMT_LEN; do
       for b in "${UNMERGED_BRANCHES[@]}"; do
         echo "  - $b" >&2
       done
-      echo "[branch-guard] After squash-merge via PR, delete the local branch: git branch -D <name>" >&2
+      echo "[branch-guard] Branch cleanup after a merge is governed by .agents/rules/git-branch.md" >&2
+      echo "[branch-guard] (see 'Deleting a merged branch') — read it there, it is the only copy." >&2
       if [[ "$MERGED_REFS_READ" != "true" ]]; then
         echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
         echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -695,7 +695,11 @@ while read -r STMT_START STMT_LEN; do
     # Ranges are 1-based (awk substr); bash slicing is 0-based.
     STMT_RAW="${COMMAND:$((STMT_START - 1)):$STMT_LEN}"
     echo "[branch-guard] Blocked: '--delete-branch' is prohibited in 'gh pr merge'. Zero exceptions." >&2
-    if [[ $(printf '%s' "$STMT_RAW" | grep -o -- '--delete-branch' | grep -c .) -eq 1 ]]; then
+    # Counted with the SAME boundary the sed strips with — a bare substring count read
+    # `--delete-branch-like` (a different flag) as an occurrence, chose the single-occurrence
+    # branch, and the sed then stripped nothing, so "Run this instead" repeated the refused
+    # command verbatim. (#1672 review)
+    if [[ $(printf '%s' "$STMT_RAW" | grep -oE -- '--delete-branch(=[^[:space:]]*)?([^-[:alnum:]_]|$)' | grep -c .) -eq 1 ]]; then
       # An explicit boundary class, not \b: `-` is not a word character, so \b matched inside
       # `--delete-branch-like` names and the sed would strip a prefix of a different flag. The
       # `=value` spelling is consumed WITH the flag — keeping the boundary alone turned

--- a/.claude/skills/architecture-refresh
+++ b/.claude/skills/architecture-refresh
@@ -1,0 +1,1 @@
+../../.agents/skills/architecture-refresh

--- a/.claude/skills/backlog-execution-orchestrator
+++ b/.claude/skills/backlog-execution-orchestrator
@@ -1,0 +1,1 @@
+../../.agents/skills/backlog-execution-orchestrator

--- a/.claude/skills/backlog-pipeline
+++ b/.claude/skills/backlog-pipeline
@@ -1,0 +1,1 @@
+../../.agents/skills/backlog-pipeline

--- a/.claude/skills/backlog-writer
+++ b/.claude/skills/backlog-writer
@@ -1,0 +1,1 @@
+../../.agents/skills/backlog-writer

--- a/.claude/skills/documentation-refresh
+++ b/.claude/skills/documentation-refresh
@@ -1,0 +1,1 @@
+../../.agents/skills/documentation-refresh

--- a/.claude/skills/lesson-to-harness
+++ b/.claude/skills/lesson-to-harness
@@ -1,0 +1,1 @@
+../../.agents/skills/lesson-to-harness

--- a/.claude/skills/multi-backlog-initiative
+++ b/.claude/skills/multi-backlog-initiative
@@ -1,0 +1,1 @@
+../../.agents/skills/multi-backlog-initiative

--- a/.claude/skills/post-implementation-checklist
+++ b/.claude/skills/post-implementation-checklist
@@ -1,0 +1,1 @@
+../../.agents/skills/post-implementation-checklist

--- a/.claude/skills/pr-finding-resolution-loop
+++ b/.claude/skills/pr-finding-resolution-loop
@@ -1,0 +1,1 @@
+../../.agents/skills/pr-finding-resolution-loop

--- a/.claude/skills/release-orchestration
+++ b/.claude/skills/release-orchestration
@@ -1,0 +1,1 @@
+../../.agents/skills/release-orchestration

--- a/.claude/skills/user-request-gate
+++ b/.claude/skills/user-request-gate
@@ -1,0 +1,1 @@
+../../.agents/skills/user-request-gate

--- a/.claude/skills/vercel-composition-patterns
+++ b/.claude/skills/vercel-composition-patterns
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-composition-patterns

--- a/.claude/skills/vercel-react-best-practices
+++ b/.claude/skills/vercel-react-best-practices
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-react-best-practices

--- a/.claude/skills/worktree-parallel-orchestration
+++ b/.claude/skills/worktree-parallel-orchestration
@@ -1,0 +1,1 @@
+../../.agents/skills/worktree-parallel-orchestration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ You are a senior TypeScript engineer working in this pnpm monorepo. Your experti
 
 This file is the entry point for all agent guidance in the Robota monorepo.
 
+> **Open action:** [.agents/token-cost-report.md](.agents/token-cost-report.md) holds a harness
+> audit — five floors already landed, and **ten decisions (D1–D10) that need an owner's answer**.
+> Read it before starting long-running work. Delete the file and its row below once the decisions
+> are answered and the checklist is clear.
+
 ## Document Discovery Policy
 
 This file contains only domain-free rules and routing. It does not contain package-specific knowledge, domain logic, or implementation details.
@@ -25,6 +30,7 @@ This file contains only domain-free rules and routing. It does not contain packa
 
 | Document                                                                               | Purpose                                                                                                             |
 | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [.agents/token-cost-report.md](.agents/token-cost-report.md)                           | **OPEN ACTION** — harness audit; D1–D10 await an owner decision. Delete this row when they are answered             |
 | [.agents/rules/index.md](.agents/rules/index.md)                                       | Rule group listing and routing                                                                                      |
 | [.agents/rules/code-quality.md](.agents/rules/code-quality.md)                         | Type system, imports, dev patterns                                                                                  |
 | [.agents/rules/process.md](.agents/rules/process.md)                                   | Routing file → spec-workflow, tdd-and-planning, verification, publish, backlog-execution (done gate), operational   |

--- a/scripts/harness/__tests__/scan-hook-syntax.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-syntax.test.mjs
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { collectHookSyntaxFindings } from '../scan-hook-syntax.mjs';
+
+/**
+ * ACCEPTANCE CRITERION (written before the scan).
+ *
+ * A hook that no longer parses exits 127, and the hook protocol treats a non-2 exit as PASS. So a
+ * single bad edit to a shared helper takes every guard that sources it offline, and every command
+ * afterwards sails through with nothing to show that anything changed. Registration floors prove a
+ * hook is WIRED; nothing proved it still PARSES.
+ *
+ * The scan FAILS when any shell file under `.claude/hooks/`, including `lib/`, does not parse.
+ */
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+function shellScripts(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = path.join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...shellScripts(full));
+    else if (name.endsWith('.sh')) out.push(full);
+  }
+  return out;
+}
+
+describe('scan-hook-syntax', () => {
+  it('is registered in run-all-scans.mjs', () => {
+    const runner = readFileSync(
+      path.join(WORKSPACE_ROOT, 'scripts/harness/run-all-scans.mjs'),
+      'utf8',
+    );
+    expect(runner).toContain('scan-hook-syntax.mjs');
+  });
+
+  it('passes on the live repository', () => {
+    expect(collectHookSyntaxFindings()).toEqual([]);
+  });
+
+  it('examines something — a pass over nothing is not a pass', () => {
+    expect(shellScripts(HOOKS_DIR).length).toBeGreaterThan(0);
+  });
+
+  it('covers lib/, which registration floors deliberately exclude', () => {
+    // Helpers are not registered to events, so a registration scan cannot see them — and they are
+    // sourced by several guards, which makes them the highest blast radius in the directory.
+    const libDir = path.join(HOOKS_DIR, 'lib');
+    if (!existsSync(libDir)) return;
+    const covered = shellScripts(HOOKS_DIR).map((f) => path.relative(WORKSPACE_ROOT, f));
+    const helpers = readdirSync(libDir).filter((n) => n.endsWith('.sh'));
+    for (const helper of helpers) {
+      expect(covered).toContain(path.join('.claude/hooks/lib', helper));
+    }
+  });
+});

--- a/scripts/harness/__tests__/scan-hook-syntax.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-syntax.test.mjs
@@ -1,7 +1,8 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 import { collectHookSyntaxFindings } from '../scan-hook-syntax.mjs';
 
@@ -30,6 +31,11 @@ function shellScripts(dir) {
   return out;
 }
 
+const scratch = [];
+afterAll(() => {
+  while (scratch.length > 0) rmSync(scratch.pop(), { recursive: true, force: true });
+});
+
 describe('scan-hook-syntax', () => {
   it('is registered in run-all-scans.mjs', () => {
     const runner = readFileSync(
@@ -45,6 +51,16 @@ describe('scan-hook-syntax', () => {
 
   it('examines something — a pass over nothing is not a pass', () => {
     expect(shellScripts(HOOKS_DIR).length).toBeGreaterThan(0);
+  });
+
+  it('REFUSES a hook directory with nothing in it', () => {
+    // The empty-tree case, and the reason it is a throw rather than a pass: the one state that
+    // produces "0 shell scripts" is the state in which every guard in this repository is already
+    // gone. Reporting clean there is the scan agreeing with its own worst outcome.
+    const bare = mkdtempSync(path.join(tmpdir(), 'no-hooks-'));
+    scratch.push(bare);
+
+    expect(() => collectHookSyntaxFindings(bare)).toThrow(/examined nothing/);
   });
 
   it('covers lib/, which registration floors deliberately exclude', () => {

--- a/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
+++ b/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
@@ -43,18 +43,25 @@ describe('scan-named-mechanism-resolves', () => {
     expect(hooks.resolves('.claude/hooks/does-not-exist.sh')).toBe(false);
   });
 
-  it('reads the bare `pnpm <script>` shorthand the binding documents actually use', () => {
-    // AGENTS.md's Harness Entrypoints carry no `run`; a matcher demanding it could not see the
-    // most-load-bearing command list it exists for.
+  it('reads the shorthand in both homes — inline backticks and bare at line start', () => {
+    // AGENTS.md's Harness Entrypoints carry no `run` AND no backticks (a fenced block); the
+    // matcher must see both, or the most-load-bearing command list goes unchecked.
     const scripts = MATCHERS.find((m) => m.kind === 'package script');
-    scripts.pattern.lastIndex = 0;
-    const hit = scripts.pattern.exec('Run `pnpm harness:scan` before pushing.');
-    expect(hit?.[1]).toBe('harness:scan');
+    const name = (text) => {
+      scripts.pattern.lastIndex = 0;
+      const hit = scripts.pattern.exec(text);
+      return hit ? (hit[1] ?? hit[2]) : null;
+    };
+    expect(name('Run `pnpm harness:scan` before pushing.')).toBe('harness:scan');
+    expect(name('pnpm harness:scan')).toBe('harness:scan');
+    expect(name('  pnpm harness:record -- --scope x')).toBe('harness:record');
+    // Bare mid-sentence is prose, not a command.
+    expect(name('this pnpm monorepo uses workspaces')).toBeNull();
   });
 
   it('does not read a package-manager builtin as a script name', () => {
     const scripts = MATCHERS.find((m) => m.kind === 'package script');
-    for (const text of ['Run `pnpm install` first.', 'Use `pnpm run` to list them.']) {
+    for (const text of ['Run `pnpm install` first.', 'Use `pnpm run` to list them.', 'pnpm install --frozen-lockfile']) {
       scripts.pattern.lastIndex = 0;
       expect(scripts.pattern.exec(text), `${text} was read as a script`).toBeNull();
     }

--- a/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
+++ b/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
@@ -61,7 +61,11 @@ describe('scan-named-mechanism-resolves', () => {
 
   it('does not read a package-manager builtin as a script name', () => {
     const scripts = MATCHERS.find((m) => m.kind === 'package script');
-    for (const text of ['Run `pnpm install` first.', 'Use `pnpm run` to list them.', 'pnpm install --frozen-lockfile']) {
+    for (const text of [
+      'Run `pnpm install` first.',
+      'Use `pnpm run` to list them.',
+      'pnpm install --frozen-lockfile',
+    ]) {
       scripts.pattern.lastIndex = 0;
       expect(scripts.pattern.exec(text), `${text} was read as a script`).toBeNull();
     }

--- a/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
+++ b/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { collectNamedMechanismFindings } from '../scan-named-mechanism-resolves.mjs';
+
+/**
+ * ACCEPTANCE CRITERION (written before the scan).
+ *
+ * A rule saying "use X" where X is absent is worse than a rule with no mechanism at all. The
+ * unmechanized rule is honestly prose and a reader treats it as judgement; the phantom one reads as
+ * satisfiable, so a reader either believes the obligation was met or drops it silently, and nothing
+ * afterwards distinguishes either from compliance.
+ *
+ * The scan FAILS when a rule or routing document names, by identity, a harness script, a hook, a
+ * package script, or an MCP server that does not resolve in this repository or its declared
+ * environment.
+ */
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+describe('scan-named-mechanism-resolves', () => {
+  it('is registered in run-all-scans.mjs', () => {
+    const runner = readFileSync(
+      path.join(WORKSPACE_ROOT, 'scripts/harness/run-all-scans.mjs'),
+      'utf8',
+    );
+    expect(runner).toContain('scan-named-mechanism-resolves.mjs');
+  });
+
+  it('passes on the live repository', () => {
+    expect(collectNamedMechanismFindings()).toEqual([]);
+  });
+
+  it('asserts presence, never behaviour', () => {
+    // Correctness of a named mechanism is owned by guards-pass-silently and
+    // hooks-have-execution-coverage. This floor sits beneath them: those scans cannot judge a
+    // file that is not there. Naming an existing-but-inert mechanism must therefore pass here.
+    expect(collectNamedMechanismFindings()).toEqual([]);
+  });
+});

--- a/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
+++ b/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { collectNamedMechanismFindings } from '../scan-named-mechanism-resolves.mjs';
+import { collectNamedMechanismFindings, MATCHERS } from '../scan-named-mechanism-resolves.mjs';
 
 /**
  * ACCEPTANCE CRITERION (written before the scan).
@@ -33,10 +33,40 @@ describe('scan-named-mechanism-resolves', () => {
     expect(collectNamedMechanismFindings()).toEqual([]);
   });
 
-  it('asserts presence, never behaviour', () => {
+  it('asserts presence, never behaviour — resolution reads existence, not content', () => {
     // Correctness of a named mechanism is owned by guards-pass-silently and
-    // hooks-have-execution-coverage. This floor sits beneath them: those scans cannot judge a
-    // file that is not there. Naming an existing-but-inert mechanism must therefore pass here.
-    expect(collectNamedMechanismFindings()).toEqual([]);
+    // hooks-have-execution-coverage; this floor sits beneath them. Asserted on the resolver
+    // itself: an existing hook resolves whatever its body does, and a phantom one does not —
+    // the earlier version of this case just repeated the live-repository assertion.
+    const hooks = MATCHERS.find((m) => m.kind === 'hook');
+    expect(hooks.resolves('.claude/hooks/branch-guard.sh')).toBe(true);
+    expect(hooks.resolves('.claude/hooks/does-not-exist.sh')).toBe(false);
+  });
+
+  it('reads the bare `pnpm <script>` shorthand the binding documents actually use', () => {
+    // AGENTS.md's Harness Entrypoints carry no `run`; a matcher demanding it could not see the
+    // most-load-bearing command list it exists for.
+    const scripts = MATCHERS.find((m) => m.kind === 'package script');
+    scripts.pattern.lastIndex = 0;
+    const hit = scripts.pattern.exec('Run `pnpm harness:scan` before pushing.');
+    expect(hit?.[1]).toBe('harness:scan');
+  });
+
+  it('does not read a package-manager builtin as a script name', () => {
+    const scripts = MATCHERS.find((m) => m.kind === 'package script');
+    for (const text of ['Run `pnpm install` first.', 'Use `pnpm run` to list them.']) {
+      scripts.pattern.lastIndex = 0;
+      expect(scripts.pattern.exec(text), `${text} was read as a script`).toBeNull();
+    }
+  });
+
+  it('does not read a determiner in front of MCP as a server name', () => {
+    const mcp = MATCHERS.find((m) => m.kind === 'MCP server');
+    for (const text of ['This MCP server does X.', 'Every MCP server is declared.']) {
+      mcp.pattern.lastIndex = 0;
+      expect(mcp.pattern.exec(text), `${text} was read as a name`).toBeNull();
+    }
+    mcp.pattern.lastIndex = 0;
+    expect(mcp.pattern.exec('Use the Playwright MCP server.')?.[1]).toBe('Playwright');
   });
 });

--- a/scripts/harness/__tests__/scan-skill-registration.test.mjs
+++ b/scripts/harness/__tests__/scan-skill-registration.test.mjs
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { collectSkillRegistrationFindings } from '../scan-skill-registration.mjs';
+import { asScalar, frontmatterObject } from '../frontmatter.mjs';
+
+/**
+ * ACCEPTANCE CRITERION (written before the scan).
+ *
+ * `.claude/skills/` is the only directory the Skill tool reads. Skills are authored elsewhere and
+ * linked in. Nothing compared the two, so all four of these stayed green:
+ *
+ *   A. a registration resolving to nothing — the name is offered and cannot load;
+ *   B. a document ordering a skill by name that is not registered — an instruction that cannot
+ *      succeed, re-issued every time the document is read;
+ *   C. a skill declaring itself invocable while unregistered, or registered without declaring it;
+ *   D. registered descriptions growing without bound — every one is loaded into every session.
+ *
+ * The scan FAILS on each and names the offender. This test asserts the scan is reachable, that it
+ * is registered in the runner, and that it passes on the live tree — the same shape as
+ * `scan-hook-registration.test.mjs`, whose floor this one mirrors for the layer above.
+ */
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const REGISTRY_DIR = path.join(WORKSPACE_ROOT, '.claude/skills');
+const SOURCE_DIR = path.join(WORKSPACE_ROOT, '.agents/skills');
+
+function registeredNames() {
+  if (!existsSync(REGISTRY_DIR)) return [];
+  return readdirSync(REGISTRY_DIR)
+    .filter((n) => !n.startsWith('.'))
+    .sort();
+}
+
+describe('scan-skill-registration', () => {
+  it('is registered in run-all-scans.mjs', () => {
+    const runner = readFileSync(
+      path.join(WORKSPACE_ROOT, 'scripts/harness/run-all-scans.mjs'),
+      'utf8',
+    );
+    expect(runner).toContain('scan-skill-registration.mjs');
+  });
+
+  it('passes on the live repository', () => {
+    expect(collectSkillRegistrationFindings()).toEqual([]);
+  });
+
+  it('examines something — a pass over nothing is not a pass', () => {
+    expect(registeredNames().length).toBeGreaterThan(0);
+  });
+
+  it('every registration resolves to a SKILL.md', () => {
+    for (const name of registeredNames()) {
+      expect(
+        existsSync(path.join(REGISTRY_DIR, name, 'SKILL.md')),
+        `.claude/skills/${name} does not resolve`,
+      ).toBe(true);
+    }
+  });
+
+  it('registration and the skill’s own declaration agree in both directions', () => {
+    const registered = new Set(registeredNames());
+    for (const name of readdirSync(SOURCE_DIR).filter((n) => !n.startsWith('.'))) {
+      const file = path.join(SOURCE_DIR, name, 'SKILL.md');
+      if (!existsSync(file)) continue;
+      const declared =
+        asScalar(frontmatterObject(readFileSync(file, 'utf8')).invocable).toLowerCase() === 'true';
+      expect(declared, `${name}: declaration and registry disagree`).toBe(registered.has(name));
+    }
+  });
+
+  it('every skill a hook orders by name is registered', () => {
+    // The failure this floor was built for: a hook fires on every prompt and names a skill the
+    // Skill tool cannot load, so the instruction cannot succeed and is re-issued forever.
+    const hooksDir = path.join(WORKSPACE_ROOT, '.claude/hooks');
+    const registered = new Set(registeredNames());
+    const orders = [
+      /Use skill:\s*`([a-z0-9-]+)`/g,
+      /invoke the ([a-z0-9-]+) skill/gi,
+      /Run gate pipeline:\s*`([a-z0-9-]+)`/g,
+    ];
+
+    for (const file of readdirSync(hooksDir).filter((n) => n.endsWith('.sh'))) {
+      const text = readFileSync(path.join(hooksDir, file), 'utf8');
+      for (const pattern of orders) {
+        pattern.lastIndex = 0;
+        let m;
+        while ((m = pattern.exec(text)) !== null) {
+          if (!existsSync(path.join(SOURCE_DIR, m[1], 'SKILL.md'))) continue;
+          expect(registered.has(m[1]), `${file} orders \`${m[1]}\`, which is not registered`).toBe(
+            true,
+          );
+        }
+      }
+    }
+  });
+});

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -269,9 +269,8 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/scan-action-references.mjs'],
   },
   {
-    // Skills counterpart to INFRA-078's hook-registration floor. Measured on session 50cb28dd:
-    // 53 skills on disk, 5 registered, 3 of those dangling, and every project-skill invocation
-    // returned `Unknown skill` (13/13) because two hooks order skills by name on every prompt.
+    // A rule or routing document that names a mechanism (a harness script, a hook, a package
+    // script, an MCP server) must name one that resolves — a phantom name reads as satisfiable.
     name: 'named-mechanism-resolves',
     command: ['node', 'scripts/harness/scan-named-mechanism-resolves.mjs'],
   },
@@ -280,6 +279,9 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/scan-hook-syntax.mjs'],
   },
   {
+    // Skills counterpart to INFRA-078's hook-registration floor. Measured on session 50cb28dd:
+    // 53 skills on disk, 5 registered, 3 of those dangling, and every project-skill invocation
+    // returned `Unknown skill` (13/13) because two hooks order skills by name on every prompt.
     name: 'skill-registration',
     command: ['node', 'scripts/harness/scan-skill-registration.mjs'],
   },

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -268,6 +268,21 @@ export const SCAN_COMMANDS = [
     name: 'action-references',
     command: ['node', 'scripts/harness/scan-action-references.mjs'],
   },
+  {
+    // Skills counterpart to INFRA-078's hook-registration floor. Measured on session 50cb28dd:
+    // 53 skills on disk, 5 registered, 3 of those dangling, and every project-skill invocation
+    // returned `Unknown skill` (13/13) because two hooks order skills by name on every prompt.
+    name: 'named-mechanism-resolves',
+    command: ['node', 'scripts/harness/scan-named-mechanism-resolves.mjs'],
+  },
+  {
+    name: 'hook-syntax',
+    command: ['node', 'scripts/harness/scan-hook-syntax.mjs'],
+  },
+  {
+    name: 'skill-registration',
+    command: ['node', 'scripts/harness/scan-skill-registration.mjs'],
+  },
   { name: 'document-authority', command: ['node', 'scripts/harness/check-document-authority.mjs'] },
   { name: 'commands', command: ['node', 'scripts/harness/check-command-layering.mjs'] },
   {

--- a/scripts/harness/scan-hook-syntax.mjs
+++ b/scripts/harness/scan-hook-syntax.mjs
@@ -15,6 +15,8 @@
  *
  * Usage: `node scripts/harness/scan-hook-syntax.mjs`
  * Exit 0 = clean, 1 = blocking findings.
+ *
+ * fail-direction: refuse — an empty hook directory THROWS rather than reporting a clean pass.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -35,8 +37,18 @@ function shellScripts(dir) {
   return out.sort();
 }
 
-export function collectHookSyntaxFindings() {
-  const scripts = shellScripts(HOOKS_DIR);
+export function collectHookSyntaxFindings(hooksDir = HOOKS_DIR) {
+  const scripts = shellScripts(hooksDir);
+  // Nothing-examined is not nothing-wrong. With no hooks found this printed a clean pass, and the
+  // one state that produces it — the hook directory moved, renamed or emptied — is the state in
+  // which every guard in this repository is already gone.
+  if (scripts.length === 0) {
+    throw new Error(
+      `[hook-syntax] no shell scripts under ${path.relative(WORKSPACE_ROOT, hooksDir)}. ` +
+        'This scan judges the guards; with none present it has examined nothing, and reporting a ' +
+        'pass over nothing is the failure it exists to catch.',
+    );
+  }
   const broken = [];
 
   for (const file of scripts) {

--- a/scripts/harness/scan-hook-syntax.mjs
+++ b/scripts/harness/scan-hook-syntax.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * Hook SYNTAX floor — a hook that no longer parses disarms every guard that sources it.
+ *
+ * `scan-hook-registration.mjs` proves a hook is wired; nothing proved it still parses. Four
+ * outages in session 50cb28dd (2026-07-28/30/31, 08-01) came from live edits that left
+ * `lib/command-scan.sh` and `worktree-cwd-guard.sh` syntactically broken. A hook that cannot
+ * run exits 127, and the hook protocol treats a non-2 exit as PASS — so the failure mode is
+ * silent: four PreToolUse Bash guards go quiet at once and every command sails through.
+ *
+ * `lib/` is deliberately included. `scan-hook-registration.mjs` excludes it because helpers are
+ * not registered to events, but they are sourced by four guards, which makes them the highest
+ * blast-radius files in the directory.
+ *
+ * Usage: `node scripts/harness/scan-hook-syntax.mjs`
+ * Exit 0 = clean, 1 = blocking findings.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+function shellScripts(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = path.join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...shellScripts(full));
+    else if (name.endsWith('.sh')) out.push(full);
+  }
+  return out.sort();
+}
+
+export function collectHookSyntaxFindings() {
+  const scripts = shellScripts(HOOKS_DIR);
+  const broken = [];
+
+  for (const file of scripts) {
+    try {
+      execFileSync('bash', ['-n', file], { stdio: ['ignore', 'ignore', 'pipe'] });
+    } catch (error) {
+      broken.push({
+        file: path.relative(WORKSPACE_ROOT, file),
+        err: String(error.stderr ?? '').trim(),
+      });
+    }
+  }
+
+  if (broken.length > 0) {
+    console.error('[hook-syntax] blocking findings:\n');
+    for (const b of broken) {
+      console.error(`  - ${b.file} does not parse. Every guard that sources it is disarmed —`);
+      console.error(`    a hook that cannot run exits 127, which the protocol treats as PASS.`);
+      for (const line of b.err.split('\n').slice(0, 4)) console.error(`      ${line}`);
+      console.error('');
+    }
+    process.exitCode = 1;
+    return broken;
+  }
+
+  console.log(`[hook-syntax] clean — ${scripts.length} shell scripts parse.`);
+
+  return broken;
+}
+
+function main() {
+  collectHookSyntaxFindings();
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/harness/scan-named-mechanism-resolves.mjs
+++ b/scripts/harness/scan-named-mechanism-resolves.mjs
@@ -57,15 +57,17 @@ export const MATCHERS = [
   },
   {
     kind: 'package script',
-    // Both spellings: `pnpm run x` and the bare `pnpm x` shorthand — the shorthand is what the
-    // binding documents actually use (AGENTS.md's Harness Entrypoints carries no `run`), so a
-    // matcher demanding `run` could not see the most-load-bearing command list it exists for.
+    // Both spellings (`pnpm run x` and the bare `pnpm x` shorthand), in both homes: inline
+    // backticks anywhere, and BARE at line start — which is where fenced command blocks put
+    // them, and where the most-load-bearing lists live (AGENTS.md's Harness Entrypoints, the
+    // release runbooks). Bare mid-sentence stays unmatched, or prose like "this pnpm monorepo"
+    // reads as a script name.
     // Package-manager BUILT-INS are not package scripts and are excluded, or `pnpm install`
     // would be flagged for not appearing in `scripts`. `test` and `start` are NOT in that list:
     // like `build`, they resolve through the scripts field, and excluding them would leave the
     // most ordinary commands documents name permanently unchecked.
     pattern:
-      /`(?:pnpm|npm)(?: run)? (?!(?:run|install|add|remove|update|publish|exec|dlx|link|why|list|store|patch|import|prune|rebuild|audit|outdated|create|init|config|help|setup|whoami|login|logout|-)\b)([\w:-]+)`/g,
+      /(?:^\s*(?:pnpm|npm)(?: run)? (?!(?:run|install|add|remove|update|publish|exec|dlx|link|why|list|store|patch|import|prune|rebuild|audit|outdated|create|init|config|help|setup|whoami|login|logout|-)\b)([\w:-]+)(?=$|[^\w:-])|`(?:pnpm|npm)(?: run)? (?!(?:run|install|add|remove|update|publish|exec|dlx|link|why|list|store|patch|import|prune|rebuild|audit|outdated|create|init|config|help|setup|whoami|login|logout|-)\b)([\w:-]+)`)/g,
     resolves: (name) => {
       const pkg = path.join(WORKSPACE_ROOT, 'package.json');
       // No manifest means the question cannot be answered, and answering `true` made every
@@ -151,7 +153,7 @@ export function collectNamedMechanismFindings() {
         matcher.pattern.lastIndex = 0;
         let match;
         while ((match = matcher.pattern.exec(line)) !== null) {
-          const name = match[1];
+          const name = match[1] ?? match[2];
           if (matcher.resolves(name)) continue;
           findings.push(
             `${doc.label}:${index + 1} names the ${matcher.kind} \`${name}\`, which does not ` +

--- a/scripts/harness/scan-named-mechanism-resolves.mjs
+++ b/scripts/harness/scan-named-mechanism-resolves.mjs
@@ -61,9 +61,11 @@ export const MATCHERS = [
     // binding documents actually use (AGENTS.md's Harness Entrypoints carries no `run`), so a
     // matcher demanding `run` could not see the most-load-bearing command list it exists for.
     // Package-manager BUILT-INS are not package scripts and are excluded, or `pnpm install`
-    // would be flagged for not appearing in `scripts`.
+    // would be flagged for not appearing in `scripts`. `test` and `start` are NOT in that list:
+    // like `build`, they resolve through the scripts field, and excluding them would leave the
+    // most ordinary commands documents name permanently unchecked.
     pattern:
-      /`(?:pnpm|npm)(?: run)? (?!(?:run|install|add|remove|update|publish|exec|dlx|link|why|list|store|patch|import|prune|rebuild|audit|outdated|test|start|create|init|config|help|setup|whoami|login|logout|-)\b)([\w:-]+)`/g,
+      /`(?:pnpm|npm)(?: run)? (?!(?:run|install|add|remove|update|publish|exec|dlx|link|why|list|store|patch|import|prune|rebuild|audit|outdated|create|init|config|help|setup|whoami|login|logout|-)\b)([\w:-]+)`/g,
     resolves: (name) => {
       const pkg = path.join(WORKSPACE_ROOT, 'package.json');
       // No manifest means the question cannot be answered, and answering `true` made every

--- a/scripts/harness/scan-named-mechanism-resolves.mjs
+++ b/scripts/harness/scan-named-mechanism-resolves.mjs
@@ -25,6 +25,9 @@
  *
  * Usage: `node scripts/harness/scan-named-mechanism-resolves.mjs`
  * Exit 0 = clean, 1 = blocking findings.
+ *
+ * fail-direction: refuse — an empty document scope, an absent root manifest, or a missing
+ * `run-all-scans.mjs` each THROW rather than reporting a clean pass over what could not be read.
  */
 
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
@@ -57,7 +60,15 @@ const MATCHERS = [
     pattern: /`(?:pnpm|npm) run ([\w:-]+)`/g,
     resolves: (name) => {
       const pkg = path.join(WORKSPACE_ROOT, 'package.json');
-      if (!existsSync(pkg)) return true;
+      // No manifest means the question cannot be answered, and answering `true` made every
+      // `pnpm run …` claim in every rule resolve by default — the scan reporting clean precisely
+      // when it could see nothing.
+      if (!existsSync(pkg)) {
+        throw new Error(
+          '[named-mechanism-resolves] no package.json at the workspace root, so no `pnpm run` ' +
+            'claim can be checked. Refusing rather than resolving them all by default.',
+        );
+      }
       return Boolean(JSON.parse(readFileSync(pkg, 'utf8')).scripts?.[name]);
     },
     hint: 'Add the script to package.json, or name an existing one.',
@@ -108,8 +119,18 @@ function documents() {
 
 export function collectNamedMechanismFindings() {
   const findings = [];
+  const scope = documents();
+  // The binding documents are mandatory in this repository, so an empty scope is a broken checkout
+  // rather than a repository with nothing to check. Reporting "no findings" here would mean
+  // "nothing was examined".
+  if (scope.length === 0) {
+    throw new Error(
+      '[named-mechanism-resolves] no binding documents found (.agents/rules/*.md, AGENTS.md). ' +
+        'Refusing rather than reporting a pass over nothing.',
+    );
+  }
 
-  for (const doc of documents()) {
+  for (const doc of scope) {
     const text = readFileSync(doc.full, 'utf8');
     const lines = text.split('\n');
 
@@ -132,10 +153,15 @@ export function collectNamedMechanismFindings() {
 
   // A scan that is not registered cannot report that it is not registered.
   const runner = path.join(WORKSPACE_ROOT, 'scripts/harness/run-all-scans.mjs');
-  if (
-    existsSync(runner) &&
-    !readFileSync(runner, 'utf8').includes('scan-named-mechanism-resolves.mjs')
-  ) {
+  // An `existsSync(runner) &&` guard stood here, which turned a missing runner into a silently
+  // skipped registration check — the same shape the check itself is about.
+  if (!existsSync(runner)) {
+    throw new Error(
+      '[named-mechanism-resolves] run-all-scans.mjs is missing, so registration cannot be ' +
+        'checked. That is the condition this check exists to report, not one to skip it for.',
+    );
+  }
+  if (!readFileSync(runner, 'utf8').includes('scan-named-mechanism-resolves.mjs')) {
     findings.push(
       'scan-named-mechanism-resolves.mjs is absent from run-all-scans.mjs — it would never run, ' +
         'which is the failure class it exists to catch.',
@@ -149,7 +175,7 @@ export function collectNamedMechanismFindings() {
     return findings;
   }
 
-  console.log(`[named-mechanism-resolves] clean — ${documents().length} documents examined.`);
+  console.log(`[named-mechanism-resolves] clean — ${scope.length} documents examined.`);
   return findings;
 }
 

--- a/scripts/harness/scan-named-mechanism-resolves.mjs
+++ b/scripts/harness/scan-named-mechanism-resolves.mjs
@@ -42,7 +42,7 @@ const SCOPE = [{ dir: '.agents/rules', suffix: '.md' }, { file: 'AGENTS.md' }];
  * Each matcher pairs a way of naming a mechanism with the question "does this exist?".
  * `kind` is only used to phrase the finding.
  */
-const MATCHERS = [
+export const MATCHERS = [
   {
     kind: 'harness script',
     pattern: /`?(scripts\/harness\/[\w.-]+\.mjs)`?/g,
@@ -57,7 +57,13 @@ const MATCHERS = [
   },
   {
     kind: 'package script',
-    pattern: /`(?:pnpm|npm) run ([\w:-]+)`/g,
+    // Both spellings: `pnpm run x` and the bare `pnpm x` shorthand — the shorthand is what the
+    // binding documents actually use (AGENTS.md's Harness Entrypoints carries no `run`), so a
+    // matcher demanding `run` could not see the most-load-bearing command list it exists for.
+    // Package-manager BUILT-INS are not package scripts and are excluded, or `pnpm install`
+    // would be flagged for not appearing in `scripts`.
+    pattern:
+      /`(?:pnpm|npm)(?: run)? (?!(?:run|install|add|remove|update|publish|exec|dlx|link|why|list|store|patch|import|prune|rebuild|audit|outdated|test|start|create|init|config|help|setup|whoami|login|logout|-)\b)([\w:-]+)`/g,
     resolves: (name) => {
       const pkg = path.join(WORKSPACE_ROOT, 'package.json');
       // No manifest means the question cannot be answered, and answering `true` made every
@@ -75,8 +81,11 @@ const MATCHERS = [
   },
   {
     kind: 'MCP server',
-    // "Playwright MCP", "the Foo MCP server" — an identity, not a description.
-    pattern: /\b([A-Z][\w-]*)\s+MCP(?:\s+server)?\b/g,
+    // "Playwright MCP", "the Foo MCP server" — an identity, not a description. A sentence-form
+    // determiner in front of "MCP" ("This MCP server…", "Every MCP…") is grammar, not a name,
+    // and reading it as one would fail the scan the moment a rule gains an idiomatic sentence.
+    pattern:
+      /\b(?!(?:This|That|The|These|Those|A|An|Any|Every|Each|No|Some|Its|Their|Our|Which|One)\b)([A-Z][\w-]*)\s+MCP(?:\s+server)?\b/g,
     resolves: (name) => {
       const declared = new Set();
       const mcpFile = path.join(WORKSPACE_ROOT, '.mcp.json');

--- a/scripts/harness/scan-named-mechanism-resolves.mjs
+++ b/scripts/harness/scan-named-mechanism-resolves.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+/**
+ * A document that names a mechanism as required must name one that exists.
+ *
+ * A rule saying "use X" where X is absent is worse than a rule with no mechanism at all. The
+ * unmechanized rule is honestly prose and a reader treats it as judgement. The phantom one reads
+ * as satisfiable, so a reader either believes the obligation was met or silently drops it — and
+ * either way nothing distinguishes that from compliance afterwards.
+ *
+ * WHAT IT FLAGS: a mechanism named by identity in a rule or routing document, whose identity does
+ * not resolve in this repository or its declared environment — a harness script, a hook, a package
+ * script, an MCP server. Those are the marks of a named mechanism, and they are what a machine can
+ * see.
+ *
+ * WHAT IT CANNOT SEE: a mechanism named descriptively rather than by identity ("verify in a
+ * browser", "run the linter"). Prose that names no artifact is out of reach here; whether such an
+ * obligation is reachable at all is a separate, human obligation, and this scan going green does
+ * not discharge it.
+ *
+ * WHY BY IDENTITY AND NOT BY BEHAVIOUR: this scan asserts presence, never correctness. A hook that
+ * exists and does nothing passes here — `guards-pass-silently` and `hooks-have-execution-coverage`
+ * own that question. Presence is the floor beneath them: those scans cannot judge a file that is
+ * not there.
+ *
+ * Usage: `node scripts/harness/scan-named-mechanism-resolves.mjs`
+ * Exit 0 = clean, 1 = blocking findings.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** Documents whose statements bind. Skills and tasks describe work; rules and routing bind it. */
+const SCOPE = [{ dir: '.agents/rules', suffix: '.md' }, { file: 'AGENTS.md' }];
+
+/**
+ * Each matcher pairs a way of naming a mechanism with the question "does this exist?".
+ * `kind` is only used to phrase the finding.
+ */
+const MATCHERS = [
+  {
+    kind: 'harness script',
+    pattern: /`?(scripts\/harness\/[\w.-]+\.mjs)`?/g,
+    resolves: (name) => existsSync(path.join(WORKSPACE_ROOT, name)),
+    hint: 'Add the script, or name the one that carries the obligation.',
+  },
+  {
+    kind: 'hook',
+    pattern: /`?(\.claude\/hooks\/[\w./-]+\.sh)`?/g,
+    resolves: (name) => existsSync(path.join(WORKSPACE_ROOT, name)),
+    hint: 'Add the hook, or name the one that carries the obligation.',
+  },
+  {
+    kind: 'package script',
+    pattern: /`(?:pnpm|npm) run ([\w:-]+)`/g,
+    resolves: (name) => {
+      const pkg = path.join(WORKSPACE_ROOT, 'package.json');
+      if (!existsSync(pkg)) return true;
+      return Boolean(JSON.parse(readFileSync(pkg, 'utf8')).scripts?.[name]);
+    },
+    hint: 'Add the script to package.json, or name an existing one.',
+  },
+  {
+    kind: 'MCP server',
+    // "Playwright MCP", "the Foo MCP server" — an identity, not a description.
+    pattern: /\b([A-Z][\w-]*)\s+MCP(?:\s+server)?\b/g,
+    resolves: (name) => {
+      const declared = new Set();
+      const mcpFile = path.join(WORKSPACE_ROOT, '.mcp.json');
+      if (existsSync(mcpFile)) {
+        for (const k of Object.keys(JSON.parse(readFileSync(mcpFile, 'utf8')).mcpServers ?? {})) {
+          declared.add(k.toLowerCase());
+        }
+      }
+      const settings = path.join(WORKSPACE_ROOT, '.claude/settings.json');
+      if (existsSync(settings)) {
+        for (const k of Object.keys(JSON.parse(readFileSync(settings, 'utf8')).mcpServers ?? {})) {
+          declared.add(k.toLowerCase());
+        }
+      }
+      return declared.has(name.toLowerCase());
+    },
+    hint:
+      'Declare the server in .mcp.json or .claude/settings.json, or restate the obligation ' +
+      'in terms of an outcome rather than a tool this repository does not configure.',
+  },
+];
+
+function documents() {
+  const out = [];
+  for (const entry of SCOPE) {
+    if (entry.file) {
+      const full = path.join(WORKSPACE_ROOT, entry.file);
+      if (existsSync(full)) out.push({ label: entry.file, full });
+      continue;
+    }
+    const dir = path.join(WORKSPACE_ROOT, entry.dir);
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir).sort()) {
+      if (!name.endsWith(entry.suffix)) continue;
+      out.push({ label: `${entry.dir}/${name}`, full: path.join(dir, name) });
+    }
+  }
+  return out;
+}
+
+export function collectNamedMechanismFindings() {
+  const findings = [];
+
+  for (const doc of documents()) {
+    const text = readFileSync(doc.full, 'utf8');
+    const lines = text.split('\n');
+
+    lines.forEach((line, index) => {
+      // A line that only links to a document is routing, not an obligation to run something.
+      for (const matcher of MATCHERS) {
+        matcher.pattern.lastIndex = 0;
+        let match;
+        while ((match = matcher.pattern.exec(line)) !== null) {
+          const name = match[1];
+          if (matcher.resolves(name)) continue;
+          findings.push(
+            `${doc.label}:${index + 1} names the ${matcher.kind} \`${name}\`, which does not ` +
+              `resolve. ${matcher.hint}`,
+          );
+        }
+      }
+    });
+  }
+
+  // A scan that is not registered cannot report that it is not registered.
+  const runner = path.join(WORKSPACE_ROOT, 'scripts/harness/run-all-scans.mjs');
+  if (
+    existsSync(runner) &&
+    !readFileSync(runner, 'utf8').includes('scan-named-mechanism-resolves.mjs')
+  ) {
+    findings.push(
+      'scan-named-mechanism-resolves.mjs is absent from run-all-scans.mjs — it would never run, ' +
+        'which is the failure class it exists to catch.',
+    );
+  }
+
+  if (findings.length > 0) {
+    console.error('[named-mechanism-resolves] blocking findings:\n');
+    for (const f of findings) console.error(`  - ${f}\n`);
+    process.exitCode = 1;
+    return findings;
+  }
+
+  console.log(`[named-mechanism-resolves] clean — ${documents().length} documents examined.`);
+  return findings;
+}
+
+function main() {
+  collectNamedMechanismFindings();
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/harness/scan-skill-registration.mjs
+++ b/scripts/harness/scan-skill-registration.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+
+/**
+ * Skill REGISTRATION floor — `.claude/skills/` was read by nothing.
+ *
+ * Counterpart to `scan-hook-registration.mjs` (INFRA-078), one layer up. That scan closed the same
+ * hole for hooks: a directory of capabilities, a separate file that decides whether anything ever
+ * CALLS them, and nothing comparing the two. Skills had the identical gap and it stayed open.
+ *
+ * Measured on session 50cb28dd (34.6 days, 26,068 turns) before this scan existed:
+ *   - `.agents/skills/` held 53 skills; `.claude/skills/` held 5 symlinks, 3 of them DANGLING.
+ *   - Two hooks named skills imperatively on every UserPromptSubmit
+ *     (`spec-first-gate.sh:64,70`, `correction-detect.sh:45`).
+ *   - Every project-skill invocation failed: `Unknown skill` ×13 (lesson-to-harness 6,
+ *     backlog-writer 3, backlog-pipeline 3, user-request-gate 1).
+ *   - `learning-loop.md:8` names `lesson-to-harness` as THE procedure for turning a repeated
+ *     lesson into an enforced rule. The repo's learning loop had a 0% invocation success rate.
+ *
+ * Four states this refuses, each one live at the time it was written:
+ *
+ *   A. a registration resolves to nothing — the name is offered and cannot load;
+ *   B. a hook or skill body orders a skill by name that is not registered — an instruction that
+ *      cannot succeed, re-issued on every prompt;
+ *   C. a skill declares `invocable: true` but is not registered, or is registered without
+ *      declaring it — the declaration and the wiring disagree;
+ *   D. the registered descriptions exceed the context budget — every one is loaded into every
+ *      session, so this grows silently one PR at a time.
+ *
+ * `invocable: true` is a declaration each SKILL.md carries in its own frontmatter, cross-checked
+ * against the registry. It is deliberately NOT an exemption list — per the lesson recorded in
+ * `scan-hook-registration.mjs`, an exemption list is the hole the floor was built to close.
+ *
+ * Usage: `node scripts/harness/scan-skill-registration.mjs`
+ * Exit 0 = clean, 1 = blocking findings.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { asScalar, frontmatterObject } from './frontmatter.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const SOURCE_DIR = path.join(WORKSPACE_ROOT, '.agents/skills');
+const REGISTRY_DIR = path.join(WORKSPACE_ROOT, '.claude/skills');
+const HOOKS_DIR = path.join(WORKSPACE_ROOT, '.claude/hooks');
+
+/**
+ * Every registered description is loaded into every session, so this only ever ratchets DOWN.
+ *
+ * These are the measured totals on the day the floor landed, not a design target. Nine of the
+ * twelve descriptions carry a procedure summary and a policy statement after their trigger
+ * clause — material that belongs in the body, which is loaded only on invocation. Trimming them
+ * is a content change for the skill owners; this floor exists so the number cannot grow while
+ * that is pending. **Lower these as descriptions are trimmed. Never raise them.**
+ */
+const DESCRIPTION_BUDGET_BYTES = 5720;
+const SINGLE_DESCRIPTION_MAX_BYTES = 872;
+
+export function collectSkillRegistrationFindings() {
+  const findings = [];
+
+  /**
+   * `frontmatter.mjs` is the single owner of frontmatter parsing for harness scripts (HARNESS-046).
+   * A per-line regex here would be a fifth fork of the same single-line assumption.
+   */
+  function frontmatter(file) {
+    if (!existsSync(file)) return null;
+    const parsed = frontmatterObject(readFileSync(file, 'utf8'));
+    return {
+      description: asScalar(parsed.description),
+      invocable: asScalar(parsed.invocable).toLowerCase() === 'true',
+    };
+  }
+
+  function listDirs(dir) {
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((name) => !name.startsWith('.'))
+      .sort();
+  }
+
+  // ── A. every registration resolves ───────────────────────────────────────────
+  const registered = listDirs(REGISTRY_DIR);
+  const resolved = [];
+  for (const name of registered) {
+    const entry = path.join(REGISTRY_DIR, name);
+    const skillFile = path.join(entry, 'SKILL.md');
+    if (!existsSync(entry) || !existsSync(skillFile)) {
+      findings.push(
+        `A. .claude/skills/${name} does not resolve to a SKILL.md — the name is offered to the ` +
+          `Skill tool and cannot load. Remove the entry or restore its target.`,
+      );
+      continue;
+    }
+    if (!statSync(entry).isDirectory()) {
+      findings.push(`A. .claude/skills/${name} is not a directory.`);
+      continue;
+    }
+    resolved.push(name);
+  }
+
+  // ── B. nothing orders a skill that is not registered ─────────────────────────
+  // Imperative shapes only. A markdown link to a SKILL.md path is satisfied by Read and is fine.
+  const ORDER_PATTERNS = [
+    /Use skill:\s*`([a-z0-9-]+)`/g,
+    /invoke the ([a-z0-9-]+) skill/gi,
+    /Run gate pipeline:\s*`([a-z0-9-]+)`/g,
+    /Invoke\s+`([a-z0-9-]+)`\s+skill/gi,
+    /`([a-z0-9-]+)`\s+skill\s+\(Skill tool\)/gi,
+  ];
+
+  const orderSites = [];
+  function scanForOrders(file, label) {
+    const text = readFileSync(file, 'utf8');
+    for (const pattern of ORDER_PATTERNS) {
+      pattern.lastIndex = 0;
+      let m;
+      while ((m = pattern.exec(text)) !== null) {
+        const line = text.slice(0, m.index).split('\n').length;
+        orderSites.push({ skill: m[1], where: `${label}:${line}` });
+      }
+    }
+  }
+
+  for (const name of existsSync(HOOKS_DIR) ? readdirSync(HOOKS_DIR) : []) {
+    if (!name.endsWith('.sh')) continue;
+    scanForOrders(path.join(HOOKS_DIR, name), `.claude/hooks/${name}`);
+  }
+  for (const name of listDirs(SOURCE_DIR)) {
+    const file = path.join(SOURCE_DIR, name, 'SKILL.md');
+    if (existsSync(file)) scanForOrders(file, `.agents/skills/${name}/SKILL.md`);
+  }
+
+  const registeredSet = new Set(resolved);
+  for (const site of orderSites) {
+    if (registeredSet.has(site.skill)) continue;
+    if (!existsSync(path.join(SOURCE_DIR, site.skill, 'SKILL.md'))) continue; // not one of ours
+    findings.push(
+      `B. ${site.where} orders \`${site.skill}\` by name, but it is not in .claude/skills/. ` +
+        `The Skill tool will answer "Unknown skill" every time this fires.`,
+    );
+  }
+
+  // ── C. declaration and wiring agree ──────────────────────────────────────────
+  for (const name of listDirs(SOURCE_DIR)) {
+    const meta = frontmatter(path.join(SOURCE_DIR, name, 'SKILL.md'));
+    if (meta === null) continue;
+    const isRegistered = registeredSet.has(name);
+    if (meta.invocable && !isRegistered) {
+      findings.push(
+        `C. .agents/skills/${name}/SKILL.md declares \`invocable: true\` but is not registered ` +
+          `in .claude/skills/. Register it, or drop the declaration.`,
+      );
+    }
+    if (!meta.invocable && isRegistered) {
+      findings.push(
+        `C. .claude/skills/${name} is registered but its SKILL.md does not declare ` +
+          `\`invocable: true\`. Add the declaration so the intent is readable at the source.`,
+      );
+    }
+  }
+
+  // ── D. the listing cannot silently re-inflate ────────────────────────────────
+  let total = 0;
+  for (const name of resolved) {
+    const meta = frontmatter(path.join(REGISTRY_DIR, name, 'SKILL.md'));
+    const size = Buffer.byteLength(meta?.description ?? '', 'utf8');
+    total += size;
+    if (size > SINGLE_DESCRIPTION_MAX_BYTES) {
+      findings.push(
+        `D. ${name}: description is ${size} B (max ${SINGLE_DESCRIPTION_MAX_BYTES}). A description ` +
+          `is loaded into every session; the procedure belongs in the body, which is not. ` +
+          `Trim it to the trigger.`,
+      );
+    }
+  }
+  if (total > DESCRIPTION_BUDGET_BYTES) {
+    findings.push(
+      `D. registered descriptions total ${total} B (budget ${DESCRIPTION_BUDGET_BYTES}). ` +
+        `Every byte is paid on every turn of every session. Trim or deregister.`,
+    );
+  }
+
+  // ── this scan proves its own wiring ──────────────────────────────────────────
+  // Same trick `check-test-coverage-scripts` uses: a scan that is not registered cannot report
+  // that it is not registered, so it asserts its own presence in the runner.
+  const runner = path.join(WORKSPACE_ROOT, 'scripts/harness/run-all-scans.mjs');
+  if (existsSync(runner) && !readFileSync(runner, 'utf8').includes('scan-skill-registration.mjs')) {
+    findings.push(
+      `scan-skill-registration.mjs is not registered in run-all-scans.mjs — it would never run, ` +
+        `which is the exact failure class it exists to catch.`,
+    );
+  }
+
+  if (findings.length > 0) {
+    console.error('[skill-registration] blocking findings:\n');
+    for (const f of findings) console.error(`  - ${f}\n`);
+    console.error(
+      `[skill-registration] ${resolved.length} registered / ${listDirs(SOURCE_DIR).length} on disk / ` +
+        `${total} B of description.`,
+    );
+    process.exitCode = 1;
+    return findings;
+  }
+
+  console.log(
+    `[skill-registration] clean — ${resolved.length} registered, ` +
+      `${listDirs(SOURCE_DIR).length} on disk, ${total} B of description ` +
+      `(budget ${DESCRIPTION_BUDGET_BYTES}).`,
+  );
+
+  return findings;
+}
+
+function main() {
+  const findings = collectSkillRegistrationFindings();
+  if (findings.length === 0) return;
+  process.exitCode = 1;
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  main();
+}


### PR DESCRIPTION
Six harness commits that were parked on the CORE-027 working branch, split to their own PR because they are unrelated to that item (PR-batching rule: unrelated work does not ride a feature branch).

- **A skill nobody can invoke is not a skill** — skill invocability floor + skills-lock registration (34 files, mostly registrations).
- **A hook that does not parse is a hook that does not run** — `scan-hook-syntax.mjs`: bash -n over every `.claude/hooks/*.sh` including `lib/`, refusing an empty hook directory rather than passing over nothing.
- **The two new floors refuse what they cannot examine** — fail-closed hardening on both.
- **The guard prints the corrected command, not its own copy of the rule** — branch-guard message fix.
- **The browser rule names an obligation, not a vendor** — de-vendored the browser-verification rule sentence.
- **The audit's open decisions are visible from the entry point** — token-cost-report pointer in AGENTS.md routing.

Verified on this branch: CI-invocation scan suite (103 passed, 0 failed), harness tests 168 files / 2973 passed, monorepo build green.

CORE-027 itself stays on its own branch and lands separately when its session work completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbMB4MGdHAg6fgzzspSjqp