### PR TITLE
fix(harness): propagate pnpm path through promotion

### DIFF
--- a/.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md
+++ b/.agents/spec-docs/active/INFRA-088-promotion-scan-baseline.md
@@ -114,9 +114,10 @@ Add a red regression assertion that the main-only release job declares
 `HARNESS_BASE_REF: origin/develop` while retaining `PR_HEAD_SHA`, and that `promote.mjs` passes the
 same override to its local `pnpm harness:verify:release` child. Add a resolver test proving
 `check-document-authority.mjs` prefers `HARNESS_BASE_REF` over `GITHUB_BASE_REF`, then implement that
-precedence. Invoke the local pnpm child through the repository's Node/Corepack toolchain so the
-sanctioned direct Node entrypoint does not depend on an interactive shell exporting a Volta shim
-directory. Preserve the global shared resolver and every promotion-context reader unchanged.
+precedence. Explicitly add declared package-manager homes (`PNPM_HOME` and `VOLTA_HOME/bin`) to the
+local release child's `PATH` so both the first pnpm process and nested pnpm scripts resolve without
+depending on interactive-shell mutation. Preserve the global shared resolver and every
+promotion-context reader unchanged.
 
 ## Affected Files
 

--- a/.agents/tasks/INFRA-088-promotion-scan-baseline.md
+++ b/.agents/tasks/INFRA-088-promotion-scan-baseline.md
@@ -54,9 +54,13 @@ develop tree being promoted, while preserving `GITHUB_BASE_REF=main` for promoti
   resolved Volta's `pnpm` shim, but Node's exported child `PATH` did not, so `spawnSync('pnpm')`
   returned `ENOENT`. Running the identical gate directly with `HARNESS_BASE_REF=origin/develop`
   passed the full build, scan, test, release-suite, typecheck, and lint chain.
-- RED/GREEN: the promotion test first failed when requiring `corepack pnpm`, then passed 9/9 after
-  the runner used Node 22's Corepack entrypoint. This keeps pnpm pinned to packageManager 8.15.4
-  while removing reliance on shell-only PATH mutation.
+- RED/GREEN round 1: the promotion test first failed when requiring `corepack pnpm`, then passed 9/9
+  after the runner used Node 22's Corepack entrypoint. The first process started, but the real
+  release script's nested `pnpm build:deps` still failed because its shell inherited no pnpm shim.
+- RED/GREEN round 2: the test required a direct `pnpm` spawn with `VOLTA_HOME/bin` prepended to the
+  child `PATH` and failed against the Corepack implementation, then passed 9/9 after package-manager
+  homes were propagated. A process-level probe in that exact environment resolved pnpm 8.15.4 with
+  exit 0, covering both the outer process and the nested-script lookup mechanism.
 
 ## Decisions
 

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -53,13 +53,14 @@ async function newRepo() {
 }
 
 /** Same as `run`, but WITHOUT `--skip-release-gate`, so the preflight actually executes. */
-async function runWithGate(root, extraArgv = [], spawn) {
+async function runWithGate(root, extraArgv = [], spawn, env) {
   let output = '';
   const code = await main({
     argv: [...extraArgv, '--main-ref', 'main', '--develop-ref', 'develop', '--baseline', 'develop'],
     cwd: root,
     fetch: false,
     spawn,
+    env,
     out: (text) => {
       output += text;
     },
@@ -217,15 +218,27 @@ describe('promote.mjs (INFRA-051)', () => {
     commit(root, git, 'feature.md', 'work\n', 'feat: something');
     let invocation;
 
-    const { code, output } = await runWithGate(root, [], (command, args, options) => {
-      invocation = { command, args, options };
-      return { status: 0 };
-    });
+    const childEnv = {
+      ...process.env,
+      PNPM_HOME: undefined,
+      VOLTA_HOME: '/opt/volta',
+      PATH: '/usr/bin',
+    };
+    const { code, output } = await runWithGate(
+      root,
+      [],
+      (command, args, options) => {
+        invocation = { command, args, options };
+        return { status: 0 };
+      },
+      childEnv,
+    );
 
     expect(code).toBe(0);
     expect(output).toMatch(/release gate PASSED locally/);
-    expect(invocation.command).toBe('corepack');
-    expect(invocation.args).toEqual(['pnpm', 'harness:verify:release']);
+    expect(invocation.command).toBe('pnpm');
+    expect(invocation.args).toEqual(['harness:verify:release']);
+    expect(invocation.options.env.PATH).toBe(`/opt/volta/bin${path.delimiter}/usr/bin`);
     expect(invocation.options.env.HARNESS_BASE_REF).toBe('develop');
     expect(invocation.options.env.GITHUB_BASE_REF).toBe(process.env.GITHUB_BASE_REF);
   });

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -60,6 +60,7 @@ export async function main({
   out = (text) => process.stdout.write(text),
   fetch: shouldFetch = true,
   spawn = spawnSync,
+  env = process.env,
 } = {}) {
   const git = (args) => runGit(args, cwd);
   const branch = flag(argv, '--branch', DEFAULT_BRANCH);
@@ -202,20 +203,23 @@ export async function main({
       // the gate must run in the SAME repository or it verifies the wrong tree while reporting on
       // this one. Omitted at first, which would have made a scratch-root invocation silently verify
       // the developer's own checkout.
-      // Run pnpm through Corepack instead of relying on a package-manager shim being exported in
-      // the child PATH. Volta can make `pnpm` available to an interactive shell without exporting
-      // its shim directory to Node children; in that environment spawnSync('pnpm') returns ENOENT
-      // and the sanctioned `node scripts/harness/promote.mjs` entrypoint cannot run its gate.
-      // Corepack ships with the repository's pinned Node 22 toolchain and selects packageManager's
-      // pnpm version, so this preserves the command semantics without the shell-specific lookup.
-      const gate = spawn('corepack', ['pnpm', 'harness:verify:release'], {
+      // Package-manager homes can be added by an interactive shell without being exported in the
+      // PATH Node passes to children. Add their canonical bin directories explicitly: the first
+      // pnpm process and every nested `pnpm` in the release script then resolve the same pinned
+      // executable instead of failing at a different nesting level.
+      const packageManagerPaths = [
+        env.PNPM_HOME,
+        env.VOLTA_HOME ? path.join(env.VOLTA_HOME, 'bin') : undefined,
+      ].filter(Boolean);
+      const childPath = [...packageManagerPaths, env.PATH].filter(Boolean).join(path.delimiter);
+      const gate = spawn('pnpm', ['harness:verify:release'], {
         cwd,
         stdio: 'inherit',
         shell: false,
         // The promotion tree is develop's tree. The PR target (`GITHUB_BASE_REF=main`) remains the
         // promotion-context signal, while this explicit override scopes novelty diffs to content the
         // promotion step itself introduced. The CI release job declares the same environment.
-        env: { ...process.env, HARNESS_BASE_REF: developRef },
+        env: { ...env, PATH: childPath, HARNESS_BASE_REF: developRef },
       });
       if (gate.status !== 0) {
         restore(previousBranch, branchExisted);


### PR DESCRIPTION
Summary: prepend PNPM_HOME and VOLTA_HOME/bin to the promotion release child PATH so the outer gate and nested pnpm scripts resolve pnpm 8.15.4. This replaces the insufficient Corepack-only launch from PR #1692. Verification: RED then GREEN focused promotion test (9/9); exact-environment process probe resolved pnpm 8.15.4 with exit 0; harness scan 107 passed; pre-push ran both full harness suites successfully (173 files, 3,182 tests) and scans passed.