### PR TITLE
fix(build): order declarations by workspace graph

### DIFF
--- a/.agents/spec-docs/done/INFRA-092-declaration-build-workspace-topology.md
+++ b/.agents/spec-docs/done/INFRA-092-declaration-build-workspace-topology.md
@@ -1,0 +1,392 @@
+---
+status: done
+type: INFRA
+tags: [typescript]
+---
+
+# INFRA-092: Declaration Build Must Follow the Complete Workspace Type Graph
+
+## Problem
+
+`pnpm build` runs JavaScript builds for all packages and then `scripts/build-types-ordered.mjs` to
+generate declarations. The scheduler claims strict topological order but reads only each package's
+`dependencies`. Packages whose declaration inputs are workspace `devDependencies`,
+`peerDependencies`, or `optionalDependencies` are therefore assigned before their inputs.
+
+On the current tree, `@robota-sdk/agent-cli` has no recognized production dependency and is placed
+in Tier 1 even though its TypeScript sources import 23 buildable `@robota-sdk/*` packages declared as
+`devDependencies`. After the JavaScript pass cleans prior declaration output, Tier 1 executes
+`agent-cli build:types` before its declaration inputs and fails. The same command succeeds after its
+workspace declaration inputs have been built. This repeatedly blocked the pre-push gate for
+RUNTIME-003.
+
+## Prior Art Research
+
+Research date: 2026-08-13. Official pnpm, npm, TypeScript, and build-graph documentation was
+cross-checked against the reproduced clean-build failure and the current
+`scripts/build-types-ordered.mjs` implementation.
+
+- pnpm recursive execution topologically sorts workspace packages by default, with dependencies
+  before dependents, and bounds concurrent workspace tasks. Its filtering documentation
+  distinguishes `--filter-prod` precisely by saying that it omits `devDependencies`; ordinary
+  workspace dependency selection therefore includes development relationships rather than
+  equating the workspace graph with only the `dependencies` field. See
+  [pnpm recursive execution](https://pnpm.io/cli/recursive) and
+  [pnpm filtering](https://pnpm.io/filtering#--filter-prod-filtering_pattern).
+- npm defines `devDependencies` as packages needed for local development/testing and explicitly
+  documents build tooling as a `devDependency` use case. Thus a declaration-generation task may
+  legitimately require a workspace package listed only there. npm defines `peerDependencies`
+  separately as a compatibility relationship with a host; when a local peer's exported types are
+  build inputs, its declarations must also exist first. See
+  [npm dependencies and devDependencies](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file/)
+  and [npm package.json fields](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/#devdependencies).
+- TypeScript documents the artifact relationship behind the failure: a dependent project consumes
+  declaration output from referenced projects, ordinary `tsc` does not build dependencies
+  automatically, and `tsc --build` discovers and orders referenced projects. See
+  [TypeScript Project References](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript).
+- Build-graph tools distinguish project edges from scheduled tasks and run dependency builds before
+  dependents while retaining parallelism between independent nodes. Nx documents this as
+  `dependsOn: ["^build"]`. See [Nx task pipelines](https://nx.dev/docs/concepts/task-pipeline-configuration).
+
+The measured repository graph supports this model. Merging all four local workspace dependency
+fields moves `agent-cli` from Tier 1 to Tier 9 and remains acyclic. The current graph includes three
+buildable local `optionalDependencies` edges, so excluding that field would make the word “complete”
+false even though it would happen to fix `agent-cli`. The complete graph explains the cold/root-build
+failure and warm standalone success.
+
+## Architecture Review
+
+### Affected Scope
+
+- Root build orchestration:
+  - `scripts/build-types-ordered.mjs`
+  - `package.json` root `build` contract (command unchanged)
+- Deterministic graph tests:
+  - `scripts/harness/__tests__/build-types-ordered.test.mjs` (new)
+- Verification owner documentation:
+  - `.agents/specs/verification-pipeline-plan.md`
+
+### Alternatives Considered
+
+1. **Move `agent-cli` workspace entries into `dependencies`.**
+   - Pro: the current scheduler would happen to order this package correctly.
+   - Con: corrupts install-time package semantics to compensate for an orchestrator defect and
+     leaves every future dev-only/peer type input exposed.
+2. **Replace the scheduler now with pnpm recursive execution or TypeScript project references.**
+   - Pro: delegates graph scheduling to a documented owner.
+   - Con: project references require a broad migration from the current `tsdown --dts` and
+     `composite: false` setup; replacing the pnpm-8-era behavior needs wider compatibility proof.
+3. **Merge local workspace dependency fields in the existing scheduler.**
+   - Pro: repairs the graph at its owner, preserves the existing tier-ordered commands, and covers
+     every local workspace dependency field that may supply declaration inputs.
+   - Con: test-only edges may serialize more work, and a local peer cycle becomes an explicit build
+     cycle requiring resolution rather than being silently ignored.
+4. **Keep dependency-only ordering and require callers to prebuild.**
+   - Pro: no code change.
+   - Con: preserves a clean-root-build failure and makes success depend on stale artifacts.
+
+### Decision
+
+Choose alternative 3. For every package with `build:types`, the scheduler derives a deduplicated
+local declaration prerequisite set from `dependencies`, `devDependencies`, `peerDependencies`, and
+`optionalDependencies`. External names and workspace packages without `build:types` remain outside
+the scheduled graph, as today. Package names, prerequisite names, tiers, and cycle diagnostics are
+sorted so filesystem enumeration order cannot change the plan or its output. The existing
+tier-by-tier execution and fail-closed cycle report remain.
+
+Despite its current `runParallel` name, the implementation wraps `execSync` and therefore executes a
+tier serially. INFRA-092 does not silently broaden into a process-execution refactor: it preserves that
+behavior and renames the helper to describe it honestly. True bounded parallel execution is a separate
+performance concern that needs its own failure handling and resource-budget design.
+
+Validation before implementation: the real workspace was evaluated with the proposed relation; it
+produces nine acyclic tiers and places `agent-cli` in Tier 9. Reachability covers all 75 packages that
+currently declare `build:types` and the root `pnpm build` caller. The adversarial cases are duplicate
+field declarations, external and non-buildable names, cross-field cycles, packages with only
+dev/peer/optional workspace inputs, and permuted discovery order. Tests exercise each rather than
+asserting a package name token exists.
+
+### Structural Analog and Placement
+
+The exact structural analog is the existing root repository-infrastructure module family under
+`scripts/harness/*.mjs`. In particular, `scripts/harness/check-plan.mjs` and
+`scripts/harness/scan-build-tooling-scope.mjs` both export pure functions for co-located harness
+tests while retaining direct command execution. Their tests import those helpers through
+repository-relative paths; no workspace package or application consumes them as a product API.
+
+Package discovery reuses `scripts/harness/workspace-packages.mjs#listManifestPackageDirs`, the
+existing SSOT for manifest-owning directories under `packages/**`, including nested package groups
+and canonical exclusions. INFRA-092 owns only buildability filtering and declaration edges; it does
+not create a second filesystem walker.
+
+`scripts/build-types-ordered.mjs` belongs to that same root INFRA/developer-workflow family. The
+root package is `private`, has no package `exports`, and already owns the workspace-wide build
+entrypoint. Exporting graph discovery and tier calculation functions therefore creates only an
+internal deterministic-test seam, not a shipped CLI, SDK, application, or reusable sibling-product
+surface. The implementation continues to depend only on Node built-ins and workspace manifest
+data. It does not import, wrap, filter through, or otherwise depend on any package or application
+product API.
+
+This placement reuses the lowest existing owner directly: the root build script remains the sole
+declaration-task graph owner, and its co-located harness tests exercise the same pure relation used
+by direct execution. Creating a workspace package for this logic, or importing a sibling product
+factory, would introduce a dependency boundary that the existing root harness analog does not need.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — `check-plan.mjs` and `scan-build-tooling-scope.mjs` provide the exact
+      root-private ESM helper-export/test analog; packages and apps do not consume that seam
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+1. Export pure workspace-package discovery and tier calculation functions from
+   `build-types-ordered.mjs`; preserve direct-execution behavior behind a main-module guard.
+2. Build each package edge set from the union of local `dependencies`, `devDependencies`,
+   `peerDependencies`, and `optionalDependencies`, deduplicated and sorted before topology
+   calculation.
+3. Add reverse-direction fixtures proving each dependency field creates an edge, duplicates do not
+   duplicate edges, irrelevant packages do not block, merged-field cycles fail with waiting details,
+   input permutations produce identical tiers/diagnostics, and the live `agent-cli` graph is not
+   Tier 1.
+4. Run the root two-pass build from the post-fix tree and retain the existing package-owned
+   `build:types` commands and tier-by-tier serial execution.
+
+## Affected Files
+
+- `scripts/build-types-ordered.mjs`
+- `scripts/harness/__tests__/build-types-ordered.test.mjs`
+- `.agents/specs/verification-pipeline-plan.md`
+
+## Completion Criteria
+
+- [x] TC-01: A fixture with local workspace edges in each of `dependencies`, `devDependencies`,
+      `peerDependencies`, and `optionalDependencies` places every dependency before its consumer;
+      duplicate field declarations produce one edge.
+- [x] TC-02: External packages and workspace packages without `build:types` do not block the graph;
+      a cross-field cycle exits non-zero and names every remaining package and waiting edge.
+- [x] TC-03: The live workspace topology contains all 75 packages with `build:types`, places
+      `@robota-sdk/agent-cli` after each buildable local declaration input, and never places it in
+      Tier 1; permuting discovery input produces identical tiers and cycle diagnostics.
+- [x] TC-04: `pnpm build` exits 0 from the final tree without manually prebuilding `agent-cli` or
+      relying on a second retry.
+- [x] TC-05: The verification pipeline owner describes the complete four-field local workspace
+      declaration graph, deterministic tier order, current serial tier execution, and fail-closed
+      cycle behavior.
+
+## Test Plan
+
+| TC-ID | Test Type         | Tool / Approach                                                                                                                                               | Notes                                                 |
+| ----- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| TC-01 | INFRA unit        | `scripts/harness/__tests__/build-types-ordered.test.mjs` > `orders and deduplicates local prerequisites from every dependency field`                          | Covers all four fields and deduplication              |
+| TC-02 | INFRA unit        | Same file > `ignores external and non-buildable names and reports cross-field cycles deterministically`                                                       | Asserts actionable cycle detail                       |
+| TC-03 | INFRA integration | Same file > `covers the live declaration graph and keeps agent-cli after all local prerequisites`; `produces the same sorted tiers for every discovery order` | Covers 75 packages and deterministic Tier 9 placement |
+| TC-04 | CI smoke          | `pnpm build` (engineering command; no separate automated test)                                                                                                | Cold two-pass root build contract                     |
+| TC-05 | Governance        | `node scripts/harness/scan-harness-script-import-safety.mjs`; owner-doc review (engineering checks)                                                           | Verifies import safety and owner-document claim       |
+
+## User Execution Test Scenarios
+
+**Applicability:** not-applicable
+
+This item changes only repository-internal declaration-build scheduling. It does not alter a shipped
+Robota CLI, application, transport, or public SDK behavior. Root build output is engineering
+verification and, by the backlog-execution rule, cannot be repackaged as user-execution evidence.
+
+## Tasks
+
+- [x] `.agents/tasks/completed/INFRA-092-declaration-build-workspace-topology.md`
+
+## Evidence Log
+
+### [GATE-WRITE] — ❌ FAIL | 2026-08-13
+
+Independent review found the problem, prior art, alternatives, decision, completion criteria, test
+plan, and not-applicable user-scenario classification otherwise complete. The draft was returned
+because exporting pure graph functions creates a module/interface seam, while the Architecture
+Review did not identify its closest structural analog, product-family classification, or dependency
+proof. Required correction: classify the seam, name the existing repository analog, and prove that
+it does not introduce sibling-product coupling before re-review.
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** draft → review-ready
+
+- Frontmatter: YAML delimiters, `status: draft`, allowed `type: INFRA`, and `tags: [typescript]` were
+  present at gate input.
+- Problem: identifies the failing `pnpm build` declaration phase, Tier 1 `agent-cli` ordering, the
+  cold-build reproduction condition, and the successful prerequisite-built comparison.
+- Prior Art Research: cites pnpm, npm, TypeScript, and Nx documentation and carries their
+  dependency/task-graph findings into the alternatives and selected complete-workspace-edge decision.
+- Architecture placement: classifies the exported seam as root-private INFRA/developer-workflow
+  infrastructure, identifies the existing `scan-build-tooling-scope.mjs` helper-export,
+  co-located-test, direct-execution analog, and confirms no sibling package or application product
+  dependency is introduced.
+- Completion Criteria and Test Plan: TC-01 through TC-05 are concrete, observable, and map exactly
+  to five populated test-plan rows.
+- Structure: Tasks contains the pre-approval placeholder, and the prior failed gate is retained for
+  audit history.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-13
+
+- Owner approval (verbatim): “타당한 이유와 함께 추천안을 제시하면 타당할 경우 자동으로
+  승인하겠습니다”.
+- The INFRA-092 recommendation builds declaration order from the deduplicated union of local
+  workspace `dependencies`, `devDependencies`, and `peerDependencies`, retaining the existing
+  root-private scheduler and established helper-export/co-located-test structure.
+- The owner's condition became true when the corrected final recommendation received independent
+  GATE-WRITE PASS, including verification of the nine-tier graph, `agent-cli` Tier 9 placement,
+  structural analog, INFRA classification, and absence of sibling-product coupling.
+- No post-approval drift occurred in Architecture Review or frontmatter `type`/`tags`.
+- A separate architecture-placement verdict is not applicable because no package, app, shipped
+  interface, reusable product surface, or layer/product-family boundary is introduced.
+- No implementation began before approval; the scheduler still reads only `dependencies`.
+
+### [RECOMMENDATION REVIEW] — ❌ REVISE | 2026-08-13
+
+- The graph-owner placement and existing scheduler strategy were endorsed in direction, but the
+  recommendation understated the live graph and overstated the executor.
+- Required corrections: use the measured 75 `build:types` packages; include the three current
+  buildable local `optionalDependencies` edges in the complete relation; stop describing the
+  `execSync` implementation as parallel; and sort graph/output data with permutation tests.
+- Depth review: `DEPTH: LOCAL` — the task targets the scheduler's incomplete edge model itself rather
+  than patching the `agent-cli` symptom (`0 FOUNDATIONAL of 1`).
+
+### [RECOMMENDATION RE-REVIEW] — ❌ REVISE | 2026-08-13
+
+- The corrected four-field graph, measured package count, deterministic ordering, test plan, and
+  root-private placement were accepted in substance.
+- One factual contradiction remained: the Problem called the Tier 1 execution concurrent while the
+  Decision correctly documented the current `execSync` tier executor as serial. The Problem was
+  corrected to state that `agent-cli` runs before its declaration inputs.
+
+### [RECOMMENDATION FINAL REVIEW] — ✅ ENDORSE | 2026-08-13
+
+- Independent review confirmed the measured scope of 75 packages declaring `build:types`.
+- The selected relation is the sorted, deduplicated union of all four local dependency fields and
+  includes the three current buildable local optional edges.
+- The reproduced graph has nine acyclic tiers and places `@robota-sdk/agent-cli` in Tier 9 after all
+  of its buildable local declaration inputs.
+- Deterministic package, prerequisite, tier, and cycle-diagnostic ordering is covered by permuted
+  fixture inputs.
+- The recommendation preserves the existing serial `execSync` executor and keeps true process
+  parallelism outside this correctness task.
+- Root-private placement and the pure helper/main-guard test seam introduce no product coupling.
+
+**REVIEW VERDICT: ENDORSE**
+
+### [OWNER CONDITIONAL APPROVAL — CORRECTED SCOPE] — ✅ PASS | 2026-08-13
+
+- Owner instruction: “타당한 이유와 함께 추천안을 제시하면 타당할 경우 자동으로
+  승인하겠습니다”.
+- The material correction from three to four dependency fields was not inferred as silently covered
+  by the earlier approval. It was independently re-reviewed after the measured optional edges,
+  package count, deterministic ordering, and serial execution semantics were added.
+- The owner's stated condition became true when that corrected recommendation received
+  `REVIEW VERDICT: ENDORSE`; implementation approval therefore applies to this final four-field
+  recommendation.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** approved → in-progress
+
+- Ordering: the Evidence Log contains a prior `GATE-APPROVAL` PASS, and the document entered this
+  gate with `status: approved` in the expected `todo` lifecycle folder.
+- Tasks artifact: `.agents/tasks/INFRA-092-declaration-build-workspace-topology.md` exists and is
+  named exactly in this spec's `## Tasks` section.
+- TC-01 task: model and deduplicate all four workspace dependency fields.
+- TC-02 task: ignore irrelevant nodes and fail closed with deterministic cycle details.
+- TC-03 task: cover all 75 live declaration packages and keep `agent-cli` after its local inputs.
+- TC-04 task: pass a clean root `pnpm build` without a preparatory retry.
+- TC-05 task: synchronize the verification pipeline owner document.
+- Test-plan requirement: the task artifact contains a substantive `## Test Plan` describing the TDD
+  sequence and focused, live-topology, root-build, harness-scan, and CI-equivalent verification.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** in-progress → verifying
+
+- Task completion: `.agents/tasks/INFRA-092-declaration-build-workspace-topology.md` exists; TC-01
+  through TC-05 are all marked `[x]`, its Blockers section is `None`, and it contains no unchecked,
+  blocked, or pending task.
+- Build verification: independently ran `pnpm build`; it exited 0 after building the package JavaScript
+  pass and all 75 `build:types` packages across nine deterministic tiers, ending with
+  `✓ All build:types complete.`
+- Test verification: independently ran `pnpm test`; it exited 0 across the recursive workspace test
+  run (`Scope: 102 of 103 workspace projects`), including the terminal package result
+  `packages/agent-cli test: Done`.
+
+### [GATE-COMPLETE: TC-01] — ✅ VERIFIED | 2026-08-13
+
+- Command: `pnpm exec vitest run scripts/harness/__tests__/build-types-ordered.test.mjs`.
+- Result: exit 0; `orders and deduplicates local prerequisites from every dependency field` passed,
+  proving four-field ordering and deduplication.
+
+### [GATE-COMPLETE: TC-02] — ✅ VERIFIED | 2026-08-13
+
+- Command: `pnpm exec vitest run scripts/harness/__tests__/build-types-ordered.test.mjs`.
+- Result: exit 0; the irrelevant-node/cross-field-cycle test passed with deterministic waiting-edge
+  diagnostics, and the discovery test excluded a package without `build:types`.
+
+### [GATE-COMPLETE: TC-03] — ✅ VERIFIED | 2026-08-13
+
+- Command: `pnpm exec vitest run scripts/harness/__tests__/build-types-ordered.test.mjs`.
+- Result: exit 0; 5/5 tests passed. The live graph contained 75 packages in nine tiers,
+  `@robota-sdk/agent-cli` was Tier 9, and all of its local inputs preceded it. Permuted fixtures
+  produced identical tiers and cycle diagnostics.
+
+### [GATE-COMPLETE: TC-04] — ✅ VERIFIED | 2026-08-13
+
+- Command: `pnpm build`.
+- Result: exit 0 on the first final-tree run without a preparatory package build or retry; all 75
+  declaration packages completed across nine tiers and the command ended `✓ All build:types complete.`
+- Test disposition: no separate automated test; the root build command is the authoritative
+  engineering smoke and was also rerun independently by GATE-VERIFY.
+
+### [GATE-COMPLETE: TC-05] — ✅ VERIFIED | 2026-08-13
+
+- Commands/actions: reviewed `.agents/specs/verification-pipeline-plan.md`; ran
+  `node scripts/harness/scan-harness-script-import-safety.mjs` and `pnpm harness:verify-like-ci`.
+- Result: import-safety scan exited 0 after examining 152 harness scripts; the owner document states
+  the four-field `packages/**` graph, deterministic tier/cycle ordering, serial execution, and
+  fail-closed cycles; verify-like-CI passed all 11 stages in 7m58.6s.
+- Test disposition: governance claims are covered by the import-safety scan, owner-doc inspection,
+  and the CI-equivalent engineering gate rather than a product test.
+
+### [GATE-COMPLETE EVIDENCE SUMMARY] — READY | 2026-08-13
+
+- TC-01 through TC-05 are checked and each has exact verification output plus a test reference or
+  explicit engineering-test disposition.
+- The active task is completion-ready with every plan item checked and no blockers.
+- User-execution applicability remains `not-applicable` because no shipped product surface changed.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** verifying → done
+
+- Ordering: the Evidence Log contains a prior `GATE-VERIFY` PASS, and the document entered this gate
+  with `status: verifying` in the expected `active` lifecycle folder.
+- TC-01: checked; its evidence records the exact focused Vitest command, exit 0, and the named test
+  proving four-field prerequisite ordering and deduplication.
+- TC-02: checked; its evidence records the same exact command, exit 0, and the named tests proving
+  irrelevant-node exclusion plus deterministic cross-field cycle diagnostics.
+- TC-03: checked; its evidence records exit 0 and 5/5 focused tests. Independent gate execution
+  reconfirmed 75 declaration packages, nine tiers, `agent-cli` in Tier 9, and all 23 local inputs in
+  earlier tiers.
+- TC-04: checked; its evidence records the authoritative `pnpm build` action, first-run exit 0, and
+  the explicit reason no separate automated test is used for this engineering smoke contract.
+- TC-05: checked; its evidence records owner-document inspection, the exact import-safety and
+  CI-equivalent commands, exit-0/pass results, and the explicit governance-test disposition.
+- Test Plan: all five rows name a test file and test case or give an explicit engineering-check
+  disposition; no TC is silently unaddressed.
+- Task readiness: `.agents/tasks/INFRA-092-declaration-build-workspace-topology.md` is the exact active
+  path named by the spec, exists, has TC-01 through TC-05 checked, reports `None` under Blockers, and
+  contains no pending task.
+- Independent recheck: the focused test file passed 5/5 with exit 0, import-safety passed for 152
+  scripts with exit 0, and live graph inspection returned
+  `{"packages":75,"tiers":9,"agentCliTier":9,"agentCliInputs":23}`.

--- a/.agents/specs/verification-pipeline-plan.md
+++ b/.agents/specs/verification-pipeline-plan.md
@@ -101,6 +101,19 @@ When the plan genuinely selects the full workspace, package-owned commands run t
 recursive/filter scheduler with complete per-scope result accounting; no global worker ceiling is
 raised. Every CI-equivalent stage and the total command report measured elapsed time.
 
+## Declaration Build Topology (INFRA-092)
+
+The root declaration scheduler derives its local prerequisite graph from the sorted, deduplicated
+union of `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies` for every
+package under `packages/**` that declares `build:types`. External packages, apps, and local packages
+without that script are outside this package-family declaration graph.
+
+Graph discovery, prerequisites, tiers, and cycle diagnostics are deterministic: filesystem and input
+enumeration order cannot change the plan. The scheduler executes tiers in topological order and
+fails closed with every remaining package and waiting local edge when no next tier exists. Within a
+tier, the current `execSync` implementation remains serial; true bounded process parallelism is a
+separate performance concern rather than an implied property of this correctness contract.
+
 ## Prior Art Findings
 
 - GitHub Actions supports branch and path filters, but skipped required workflows can remain pending; GitHub also limits path-filter diff evaluation, so path filters should not be the only correctness boundary.

--- a/.agents/tasks/completed/INFRA-092-declaration-build-workspace-topology.md
+++ b/.agents/tasks/completed/INFRA-092-declaration-build-workspace-topology.md
@@ -1,0 +1,79 @@
+---
+title: 'INFRA-092: Declaration Build Must Follow the Complete Workspace Type Graph'
+status: done
+created: 2026-08-13
+completed: 2026-08-13
+priority: high
+urgency: now
+area: scripts/build-types-ordered.mjs, scripts/harness, verification pipeline
+depends_on: []
+---
+
+# INFRA-092 Declaration Build Workspace Topology
+
+- **Branch**: `fix/infra-092-declaration-build-topology`
+- **Spec**: `.agents/spec-docs/done/INFRA-092-declaration-build-workspace-topology.md`
+
+## Objective
+
+Make root declaration builds follow the complete, deterministic local workspace dependency graph so
+cold builds do not depend on stale declaration artifacts or retry order.
+
+## Plan
+
+- [x] TC-01: Model and deduplicate all four workspace dependency fields.
+- [x] TC-02: Ignore irrelevant nodes and fail closed with deterministic cycle details.
+- [x] TC-03: Cover all 75 live declaration packages and keep `agent-cli` after its local inputs.
+- [x] TC-04: Pass a clean root `pnpm build` without a preparatory retry.
+- [x] TC-05: Synchronize the verification pipeline owner document.
+
+## Test Plan
+
+Use TDD: first add fixtures that fail against the dependency-only, enumeration-order-sensitive graph;
+then expose the root-private pure seam and make the smallest graph correction. Verify focused harness
+tests, the live topology, the root build, harness scans, and the final CI-equivalent gate.
+
+## User Execution Test Scenarios
+
+**Applicability:** not-applicable
+
+This changes repository-internal declaration-build scheduling only. Build and harness outputs are
+engineering verification, not a shipped product surface.
+
+## Progress
+
+### 2026-08-13
+
+- GATE-WRITE and owner approval passed before implementation.
+- Independent depth review classified the problem as `DEPTH: LOCAL` (root-cause scoped).
+- First proposal review returned REVISE: correct the live count to 75, include
+  `optionalDependencies`, preserve serial tier execution honestly, and add deterministic ordering.
+- The corrected recommendation received independent `REVIEW VERDICT: ENDORSE`; the owner's stated
+  conditional automatic-approval criterion is satisfied for this final scope.
+- RED: importing the old script from the new test immediately launched the live build and exposed
+  both the absent main guard and dependency-only Tier 1 ordering.
+- GREEN: five focused Vitest cases passed for four-field deduplication, irrelevant nodes,
+  deterministic cycles and input permutations, nested discovery, all 75 live packages, and
+  `agent-cli` Tier 9.
+- A single root `pnpm build` passed without preparatory package builds or retry; declaration output
+  showed nine tiers and `agent-cli` alone in Tier 9.
+- The final CI-equivalent gate passed all 11 stages in 7m58.6s. It included the complete harness
+  suite, build, typecheck, 86-scope affected verification, binary E2E, examples, and TUI PTY tests.
+- User Execution PLAN independently returned `NOT-APPLICABLE`: this work has no shipped product
+  surface and engineering verification is not user-execution evidence.
+
+## Decisions
+
+- Keep the existing root graph owner and tier-by-tier execution; do not mix true process parallelism
+  into this correctness fix.
+- Define completeness as the sorted, deduplicated union of all four npm dependency fields for local
+  packages that own `build:types`.
+
+## Blockers
+
+- None.
+
+## Result
+
+Implementation, engineering verification, independent local review convergence, and the completion
+gate are complete. The task and spec were archived atomically in the closing commit.

--- a/scripts/build-types-ordered.mjs
+++ b/scripts/build-types-ordered.mjs
@@ -1,61 +1,66 @@
 #!/usr/bin/env node
 /**
- * Runs build:types for all workspace packages in strict topological order.
- * Packages at the same dependency tier run in parallel.
+ * Runs build:types for packages under packages/** in strict topological order.
+ * Packages are executed one tier at a time in deterministic order.
  */
 
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { listManifestPackageDirs } from './harness/workspace-packages.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 
-function findPackages() {
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+export function findBuildTypePackages(workspaceRoot = root) {
   const results = new Map(); // name -> pkg info
-
-  const scanDir = (dir) => {
-    if (!fs.existsSync(dir)) return;
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
-      const childDir = path.join(dir, entry.name);
-      const pkgPath = path.join(childDir, 'package.json');
-      if (!fs.existsSync(pkgPath)) {
-        // Package-group container (e.g. packages/dag-nodes/) — recurse one level
-        // so nested members (packages/dag-nodes/*) get their types built too.
-        scanDir(childDir);
-        continue;
-      }
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      if (!pkg.name || !pkg.scripts?.['build:types']) continue;
-      if (results.has(pkg.name)) continue; // skip duplicates
-      results.set(pkg.name, {
-        name: pkg.name,
-        dir: childDir,
-        deps: Object.keys(pkg.dependencies ?? {}).filter((d) => d.startsWith('@robota-sdk/')),
-      });
-    }
-  };
-
-  scanDir(path.join(root, 'packages'));
-  return [...results.values()];
+  for (const packageDir of listManifestPackageDirs(workspaceRoot)) {
+    const pkg = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+    if (!pkg.name || !pkg.scripts?.['build:types'] || results.has(pkg.name)) continue;
+    results.set(pkg.name, { name: pkg.name, dir: packageDir, manifest: pkg });
+  }
+  return [...results.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function topoSort(packages) {
-  const byName = new Map(packages.map((p) => [p.name, p]));
+function localDependencies(pkg, localNames) {
+  const names = new Set();
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const name of Object.keys(pkg.manifest[field] ?? {})) {
+      if (localNames.has(name)) names.add(name);
+    }
+  }
+  return [...names].sort((left, right) => left.localeCompare(right));
+}
+
+export function createBuildTypeTiers(discoveredPackages) {
+  const packages = [...discoveredPackages].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  const localNames = new Set(packages.map((pkg) => pkg.name));
+  const normalized = packages.map((pkg) => ({
+    ...pkg,
+    deps: localDependencies(pkg, localNames),
+  }));
+  const byName = new Map(normalized.map((pkg) => [pkg.name, pkg]));
   const tiers = [];
   const built = new Set();
 
-  while (built.size < packages.length) {
-    const tier = packages.filter((p) => {
+  while (built.size < normalized.length) {
+    const tier = normalized.filter((p) => {
       if (built.has(p.name)) return false;
       return p.deps.every((d) => !byName.has(d) || built.has(d));
     });
 
     if (tier.length === 0) {
-      const remaining = packages.filter((p) => !built.has(p.name));
+      const remaining = normalized.filter((p) => !built.has(p.name));
       const details = remaining.map(
         (p) =>
           `${p.name} (waiting on: ${p.deps.filter((d) => byName.has(d) && !built.has(d)).join(', ')})`,
@@ -70,40 +75,36 @@ function topoSort(packages) {
   return tiers;
 }
 
-async function runParallel(packages) {
-  return Promise.all(
-    packages.map(
-      (pkg) =>
-        new Promise((resolve, reject) => {
-          try {
-            execSync('pnpm build:types', { cwd: pkg.dir, stdio: 'inherit' });
-            resolve();
-          } catch (e) {
-            reject(new Error(`FAILED: ${pkg.name} build:types`));
-          }
-        }),
-    ),
-  );
+function runTierSerially(packages) {
+  for (const pkg of packages) {
+    try {
+      execSync('pnpm build:types', { cwd: pkg.dir, stdio: 'inherit' });
+    } catch {
+      throw new Error(`FAILED: ${pkg.name} build:types`);
+    }
+  }
 }
 
 async function main() {
-  const packages = findPackages();
+  const packages = findBuildTypePackages();
   console.log(`Building types for ${packages.length} packages in topological order...\n`);
 
-  const tiers = topoSort(packages);
+  const tiers = createBuildTypeTiers(packages);
 
   for (let i = 0; i < tiers.length; i++) {
     const tier = tiers[i];
     const names = tier.map((p) => p.name.replace('@robota-sdk/', '')).join(', ');
     console.log(`Tier ${i + 1}/${tiers.length} [${tier.length} packages]: ${names}`);
-    await runParallel(tier);
+    runTierSerially(tier);
     console.log(`  ✓ done\n`);
   }
 
   console.log('✓ All build:types complete.');
 }
 
-main().catch((e) => {
-  console.error('\n' + e.message);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main().catch((e) => {
+    console.error('\n' + e.message);
+    process.exit(1);
+  });
+}

--- a/scripts/harness/__tests__/build-types-ordered.test.mjs
+++ b/scripts/harness/__tests__/build-types-ordered.test.mjs
@@ -1,0 +1,129 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createBuildTypeTiers, findBuildTypePackages } from '../../build-types-ordered.mjs';
+
+const temporaryRoots = [];
+
+afterEach(() => {
+  while (temporaryRoots.length > 0) {
+    rmSync(temporaryRoots.pop(), { recursive: true, force: true });
+  }
+});
+
+function packageInfo(name, manifest = {}) {
+  return {
+    name,
+    dir: `/workspace/${name}`,
+    manifest: {
+      name,
+      scripts: { 'build:types': 'tsdown --dts' },
+      ...manifest,
+    },
+  };
+}
+
+describe('createBuildTypeTiers', () => {
+  it('orders and deduplicates local prerequisites from every dependency field', () => {
+    const packages = [
+      packageInfo('@fixture/consumer', {
+        dependencies: { '@fixture/a': 'workspace:*' },
+        devDependencies: { '@fixture/b': 'workspace:*', '@fixture/a': 'workspace:*' },
+        peerDependencies: { '@fixture/c': 'workspace:*' },
+        optionalDependencies: { '@fixture/d': 'workspace:*' },
+      }),
+      packageInfo('@fixture/d'),
+      packageInfo('@fixture/c'),
+      packageInfo('@fixture/b'),
+      packageInfo('@fixture/a'),
+    ];
+
+    const tiers = createBuildTypeTiers(packages);
+
+    expect(tiers.map((tier) => tier.map((pkg) => pkg.name))).toEqual([
+      ['@fixture/a', '@fixture/b', '@fixture/c', '@fixture/d'],
+      ['@fixture/consumer'],
+    ]);
+    expect(tiers[1][0].deps).toEqual(['@fixture/a', '@fixture/b', '@fixture/c', '@fixture/d']);
+  });
+
+  it('ignores external and non-buildable names and reports cross-field cycles deterministically', () => {
+    const cycle = [
+      packageInfo('@fixture/b', {
+        peerDependencies: { '@fixture/a': 'workspace:*', external: '^1.0.0' },
+      }),
+      packageInfo('@fixture/a', {
+        optionalDependencies: {
+          '@fixture/b': 'workspace:*',
+          '@fixture/non-buildable': 'workspace:*',
+        },
+      }),
+    ];
+
+    const expected =
+      'Circular dependencies detected:\n' +
+      '  @fixture/a (waiting on: @fixture/b)\n' +
+      '  @fixture/b (waiting on: @fixture/a)';
+
+    expect(() => createBuildTypeTiers(cycle)).toThrow(expected);
+    expect(() => createBuildTypeTiers([...cycle].reverse())).toThrow(expected);
+  });
+
+  it('produces the same sorted tiers for every discovery order', () => {
+    const packages = [
+      packageInfo('@fixture/c', { devDependencies: { '@fixture/a': 'workspace:*' } }),
+      packageInfo('@fixture/b'),
+      packageInfo('@fixture/a'),
+    ];
+
+    const names = (input) => createBuildTypeTiers(input).map((tier) => tier.map((pkg) => pkg.name));
+
+    expect(names(packages)).toEqual([['@fixture/a', '@fixture/b'], ['@fixture/c']]);
+    expect(names([...packages].reverse())).toEqual(names(packages));
+  });
+
+  it('covers the live declaration graph and keeps agent-cli after all local prerequisites', () => {
+    const packages = findBuildTypePackages();
+    const tiers = createBuildTypeTiers(packages);
+    const tierByName = new Map(
+      tiers.flatMap((tier, tierIndex) => tier.map((pkg) => [pkg.name, tierIndex])),
+    );
+    const cli = tiers.flat().find((pkg) => pkg.name === '@robota-sdk/agent-cli');
+
+    expect(packages).toHaveLength(75);
+    expect(tiers).toHaveLength(9);
+    expect(tierByName.get('@robota-sdk/agent-cli')).toBe(8);
+    expect(cli).toBeDefined();
+    for (const dependency of cli.deps) {
+      expect(tierByName.get(dependency), dependency).toBeLessThan(
+        tierByName.get('@robota-sdk/agent-cli'),
+      );
+    }
+  });
+});
+
+describe('findBuildTypePackages', () => {
+  it('discovers nested buildable packages and excludes workspaces without build:types', () => {
+    const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'build-types-ordered-'));
+    temporaryRoots.push(workspaceRoot);
+    const buildableDir = path.join(workspaceRoot, 'packages', 'nested', 'buildable');
+    const skippedDir = path.join(workspaceRoot, 'packages', 'skipped');
+    mkdirSync(buildableDir, { recursive: true });
+    mkdirSync(skippedDir, { recursive: true });
+    writeFileSync(
+      path.join(buildableDir, 'package.json'),
+      JSON.stringify({ name: '@fixture/buildable', scripts: { 'build:types': 'tsdown --dts' } }),
+    );
+    writeFileSync(
+      path.join(skippedDir, 'package.json'),
+      JSON.stringify({ name: '@fixture/skipped', scripts: { build: 'tsdown' } }),
+    );
+
+    expect(findBuildTypePackages(workspaceRoot).map((pkg) => pkg.name)).toEqual([
+      '@fixture/buildable',
+    ]);
+  });
+});


### PR DESCRIPTION
## Accepted recommendation

Keep the existing root-private declaration scheduler and derive each buildable package's prerequisite set from the sorted, deduplicated union of local `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies`. Reuse `listManifestPackageDirs` as the discovery SSOT, preserve deterministic tier-by-tier serial execution, and fail closed on cycles. Do not change package dependency semantics or mix true process parallelism into this correctness fix.

**Independent review verdict:** `ENDORSE`.

Rationale: the measured graph contains 75 declaration packages and three buildable optional-dependency edges; the corrected relation is acyclic, produces nine tiers, and moves `@robota-sdk/agent-cli` from invalid Tier 1 placement to Tier 9 after all 23 local declaration inputs.

## Verification

- focused graph/discovery tests: 5/5 pass
- `pnpm build`: pass, 75 packages / 9 tiers
- `pnpm test`: pass across 102/103 workspace projects
- `pnpm harness:verify-like-ci`: all 11 stages pass
- pre-push: 86/86 scopes, 107 scans, CLI smoke pass
- local independent review: `ACTIONABLE FINDINGS: 0`

## User execution scenarios

Not applicable. This changes repository-internal declaration-build scheduling only; no shipped CLI, app, transport, or public SDK behavior changes.

## Tracking

- `INFRA-092`
- Task and spec are archived as done in this PR.