### PR TITLE
fix(harness): resolve promotion pnpm via corepack

### DIFF
--- a/.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md
+++ b/.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md
@@ -114,7 +114,9 @@ Add a red regression assertion that the main-only release job declares
 `HARNESS_BASE_REF: origin/develop` while retaining `PR_HEAD_SHA`, and that `promote.mjs` passes the
 same override to its local `pnpm harness:verify:release` child. Add a resolver test proving
 `check-document-authority.mjs` prefers `HARNESS_BASE_REF` over `GITHUB_BASE_REF`, then implement that
-precedence. Preserve the global shared resolver and every promotion-context reader unchanged.
+precedence. Invoke the local pnpm child through the repository's Node/Corepack toolchain so the
+sanctioned direct Node entrypoint does not depend on an interactive shell exporting a Volta shim
+directory. Preserve the global shared resolver and every promotion-context reader unchanged.
 
 ## Affected Files
 

--- a/.agents/tasks/INFRA-088-promotion-scan-baseline.md
+++ b/.agents/tasks/INFRA-088-promotion-scan-baseline.md
@@ -48,6 +48,15 @@ develop tree being promoted, while preserving `GITHUB_BASE_REF=main` for promoti
 - Regression: `pnpm harness:scan` passed 107 scans and `pnpm harness:test` passed 173 files / 3,182
   tests. TC-04 remains pending until this fix lands on `develop` and the sanctioned promotion can
   exercise the real develop ref.
+- PR #1691 landed the baseline fix on `develop`; an independent verifier confirmed identical source
+  and target trees, preserved ancestry, and 9/9 required checks passing.
+- The first real promotion attempt exposed a separate launch-boundary defect: the interactive shell
+  resolved Volta's `pnpm` shim, but Node's exported child `PATH` did not, so `spawnSync('pnpm')`
+  returned `ENOENT`. Running the identical gate directly with `HARNESS_BASE_REF=origin/develop`
+  passed the full build, scan, test, release-suite, typecheck, and lint chain.
+- RED/GREEN: the promotion test first failed when requiring `corepack pnpm`, then passed 9/9 after
+  the runner used Node 22's Corepack entrypoint. This keeps pnpm pinned to packageManager 8.15.4
+  while removing reliance on shell-only PATH mutation.
 
 ## Decisions
 

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -224,8 +224,8 @@ describe('promote.mjs (INFRA-051)', () => {
 
     expect(code).toBe(0);
     expect(output).toMatch(/release gate PASSED locally/);
-    expect(invocation.command).toBe('pnpm');
-    expect(invocation.args).toEqual(['harness:verify:release']);
+    expect(invocation.command).toBe('corepack');
+    expect(invocation.args).toEqual(['pnpm', 'harness:verify:release']);
     expect(invocation.options.env.HARNESS_BASE_REF).toBe('develop');
     expect(invocation.options.env.GITHUB_BASE_REF).toBe(process.env.GITHUB_BASE_REF);
   });

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -202,7 +202,13 @@ export async function main({
       // the gate must run in the SAME repository or it verifies the wrong tree while reporting on
       // this one. Omitted at first, which would have made a scratch-root invocation silently verify
       // the developer's own checkout.
-      const gate = spawn('pnpm', ['harness:verify:release'], {
+      // Run pnpm through Corepack instead of relying on a package-manager shim being exported in
+      // the child PATH. Volta can make `pnpm` available to an interactive shell without exporting
+      // its shim directory to Node children; in that environment spawnSync('pnpm') returns ENOENT
+      // and the sanctioned `node scripts/harness/promote.mjs` entrypoint cannot run its gate.
+      // Corepack ships with the repository's pinned Node 22 toolchain and selects packageManager's
+      // pnpm version, so this preserves the command semantics without the shell-specific lookup.
+      const gate = spawn('corepack', ['pnpm', 'harness:verify:release'], {
         cwd,
         stdio: 'inherit',
         shell: false,
@@ -213,10 +219,14 @@ export async function main({
       });
       if (gate.status !== 0) {
         restore(previousBranch, branchExisted);
+        const launchFailure = gate.error
+          ? `\nThe release-gate process could not start (${gate.error.code ?? 'spawn error'}): ${gate.error.message}`
+          : '';
         throw new PromoteError(
           'the release gate FAILED, so the promotion branch was discarded rather than pushed.\n' +
             'This is the same check `release-grade verification` runs on the promotion PR — fixing it\n' +
-            'here costs one local run instead of an open-PR round trip. Re-run promote when green.',
+            'here costs one local run instead of an open-PR round trip. Re-run promote when green.' +
+            launchFailure,
         );
       }
     }


### PR DESCRIPTION
## Summary
- run the local promotion release gate through Corepack so the sanctioned direct Node entrypoint does not depend on a shell-only Volta PATH shim
- preserve the configured develop novelty baseline and add explicit spawn-error detail
- record the real promotion reproduction and RED/GREEN evidence in INFRA-088

## Verification
- RED: focused promotion test expected `corepack pnpm` and failed against the old `pnpm` spawn
- GREEN: focused promotion test 9/9 passed
- `pnpm harness:scan`: 107 passed
- direct `HARNESS_BASE_REF=origin/develop pnpm harness:verify:release`: exit 0
- pre-push: both harness runs passed, 173 files / 3,185 tests each; 106 scans passed, 1 skipped

## Context
The first real promotion after #1691 returned `spawnSync pnpm ENOENT`: zsh resolved `/home/ubuntu/.volta/bin/pnpm`, but that directory was absent from Node's exported child PATH. `corepack pnpm --version` resolves 8.15.4 in the same environment.