### PR TITLE
fix(harness): scope promotion novelty to develop

### DIFF
--- a/.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md
+++ b/.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md
@@ -1,0 +1,187 @@
+---
+status: in-progress
+type: INFRA
+tags: [harness, ci]
+---
+
+# INFRA-088: Make promotion novelty scans compare against develop
+
+## Problem
+
+The `release-grade verification` job on develop→main promotion PR #1690 failed in
+`new-rule-declares-enforcement`. The promotion head had the exact `origin/develop` tree, but the
+shared base resolver selected `origin/main` from `GITHUB_BASE_REF=main`. Its three-dot diff therefore
+treated the full historical develop delta as promotion-local work and reported eleven already-landed
+rule sections as newly introduced.
+
+Reproduction condition: create the sanctioned promotion merge from `origin/develop`, run
+`pnpm harness:verify:release` in a pull-request environment with `GITHUB_BASE_REF=main`, and leave
+`HARNESS_BASE_REF` unset. Diff-sensitive scans inspect `origin/main...HEAD`, even though the
+promotion's content is already the verified develop tree. The same incorrect baseline also affects
+the local release preflight in `scripts/harness/promote.mjs`; additionally,
+`check-document-authority.mjs` does not currently honor the shared `HARNESS_BASE_REF` override.
+
+## Prior Art Research
+
+### Official behavior
+
+GitHub exposes `github.base_ref` as the pull request's target branch, so a develop→main promotion
+correctly receives `main` as its event base ([GitHub Actions contexts reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context)).
+For `pull_request`, GitHub checks out a synthetic merge result by default
+([pull-request event reference](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)).
+With `fetch-depth: 0`, all branch history—including `origin/develop`—is available
+([actions/checkout documentation](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches)).
+
+Git defines `git diff A...B` as the diff from `merge-base(A, B)` to `B`
+([git-diff documentation](https://git-scm.com/docs/git-diff.html#_description)); the merge base is the
+best common ancestor reachable through parent links
+([git-merge-base documentation](https://git-scm.com/docs/git-merge-base#_description)). GitHub pull
+requests likewise use three-dot comparison
+([GitHub branch-comparison documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons)).
+Consequently, `origin/main...HEAD` on a promotion includes the accumulated develop delta since the
+last main/develop merge base. That is correct for the release delta, but wrong for scans asking
+whether the promotion step newly introduced a rule or document.
+
+### Observed common behavior
+
+PR automation normally uses the event's target branch because that answers what merging the PR
+changes in the target. A promotion gate has two legitimate baselines: `main` for release contents
+and `develop` for promotion-local novelty. These meanings should be explicit rather than hidden
+behind a global resolver heuristic.
+
+### Robota constraint and recommendation
+
+Robota separately asserts that the promotion carries `main` ancestry and that its tree equals
+`develop`. The release job must retain `GITHUB_BASE_REF=main` so promotion-only gates continue to
+recognize main-promotion context. Set `HARNESS_BASE_REF: origin/develop` only on the release-grade
+verification step and on the local promotion preflight process. Bring the independent
+`check-document-authority.mjs` resolver under the same explicit-override precedence. Do not globally
+reinterpret main-targeted PRs and do not retrofit historic develop documents to compensate for a
+baseline defect.
+
+## Architecture Review
+
+### Affected Scope
+
+- `.github/workflows/ci.yml` — release-grade verification environment.
+- `scripts/harness/promote.mjs` — local release preflight environment.
+- `scripts/harness/check-document-authority.mjs` — independent diff-base resolver.
+- `scripts/harness/__tests__/promotion-preflight-parity.test.mjs` — workflow/preflight parity.
+- `scripts/harness/__tests__/check-document-authority.test.mjs` — resolver precedence.
+- Sibling scan: all direct `GITHUB_BASE_REF` and `HARNESS_BASE_REF` readers under
+  `scripts/harness/` were inspected. `scan-promotion-ancestry` and `scan-action-references` use
+  `GITHUB_BASE_REF` for promotion context rather than novelty diffs and must remain unchanged.
+
+### Alternatives Considered
+
+1. **Step-scoped develop novelty baseline (recommended).** Set `HARNESS_BASE_REF=origin/develop` only
+   for local and CI release verification, and make the one independent diff resolver honor it.
+   Pro: uses the existing explicit override seam, preserves main-promotion context, and matches the
+   tree-equality promotion invariant. Con: the release gate intentionally uses a different novelty
+   baseline from the PR target and therefore needs parity tests and an explanatory comment.
+2. **Change the shared resolver globally for main PRs.** Infer `origin/develop` whenever
+   `GITHUB_BASE_REF=main`. Pro: one centralized code change. Con: silently undercounts legitimate
+   main-targeted diffs outside the sanctioned promotion workflow and conflates event context with
+   analysis intent.
+3. **Add enforcement declarations to the eleven historical rule sections.** Pro: makes the observed
+   scan green without resolver changes. Con: edits domain documents that were not introduced by the
+   promotion, leaves every other diff-sensitive scan on the wrong time horizon, and creates content
+   solely to satisfy a false finding.
+
+### Decision
+
+Choose alternative 1. Promotion ancestry and tree equality remain checked against `main` and
+`develop` by their owning gate, while diff-sensitive novelty scans explicitly compare the release
+candidate to the already-verified develop tree. This is the narrowest change that preserves both
+meanings and keeps ordinary PR base resolution unchanged. The affected consumers were inspected:
+shared resolver users already prioritize `HARNESS_BASE_REF`; the only independent diff resolver in
+the release sweep will be aligned; promotion-context readers remain on `GITHUB_BASE_REF=main`.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — `GITHUB_BASE_REF`/`HARNESS_BASE_REF` 직접 사용처를 전수 확인
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+Add a red regression assertion that the main-only release job declares
+`HARNESS_BASE_REF: origin/develop` while retaining `PR_HEAD_SHA`, and that `promote.mjs` passes the
+same override to its local `pnpm harness:verify:release` child. Add a resolver test proving
+`check-document-authority.mjs` prefers `HARNESS_BASE_REF` over `GITHUB_BASE_REF`, then implement that
+precedence. Preserve the global shared resolver and every promotion-context reader unchanged.
+
+## Affected Files
+
+- `.github/workflows/ci.yml`
+- `scripts/harness/promote.mjs`
+- `scripts/harness/check-document-authority.mjs`
+- `scripts/harness/__tests__/promotion-preflight-parity.test.mjs`
+- `scripts/harness/__tests__/check-document-authority.test.mjs`
+- `.agents/tasks/INFRA-088-promotion-scan-baseline.md`
+
+## Completion Criteria
+
+- [ ] TC-01: The `release-grade verification` workflow step runs with
+      `HARNESS_BASE_REF=origin/develop` while `GITHUB_BASE_REF` remains the GitHub-provided `main`, and a
+      focused workflow test verifies the declaration.
+- [ ] TC-02: `scripts/harness/promote.mjs` runs its local `pnpm harness:verify:release` child with
+      `HARNESS_BASE_REF` equal to its configured develop ref, and the preflight parity test verifies it.
+- [ ] TC-03: `check-document-authority.mjs` resolves an existing `HARNESS_BASE_REF` before
+      `GITHUB_BASE_REF`, while ordinary PR resolution remains covered and unchanged.
+- [ ] TC-04: A fresh sanctioned promotion runs the full release gate without reporting historical
+      develop rules as promotion-local additions.
+
+## Test Plan
+
+| TC-ID | Test Type                   | Tool / Approach                                                      | Notes                                                                                     |
+| ----- | --------------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| TC-01 | CI configuration regression | Vitest source assertion over `.github/workflows/ci.yml`              | Assert step scope and preserve promotion context.                                         |
+| TC-02 | Unit/integration            | Vitest injected promotion fixture                                    | Assert child process environment matches configured develop ref.                          |
+| TC-03 | Unit                        | Vitest temporary git fixture                                         | Assert resolver precedence and ordinary PR behavior.                                      |
+| TC-04 | Release smoke               | `node scripts/harness/promote.mjs` and `pnpm harness:verify:release` | Require a green, non-skipped local promotion preflight before opening the replacement PR. |
+
+## Tasks
+
+- [x] `.agents/tasks/INFRA-088-promotion-scan-baseline.md` — TC-01 through TC-04 implementation and verification plan
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-12
+
+**Status upgrade:** draft → review-ready
+Frontmatter: YAML block is present first; `status: draft`, valid `type: INFRA`, and `tags: [harness, ci]` are present.
+Problem: identifies the concrete `release-grade verification` / `new-rule-declares-enforcement` failure and reproduces it under a develop→main PR with `GITHUB_BASE_REF=main` and no `HARNESS_BASE_REF`; no TBD, TODO, or vague one-line description is present.
+Prior Art Research: cites official GitHub Actions, actions/checkout, Git diff/merge-base, and GitHub comparison documentation; the findings directly support the explicit-baseline alternatives and Decision.
+Architecture Review: all four checklist items are checked; the sibling scan names the inspected baseline readers and explains why promotion-context readers remain unchanged.
+Alternatives and Decision: three alternatives each state a pro and con; the Decision selects the step-scoped baseline because it preserves promotion context while narrowing novelty scans to the verified develop tree.
+New-surface placement: N/A — the spec changes CI/harness baseline resolution and introduces no package, app, presentation/interface surface, or layer/product-family boundary.
+Completion Criteria: TC-01 through TC-04 cover workflow configuration, local promotion parity, resolver precedence, and release smoke behavior; all are command or observable-behavior criteria and contain none of the prohibited vague phrases.
+Test Plan: 4 Completion Criteria and 4 matching non-empty Test Plan rows (4/4 = 100%); every row names a test type and tool/approach, and none uses a manual tool requiring a waiver note.
+Structure: Tasks contains the required post-approval placeholder; Evidence Log was empty before this first gate run; no body `## Status` or `## Classification` section exists.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-12
+
+**Status upgrade:** review-ready → approved
+Ordering: GATE-WRITE has a specific recorded PASS and the document is `status: review-ready` in `.agents/spec-docs/backlog/`, matching the required input state.
+Explicit approval: the user stated verbatim, “그런거 나에게 뭍너보지 말고 타당한 이유와 함께 추천안을 제시하면 타당할 경우 내가 사전 승인합키다” (2026-08-12), then separately directed completion of the branch integration into `main`; this is an explicit pre-authorization for a reasoned recommendation necessary to that integration, not silence or inferred assent.
+Directness and scope: the presented recommendation was specifically to set the promotion novelty baseline to `origin/develop` because the promotion tree equals develop while ancestry remains independently checked, rather than editing historical rules; this document records that same recommendation and trade-off without expanding its scope, so the user's stated pre-approval applies directly to this design.
+Post-approval integrity: the Architecture Review, `type: INFRA`, and `tags: [harness, ci]` encode the recommendation as presented; no implementation edit or later design/type/tag change is present after the pre-approved recommendation was recorded.
+Independent architecture validation: N/A — the design changes CI/harness baseline selection and introduces no package, app, interface/presentation surface, or layer/product-family reclassification.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-12
+
+**Status upgrade:** approved → in-progress
+Ordering: GATE-APPROVAL has a specific recorded PASS, and the document is `status: approved` in `.agents/spec-docs/todo/`, matching the required input state and folder.
+Tasks file: `.agents/tasks/INFRA-088-promotion-scan-baseline.md` exists and is recorded in this document's `## Tasks` section.
+TC-01 task: red-prove and add the release-grade workflow's step-scoped `HARNESS_BASE_REF=origin/develop` declaration; this maps directly to Completion Criterion TC-01.
+TC-02 task: red-prove and pass the configured develop ref as `HARNESS_BASE_REF` to the local promotion preflight child; this maps directly to Completion Criterion TC-02.
+TC-03 task: red-prove and align `check-document-authority.mjs` explicit-override precedence while preserving ordinary PR resolution; this maps directly to Completion Criterion TC-03.
+TC-04 task: run the focused suites and full release verification, then create a fresh sanctioned promotion without skipping the release gate; this maps directly to Completion Criterion TC-04.
+Task test plan: the tasks file contains a substantive `## Test Plan` section covering the two focused Vitest suites, `pnpm harness:test`, `pnpm harness:scan`, the release gate, and the sanctioned promotion command; its content exceeds the required 50 characters.
+Process integrity: no implementation commit for the INFRA-088 affected files exists on the current branch; the spec and tasks files are untracked and implementation has not begun, so the missing-task NON-COMPLIANCE trigger does not apply.

--- a/.agents/tasks/INFRA-088-promotion-scan-baseline.md
+++ b/.agents/tasks/INFRA-088-promotion-scan-baseline.md
@@ -1,0 +1,63 @@
+---
+title: 'INFRA-088: promotion novelty scans use the develop baseline'
+status: in-progress
+created: 2026-08-12
+priority: high
+urgency: now
+area: .github/workflows, scripts/harness
+depends_on: []
+---
+
+# INFRA-088: promotion novelty scans use the develop baseline
+
+Spec: `.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md`
+
+## Objective
+
+Make the local and CI develop→main release gates compare promotion-local novelty against the exact
+develop tree being promoted, while preserving `GITHUB_BASE_REF=main` for promotion-context gates.
+
+## Plan
+
+- [x] TC-01 — Red-prove and add the release-grade workflow's step-scoped
+      `HARNESS_BASE_REF=origin/develop` declaration.
+- [x] TC-02 — Red-prove and make the local promotion preflight pass its configured develop ref as
+      `HARNESS_BASE_REF` to the release-gate child process.
+- [x] TC-03 — Red-prove and align `check-document-authority.mjs` with the explicit override
+      precedence while preserving ordinary PR resolution.
+- [ ] TC-04 — Run the focused suites, complete release verification, and create a fresh sanctioned
+      promotion without skipping the release gate.
+
+## Test Plan
+
+- Run the focused Vitest files for promotion preflight parity and document-authority base
+  resolution after first observing each new regression assertion fail.
+- Run `pnpm harness:test`, `pnpm harness:scan`, and the release gate required by the promotion path.
+- Run `node scripts/harness/promote.mjs`; it must report `release gate PASSED locally` and create a
+  promotion whose tree equals `origin/develop` without `--skip-release-gate`.
+
+## Progress
+
+### 2026-08-12
+
+- PR #1690 reproduced the false-positive baseline against eleven historical rule sections.
+- GATE-WRITE and GATE-APPROVAL passed for the develop-baseline design.
+- RED: focused Vitest run failed exactly three new assertions (workflow baseline, local preflight
+  child environment, document-authority override precedence).
+- GREEN: the same focused run passed 31/31 tests after the minimal changes.
+- Regression: `pnpm harness:scan` passed 107 scans and `pnpm harness:test` passed 173 files / 3,182
+  tests. TC-04 remains pending until this fix lands on `develop` and the sanctioned promotion can
+  exercise the real develop ref.
+
+## Decisions
+
+- Keep `GITHUB_BASE_REF=main` as event/promotion context and use the existing explicit
+  `HARNESS_BASE_REF` seam only for diff-sensitive release verification.
+
+## Blockers
+
+- None.
+
+## Result
+
+Pending.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,10 @@ jobs:
       # silently-skipped-but-green shape.
       - name: Run release-grade verification
         env:
+          # INFRA-088: `main` is the event/promotion context, but the promotion introduces no content
+          # beyond the already-verified develop tree. Diff-sensitive novelty scans must therefore
+          # compare to develop; promotion-ancestry still reads the untouched GITHUB_BASE_REF=main.
+          HARNESS_BASE_REF: origin/develop
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: pnpm harness:verify:release
 

--- a/scripts/harness/__tests__/check-document-authority.test.mjs
+++ b/scripts/harness/__tests__/check-document-authority.test.mjs
@@ -169,6 +169,17 @@ describe('base-ref resolution', () => {
     expect(resolveBaseRef({ argv: ['--base-ref', 'base'], env: {}, cwd: root })).toBe('base');
   });
 
+  it('prefers HARNESS_BASE_REF over the GitHub PR target', async () => {
+    const root = await createGitFixture({});
+    expect(
+      resolveBaseRef({
+        argv: [],
+        env: { HARNESS_BASE_REF: 'base', GITHUB_BASE_REF: 'main' },
+        cwd: root,
+      }),
+    ).toBe('base');
+  });
+
   it('returns undefined when no candidate resolves (the caller must FAIL, not pass)', async () => {
     const root = await createGitFixture({});
     expect(resolveBaseRef({ argv: [], env: {}, cwd: root })).toBeUndefined();

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -53,12 +53,13 @@ async function newRepo() {
 }
 
 /** Same as `run`, but WITHOUT `--skip-release-gate`, so the preflight actually executes. */
-async function runWithGate(root, extraArgv = []) {
+async function runWithGate(root, extraArgv = [], spawn) {
   let output = '';
   const code = await main({
     argv: [...extraArgv, '--main-ref', 'main', '--develop-ref', 'develop', '--baseline', 'develop'],
     cwd: root,
     fetch: false,
+    spawn,
     out: (text) => {
       output += text;
     },
@@ -209,5 +210,23 @@ describe('promote.mjs (INFRA-051)', () => {
     // none, because the next run would push it.
     const branches = git(['branch', '--list', 'release/promote-develop-to-main']).stdout.trim();
     expect(branches).toBe('');
+  });
+
+  it('runs the release gate against the configured develop novelty baseline', async () => {
+    const { root, git } = await newRepo();
+    commit(root, git, 'feature.md', 'work\n', 'feat: something');
+    let invocation;
+
+    const { code, output } = await runWithGate(root, [], (command, args, options) => {
+      invocation = { command, args, options };
+      return { status: 0 };
+    });
+
+    expect(code).toBe(0);
+    expect(output).toMatch(/release gate PASSED locally/);
+    expect(invocation.command).toBe('pnpm');
+    expect(invocation.args).toEqual(['harness:verify:release']);
+    expect(invocation.options.env.HARNESS_BASE_REF).toBe('develop');
+    expect(invocation.options.env.GITHUB_BASE_REF).toBe(process.env.GITHUB_BASE_REF);
   });
 });

--- a/scripts/harness/__tests__/promotion-preflight-parity.test.mjs
+++ b/scripts/harness/__tests__/promotion-preflight-parity.test.mjs
@@ -94,4 +94,13 @@ describe('promotion preflight mirrors protect-main', () => {
     expect(promoteSource).toMatch(/status\s*!==\s*0/);
     expect(promoteSource).toMatch(/PromoteError/);
   });
+
+  it('compares promotion-local novelty against develop in the main-only release job', () => {
+    const nameIndex = workflowText.indexOf(`name: ${MAIN_ONLY_JOB}`);
+    const nextJobIndex = workflowText.indexOf('\n  # ', nameIndex + 1);
+    const jobBlock = workflowText.slice(nameIndex, nextJobIndex === -1 ? undefined : nextJobIndex);
+
+    expect(jobBlock).toMatch(/HARNESS_BASE_REF:\s*origin\/develop/);
+    expect(jobBlock).toMatch(/PR_HEAD_SHA:/);
+  });
 });

--- a/scripts/harness/check-document-authority.mjs
+++ b/scripts/harness/check-document-authority.mjs
@@ -18,8 +18,9 @@
  *
  * Base-ref resolution:
  * 1. `--base-ref <ref>` CLI argument, if given.
- * 2. `origin/$GITHUB_BASE_REF` (PR events).
- * 3. `origin/develop` (default).
+ * 2. `$HARNESS_BASE_REF` when the harness declares an analysis baseline.
+ * 3. `origin/$GITHUB_BASE_REF` (PR events).
+ * 4. `origin/develop` (default).
  *
  * FAIL-CLOSED (INFRA-048-B). When no base resolves, or the diff against it cannot run, this scan
  * exits **1**. It previously printed `SKIPPED … Not a pass` and exited **0** — which every caller
@@ -95,8 +96,9 @@ function refExists(ref, options) {
 
 /**
  * Resolve the base ref to diff against. Candidates in priority order: an explicit `--base-ref`
- * argument, `origin/$GITHUB_BASE_REF` (PR CI), then `origin/<default>`. Returns the resolved ref,
- * or `undefined` when none resolves — which the caller must treat as a FAILURE, not a pass.
+ * argument, `$HARNESS_BASE_REF` (an explicit harness-wide analysis baseline),
+ * `origin/$GITHUB_BASE_REF` (PR CI), then `origin/<default>`. Returns the resolved ref, or
+ * `undefined` when none resolves — which the caller must treat as a FAILURE, not a pass.
  *
  * No fetch is attempted here (INFRA-048-B/INFRA-050): the only fetch that could help is a full one,
  * and a depth-limited one grafts the history it is trying to supply. Callers check out complete.
@@ -108,6 +110,8 @@ export function resolveBaseRef({ argv = process.argv.slice(2), env = process.env
 
   const candidates = [];
   if (explicit) candidates.push(explicit);
+  const harnessBase = env.HARNESS_BASE_REF?.trim();
+  if (harnessBase) candidates.push(harnessBase);
   const prBase = env.GITHUB_BASE_REF?.trim();
   if (prBase) candidates.push(`origin/${prBase}`);
   candidates.push(`origin/${DEFAULT_BASE_BRANCH}`);
@@ -235,7 +239,7 @@ export async function main() {
   if (baseRef === undefined) {
     process.stdout.write(
       'document authority scan FAILED: no base ref could be resolved ' +
-        '(tried --base-ref, origin/$GITHUB_BASE_REF, origin/develop). ' +
+        '(tried --base-ref, $HARNESS_BASE_REF, origin/$GITHUB_BASE_REF, origin/develop). ' +
         'This gate cannot report a pass it did not compute — an unresolvable base used to exit 0 ' +
         'and silently stop enforcing (INFRA-048). Check out with full history ' +
         '(`fetch-depth: 0`) or pass `--base-ref <ref>`.\n',

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -59,6 +59,7 @@ export async function main({
   cwd = WORKSPACE_ROOT,
   out = (text) => process.stdout.write(text),
   fetch: shouldFetch = true,
+  spawn = spawnSync,
 } = {}) {
   const git = (args) => runGit(args, cwd);
   const branch = flag(argv, '--branch', DEFAULT_BRANCH);
@@ -201,10 +202,14 @@ export async function main({
       // the gate must run in the SAME repository or it verifies the wrong tree while reporting on
       // this one. Omitted at first, which would have made a scratch-root invocation silently verify
       // the developer's own checkout.
-      const gate = spawnSync('pnpm', ['harness:verify:release'], {
+      const gate = spawn('pnpm', ['harness:verify:release'], {
         cwd,
         stdio: 'inherit',
         shell: false,
+        // The promotion tree is develop's tree. The PR target (`GITHUB_BASE_REF=main`) remains the
+        // promotion-context signal, while this explicit override scopes novelty diffs to content the
+        // promotion step itself introduced. The CI release job declares the same environment.
+        env: { ...process.env, HARNESS_BASE_REF: developRef },
       });
       if (gate.status !== 0) {
         restore(previousBranch, branchExisted);


### PR DESCRIPTION
## Summary

- give the main-only release gate an explicit `origin/develop` novelty baseline while preserving `GITHUB_BASE_REF=main` for promotion context
- pass the configured develop ref into the local promotion preflight's release-gate child
- align `check-document-authority` with the existing `HARNESS_BASE_REF` precedence

## Why

Promotion PR #1690 carried the exact develop tree, but diff-sensitive scans compared it to main and treated eleven historical rule sections as newly introduced. Promotion ancestry and tree equality are already verified separately, so novelty checks should compare the promotion candidate to the develop tree it carries unchanged.

## TDD evidence

- RED: 3 focused assertions failed for the missing workflow baseline, missing child-process environment, and ignored document-authority override
- GREEN: 31/31 focused tests passed
- `pnpm harness:scan`: 107 scans passed
- `pnpm harness:test`: 173 files / 3,182 tests passed
- `pnpm harness:verify-like-ci`: PASS, all 11 local stages

## Spec

- `.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md`
- GATE-WRITE, GATE-APPROVAL, and GATE-IMPLEMENT passed
