### PR TITLE
fix(framework): preserve turn ownership through capture

### DIFF
--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -953,7 +953,9 @@ agent-cli (Ink TUI — CLI-specific)
 - **Queue behavior**: If `executing` is true, the incoming prompt is queued and auto-executes after
   the current one completes. The co-drive queue is bounded at 32 entries: a same-driver submission
   replaces that driver's tail entry, a different driver appends in submission order, and a new
-  entry is refused when the queue is full.
+  entry is refused when the queue is full. Execution ownership remains claimed through awaited
+  post-turn capture and persistence; releasing `executing` and draining the queued head are one
+  synchronous handoff with no intervening `await`, so a public submission cannot start in between.
 - **Abort**: `abort()` clears the queue and delegates to `session.abort()`. An `interrupted` event fires when the abort completes.
 - **No-op terminal**: Uses a built-in NOOP_TERMINAL so no `ITerminalOutput` implementation is required by callers
 - **Session persistence**: When an SDK-owned `sessionStore` facade is provided in options, auto-persists session state (messages, history, cwd, timestamps, system prompt, tool schemas, memory events, used memory references, and provider sandbox snapshot ids when available) after each `submit()` completion and on shutdown. The SDK facade delegates to the concrete `SessionStore` implementation from `agent-session` internally and exposes resumable-session summaries for hosts such as the CLI. Session JSON is the fast snapshot, while append-only JSONL replay logs are the recovery source when the JSON snapshot is missing.

--- a/packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/runtime-12-turn-double-start.test.ts
@@ -21,6 +21,10 @@ const refreshCtl = vi.hoisted(() => {
   return { blocking: false, release: undefined as (() => void) | undefined };
 });
 
+const captureCtl = vi.hoisted(() => {
+  return { blockNext: false, release: undefined as (() => void) | undefined };
+});
+
 vi.mock('../interactive-session-context-refresh.js', () => ({
   checkAndRefreshContextIfStale: (): Promise<void> =>
     refreshCtl.blocking
@@ -30,12 +34,24 @@ vi.mock('../interactive-session-context-refresh.js', () => ({
       : Promise.resolve(),
 }));
 
+vi.mock('../interactive-session-post-turn-memory.js', () => ({
+  capturePostTurnMemory: (): Promise<void> => {
+    if (!captureCtl.blockNext) return Promise.resolve();
+    captureCtl.blockNext = false;
+    return new Promise<void>((resolve) => {
+      captureCtl.release = resolve;
+    });
+  },
+}));
+
 describe('CORE-026 RUNTIME-12 — no turn double-start', () => {
   let harness: ScriptedSessionHarness | undefined;
 
   afterEach(async () => {
     refreshCtl.blocking = false;
     refreshCtl.release?.();
+    captureCtl.blockNext = false;
+    captureCtl.release?.();
     await harness?.dispose();
     harness = undefined;
   });
@@ -74,5 +90,26 @@ describe('CORE-026 RUNTIME-12 — no turn double-start', () => {
     for (let i = 0; i < 200 && (session.isExecuting() || session.getPendingCount() > 0); i++) {
       await new Promise((r) => setTimeout(r, 0));
     }
+  });
+
+  it('keeps execution ownership while awaited post-turn capture is in flight', async () => {
+    harness = scriptedSession({ turns: [{ text: 'a' }, { text: 'b' }] });
+    const session = harness.session;
+    captureCtl.blockNext = true;
+
+    const first = session.submit('one');
+    for (let i = 0; i < 200 && !captureCtl.release; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(captureCtl.release, 'first turn should be parked in post-turn capture').toBeDefined();
+
+    const second = session.submit('two');
+    for (let i = 0; i < 20 && session.getPendingCount() === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(session.getPendingCount(), 'post-turn capture released execution ownership').toBe(1);
+
+    captureCtl.release?.();
+    await Promise.all([first, second]);
   });
 });

--- a/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
@@ -314,12 +314,6 @@ export class SessionExecutionController {
       } catch (error) {
         this.callbacks.emit('error', error instanceof Error ? error : new Error(String(error)));
       }
-      this.executing = false;
-      this.activeDriverId = null; // REMOTE-014 E5: turn ended — events after this are not turn-authored
-      this.callbacks.emit('thinking', false);
-      // FLOW-002: the wake for this task id is no longer in flight; allow future wakes to inject.
-      if (turnOptions.wakeTaskId !== undefined) this.wakeTaskIds.delete(turnOptions.wakeTaskId);
-      this.emitExecutionWorkspaceUpdated('main_thread');
       // SELFHOST-008 P2: post-turn auto-capture, awaited here so its events land in THIS turn's record.
       await capturePostTurnMemory({
         capture: this.callbacks.captureMemory,
@@ -334,6 +328,15 @@ export class SessionExecutionController {
       // answered by ITS turn, and a turn that threw where onError never saw still settles.
       if (terminalResult !== undefined) this.turns.settle(turnId, terminalResult);
       else this.turns.fail(turnId, turnError ?? new Error('the turn ended without a result'));
+      // Release and hand off synchronously. No await may appear between these assignments and the
+      // drain: a public submit in that gap could start a new turn before the queued head claims the
+      // same execution ownership, allowing both turns to run concurrently.
+      this.executing = false;
+      this.activeDriverId = null; // REMOTE-014 E5: turn ended — events after this are not turn-authored
+      this.callbacks.emit('thinking', false);
+      // FLOW-002: the wake for this task id is no longer in flight; allow future wakes to inject.
+      if (turnOptions.wakeTaskId !== undefined) this.wakeTaskIds.delete(turnOptions.wakeTaskId);
+      this.emitExecutionWorkspaceUpdated('main_thread');
       this.drainPendingQueue(resumeQueuedTurn);
     }
   }

--- a/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
@@ -328,9 +328,6 @@ export class SessionExecutionController {
       // answered by ITS turn, and a turn that threw where onError never saw still settles.
       if (terminalResult !== undefined) this.turns.settle(turnId, terminalResult);
       else this.turns.fail(turnId, turnError ?? new Error('the turn ended without a result'));
-      // Release and hand off synchronously. No await may appear between these assignments and the
-      // drain: a public submit in that gap could start a new turn before the queued head claims the
-      // same execution ownership, allowing both turns to run concurrently.
       this.executing = false;
       this.activeDriverId = null; // REMOTE-014 E5: turn ended — events after this are not turn-authored
       this.callbacks.emit('thinking', false);


### PR DESCRIPTION
Fixes the actionable concurrency finding from promotion PR #1698. Execution ownership now remains claimed through awaited post-turn capture and persistence, then releases and drains synchronously. Includes a red-before-fix regression test that parks capture and submits a second turn.