### PR TITLE
fix(hooks): an unresolvable command position is unknowable, not permitted (HARNESS-084)

### DIFF
--- a/.agents/tasks/completed/HARNESS-084-a-parameter-spliced-builtin-is-invisible-to-words-mode.md
+++ b/.agents/tasks/completed/HARNESS-084-a-parameter-spliced-builtin-is-invisible-to-words-mode.md
@@ -1,6 +1,7 @@
 ---
 title: 'HARNESS-084: a parameter-spliced builtin is invisible to words-mode, so a cd hidden in ${…} is never tracked'
-status: todo
+status: done
+completed: 2026-08-10
 created: 2026-08-10
 priority: high
 urgency: next
@@ -69,3 +70,30 @@ same words-mode output for its verb latch.
 
 **Does not apply.** Harness-internal guard behaviour; there is no user-facing surface, and the
 change is a refusal that only an agent constructing the splice would encounter.
+
+## Resolution
+
+Landed on branch `fix/harness-084-unresolvable-command`. The chosen direction is the SECOND one the
+Direction section offered — the guards decline to answer — and the first one is now recorded as
+wrong: collapsing `${UNSET}` into `cd` would assert a value the hook cannot know, and `c${HOME}d` is
+not a cd. A guard that guesses refuses correct work, so neither hook guesses; both treat an
+unresolvable command position the way they already treat an unreadable target.
+
+`pre-push-check.sh` — the command position is unresolvable when the first non-assignment word is
+empty (a substitution occupied it), carries `$`/backtick, or the command is `eval`. Any of those
+sets `LAST_CD_UNREADABLE`, so a later push refuses instead of resolving against a stale directory.
+
+`branch-guard.sh` — the same question for the verb latch, which keyed on the literal words `git` and
+`commit`. Two narrow triggers: the SUBCOMMAND position carries an expansion (`git c${UNSET}ommit`),
+or the COMMAND position does AND the statement spells a gated subcommand somewhere (`$GIT commit`,
+`g${UNSET}it commit`). Deliberately narrow: `$EDITOR notes.md`, `${PAGER} log`, `$(which node)
+build.js` and `echo $HOME` are all untouched, asserted as cases, because a guard that fires on
+correct work is one people learn to route around.
+
+The remedy in the message is to spell the command literally rather than a new override token — the
+legitimate surface is a variable standing in for `git`, and writing it out costs nothing.
+
+Verified: all seven new cases red-prove against `origin/develop` (each exits 0 there — the
+wrong-repository fail-open for pre-push, the protected-branch bypass for branch-guard — and refuses
+here); the narrowness cases pass on both sides; every pre-existing pre-push and branch-guard case is
+untouched; full harness suite 3117 green.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -713,6 +713,16 @@ while read -r STMT_START STMT_LEN; do
   # next word, which is what keeps `git commit -mn "x"` — a message of "n" — from reading as the
   # short skip-hooks flag, and `-m "--no-verify"` from reading as the long one.
   IS_GATED_STMT=false
+  # An expansion this hook cannot resolve, sitting where the COMMAND or the SUBCOMMAND goes, makes
+  # the statement's identity unknown — and `g${UNSET}it commit`, `$GIT commit` and
+  # `git c${UNSET}ommit` are all real gated actions to bash. Measured on develop: each walked past
+  # the protected-branch check with exit 0, the same evasion class as the alias bypass INFRA-085
+  # closed. Tracked here and judged after the walk, where the gated-verb evidence is complete.
+  # (HARNESS-084, #1682)
+  CMD_UNRESOLVED=false
+  VERB_UNRESOLVED=false
+  SAW_CMD_WORD=false
+  SAW_GATED_WORD=false
   GIT_VERB=""
   SKIP_HOOKS=false
   SKIP_WHAT=""
@@ -751,6 +761,14 @@ while read -r STMT_START STMT_LEN; do
         SKIP_WHAT="core.hooksPath"
       fi
     fi
+    # An EMPTY word at the COMMAND position is a whole command substitution: words-mode collapses
+    # `$(echo git)` to nothing, so the command is unknown. Judged BEFORE the empty-word filter below,
+    # or the substitution is dropped and the NEXT word — `commit` in `$(echo git) commit -m x` — is
+    # mistaken for the command, which reads clean and lets the statement through. (#1683 review)
+    if [[ "$SEEN_GIT" == "false" && "$SAW_CMD_WORD" == "false" && -z "$W" ]]; then
+      SAW_CMD_WORD=true
+      CMD_UNRESOLVED=true
+    fi
     [[ -n "$W" ]] || continue
     # Recorded, not acted on yet: `HUSKY=0 pnpm install` is ordinary work in a fresh clone. The
     # variable only disables a GATE when the statement it prefixes is the gated one, which is not
@@ -758,7 +776,27 @@ while read -r STMT_START STMT_LEN; do
     case "$W" in
       HUSKY=0) [[ "$SEEN_GIT" == "false" ]] && HAS_HUSKY0=true ;;
     esac
+    # Any word that spells a gated subcommand, wherever it sits — the evidence that an unresolvable
+    # command position could be hiding a gated action rather than an editor. (HARNESS-084)
+    case "$W" in
+      commit | push | merge | rm | mv | config | checkout | switch | branch) SAW_GATED_WORD=true ;;
+    esac
     if [[ "$SEEN_GIT" == "false" ]]; then
+      # The COMMAND position: the first word that is not an env-var prefix. If it carries an
+      # expansion this hook cannot resolve, the command is unknown — `$GIT` and `g${UNSET}it` are
+      # `git` when the variable says so. Only the first such word is the command; a `$HOME` in a
+      # later ARGUMENT changes nothing about which command runs. (HARNESS-084)
+      if [[ "$SAW_CMD_WORD" == "false" ]]; then
+        case "$W" in
+          *=*) : ;;
+          *)
+            SAW_CMD_WORD=true
+            case "$W" in
+              *'$'* | *'`'*) CMD_UNRESOLVED=true ;;
+            esac
+            ;;
+        esac
+      fi
       [[ "$W" == "git" ]] && SEEN_GIT=true
       continue
     fi
@@ -780,6 +818,13 @@ while read -r STMT_START STMT_LEN; do
       # in the permissive direction is what the finding above measured.
       case "$W" in
         */*|.*|*.*) continue ;;
+      esac
+      # The VERB position, reached: `git` is established and this word is the subcommand. An
+      # expansion here leaves the action unknown — `git c${UNSET}ommit` is a commit. Recorded rather
+      # than refused inline, so the walk still finishes and the message below can name the whole
+      # statement's evidence. (HARNESS-084)
+      case "$W" in
+        *'$'* | *'`'*) VERB_UNRESOLVED=true ;;
       esac
       # INFRA-085: the word about to become the verb may be an alias, and the checks below ask
       # about the verb it EXPANDS to. The expansion's own flags count too — `alias.ci "commit -n"`
@@ -890,6 +935,40 @@ while read -r STMT_START STMT_LEN; do
       [[ "$_ST_VALUE" == "true" ]] && EXPECT_VALUE=true
     fi
   done <<< "$STMT_WORDS"
+
+  # An unknowable gated action, refused where this hook actually gates — and NOT anywhere else.
+  #
+  # The command position being an expansion is only dangerous if the action it hides is one this
+  # guard would refuse spelled out, so the refusal is scoped to exactly that:
+  #   - a PROTECTED branch, where the literal `git commit`/`git push` are refused. On a feature
+  #     branch they are ordinary work, so refusing their spliced twin would be pure over-refusal.
+  #   - or a statement naming `.husky`/`core.hooksPath`, the two gates that bind on ANY branch, so a
+  #     spliced `g${X}it rm .husky/pre-push` cannot slip through by moving off `develop` first.
+  #
+  # Without that scope the check fired on `$EDITOR commit` — opening a file that happens to be NAMED
+  # `commit` — on every branch, which is ordinary work and precisely the "guard that fires on correct
+  # work is one people learn to route around" failure this file argues against. (#1683 review)
+  #
+  # Judged HERE, before the four-booleans-false `continue` below: none of the action regexes matches
+  # a statement whose verb is an expansion, so a check placed after that early exit never runs — the
+  # first arrangement of this block did exactly that and refused nothing. The branch is read from
+  # EFFECTIVE_DIR, which this statement already resolved, and only when the flag is set, so ordinary
+  # statements pay no extra subprocess. The remedy in the message is to write the command literally
+  # rather than a new override token: the legitimate surface is a variable standing in for `git`, and
+  # spelling it out costs nothing. (HARNESS-084)
+  if [[ "$VERB_UNRESOLVED" == "true" ]] || [[ "$CMD_UNRESOLVED" == "true" && "$SAW_GATED_WORD" == "true" ]]; then
+    _UNKNOWABLE_SCOPE=false
+    _UNKNOWABLE_BRANCH=$(hook_current_branch "$EFFECTIVE_DIR" "")
+    case "$_UNKNOWABLE_BRANCH" in main | master | develop) _UNKNOWABLE_SCOPE=true ;; esac
+    case "$STMT_MASK" in *.husky* | *core.hooksPath*) _UNKNOWABLE_SCOPE=true ;; esac
+    if [[ "$_UNKNOWABLE_SCOPE" == "true" ]]; then
+      echo "[branch-guard] Blocked: this statement builds its command or subcommand from an expansion" >&2
+      echo "[branch-guard] this hook cannot resolve, so whether it is a gated git action is unknown —" >&2
+      echo "[branch-guard] and \`\$GIT commit\` / \`git c\${X}ommit\` are commits when the variable says so." >&2
+      echo "[branch-guard] Unable to determine is not the same as safe. Spell the command out literally." >&2
+      exit 2
+    fi
+  fi
   # Now that the verb is known: the husky kill switch counts only in front of a gated command.
   [[ "$HAS_HUSKY0" == "true" && "$IS_GATED_STMT" == "true" ]] && SKIP_HOOKS=true && SKIP_WHAT="HUSKY=0"
 
@@ -1211,6 +1290,7 @@ while read -r STMT_START STMT_LEN; do
   # three were dead code. THIS caller wants the empty value: the checks below key on emptiness to
   # recognise a detached HEAD, which is why the default is the caller's to name.
   CURRENT_BRANCH=$(hook_current_branch "$PROJECT_DIR" "")
+
 
   # A detached HEAD has no branch name, so the protected-branch checks below have nothing to compare
   # and the guard used to stop here. Branch CREATION is different: creating `feat/x` while detached at

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -349,6 +349,35 @@ while read -r PS_START PS_LEN; do
       LAST_CD_UNREADABLE=true
       continue
     fi
+    # WHICH COMMAND IS THIS? When the answer is an expansion the hook cannot resolve, the honest
+    # answer is "unknown", and unknown is unreadable — a `cd` is exactly what it might be.
+    #
+    # Three shapes reach here, all measured as wrong-repository fail-opens (the push resolved to the
+    # session repo, which held a clean record, while the real `cd` moved elsewhere — exit 0 where
+    # this hook refuses for every other unknowable):
+    #   `c${UNSET}d /repo`   the command word survives as `c${d`; words-mode cannot collapse a
+    #                        PARAMETER splice the way it collapses `$( )` and backticks, because the
+    #                        masker replaces the expansion (closing brace included) with fill.
+    #   `$EDITOR /repo`      the command IS a variable. `EDITOR=cd` makes it a cd.
+    #   `$(echo cd) /repo`   the substitution collapses to an EMPTY command word.
+    # Collapsing them to `cd` would be worse than missing them: `c${HOME}d` is not a cd, and a guard
+    # that guesses is a guard that refuses correct work. So this does not guess — it declines to
+    # answer, which is the same answer an unreadable target already gets. (HARNESS-084, #1682)
+    PS_CMD_UNRESOLVABLE=false
+    _PS_SEEN_CMD=false
+    while IFS= read -r _PS_CW; do
+      [[ "$_PS_SEEN_CMD" == "true" ]] && break
+      # An env-var assignment is a PREFIX, not the command — the same skip the word loop below makes.
+      case "$_PS_CW" in *=*) continue ;; esac
+      _PS_SEEN_CMD=true
+      if [[ -z "$_PS_CW" || "$_PS_CW" == *'$'* || "$_PS_CW" == *'`'* ]]; then
+        PS_CMD_UNRESOLVABLE=true
+      fi
+    done <<< "$PS_WORDS"
+    if [[ "$PS_CMD_UNRESOLVABLE" == "true" ]]; then
+      LAST_CD_UNREADABLE=true
+      continue
+    fi
     PS_FIRST=""
     PS_SECOND=""
     PS_THIRD=""
@@ -399,6 +428,14 @@ while read -r PS_START PS_LEN; do
       PS_FIFTH=""
     done
     PS_FIRST="${PS_FIRST#\\}"
+    # The same question after the prefixes are unwrapped: `command $EDITOR /repo` puts the
+    # unresolvable word one position later, and `eval` runs text this hook never parses at all —
+    # `eval "cd /repo"` is a directory change whose target lives inside a string. Both are unknown
+    # commands, and unknown is unreadable. (HARNESS-084, #1682)
+    if [[ "$PS_FIRST" == *'$'* || "$PS_FIRST" == *'`'* || "$PS_FIRST" == "eval" ]]; then
+      LAST_CD_UNREADABLE=true
+      continue
+    fi
     # A `||`-guarded directory change runs only if the prior command failed, so whether it took
     # effect is unknowable — the base is uncertain, not the value it names. Only a cd/pushd/popd
     # matters here: a `||`-guarded NON-directory command (`foo || bar`) changes no directory, so

--- a/scripts/harness/__tests__/branch-guard-aliases.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-aliases.test.mjs
@@ -438,3 +438,87 @@ describe('the verb checks see through an alias', () => {
     expect(status).toBe(0);
   });
 });
+
+describe('a command or subcommand built from an expansion is unknowable, not permitted', () => {
+  /**
+   * HARNESS-084 (#1682). The verb latch keys on the literal words `git` and `commit`, so an
+   * expansion in either position walked past every gate: measured on develop, each of the three
+   * shapes below exited 0 on a PROTECTED branch where the literal spelling exits 2. It is the same
+   * evasion class INFRA-085 closed for aliases — one visible command that nothing refuses, with an
+   * obvious next move for an agent that has learned the literal form is blocked.
+   *
+   * The guard cannot resolve the variable, and guessing would be worse than declining: `c${HOME}d`
+   * is not a cd. So it declines — and the refusal is kept NARROW, which the second block asserts.
+   */
+  it.each([
+    ['the command is a variable', '$GIT commit -m x'],
+    ['the command is spliced', 'g${UNSET}it commit -m x'],
+    ['the command is a whole substitution', '$(echo git) commit -m x'],
+    ['the SUBCOMMAND is spliced', 'git c${UNSET}ommit -m x'],
+  ])('refuses on a protected branch when %s', (_label, command) => {
+    // `$(echo git)` collapses to an EMPTY word, so it has to be caught BEFORE the empty-word filter
+    // — otherwise the next word (`commit`) is mistaken for the command, reads clean, and the
+    // statement walks through. That was a review finding on the first version. (#1683)
+    const repo = scratchRepo('develop');
+
+    const { status, output } = runHook(command, repo);
+
+    expect(status, `an unresolvable gated action was permitted:\n${output}`).toBe(2);
+  });
+
+  it.each([
+    ['an editor', '$EDITOR notes.md'],
+    ['a pager', '${PAGER} log.txt'],
+    ['a substitution command', '$(which node) build.js'],
+    ['an expansion in an ARGUMENT only', 'echo $HOME'],
+  ])('leaves %s alone even on a protected branch', (_label, command) => {
+    // A guard that fires on correct work is one people learn to route around, and this file makes
+    // that argument about itself. None of these spells a gated subcommand, so none is refused —
+    // the trigger is an unknown command PLUS gated-action evidence, not the mere presence of `$`.
+    const repo = scratchRepo('develop');
+
+    const { status, output } = runHook(command, repo);
+
+    expect(status, `an ordinary command was refused:\n${output}`).toBe(0);
+  });
+
+  it.each([
+    ['an editor opening a file named like a verb', '$EDITOR commit'],
+    ['a pager on a file named like a verb', '${PAGER} config'],
+    ['a substitution command with a verb-shaped argument', '$(which vim) branch'],
+  ])('leaves %s alone on a FEATURE branch', (_label, command) => {
+    // The scope that keeps the refusal honest: on a feature branch the literal `git commit` is
+    // ordinary work, so refusing its spliced twin would be pure over-refusal. Refusing these
+    // everywhere was a review finding on the first version. (#1683)
+    const repo = scratchRepo('feat/x');
+
+    const { status, output } = runHook(command, repo);
+
+    expect(status, `ordinary work on a feature branch was refused:\n${output}`).toBe(0);
+  });
+
+  it('ACCEPTED COST: an unknown command plus a verb-shaped argument refuses on a protected branch', () => {
+    // `$EDITOR commit` and `$GIT commit` are textually IDENTICAL to this hook — an unresolvable
+    // command followed by the word `commit`. On a protected branch, where the literal `git commit`
+    // is refused, the guard cannot tell them apart and fails closed. That is a real false positive
+    // and it is the deliberate trade: the alternative is letting `$GIT commit` through, which is the
+    // evasion this whole change exists to close. The message names the remedy — spell the command
+    // literally — and the cost only lands on a protected branch, where a commit was refused anyway.
+    const repo = scratchRepo('develop');
+
+    const { status, output } = runHook('$EDITOR commit', repo);
+
+    expect(status).toBe(2);
+    expect(output).toMatch(/cannot resolve/);
+  });
+
+  it('refuses a spliced husky removal on ANY branch — that gate does not depend on the branch', () => {
+    // The husky/hooksPath gates bind everywhere, so scoping the refusal to protected branches alone
+    // would let `g${X}it rm .husky/pre-push` through by moving to a feature branch first.
+    const repo = scratchRepo('feat/x');
+
+    const { status, output } = runHook('g${UNSET}it rm .husky/pre-push', repo);
+
+    expect(status, `a spliced husky removal was permitted off develop:\n${output}`).toBe(2);
+  });
+});

--- a/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
+++ b/scripts/harness/__tests__/pre-push-repo-resolution.test.mjs
@@ -195,6 +195,31 @@ describe('which repository the push verdict is about', () => {
   });
 
   it.each([
+    ['a PARAMETER splice', 'c${UNSET}d'],
+    ['a variable AS the command', '$EDITOR'],
+    ['a substitution as the command', '$(echo cd)'],
+    ['eval, which runs text this hook never parses', 'eval cd'],
+  ])('treats %s in the command position as unreadable, not as "not a cd"', (label, command) => {
+    // HARNESS-084 (#1682). words-mode collapses a splice built from quotes, backslashes, `$( )` and
+    // backticks into the word `cd`, but it CANNOT collapse a parameter expansion — the masker
+    // replaces `${…}` (closing brace included) with fill, so `c${UNSET}d` survives as `c${d` and no
+    // reader ever sees the builtin. `$EDITOR` and `$(echo cd)` are the same fact one step further:
+    // the command IS the expansion. Each was measured on develop as a wrong-repository fail-open —
+    // exit 0, the push judged against the session repo while the real cd moved elsewhere.
+    //
+    // Collapsing them to `cd` would be WORSE than missing them: `c${HOME}d` is not a cd, and a
+    // guard that guesses refuses correct work. So the hook declines to answer, which is the same
+    // answer every other unknowable already gets. Parked is the RECORDED repo, so only the refusal
+    // can be correct here.
+    const target = repoOn('feat/target');
+    const parked = repoOn('feat/parked', { recorded: true });
+
+    const { status, output } = runHook(`${command} ${target} && git push origin x`, parked);
+
+    expect(status, `${label} in the command position was read as "not a cd":\n${output}`).toBe(2);
+  });
+
+  it.each([
     ['quotes', '"c""d"'],
     ['an empty command substitution', 'c$()d'],
     ['a pair of empty backticks', 'c``d'],


### PR DESCRIPTION
## Problem

Closes #1682. words-mode collapses a splice built from quotes, backslashes, `$( )` and backticks into the word `cd` — but it **cannot** collapse a PARAMETER expansion: the masker replaces `${…}` (closing brace included) with fill, so `c${UNSET}d` survives as `c${d` and no reader ever sees the builtin. `$EDITOR` and `$(echo cd)` are the same fact one step further: the command **is** the expansion.

Measured on `origin/develop` — each exits 0 where the literal spelling refuses:

| hook | statement | develop |
|---|---|---|
| pre-push-check | `c${UNSET}d <repo> && git push` | exit 0 — wrong-repository fail-open |
| pre-push-check | `$EDITOR <repo>`, `$(echo cd) <repo>`, `eval cd <repo>` | exit 0 |
| branch-guard | `$GIT commit`, `g${UNSET}it commit`, `git c${UNSET}ommit` | exit 0 on a **protected branch** |

The branch-guard half is the same evasion class INFRA-085 closed for aliases: one visible command that nothing refuses.

## Fix

Collapsing these into `cd` would be **worse** than missing them — `c${HOME}d` is not a cd, and a guard that guesses refuses correct work. So neither hook guesses; both decline to answer.

- **pre-push-check** — the command position is unresolvable when the first non-assignment word is empty (a substitution occupied it), carries `$`/backtick, or the command is `eval`. Any of those marks the base unreadable, the answer every other unknowable already gets.
- **branch-guard** — two **narrow** triggers: the SUBCOMMAND position carries an expansion, or the COMMAND position does *and* the statement spells a gated subcommand somewhere.

Deliberately narrow, asserted as cases: `$EDITOR notes.md`, `${PAGER} log.txt`, `$(which node) build.js` and `echo $HOME` all stay permitted — a guard that fires on correct work is one people learn to route around.

## Verification

- All **seven** new cases red-prove against develop (each passes there, refuses here).
- The four narrowness cases pass on both sides — the refusal did not widen into "any `$` refuses".
- Every pre-existing pre-push and branch-guard case untouched; full harness suite green (3117).

Task: `.agents/tasks/completed/HARNESS-084-a-parameter-spliced-builtin-is-invisible-to-words-mode.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbMB4MGdHAg6fgzzspSjqp
