### PR TITLE
fix(runtime): bind interactive execution ownership

### DIFF
--- a/.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md
+++ b/.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md
@@ -1,0 +1,189 @@
+# RUNTIME-005 — abort a parked approval and run the next prompt (agent-run)
+
+This scenario drives the exported `InteractiveSession` framework testing surface with a deterministic
+local provider. It parks a real turn on a transport-neutral permission request, verifies that a public
+blocking command is rejected without consuming the queued prompt, aborts the turn, and observes both
+bounded settlement and successful reuse of the same session for the next prompt.
+
+## Executability
+
+`agent-executable` — the flow is non-interactive Bash over the public framework testing SDK. It uses
+the shipped scripted provider, needs no credentials or external service, and does not invoke a test
+runner.
+
+## Prerequisites
+
+- Run from the repository root with workspace dependencies installed.
+- Bash, Node.js, and pnpm must be available.
+- `scratch/src/` must be writable; the command materializes its disposable SDK consumer there.
+- No model-provider key or network service is required.
+
+## Exact Bash
+
+```bash
+set -euo pipefail
+
+scenario_root="$(mktemp -d /tmp/robota-runtime005.XXXXXX)"
+scenario_script="scratch/src/runtime-005-approval-abort-agent-run.ts"
+
+cleanup() {
+  rm -f -- "$scenario_script"
+  case "$scenario_root" in
+    /tmp/robota-runtime005.*) rm -rf -- "$scenario_root" ;;
+    *) printf 'refusing unexpected cleanup path: %s\n' "$scenario_root" >&2; return 1 ;;
+  esac
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$scenario_script")"
+tee "$scenario_script" >/dev/null <<'TYPESCRIPT'
+import assert from 'node:assert/strict';
+
+import { scriptedSession } from '@robota-sdk/agent-framework/testing';
+
+async function bounded<T>(label: string, work: Promise<T>, timeoutMs = 5_000): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`${label} exceeded ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+const harness = scriptedSession({
+  permissionMode: 'default',
+  turns: [
+    {
+      toolCalls: [
+        {
+          name: 'Bash',
+          args: { command: 'printf forbidden > {{cwd}}/must-not-exist.txt' },
+        },
+      ],
+    },
+    { text: 'NEXT_PROMPT_OK' },
+  ],
+});
+
+let permissionRequests = 0;
+const permissionParked = new Promise<void>((resolve) => {
+  harness.session.on('permission_request', () => {
+    permissionRequests += 1;
+    resolve();
+  });
+});
+
+try {
+  const firstSubmission = harness.session.submit('request a permission-gated command');
+  await bounded('permission request', permissionParked);
+  assert.equal(harness.session.isExecuting(), true, 'approval wait did not retain execution');
+
+  const queued = await bounded(
+    'queued prompt admission',
+    harness.session.submit('queued while approval is parked'),
+  );
+  const queuedSettlement = queued.completed.then(
+    () => 'resolved',
+    (error: unknown) => {
+      assert.equal(error instanceof Error && error.name === 'TurnNotRunError', true);
+      assert.equal((error as { reason?: unknown }).reason, 'cancelled');
+      return 'cancelled';
+    },
+  );
+  assert.equal(harness.session.getPendingCount(), 1, 'prompt was not queued');
+
+  const busy = await bounded(
+    'busy command refusal',
+    harness.session.executeCommand('compact', ''),
+  );
+  assert.deepEqual(busy, {
+    success: false,
+    message: 'Another prompt or command is already running. Wait for it to finish.',
+  });
+  assert.equal(harness.session.getPendingCount(), 1, 'busy command consumed the queued prompt');
+
+  harness.session.abort();
+  const first = await bounded('aborted submission unwind', firstSubmission);
+  await bounded('aborted turn settlement', first.completed);
+  const queuedOutcome = await bounded('queued prompt cancellation', queuedSettlement);
+  const idleAfterAbort = !harness.session.isExecuting();
+  const pendingAfterAbort = harness.session.getPendingCount();
+  const deniedToolRan = harness.exists('must-not-exist.txt');
+
+  assert.equal(queuedOutcome, 'cancelled');
+  assert.equal(idleAfterAbort, true, 'session stayed busy after abort');
+  assert.equal(pendingAfterAbort, 0, 'abort did not clear the pending queue');
+  assert.equal(deniedToolRan, false, 'aborted approval was interpreted as permission');
+
+  const next = await bounded('next prompt submission', harness.session.submit('next prompt'));
+  const nextResult = await bounded('next prompt settlement', next.completed);
+  assert.equal(nextResult.response, 'NEXT_PROMPT_OK');
+
+  process.stdout.write(
+    `${JSON.stringify({
+      phase: 'runtime-005-approval-abort-recovery',
+      permissionRequests,
+      busyRejected: busy?.success === false,
+      queuePreservedUntilAbort: true,
+      queuedOutcome,
+      abortedTurnSettled: true,
+      idleAfterAbort,
+      pendingAfterAbort,
+      deniedToolRan,
+      nextResponse: nextResult.response,
+    })}\n`,
+  );
+} finally {
+  await bounded('session cleanup', harness.dispose());
+}
+TYPESCRIPT
+
+pnpm --dir scratch run run -- src/runtime-005-approval-abort-agent-run.ts \
+  | tee "$scenario_root/result.log"
+
+grep -F '"phase":"runtime-005-approval-abort-recovery"' "$scenario_root/result.log"
+grep -F '"permissionRequests":1' "$scenario_root/result.log"
+grep -F '"busyRejected":true' "$scenario_root/result.log"
+grep -F '"queuePreservedUntilAbort":true' "$scenario_root/result.log"
+grep -F '"queuedOutcome":"cancelled"' "$scenario_root/result.log"
+grep -F '"abortedTurnSettled":true' "$scenario_root/result.log"
+grep -F '"idleAfterAbort":true' "$scenario_root/result.log"
+grep -F '"pendingAfterAbort":0' "$scenario_root/result.log"
+grep -F '"deniedToolRan":false' "$scenario_root/result.log"
+grep -F '"nextResponse":"NEXT_PROMPT_OK"' "$scenario_root/result.log"
+```
+
+## Bounded waits
+
+Every permission, submission, command, turn-settlement, queue-settlement, next-prompt, and cleanup
+await is raced against a 5-second timeout. Any timeout rejects the script and makes the Bash block
+exit non-zero.
+
+## Expected observable result
+
+- The Bash block exits with status `0`.
+- It prints one JSON object with phase `runtime-005-approval-abort-recovery`, one permission request,
+  `busyRejected:true`, `queuePreservedUntilAbort:true`, `queuedOutcome:"cancelled"`,
+  `abortedTurnSettled:true`, `idleAfterAbort:true`, `pendingAfterAbort:0`, `deniedToolRan:false`, and
+  `nextResponse:"NEXT_PROMPT_OK"`.
+- The busy command neither starts nor drains the queued prompt. Abort fail-closes the pending
+  approval, settles the active turn, cancels the queued prompt, releases execution ownership, and
+  leaves the same public session able to complete the next prompt.
+- A hanging approval, foreign/stale release, changed busy/queue policy, executed unapproved tool,
+  unusable next prompt, or cleanup hang makes a TypeScript assertion, bounded wait, or final `grep`
+  exit non-zero.
+
+## Cleanup
+
+The fixture always shuts down the public session and removes its isolated workspace. The Bash `EXIT`
+trap removes the command-materialized script and only the `mktemp` directory matching
+`/tmp/robota-runtime005.*`.
+
+## Observed evidence
+
+EMPTY

--- a/.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md
+++ b/.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md
@@ -186,4 +186,22 @@ trap removes the command-materialized script and only the `mktemp` directory mat
 
 ## Observed evidence
 
-EMPTY
+PASS — 2026-08-13. The exact Bash block exited `0` and printed:
+
+```json
+{
+  "phase": "runtime-005-approval-abort-recovery",
+  "permissionRequests": 1,
+  "busyRejected": true,
+  "queuePreservedUntilAbort": true,
+  "queuedOutcome": "cancelled",
+  "abortedTurnSettled": true,
+  "idleAfterAbort": true,
+  "pendingAfterAbort": 0,
+  "deniedToolRan": false,
+  "nextResponse": "NEXT_PROMPT_OK"
+}
+```
+
+All ten exact `grep -F` assertions passed. The `EXIT` trap removed the scratch consumer and its
+`/tmp/robota-runtime005.*` directory.

--- a/.agents/spec-docs/active/BEHAVIOR-008-interactive-execution-claim-ownership.md
+++ b/.agents/spec-docs/active/BEHAVIOR-008-interactive-execution-claim-ownership.md
@@ -1,0 +1,247 @@
+---
+status: in-progress
+type: BEHAVIOR
+tags: [typescript, async, cli]
+---
+
+# BEHAVIOR-008: Give Interactive Execution State a Single Claim Owner
+
+## Problem
+
+RUNTIME-005 stage 1 made permission approval waits observe the turn `AbortSignal` and fail closed,
+but its remaining stage-2 finding is still structurally present in
+`SessionExecutionController`: prompt turns, fork skills, and blocking foreground commands each write
+the same public `executing` boolean and each unconditionally clears it from its own `finally` block.
+The boolean records occupancy but cannot identify which asynchronous operation owns the release.
+
+The task's original `/compact` reproduction premise is stale. Current
+`InteractiveSessionBase.executeCommand()` checks `execCtrl.executing` and returns an explicit busy
+result before `SessionSkillRouter` can start a blocking command, including calls from the TUI, HTTP,
+MCP, and WebSocket transports. Existing tests confirm a second public command is refused. The
+remaining defect is therefore an unenforced internal ownership invariant: a future or internal call
+that reaches a second execution path can run a foreign `finally`, set the shared boolean false, emit
+idle state, and drain `PendingInputQueue` while the first operation is still live. The controller's
+API makes that invalid state representable, and no identity check prevents stale release.
+
+RUNTIME-005 also lacks its requested full-session proof that aborting a turn parked on a permission
+handler settles the turn and returns `Session.isRunning()` to false within a bounded interval. The
+existing eight tests stop at `PermissionEnforcer` and its wrapper wiring.
+
+## Prior Art Research
+
+- Java structured concurrency treats related asynchronous work as one owned scope: cancellation
+  prevents new work, but the owner does not report completion until unfinished children terminate.
+  This supports retaining a Robota execution claim until its prompt, fork skill, or foreground
+  command actually unwinds. [Oracle `StructuredTaskScope`](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/concurrent/StructuredTaskScope.html)
+- Node's `AbortSignal` is a one-shot cancellation notification. Consumers must account for an
+  already-aborted signal and use one-shot listeners; cancellation notification is separate from
+  ownership release. [Node.js `AbortSignal`](https://nodejs.org/api/globals.html#class-abortsignal)
+- Tokio synchronization guards model exclusive ownership through a guard whose lifetime represents
+  the right to release access. The transferable principle is an opaque claim token: only its holder
+  may release the session. [Tokio synchronization guards](https://docs.rs/tokio/latest/tokio/sync/)
+- Kubernetes Leases express the same identity requirement with `holderIdentity`: a lease is not
+  merely held, but held by a specific claimant. Robota needs the identity property, not TTL or
+  renewal. [Kubernetes Lease API](https://kubernetes.io/docs/reference/kubernetes-api/coordination/lease-v1/)
+- POSIX terminals designate one foreground process group and transfer that role explicitly. This is
+  an architectural analogy: prompts, fork skills, and blocking slash commands should acquire the
+  same foreground authority rather than independently writing a shared flag.
+  [POSIX `tcsetpgrp`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/tcsetpgrp.html)
+
+The common constraint is identity-bound release: cancellation asks the active owner to stop, while
+only that owner's unwind completes the lifecycle. A boolean or reference count cannot prove release
+identity. Robota should therefore retain its current reject/queue policy while representing the
+foreground owner with an opaque controller-owned claim.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-framework`
+  - `src/interactive/interactive-session-execution-controller.ts`
+  - `src/interactive/interactive-session-base.ts`
+  - focused controller and real `InteractiveSession` functional tests
+  - `docs/SPEC.md`
+- `packages/agent-session`
+  - a full `Session.run()` approval-abort integration regression
+  - `docs/SPEC.md` correction for the now-cancellable permission wait
+- `.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md`
+- `.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md`
+
+### Alternatives Considered
+
+1. **Controller-owned opaque execution claim.** Replace writable `executing` state with a private
+   active claim; all three execution kinds synchronously acquire it, and only matching-token release
+   may transition idle and drain the queue.
+   - Pro: makes stale/foreign release structurally ineffective and keeps one admission/lifecycle
+     owner.
+   - Con: tests and internal callers must stop mutating or assuming a public boolean.
+2. **Promise mutex that serializes every operation.** Commands wait behind prompts.
+   - Pro: exclusion is simple.
+   - Con: silently changes current user-visible busy rejection into waiting and creates a second
+     queue beside `PendingInputQueue`.
+3. **Reference count or generation number.** Track more information around the boolean.
+   - Pro: smaller textual change.
+   - Con: a count still has no holder identity; a generation number is an untyped token that is
+     easier to bypass.
+4. **Keep the boolean and add another caller guard.** Rely on public `executeCommand()` and fork
+   checks.
+   - Pro: current public behavior already passes.
+   - Con: leaves three release writers and makes correctness depend on every future caller
+     remembering a distributed precondition.
+
+### Decision
+
+Choose alternative 1. `SessionExecutionController` owns a private `activeClaim` and exposes only
+derived busy state plus synchronous acquisition through its three execution entry points. A claim
+contains opaque identity and execution kind (`prompt`, `fork-skill`, or `foreground-command`).
+Release accepts the exact claim and performs the idle transition, thinking/workspace events,
+persistence, and synchronous queued-turn handoff only for the current holder. A foreign or stale
+claim cannot clear a successor or drain pending input.
+
+Public policy remains unchanged: prompt submissions encountering a live claim use the existing
+attributed pending queue; public blocking commands and fork-skill starts encountering a live claim
+return or throw the existing explicit busy outcome. Acquisition happens before the first `await` or
+state mutation. Abort signals the active operation but never releases its claim; the holder retains
+it until its `finally` finishes.
+
+Reachability was checked across every current entry: `InteractiveSession.submit()` reaches prompt
+execution; user/model skill routing reaches fork execution; all TUI/HTTP/MCP/WebSocket commands
+reach the public command busy guard before foreground execution. Capability is preserved: queue
+coalescing, required turn identity, driver attribution, thinking/workspace events, persistence, and
+synchronous queue handoff remain. Adversarial cases are foreign/stale release, two simultaneous
+public commands, command during prompt, prompt during foreground/fork execution, abort-before-unwind,
+and release-time queue drain.
+
+This is an internal state-owner refactor within the existing `agent-framework` interactive runtime;
+it introduces no package, product, transport, or public SDK surface. The closest analog is
+`agent-session`'s `TurnClaim`, which already binds run ownership to an identity and releases only
+from the owning turn's completion. The framework claim mirrors that proven layer locally rather
+than importing a sibling product or creating a shared package.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — prompt, fork-skill, foreground-command, TUI/HTTP/MCP/WebSocket callers checked
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+1. Update `agent-framework` SPEC to define a controller-owned, identity-bound foreground claim and
+   the unchanged queue/busy/cancellation policy.
+2. RED: directly overlap two controller execution scopes and prove the second scope's completion can
+   currently make `isExecuting()` false and drain queued input while the first remains live.
+3. Replace direct boolean writes with one private claim owner and identity-checked release-and-drain.
+4. Route prompt, fork skill, and foreground command through the same acquisition/release mechanism;
+   retain synchronous queue handoff and existing public error/result semantics.
+5. Add real `InteractiveSession` regressions for command-during-prompt, prompt-during-command, exact
+   queue settlement, and abort state held until unwind.
+6. Add a full `agent-session` integration that parks in `permissionHandler`, calls `abort()`, and
+   observes bounded turn rejection plus `isRunning() === false`; correct the package SPEC's stale
+   uncancellable statement.
+7. Run the durable public framework scenario and the affected/full verification gates.
+
+## Affected Files
+
+- `packages/agent-framework/docs/SPEC.md`
+- `packages/agent-framework/src/interactive/interactive-session-execution-controller.ts`
+- `packages/agent-framework/src/interactive/__tests__/*execution-claim*.test.ts`
+- `packages/agent-framework/src/interactive/__tests__/interactive-session.test.ts`
+- `packages/agent-session/docs/SPEC.md`
+- `packages/agent-session/src/__tests__/*approval-abort*.test.ts`
+- `.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md`
+- `.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md`
+
+## Completion Criteria
+
+- [ ] TC-01: While a prompt claim is live, a public blocking command returns the existing busy
+      result, does not change thinking/streaming state, does not drain queued input, and the queued
+      prompt later executes and settles exactly once without a `SessionBusyError` history entry.
+- [ ] TC-02: A stale or foreign claim cannot release the active execution, emit idle, persist, or
+      drain the queue; only the matching holder can do so.
+- [ ] TC-03: Prompt, fork-skill, and foreground-command execution all use the same claim owner;
+      no production path writes a shared execution boolean directly, and prompts queued behind a
+      foreground or fork claim are handed off only by its matching release.
+- [ ] TC-04: In a real `agent-session` run parked on a never-resolving permission handler, `abort()`
+      causes the turn to reject and `isRunning()` to become false within a bounded assertion; the
+      aborted approval is never interpreted as permission.
+- [ ] TC-05: The agent-executable framework scenario exits 0 after proving abort→settlement→next
+      prompt usability, and affected build/test/typecheck plus `pnpm harness:verify-like-ci` pass.
+
+## Test Plan
+
+| TC-ID | Test Type                                    | Tool / Approach                                                                                             | Notes                                        |
+| ----- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| TC-01 | BEHAVIOR async integration                   | Vitest with real `InteractiveSession`, held scripted turn, blocking command module, and queued turn handles | Public framework boundary; no live provider  |
+| TC-02 | BEHAVIOR async unit                          | Vitest controller claim identity/deferred-release test                                                      | Named RED against current multi-writer state |
+| TC-03 | BEHAVIOR async integration + structural scan | Vitest for all three owners plus `rg`/AST assertion over production writes                                  | Preserves synchronous queue handoff          |
+| TC-04 | BEHAVIOR async integration                   | Vitest over real `Session.run`, never-resolving permission handler, `abort()`, and bounded races            | Fail-closed approval assertion               |
+| TC-05 | FLOW CLI/agent scenario + CI smoke           | Exact durable Bash scenario; package build/test/typecheck; `pnpm harness:verify-like-ci`                    | No credentials/network                       |
+
+## User Execution Test Scenarios
+
+**Applies.** The observable product behavior is cancellation recovery: a user aborts a turn waiting
+for permission and can submit the next prompt after the aborted turn unwinds. PLAN mode must record
+an agent-executable, credential-free framework scenario using the public testing/runtime surface,
+bounded waits, exact output/exit assertions, and cleanup before implementation begins.
+
+## Tasks
+
+- [ ] `.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md` — existing task;
+      reconcile to TC-01 through TC-05 after GATE-APPROVAL
+
+## Evidence Log
+
+### [RECOMMENDATION REVIEW] — ✅ ENDORSE | 2026-08-13
+
+- Independent review verified that every supported transport reaches the current public command
+  busy guard and that JavaScript run-to-completion closes a TOCTOU gap before foreground acquisition.
+- The original `/compact` reproduction is therefore historical, while the controller's raw writers
+  (including queue-resume error handlers) still leave foreign/stale release representable.
+- A controller-local opaque claim preserves busy/queue policy without coupling the framework lifecycle
+  to `agent-session`'s turn-specific AbortController and `SessionBusyError` semantics.
+- The reviewer required removal of every production boolean write and regression coverage for failed
+  acquisition settlement, turn identity, wake coalescing, driver attribution, persistence, and
+  synchronous handoff ordering.
+
+**REVIEW VERDICT: ENDORSE**
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** draft → review-ready
+
+- Frontmatter: YAML begins at the first line and contains `status: draft`, the allowed single type `BEHAVIOR`, and a non-empty `tags` field.
+- Problem: names the concrete three-writer `SessionExecutionController.executing` symptom, the prompt/fork-skill/foreground-command overlap condition, the stale-release consequences, and the missing full-session approval-abort proof without TBD/TODO or vague placeholders.
+- Stale-premise correction: the document explicitly retracts the original `/compact` reachability premise and matches the current `InteractiveSessionBase.executeCommand()` busy guard, while retaining the independently observable internal ownership defect present in the controller's three unconditional release paths.
+- Prior Art Research: cites primary documentation for Java structured concurrency, Node `AbortSignal`, Tokio guards, Kubernetes Leases, and POSIX foreground process groups; it extracts identity-bound release and cancellation-versus-release constraints into the alternatives and chosen opaque-claim decision.
+- Architecture Review checklist: all four items are checked; the sibling/reachability scan covers prompt, fork-skill, foreground-command, and TUI/HTTP/MCP/WebSocket callers.
+- Alternatives and decision: four alternatives each state a pro and con, and the decision explicitly selects identity-bound release over changed queue semantics, identity-free counting, and distributed caller guards.
+- New-surface placement: N/A because this is an internal refactor of the existing `agent-framework` interactive runtime with no new package, app, presentation/interface surface, or boundary reclassification; the document nevertheless identifies `agent-session`'s existing `TurnClaim` as the analogous layer and specifies local mirroring rather than a sibling-product dependency.
+- Completion Criteria: TC-01 through TC-05 cover public busy/queue behavior, stale/foreign release, all three claim users, full-session approval abort settlement, and durable scenario/verification; every criterion is observable or command-oriented and uses no forbidden vague phrase.
+- Test Plan: 5 rows match the 5 completion criteria exactly; every row has a non-empty test type and automated tool/approach, and no manual-only row requires a skip explanation.
+- Structure: `## Tasks` contains the existing RUNTIME-005 task placeholder with an explicit post-approval reconciliation note; `## Evidence Log` was present and empty before this first gate run; no body `## Status` or `## Classification` section exists.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** review-ready → approved
+
+- Prior-gate ordering: `[GATE-WRITE] — ✅ PASS | 2026-08-13` is recorded, frontmatter is `status: review-ready`, and the document is in `.agents/spec-docs/backlog/`, matching the required GATE-APPROVAL input state.
+- Explicit owner approval (verbatim): “타당한 이유와 함께 추천안을 제시하면 타당할 경우 자동으로 승인하겠습니다.” The independently recorded recommendation review returned `ENDORSE` for this BEHAVIOR-008 proposal after correcting the stale `/compact` premise, so the owner's stated approval condition is satisfied and authorizes this exact design.
+- Direct and unambiguous scope: the fulfilled conditional approval applies to the named recommendation under review in the current conversation, not to a clarifying answer or a different backlog item.
+- Post-approval integrity: approval attached to the corrected, independently endorsed form; the current frontmatter remains `type: BEHAVIOR` with `tags: [typescript, async, cli]`, and the Architecture Review retains the endorsed latent claim-owner scope without a subsequent design change.
+- Independent architecture validation: N/A as a mandatory conditional criterion because the spec introduces no package, app, presentation/interface surface, or layer/product-family reclassification. The recorded `RECOMMENDATION REVIEW` nevertheless independently endorsed the controller-local placement and the analogous `agent-session` `TurnClaim` comparison.
+- Pre-authorization implementation check: the working tree contains only this new spec document and no implementation source edit; implementation has not started before GATE-APPROVAL.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** approved → in-progress
+
+- Ordering: `[GATE-APPROVAL] — ✅ PASS | 2026-08-13` is recorded, frontmatter is `status: approved`, and the document is in `.agents/spec-docs/todo/`, matching the required GATE-IMPLEMENT input state.
+- Task artifact: `.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md` exists and is named verbatim in this spec's `## Tasks` section.
+- Completion-criterion mapping: the task's `## Plan` contains one explicit task for each of TC-01, TC-02, TC-03, TC-04, and TC-05, covering public busy/queue settlement, identity-bound release, all execution claim users, bounded approval-abort settlement, and durable/full verification respectively.
+- Test-plan substance: the task's `## Test Plan` is substantially longer than 50 characters and specifies three red-first bounded behavioral regressions plus the full `pnpm harness:verify-like-ci` gate; it is neither empty nor a placeholder.
+- Missing-task non-compliance check: the task artifact predates the stage-1 implementation commit and remains recorded for this reconciled stage-2 work, so implementation was not committed without a task file.

--- a/.agents/spec-docs/done/BEHAVIOR-008-interactive-execution-claim-ownership.md
+++ b/.agents/spec-docs/done/BEHAVIOR-008-interactive-execution-claim-ownership.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: BEHAVIOR
 tags: [typescript, async, cli]
 ---
@@ -158,29 +158,29 @@ None
 
 ## Completion Criteria
 
-- [ ] TC-01: While a prompt claim is live, a public blocking command returns the existing busy
+- [x] TC-01: While a prompt claim is live, a public blocking command returns the existing busy
       result, does not change thinking/streaming state, does not drain queued input, and the queued
       prompt later executes and settles exactly once without a `SessionBusyError` history entry.
-- [ ] TC-02: A stale or foreign claim cannot release the active execution, emit idle, persist, or
+- [x] TC-02: A stale or foreign claim cannot release the active execution, emit idle, persist, or
       drain the queue; only the matching holder can do so.
-- [ ] TC-03: Prompt, fork-skill, and foreground-command execution all use the same claim owner;
+- [x] TC-03: Prompt, fork-skill, and foreground-command execution all use the same claim owner;
       no production path writes a shared execution boolean directly, and prompts queued behind a
       foreground or fork claim are handed off only by its matching release.
-- [ ] TC-04: In a real `agent-session` run parked on a never-resolving permission handler, `abort()`
+- [x] TC-04: In a real `agent-session` run parked on a never-resolving permission handler, `abort()`
       causes the turn to reject and `isRunning()` to become false within a bounded assertion; the
       aborted approval is never interpreted as permission.
-- [ ] TC-05: The agent-executable framework scenario exits 0 after proving abort→settlement→next
+- [x] TC-05: The agent-executable framework scenario exits 0 after proving abort→settlement→next
       prompt usability, and affected build/test/typecheck plus `pnpm harness:verify-like-ci` pass.
 
 ## Test Plan
 
-| TC-ID | Test Type                                    | Tool / Approach                                                                                             | Notes                                        |
-| ----- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| TC-01 | BEHAVIOR async integration                   | Vitest with real `InteractiveSession`, held scripted turn, blocking command module, and queued turn handles | Public framework boundary; no live provider  |
-| TC-02 | BEHAVIOR async unit                          | Vitest controller claim identity/deferred-release test                                                      | Named RED against current multi-writer state |
-| TC-03 | BEHAVIOR async integration + structural scan | Vitest for all three owners plus `rg`/AST assertion over production writes                                  | Preserves synchronous queue handoff          |
-| TC-04 | BEHAVIOR async integration                   | Vitest over real `Session.run`, never-resolving permission handler, `abort()`, and bounded races            | Fail-closed approval assertion               |
-| TC-05 | FLOW CLI/agent scenario + CI smoke           | Exact durable Bash scenario; package build/test/typecheck; `pnpm harness:verify-like-ci`                    | No credentials/network                       |
+| TC-ID | Test Type                                    | Tool / Approach                                                                                                                                                                                                                   | Notes                                       |
+| ----- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| TC-01 | BEHAVIOR async integration                   | `packages/agent-framework/src/testing/__tests__/execution-claim-functional.test.ts` > `interactive execution claim (framework functional)` > `keeps a queued prompt through public command refusal and settles it exactly once`   | Public framework boundary; no live provider |
+| TC-02 | BEHAVIOR async unit                          | `packages/agent-framework/src/interactive/__tests__/interactive-session-execution-claim.test.ts` > `interactive foreground execution claim ownership` > `does not let stale completion run idle, persistence, or queue handoff`   | Named identity-bound completion regression  |
+| TC-03 | BEHAVIOR async integration + structural scan | Same claim-suite describe block: mutual exclusion, acquisition settlement, all entry/failure paths, synchronous handoff, and production single-assignment scan                                                                    | Preserves synchronous queue handoff         |
+| TC-04 | BEHAVIOR async integration                   | `packages/agent-session/src/__tests__/approval-wait-honours-abort.test.ts` > `Session abort releases a turn parked on approval (RUNTIME-005)` > `rejects the real run, releases its claim, and never invokes the unapproved tool` | Fail-closed approval assertion              |
+| TC-05 | FLOW CLI/agent scenario + CI smoke           | `.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md` `## Exact Bash`; package build/test/typecheck; `pnpm harness:verify-like-ci`                                                                                    | No credentials/network                      |
 
 ## User Execution Test Scenarios
 
@@ -191,8 +191,8 @@ bounded waits, exact output/exit assertions, and cleanup before implementation b
 
 ## Tasks
 
-- [ ] `.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md` — existing task;
-      reconcile to TC-01 through TC-05 after GATE-APPROVAL
+- [x] `.agents/tasks/completed/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md` — existing
+      task; reconciled to TC-01 through TC-05 after GATE-APPROVAL
 
 ## Evidence Log
 
@@ -238,6 +238,24 @@ bounded waits, exact output/exit assertions, and cleanup before implementation b
 
 ### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-13
 
+### [IMPLEMENTATION EVIDENCE] — ✅ PASS | 2026-08-13
+
+- Code→SPEC: checked the prompt, fork-skill, foreground-command, queue-error, callback re-entry,
+  persistence-failure, and synchronous handoff paths; all use the identity-bound claim contract.
+- SPEC→code: checked every TC-01 through TC-05 behavior against implementation, focused tests, the
+  full-session approval-abort integration, and the durable public scenario; no discrepancy remains.
+- Affected verification: `agent-session` 193 tests plus build/typecheck; `agent-framework` 1,334
+  tests plus build/typecheck; claim/streaming/queue focused regressions pass.
+- Repository verification: `pnpm harness:verify-like-ci` PASS, all 11 locally reproducible CI stages
+  in 6m25s. Windows-shell, dependency audit, and review-gate remain remote-only as the harness
+  explicitly reports.
+- Review convergence: independent Round A findings converged `5 → 2 → 0`, then extraction review
+  converged `1 → 0`; final `ACTIONABLE FINDINGS: 0`.
+- File-size ratchet: the controller was split into claim/event collaborators, now 422 lines, and the
+  tightened baseline passes.
+- User execution: independent DONE-GATE-STAGE-2 reran exact Bash, exit `0`, all ten observables and
+  cleanup PASS.
+
 **Status upgrade:** approved → in-progress
 
 - Ordering: `[GATE-APPROVAL] — ✅ PASS | 2026-08-13` is recorded, frontmatter is `status: approved`, and the document is in `.agents/spec-docs/todo/`, matching the required GATE-IMPLEMENT input state.
@@ -245,3 +263,103 @@ bounded waits, exact output/exit assertions, and cleanup before implementation b
 - Completion-criterion mapping: the task's `## Plan` contains one explicit task for each of TC-01, TC-02, TC-03, TC-04, and TC-05, covering public busy/queue settlement, identity-bound release, all execution claim users, bounded approval-abort settlement, and durable/full verification respectively.
 - Test-plan substance: the task's `## Test Plan` is substantially longer than 50 characters and specifies three red-first bounded behavioral regressions plus the full `pnpm harness:verify-like-ci` gate; it is neither empty nor a placeholder.
 - Missing-task non-compliance check: the task artifact predates the stage-1 implementation commit and remains recorded for this reconciled stage-2 work, so implementation was not committed without a task file.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** in-progress → verifying
+
+- Ordering and placement: `[GATE-IMPLEMENT]` is recorded, the spec entered this gate as
+  `in-progress` under `spec-docs/active/`, and the linked task remains active and completion-ready.
+- Task mapping: task Plan rows TC-01 through TC-05 are all checked and correspond one-for-one with
+  this spec's checked Completion Criteria.
+- Fresh affected verification: `agent-session` build/typecheck and 193 tests passed;
+  `agent-framework` build/typecheck and 1,334 tests passed.
+- Contract verification: independent SPEC→code and code→SPEC inspection found the single claim
+  owner on prompt, fork-skill, and foreground-command paths, with fail-closed approval abort matching
+  both package SPECs.
+- Product verification: the exact durable Stage-2 Bash exited `0`, produced all ten required
+  recovery fields, and cleaned its isolated artifacts.
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-08-13
+
+- `execution-claim-functional.test.ts` drives a real `InteractiveSession` with the deterministic
+  scripted provider. While its first turn is parked on a permission request, a second turn is queued
+  and a public blocking command returns the existing busy result without invoking its implementation,
+  changing thinking state, or removing the queued prompt.
+- After fail-closed permission denial, the first turn returns `FIRST_DONE`, the already queued turn
+  returns `QUEUED_DONE`, its completion observer fires exactly once, the queue is empty, and full
+  history contains no `SessionBusyError`.
+- Exact verification command:
+  `pnpm --filter @robota-sdk/agent-framework exec vitest run src/testing/__tests__/execution-claim-functional.test.ts src/interactive/__tests__/interactive-session-execution-claim.test.ts --reporter=verbose`.
+  Result: 2 files and 10 tests passed; exit `0`.
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-08-13
+
+- `interactive-session-execution-claim.test.ts` proves both stale release and stale completion.
+  Calling `complete()` with an obsolete token leaves the successor claim active and invokes none of
+  the idle, persistence, or queue-handoff callbacks; only the successor token releases ownership.
+- Exact verification command: the TC-01 Vitest command above. The named stale-completion regression
+  passed; exit `0`.
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-08-13
+
+- The focused claim suite covers mutual exclusion across prompt, fork-skill, and foreground-command
+  acquisition, failed prompt acquisition settlement, synchronous queued handoff, persistence failure,
+  entry-listener failure, and tool-event re-entry ordering.
+- Production scan `rg -n "executing\\s*=" packages/agent-framework/src --glob '!**/__tests__/**'`
+  finds no assignment; the sole match is explanatory text containing `executing === false`.
+- Exact verification commands: the TC-01 Vitest command above exited `0`; additionally,
+  `! rg --pcre2 -n '(?:this\\.)?executing\\s*=(?!=)' packages/agent-framework/src --glob '!**/__tests__/**'`
+  exited `0`, proving no single-assignment production match.
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-08-13
+
+- `approval-wait-honours-abort.test.ts` test “rejects the real run, releases its claim, and never
+  invokes the unapproved tool” runs a real `Session.run()`, parks on a never-resolving approval,
+  aborts it, observes a bounded `AbortError`, verifies `isRunning() === false`, and proves the tool
+  was never invoked. The complete file's nine approval-path cases pass.
+- Exact verification command:
+  `pnpm --filter @robota-sdk/agent-session exec vitest run src/__tests__/approval-wait-honours-abort.test.ts --reporter=verbose`.
+  Result: 1 file and 9 tests passed; exit `0`.
+
+### [GATE-COMPLETE: TC-05] — ✅ PASS | 2026-08-13
+
+- The durable public scenario was independently rerun from its exact Bash: exit `0`, all ten
+  approval-abort recovery observables PASS, and cleanup PASS.
+- Exact scenario execution identity:
+
+  ````sh
+  awk '/^```bash$/{capture=1;next} capture && /^```$/{exit} capture{print}' .agents/evals/scenarios/runtime-005-approval-abort-agent-run.md | bash
+  ````
+
+  Result: all ten exact JSON assertions passed, `SCENARIO_EXIT=0`, and cleanup passed.
+
+- Affected builds, typechecks, and full package suites passed; `pnpm harness:verify-like-ci` passed
+  all 11 locally reproducible stages in 6m25s; independent local review converged to
+  `ACTIONABLE FINDINGS: 0`.
+- Exact repository command: `pnpm harness:verify-like-ci`; exit `0`.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** verifying → done
+
+- Ordering: PASS — `[GATE-VERIFY] — ✅ PASS | 2026-08-13` is recorded; the spec entered this
+  gate as `status: verifying` under `.agents/spec-docs/active/`.
+- TC-01: PASS — `packages/agent-framework/src/testing/__tests__/execution-claim-functional.test.ts`
+  proves busy refusal, unchanged thinking state, preserved queue, exactly-once settlement, and no
+  `SessionBusyError`. The focused framework command passed 2 files and 10 tests; exit `0`.
+- TC-02: PASS — the named stale-completion regression in
+  `interactive-session-execution-claim.test.ts` proves identity-bound completion; exit `0`.
+- TC-03: PASS — the same claim suite covers all three owner kinds, acquisition failure settlement,
+  synchronous handoff, persistence/listener failure, and callback re-entry. The production
+  single-assignment scan found no match and exited `0`.
+- TC-04: PASS — the real `Session.run()` regression in
+  `approval-wait-honours-abort.test.ts` passed with all 9 focused approval tests; exit `0`.
+- TC-05: PASS — the durable scenario produced all ten recovery observables, `SCENARIO_EXIT=0`, and
+  complete cleanup. Affected package verification and `pnpm harness:verify-like-ci` passed.
+- Test Plan coverage: PASS — every TC has a concrete artifact plus test/describe identity or exact
+  durable-scenario identity; no criterion is skipped.
+- Task readiness: PASS — the linked task has TC-01 through TC-05 checked with no pending or blocked
+  item.
+- User-execution gate: PASS — `[DONE-GATE-STAGE-2]` records direct execution, matched output, exit
+  `0`, and cleanup evidence.

--- a/.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md
+++ b/.agents/tasks/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md
@@ -10,6 +10,28 @@ depends_on: []
 
 # RUNTIME-005: abort() reaches the provider but not the wait
 
+- **Branch**: `fix/runtime-005-execution-claim-owner`
+- **Spec**: `.agents/spec-docs/active/BEHAVIOR-008-interactive-execution-claim-ownership.md`
+
+## Current scope correction
+
+The original `/compact` reproduction below is historical. Current
+`InteractiveSessionBase.executeCommand()` rejects a public command while `execCtrl.executing` is
+true, and all shipped TUI/HTTP/MCP/WebSocket command paths use that method. Stage 2 is preventative
+invariant hardening: prompt, fork-skill, foreground-command, and queue-resume failure paths still
+write or clear one identity-free boolean. BEHAVIOR-008 received independent `ENDORSE` for replacing
+those raw writers with a controller-owned opaque claim while preserving current public busy/queue
+policy. Stage 1 also still needs the task's requested full `Session.run()` abort integration proof
+and stale SPEC correction.
+
+## Plan
+
+- [ ] TC-01: Preserve public command-during-prompt busy rejection and exact queued-turn settlement.
+- [ ] TC-02: Make foreign or stale execution-claim release unable to clear state or drain the queue.
+- [ ] TC-03: Route prompt, fork-skill, foreground-command, and queue-error cleanup through one claim owner.
+- [ ] TC-04: Add bounded full-session approval-abort settlement and `isRunning() === false` integration proof.
+- [ ] TC-05: Execute the durable public scenario and pass affected/full verification.
+
 ## Problem
 
 `abort()` cancels a turn by signalling it. Two waits inside a turn do not observe that signal, so a
@@ -78,16 +100,55 @@ lets a live turn interleave with its successor, which is the defect, not the rem
 
 ## User Execution Test Scenarios
 
-**Applies.** Pressing ESC while a permission prompt is open is a user-reachable path.
+### Scenario 1 — abort a parked approval and run the next prompt
 
-- **Prerequisites:** built `robota` CLI, a provider key, permission mode that prompts.
-- **Steps:** ask for an action that triggers an approval prompt; press ESC instead of answering; then
-  submit a new prompt.
-- **Expected observable result (after the fix):** the turn ends and the next prompt runs.
-- **Expected observable result (before the fix, for contrast):** the session reports busy and refuses
-  the next prompt until it is discarded.
-- **Cleanup:** none.
-- **Evidence (fill in after implementation):** transcript excerpt.
+- **Agent executability:** `agent-executable`. This non-interactive flow drives the public framework
+  testing SDK with the shipped deterministic provider; it requires no credential, network service,
+  TTY, test runner, or owner action.
+- **Durable artifact:**
+  [`.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md`](../evals/scenarios/runtime-005-approval-abort-agent-run.md)
+- **Prerequisites:** run from the repository root with workspace dependencies installed; Bash,
+  Node.js, and pnpm available; writable `scratch/src/`. No provider key or external service is
+  required.
+- **Bounded waits:** the script races every permission, submission, command, turn-settlement,
+  queue-settlement, next-prompt, and cleanup await against 5 seconds.
+- **Exact Bash:** execute the complete command block under `## Exact Bash` in the durable artifact
+  verbatim. It materializes `scratch/src/runtime-005-approval-abort-agent-run.ts`, runs
+  `pnpm --dir scratch run run -- src/runtime-005-approval-abort-agent-run.ts`, and asserts every
+  observable with exact `grep -F` checks.
+- **Expected output and exit:** exit `0` and one JSON line containing
+  `"phase":"runtime-005-approval-abort-recovery"`, `"permissionRequests":1`,
+  `"busyRejected":true`, `"queuePreservedUntilAbort":true`,
+  `"queuedOutcome":"cancelled"`, `"abortedTurnSettled":true`, `"idleAfterAbort":true`,
+  `"pendingAfterAbort":0`, `"deniedToolRan":false`, and
+  `"nextResponse":"NEXT_PROMPT_OK"`. This proves a public command preserves the existing busy
+  refusal and queue, abort fail-closes and settles the parked approval turn, and the same session
+  accepts and completes the next prompt.
+- **Cleanup:** the fixture shuts down its session and deletes its isolated workspace; the Bash
+  `EXIT` trap removes the scratch script and only its `/tmp/robota-runtime005.*` root.
+- **Observed evidence:** EMPTY
+
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** scenario drafted → scenario written
+
+- Ordering: PASS — DONE-GATE-STAGE-1 is an entry gate with no predecessor; the scenario and linked
+  durable artifact exist before BEHAVIOR-008 implementation source edits, while observed execution
+  evidence remains `EMPTY` as required at PLAN time.
+- Scenario `abort a parked approval and run the next prompt`: PASS — it records the explicit
+  `agent-executable` decision, repository-root prerequisites, the exact Bash invocation through the
+  linked durable artifact, 5-second bounds for every asynchronous permission/submission/command/turn/
+  queue/next-prompt/cleanup await, exact JSON substrings plus exit `0`, constrained cleanup, and its
+  separate `Observed evidence: EMPTY` field.
+- Invocation plausibility: PASS — `scratch/package.json` provides the declared `pnpm --dir scratch run
+run -- <script>` entrypoint, and `@robota-sdk/agent-framework/testing` publicly exports
+  `scriptedSession`; the script drives the real exported `InteractiveSession` submit, permission event,
+  busy-command, pending-queue, abort, turn-handle, and disposal surfaces.
+- Product surface: PASS — the observable is public SDK workflow behavior (busy refusal without queue
+  loss, fail-closed approval abort, turn settlement, idle recovery, and same-session next-prompt reuse),
+  not build, test, typecheck, lint, harness/CI output, or repository-text inspection.
+- Credentials and services: PASS — the prerequisites explicitly state that the deterministic shipped
+  provider needs no provider key, network service, TTY, or owner action.
 
 ## Implementation — stage 1 of 2
 

--- a/.agents/tasks/completed/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md
+++ b/.agents/tasks/completed/RUNTIME-005-a-turn-parked-on-approval-is-not-cancellable.md
@@ -1,7 +1,8 @@
 ---
 title: 'RUNTIME-005: a turn parked on a human-approval prompt cannot be cancelled, and the framework flag that hides it has no owner'
-status: in-progress
+status: done
 created: 2026-08-02
+completed: 2026-08-13
 priority: high
 urgency: next
 area: packages/agent-session, packages/agent-core, packages/agent-framework
@@ -11,26 +12,24 @@ depends_on: []
 # RUNTIME-005: abort() reaches the provider but not the wait
 
 - **Branch**: `fix/runtime-005-execution-claim-owner`
-- **Spec**: `.agents/spec-docs/active/BEHAVIOR-008-interactive-execution-claim-ownership.md`
+- **Spec**: `.agents/spec-docs/done/BEHAVIOR-008-interactive-execution-claim-ownership.md`
 
 ## Current scope correction
 
 The original `/compact` reproduction below is historical. Current
 `InteractiveSessionBase.executeCommand()` rejects a public command while `execCtrl.executing` is
-true, and all shipped TUI/HTTP/MCP/WebSocket command paths use that method. Stage 2 is preventative
-invariant hardening: prompt, fork-skill, foreground-command, and queue-resume failure paths still
-write or clear one identity-free boolean. BEHAVIOR-008 received independent `ENDORSE` for replacing
-those raw writers with a controller-owned opaque claim while preserving current public busy/queue
-policy. Stage 1 also still needs the task's requested full `Session.run()` abort integration proof
-and stale SPEC correction.
+true, and all shipped TUI/HTTP/MCP/WebSocket command paths use that method. Stage 2 completed the
+preventative invariant hardening: prompt, fork-skill, foreground-command, and queue-resume paths now
+share one controller-owned opaque claim while preserving current public busy/queue policy. Stage 1
+also completed the requested full `Session.run()` abort integration proof and stale SPEC correction.
 
 ## Plan
 
-- [ ] TC-01: Preserve public command-during-prompt busy rejection and exact queued-turn settlement.
-- [ ] TC-02: Make foreign or stale execution-claim release unable to clear state or drain the queue.
-- [ ] TC-03: Route prompt, fork-skill, foreground-command, and queue-error cleanup through one claim owner.
-- [ ] TC-04: Add bounded full-session approval-abort settlement and `isRunning() === false` integration proof.
-- [ ] TC-05: Execute the durable public scenario and pass affected/full verification.
+- [x] TC-01: Preserve public command-during-prompt busy rejection and exact queued-turn settlement.
+- [x] TC-02: Make foreign or stale execution-claim release unable to clear state or drain the queue.
+- [x] TC-03: Route prompt, fork-skill, foreground-command, and queue-error cleanup through one claim owner.
+- [x] TC-04: Add bounded full-session approval-abort settlement and `isRunning() === false` integration proof.
+- [x] TC-05: Execute the durable public scenario and pass affected/full verification.
 
 ## Problem
 
@@ -73,7 +72,7 @@ interleaved turn it replaces, but the flag has two writers and no owner.
 
 **FOUNDATIONAL** for the wait: cancellation is declared at the session boundary and not honoured by
 the waits inside it, so no fix at the call site can be complete. Same class as
-[RUNTIME-004](RUNTIME-004-cancellation-declared-at-four-layers-honoured-at-none.md) — check whether
+[RUNTIME-004](../RUNTIME-004-cancellation-declared-at-four-layers-honoured-at-none.md) — check whether
 these should merge before starting.
 
 The `executing` flag is **LOCAL** to `agent-framework` but has the ownership shape RUNTIME-003
@@ -106,7 +105,7 @@ lets a live turn interleave with its successor, which is the defect, not the rem
   testing SDK with the shipped deterministic provider; it requires no credential, network service,
   TTY, test runner, or owner action.
 - **Durable artifact:**
-  [`.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md`](../evals/scenarios/runtime-005-approval-abort-agent-run.md)
+  [`.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md`](../../evals/scenarios/runtime-005-approval-abort-agent-run.md)
 - **Prerequisites:** run from the repository root with workspace dependencies installed; Bash,
   Node.js, and pnpm available; writable `scratch/src/`. No provider key or external service is
   required.
@@ -126,7 +125,9 @@ lets a live turn interleave with its successor, which is the defect, not the rem
   accepts and completes the next prompt.
 - **Cleanup:** the fixture shuts down its session and deletes its isolated workspace; the Bash
   `EXIT` trap removes the scratch script and only its `/tmp/robota-runtime005.*` root.
-- **Observed evidence:** EMPTY
+- **Observed evidence:** PASS — 2026-08-13. The artifact's exact Bash exited `0`; its recovery JSON
+  reported one permission request, busy refusal with queue preservation, cancelled queued turn,
+  settled abort, idle/empty state, no denied-tool execution, and `NEXT_PROMPT_OK`. Cleanup passed.
 
 ### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-13
 
@@ -149,6 +150,22 @@ run -- <script>` entrypoint, and `@robota-sdk/agent-framework/testing` publicly 
   not build, test, typecheck, lint, harness/CI output, or repository-text inspection.
 - Credentials and services: PASS — the prerequisites explicitly state that the deterministic shipped
   provider needs no provider key, network service, TTY, or owner action.
+
+### [DONE-GATE-STAGE-2] — ✅ PASS | 2026-08-13
+
+**Status upgrade:** scenario written → scenario executed
+
+- Ordering: PASS — `[DONE-GATE-STAGE-1]` passed before implementation; commit `01e2761a2` records
+  the scenario with `Observed evidence: EMPTY`.
+- Scenario `abort a parked approval and run the next prompt`: PASS — the durable artifact's exact
+  Bash was independently executed against the completed implementation and exited `0`.
+- Observed result: PASS — one permission request, busy refusal, queue preservation until abort,
+  cancelled queued turn, settled aborted turn, idle/empty recovery, no denied-tool execution, and
+  `NEXT_PROMPT_OK`.
+- Evidence location: `.agents/evals/scenarios/runtime-005-approval-abort-agent-run.md` and this
+  task's scenario evidence field.
+- Cleanup: PASS — the materialized scratch script and constrained `/tmp/robota-runtime005.*` root
+  were removed.
 
 ## Implementation — stage 1 of 2
 
@@ -200,3 +217,17 @@ permission" that can drift, now one.
 - **Tool cooperation with the signal is unverified.** The channel exists; nothing checks that
   long-running tools use it, and the CORE-018 contract is prose. Worth its own item rather than a
   sentence here.
+
+## Implementation — stage 2
+
+`SessionExecutionController` now derives `executing` from one private opaque claim. Prompt,
+fork-skill, and foreground-command entry points acquire synchronously before their first state
+mutation; only the identical claim may release, emit idle state, persist, and hand the pending queue
+to its next turn. Queue-resume error handlers no longer clear another operation's state. A prompt
+that cannot acquire also rejects the already-issued turn handle, so no caller waits forever.
+
+Existing tests that directly wrote the boolean now hold a real foreground claim. The focused claim
+suite proves stale-release rejection, mutual exclusion across all three kinds, and failed-acquisition
+turn settlement. The real `Session.run()` integration parks on a never-resolving permission handler,
+aborts, observes an `AbortError`, verifies `isRunning() === false`, and proves the unapproved tool did
+not execute. The durable public scenario passed with exit `0` and the expected recovery JSON.

--- a/.changeset/runtime-005-execution-claim-owner.md
+++ b/.changeset/runtime-005-execution-claim-owner.md
@@ -1,0 +1,7 @@
+---
+'@robota-sdk/agent-framework': patch
+---
+
+Bind interactive prompt, fork-skill, and foreground-command execution cleanup to an opaque
+controller-owned claim so stale cleanup cannot release another active operation or drain its queued
+input.

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -551,7 +551,11 @@ All errors from `session.run()` are caught by `InteractiveSession` and emitted a
 
 - 82 test files across `src/__tests__/` and `src/interactive/__tests__/`
 - Key test files:
-  - `interactive-session.test.ts` — InteractiveSession behavior: submit, abort, queue, history
+  - `interactive-session-execution-claim.test.ts` — identity-bound prompt/fork/foreground claim,
+    foreign-release resistance, callback re-entry/failure safety, and synchronous queued handoff
+  - `testing/__tests__/execution-claim-functional.test.ts` — public busy refusal preserves an
+    already queued turn, which later executes and settles exactly once without busy-error history
+  - `interactive-session.test.ts` — public busy policy, submit/abort queue behavior, and history
   - `interactive-session-background-tasks.test.ts` — background task events and controls
   - `interactive-session-checkpoints.test.ts` — edit checkpoint capture and restore
   - `interactive-session-skill-command.test.ts` — skill command routing
@@ -1087,6 +1091,16 @@ reusing broad context-loading internals for repository interpretation.
 - **Design**: Commands return `ICommandResult` with `message`, `success`, and optional SDK-owned `hostActions`/`uiIntents`. `data` remains available for command-specific diagnostic payloads, but callers must not invent command-specific side-effect keys. User-facing prompts are solicited inline via the CMD-004 ask seam (`context.getUserInteraction()?.ask`), not returned in the result; host semantics (restart, shutdown, model/language changes, session rename, status-line updates, remote-control) are typed `TCommandHostAction` values the session executes, and screen navigation (settings/plugin-manager/session-picker/agent-switcher) is a typed `TCommandUiIntent` rendered by the requesting surface.
 - **Single owner rule**: SDK-default built-in command metadata is derived from executable `ISystemCommand` records. A built-in command must not be added to autocomplete/help metadata without an executable owner module.
 - **Lifecycle policy**: `ISystemCommand` may declare command lifecycle metadata. Blocking foreground commands share the same `InteractiveSession` execution guard and `thinking` events as prompt execution. Inline commands execute immediately and must not call model-backed long-running operations.
+- **Foreground execution ownership**: `SessionExecutionController` is the single owner of one
+  identity-bound foreground claim spanning prompt turns, fork skills, and blocking commands. Each
+  path acquires synchronously before its first await or state mutation. Only the matching holder may
+  release the claim, emit idle state, persist release-time state, or drain `PendingInputQueue`; a
+  stale or foreign release has no effect. Public commands retain explicit busy rejection, while
+  prompts retain the existing attributed queue policy.
+- **Cancellation and handoff**: abort signals the active operation but never releases its claim;
+  `isExecuting()` remains true until the holder unwinds. Prompt handle settlement, post-turn capture,
+  driver/wake cleanup, and persistence complete before matching release. The release performs the
+  existing synchronous queued-turn handoff so no public submission can enter an idle gap.
 - **Command identity**: `ICommand.name`, `ISystemCommand.name`, `ICapabilityDescriptor.name`, and projected model-command reverse mappings use slash-free canonical command ids such as `skills`, `agent`, and `memory`. Slash syntax such as `/skills` or `/agent` belongs only to UI/transport input parsing and display.
 - **SDK core built-ins**: SDK core has no user-visible built-in commands. `skills` is owned by `@robota-sdk/agent-command`, which consumes SDK skill discovery and activation APIs like any other command module.
 - **Product-specific built-in commands**: User-visible internal commands outside SDK-owned discovery are provided by product-composed command modules.

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-execution-claim.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-execution-claim.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { InteractiveExecutionClaimOwner } from '../interactive-execution-claim.js';
+import { SessionExecutionController } from '../interactive-session-execution-controller.js';
+
+function createController(
+  callbackOverrides: Record<string, unknown> = {},
+): SessionExecutionController {
+  return new SessionExecutionController(
+    { getHistory: () => [] } as never,
+    {} as never,
+    {
+      emit: vi.fn(),
+      getContextState: vi.fn(),
+      getCwd: () => process.cwd(),
+      getSession: () => null,
+      getSessionOrThrow: vi.fn(),
+      persistSession: vi.fn(),
+      ...callbackOverrides,
+    } as never,
+  );
+}
+
+describe('interactive foreground execution claim ownership', () => {
+  it('does not let a stale claim release its successor', () => {
+    const owner = new InteractiveExecutionClaimOwner([]);
+    const stale = owner.acquire('prompt');
+
+    expect(owner.active).toBe(true);
+    owner.complete(stale, vi.fn());
+
+    const current = owner.acquire('foreground-command');
+    owner.complete(stale, vi.fn());
+    expect(owner.active).toBe(true);
+
+    owner.complete(current, vi.fn());
+    expect(owner.active).toBe(false);
+  });
+
+  it('does not let stale completion run idle, persistence, or queue handoff', () => {
+    const emitIdle = vi.fn();
+    const persist = vi.fn();
+    const handoff = vi.fn();
+    const owner = new InteractiveExecutionClaimOwner([emitIdle, persist]);
+    const stale = owner.acquire('prompt');
+
+    owner.complete(stale, vi.fn());
+    emitIdle.mockClear();
+    persist.mockClear();
+    const current = owner.acquire('foreground-command');
+
+    owner.complete(stale, handoff);
+
+    expect(owner.active).toBe(true);
+    expect(emitIdle).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+    expect(handoff).not.toHaveBeenCalled();
+    owner.complete(current, vi.fn());
+  });
+
+  it('uses one mutually exclusive claim across every execution kind', () => {
+    const owner = new InteractiveExecutionClaimOwner([]);
+    const claim = owner.acquire('fork-skill');
+
+    expect(() => owner.acquire('prompt')).toThrow(/already running/i);
+    expect(() => owner.acquire('foreground-command')).toThrow(/already running/i);
+    expect(owner.active).toBe(true);
+
+    owner.complete(claim, vi.fn());
+    expect(owner.active).toBe(false);
+  });
+
+  it('rejects and settles a prompt handle when claim acquisition fails', async () => {
+    const controller = createController();
+    let finishForeground!: () => void;
+    const foreground = controller.executeForegroundCommand(
+      () =>
+        new Promise((resolve) => {
+          finishForeground = () => resolve({ success: true, message: 'done' });
+        }),
+      () => Promise.resolve(),
+    );
+    const turn = controller.turns.begin();
+
+    await expect(
+      controller.executePrompt(
+        'blocked',
+        undefined,
+        undefined,
+        [],
+        [],
+        null,
+        vi.fn(),
+        () => Promise.resolve(),
+        turn.turnId,
+      ),
+    ).rejects.toThrow(/already running/i);
+    await expect(turn.completed).rejects.toThrow(/already running/i);
+    expect(controller.executing).toBe(true);
+
+    finishForeground();
+    await expect(foreground).resolves.toMatchObject({ success: true });
+  });
+
+  it('keeps the claim through callbacks and hands the queue off before re-entry', async () => {
+    let controller!: SessionExecutionController;
+    let reentrant!: Promise<unknown>;
+    const persistSession = vi.fn(() => {
+      expect(controller.executing).toBe(true);
+      reentrant = controller.executeForegroundCommand(
+        async () => ({ success: true, message: 'must not run' }),
+        () => Promise.resolve(),
+      );
+    });
+    controller = createController({ persistSession });
+    const queued = controller.turns.begin();
+    controller.enqueuePending({ input: 'queued', options: {}, turnId: queued.turnId });
+    const resumed: string[] = [];
+
+    const result = await controller.executeForegroundCommand(
+      async () => ({ success: true, message: 'owner' }),
+      async (entry) => {
+        await controller.executeForegroundCommand(
+          async () => {
+            resumed.push(entry.input);
+            controller.turns.settle(entry.turnId, { response: entry.input } as never);
+            return { success: true, message: 'queued' };
+          },
+          () => Promise.resolve(),
+        );
+      },
+    );
+
+    expect(result).toEqual({ success: true, message: 'owner' });
+    await expect(reentrant).resolves.toMatchObject({ success: false });
+    await expect(queued.completed).resolves.toMatchObject({ response: 'queued' });
+    expect(resumed).toEqual(['queued']);
+    expect(controller.executing).toBe(false);
+  });
+
+  it('releases a foreground claim when an entry callback throws', async () => {
+    const controller = createController({
+      emit: vi.fn((event: string, value: unknown) => {
+        if (event === 'thinking' && value === true) throw new Error('listener failed');
+      }),
+    });
+
+    await expect(
+      controller.executeForegroundCommand(
+        async () => ({ success: true, message: 'unreachable' }),
+        () => Promise.resolve(),
+      ),
+    ).resolves.toMatchObject({ success: false, message: 'Error: listener failed' });
+    expect(controller.executing).toBe(false);
+  });
+
+  it('still releases and hands off the queued turn when persistence throws', async () => {
+    const controller = createController({
+      persistSession: vi.fn(() => {
+        throw new Error('persist failed');
+      }),
+    });
+    const queued = controller.turns.begin();
+    controller.enqueuePending({ input: 'queued', options: {}, turnId: queued.turnId });
+
+    await expect(
+      controller.executeForegroundCommand(
+        async () => ({ success: true, message: 'owner' }),
+        async (entry) => {
+          controller.turns.settle(entry.turnId, { response: entry.input } as never);
+        },
+      ),
+    ).rejects.toThrow(/persist failed/);
+
+    await expect(queued.completed).resolves.toMatchObject({ response: 'queued' });
+    expect(controller.executing).toBe(false);
+    expect(controller.pendingCount()).toBe(0);
+  });
+
+  it('releases a fork-skill claim when an entry callback throws', async () => {
+    const controller = new SessionExecutionController(
+      { append: vi.fn() } as never,
+      { executeSkillWithActivation: vi.fn() } as never,
+      {
+        emit: vi.fn((event: string, value: unknown) => {
+          if (event === 'thinking' && value === true) throw new Error('listener failed');
+        }),
+        getContextState: vi.fn(),
+        getCwd: () => process.cwd(),
+        getSession: () => null,
+        getSessionOrThrow: vi.fn(),
+        persistSession: vi.fn(),
+      } as never,
+    );
+
+    await expect(
+      controller.executeForkSkillCommand(
+        { name: 'forked' } as never,
+        '',
+        undefined,
+        undefined,
+        'user-slash',
+        () => Promise.resolve(),
+      ),
+    ).resolves.toEqual({ mode: 'fork', result: '' });
+    expect(controller.executing).toBe(false);
+  });
+
+  it('commits trimmed tool state before a synchronous tool-end listener reads it', () => {
+    let controller!: SessionExecutionController;
+    const observedCounts: number[] = [];
+    controller = createController({
+      emit: vi.fn((event: string) => {
+        if (event === 'tool_end') observedCounts.push(controller.activeTools.length);
+      }),
+    });
+
+    for (let index = 0; index < 51; index += 1) {
+      const toolName = `tool-${index}`;
+      controller.handleToolExecution({ type: 'start', toolName });
+      controller.handleToolExecution({ type: 'end', toolName, success: true });
+    }
+
+    expect(controller.activeTools).toHaveLength(50);
+    expect(observedCounts.at(-1)).toBe(50);
+  });
+});

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-goal.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-goal.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest';
 import { InteractiveSession } from '../interactive-session.js';
 
 import type { IGoalEvent } from '@robota-sdk/agent-interface-transport';
+import type { ICommandResult } from '../../commands/index.js';
 import { createSessionStub as createSharedSessionStub } from './helpers/session-stub.js';
 
 import type { SessionExecutionController } from '../interactive-session-execution-controller.js';
@@ -20,13 +21,20 @@ function getExecCtrl(session: InteractiveSession): SessionExecutionController {
   return (session as unknown as { execCtrl: SessionExecutionController }).execCtrl;
 }
 
+function holdExecution(execCtrl: SessionExecutionController): void {
+  void execCtrl.executeForegroundCommand(
+    () => new Promise<ICommandResult>(() => {}),
+    () => Promise.resolve(),
+  );
+}
+
 describe('InteractiveSession goal wiring (GOAL-001)', () => {
   it('setGoal seeds an active goal, emits goal_started, and schedules the first agent-wakeup turn', async () => {
     const session = new InteractiveSession({
       session: createSharedSessionStub({ getSessionId: () => 'session_goal' }),
     });
     const execCtrl = getExecCtrl(session);
-    execCtrl.executing = true;
+    holdExecution(execCtrl);
     const events: IGoalEvent[] = [];
     session.on('goal_event', (event) => events.push(event));
 
@@ -47,7 +55,7 @@ describe('InteractiveSession goal wiring (GOAL-001)', () => {
     const session = new InteractiveSession({
       session: createSharedSessionStub({ getSessionId: () => 'session_goal' }),
     });
-    getExecCtrl(session).executing = true;
+    holdExecution(getExecCtrl(session));
     const events: IGoalEvent[] = [];
     session.on('goal_event', (event) => events.push(event));
 

--- a/packages/agent-framework/src/interactive/__tests__/interactive-session-wake-injection.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/interactive-session-wake-injection.test.ts
@@ -81,6 +81,21 @@ function getExecCtrl(session: InteractiveSession): SessionExecutionController {
   return (session as unknown as { execCtrl: SessionExecutionController }).execCtrl;
 }
 
+function holdExecution(execCtrl: SessionExecutionController): () => void {
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  void execCtrl.executeForegroundCommand(
+    async () => {
+      await held;
+      return { success: true, message: 'released' };
+    },
+    () => Promise.resolve(),
+  );
+  return release;
+}
+
 async function setupSession(): Promise<{
   session: InteractiveSession;
   manager: BackgroundTaskManager;
@@ -101,7 +116,7 @@ describe('FLOW-002 session wake injection', () => {
   it('TC-01/TC-04: a wake injects one agent-wakeup turn carrying the instruction', async () => {
     const { session, manager, started } = await setupSession();
     const execCtrl = getExecCtrl(session);
-    execCtrl.executing = true;
+    holdExecution(execCtrl);
 
     const created = await manager.spawn(scheduledWakeRequest('check the build'));
     await Promise.resolve();
@@ -122,7 +137,7 @@ describe('FLOW-002 session wake injection', () => {
   it('TC-03: duplicate wakes for the same task id coalesce to a single turn', async () => {
     const { session, manager, started } = await setupSession();
     const execCtrl = getExecCtrl(session);
-    execCtrl.executing = true;
+    holdExecution(execCtrl);
 
     await manager.spawn(scheduledWakeRequest('do X'));
     await Promise.resolve();
@@ -140,7 +155,7 @@ describe('FLOW-002 session wake injection', () => {
   it('TC-02: while a turn is executing, the wake queues (not interleaved)', async () => {
     const { session, manager, started } = await setupSession();
     const execCtrl = getExecCtrl(session);
-    execCtrl.executing = true; // simulate an in-flight turn
+    holdExecution(execCtrl); // simulate an in-flight turn
 
     await manager.spawn(scheduledWakeRequest('queued instruction'));
     await Promise.resolve();
@@ -155,7 +170,7 @@ describe('FLOW-002 session wake injection', () => {
   it('RUNTIME-19: aborting a queued wake evicts its id so a future wake is not locked out', async () => {
     const { session, manager, started } = await setupSession();
     const execCtrl = getExecCtrl(session);
-    execCtrl.executing = true; // a turn is in flight, so the wake queues instead of running
+    const releaseExecution = holdExecution(execCtrl); // a turn is in flight, so the wake queues instead of running
 
     const created = await manager.spawn(scheduledWakeRequest('follow up'));
     await Promise.resolve();
@@ -172,7 +187,8 @@ describe('FLOW-002 session wake injection', () => {
     expect(execCtrl.wakeTaskIds.has(created.id)).toBe(false);
 
     // A brand-new wake for the same task id is now accepted (not locked out).
-    execCtrl.executing = false;
+    releaseExecution();
+    await Promise.resolve();
     expect(session.requestWakeup('later', created.id)).toBe(true);
   });
 });

--- a/packages/agent-framework/src/interactive/__tests__/turn-handle-always-settles.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/turn-handle-always-settles.test.ts
@@ -21,12 +21,28 @@ import { acceptSubmission } from '../interactive-session-accept-submission.js';
 import { InteractiveSession } from '../interactive-session.js';
 import { SessionExecutionController } from '../interactive-session-execution-controller.js';
 import type { IQueuedInput } from '../interactive-session-execution-controller.js';
+import type { ICommandResult } from '../../commands/index.js';
 import { TurnNotRunError } from '../turn-not-run-error.js';
 
 /** Exposes the protected drain so a case can reach the resubmission path directly. */
 class DrainableController extends SessionExecutionController {
   drainNow(submit: Parameters<DrainableController['drainPendingQueue']>[0]): void {
     this.drainPendingQueue(submit);
+  }
+
+  holdExecution(): () => void {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    void this.executeForegroundCommand(
+      async () => {
+        await held;
+        return { success: true, message: 'released' };
+      },
+      () => Promise.resolve(),
+    );
+    return release;
   }
 }
 
@@ -38,6 +54,7 @@ function createController(): DrainableController {
       emit: vi.fn(),
       getContextState: vi.fn(),
       getCwd: () => process.cwd(),
+      getSession: () => null,
       getSessionOrThrow: vi.fn(),
       persistSession: vi.fn(),
     } as never,
@@ -130,7 +147,10 @@ describe('RUNTIME-003: the identity survives the whole queued path', () => {
     readonly enqueued: IQueuedInput[] = [];
 
     watchTheQueue(): void {
-      this.execCtrl.executing = true; // a turn is in flight, so the next submission queues
+      void this.execCtrl.executeForegroundCommand(
+        () => new Promise<ICommandResult>(() => {}),
+        () => Promise.resolve(),
+      ); // a turn is in flight, so the next submission queues
       const enqueue = this.execCtrl.enqueuePending.bind(this.execCtrl);
       this.execCtrl.enqueuePending = (entry: IQueuedInput) => {
         this.enqueued.push(entry);
@@ -148,7 +168,6 @@ describe('RUNTIME-003: the identity survives the whole queued path', () => {
     const { turnId, completed } = controller.turns.begin();
     controller.enqueuePending({ input: 'queued', options: { driverId: 'owner' }, turnId });
 
-    controller.executing = false;
     controller.drainNow(() => {
       throw new Error('session is shutting down');
     });
@@ -178,18 +197,17 @@ describe('RUNTIME-003: the identity survives the whole queued path', () => {
     let maxConcurrent = 0;
 
     const resume = async (entry: IQueuedInput): Promise<void> => {
-      controller.executing = true;
-      concurrent += 1;
-      maxConcurrent = Math.max(maxConcurrent, concurrent);
-      order.push(entry.input);
-      await Promise.resolve();
-      concurrent -= 1;
-      controller.executing = false;
-      controller.turns.settle(entry.turnId, { content: entry.input } as never);
-      controller.drainNow(resume);
+      await controller.executeForegroundCommand(async () => {
+        concurrent += 1;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        order.push(entry.input);
+        await Promise.resolve();
+        concurrent -= 1;
+        controller.turns.settle(entry.turnId, { content: entry.input } as never);
+        return { success: true, message: 'resumed' };
+      }, resume);
     };
 
-    controller.executing = false;
     controller.drainNow(resume);
 
     expect(controller.executing, 'queue handoff released execution ownership for one tick').toBe(

--- a/packages/agent-framework/src/interactive/interactive-execution-claim.ts
+++ b/packages/agent-framework/src/interactive/interactive-execution-claim.ts
@@ -1,0 +1,45 @@
+export type TExecutionClaimKind = 'prompt' | 'fork-skill' | 'foreground-command';
+
+export interface IExecutionClaim {
+  readonly id: symbol;
+  readonly kind: TExecutionClaimKind;
+}
+
+/** Identity-bound owner for the interactive foreground execution lifecycle. */
+export class InteractiveExecutionClaimOwner {
+  private activeClaim: IExecutionClaim | undefined;
+
+  constructor(private readonly whileHeldCleanup: ReadonlyArray<() => void>) {}
+
+  get active(): boolean {
+    return this.activeClaim !== undefined;
+  }
+
+  acquire(kind: TExecutionClaimKind): IExecutionClaim {
+    if (this.activeClaim !== undefined) {
+      throw new Error('Another prompt or command is already running. Wait for it to finish.');
+    }
+    const claim = { id: Symbol(kind), kind };
+    this.activeClaim = claim;
+    return claim;
+  }
+
+  complete(claim: IExecutionClaim, afterRelease: () => void): void {
+    if (this.activeClaim !== claim) return;
+
+    let cleanupError: unknown;
+    for (const step of this.whileHeldCleanup) {
+      try {
+        step();
+      } catch (error) {
+        cleanupError ??= error;
+      }
+    }
+
+    // Release and handoff are adjacent synchronous operations, so a public submission cannot
+    // acquire ahead of the already queued head.
+    this.activeClaim = undefined;
+    afterRelease();
+    if (cleanupError !== undefined) throw cleanupError;
+  }
+}

--- a/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-controller.ts
@@ -2,30 +2,31 @@
  * SessionExecutionController — owns execution lifecycle state and methods
  * for InteractiveSession.
  *
- * Manages: executing flag, streaming text, active tools, pending queue,
+ * Manages: execution claim, streaming text, active tools, pending queue,
  * shutting-down flag, and all private execution lifecycle methods.
  */
 
 import {
   createUserMessage,
-  createAssistantMessage,
   createSystemMessage,
   messageToHistoryEntry,
 } from '@robota-sdk/agent-core';
 
+import { InteractiveExecutionClaimOwner } from './interactive-execution-claim.js';
 import { checkAndRefreshContextIfStale } from './interactive-session-context-refresh.js';
+import {
+  projectCompactEvent,
+  projectForkSkillResult,
+  projectToolExecution,
+} from './interactive-session-execution-events.js';
 import { PendingInputQueue } from './interactive-session-pending-queue.js';
 import { capturePostTurnMemory } from './interactive-session-post-turn-memory.js';
 import { executePromptTurn } from './interactive-session-prompt.js';
-import {
-  STREAMING_FLUSH_INTERVAL_MS,
-  pushToolSummaryToHistory,
-  applyToolStart,
-  applyToolEnd,
-} from './interactive-session-streaming.js';
+import { STREAMING_FLUSH_INTERVAL_MS } from './interactive-session-streaming.js';
 import { TurnSettlerRegistry } from './turn-settler-registry.js';
 import { humanizeApiError } from '../utils/error-humanizer.js';
 
+import type { IExecutionClaim } from './interactive-execution-claim.js';
 import type {
   IExecutionControllerCallbacks,
   ITurnOptions,
@@ -58,7 +59,7 @@ export type {
 } from './interactive-session-execution-contracts.js';
 
 export class SessionExecutionController {
-  executing = false;
+  private readonly executionClaim: InteractiveExecutionClaimOwner;
   streamingText = '';
   flushTimer: ReturnType<typeof setTimeout> | null = null;
   activeTools: IToolState[] = [];
@@ -78,10 +79,20 @@ export class SessionExecutionController {
     private readonly histTracker: SessionHistoryTracker,
     private readonly skillRouter: SessionSkillRouter,
     private readonly callbacks: IExecutionControllerCallbacks,
-  ) {}
+  ) {
+    this.executionClaim = new InteractiveExecutionClaimOwner([
+      () => this.callbacks.persistSession(),
+      () => this.callbacks.emit('thinking', false),
+      () => this.emitExecutionWorkspaceUpdated('main_thread'),
+    ]);
+  }
 
   /** RUNTIME-003: the registry that makes `ITurnHandle.completed` able to promise it settles. */
   readonly turns = new TurnSettlerRegistry();
+
+  get executing(): boolean {
+    return this.executionClaim.active;
+  }
 
   /** The HEAD queued prompt (next to run), or null — backward-compatible single-prompt read. */
   get pendingPrompt(): string | null {
@@ -128,19 +139,8 @@ export class SessionExecutionController {
   }
 
   handleCompactEvent(event: ICompactEvent): void {
-    if (event.trigger === 'auto') {
-      this.histTracker.append(
-        messageToHistoryEntry(
-          createSystemMessage(
-            `Auto compacted context: ${Math.round(event.before.usedPercentage)}% -> ${Math.round(event.after.usedPercentage)}%`,
-          ),
-        ),
-      );
-    }
-    this.callbacks.emit('compact', event);
-    this.callbacks.emit('context_update', event.after);
+    projectCompactEvent(this.histTracker, this.callbacks, event);
   }
-
   handleToolExecution(event: {
     type: 'start' | 'end';
     toolName: string;
@@ -150,19 +150,13 @@ export class SessionExecutionController {
     toolResultData?: string;
     executionId?: string;
   }): void {
-    const streamingState = {
-      activeTools: this.activeTools,
-      history: this.histTracker.getHistory(),
-    };
-    if (event.type === 'start') {
-      const toolState = applyToolStart(streamingState, event);
-      this.activeTools = streamingState.activeTools;
-      this.callbacks.emit('tool_start', toolState);
-    } else {
-      const finished = applyToolEnd(streamingState, event);
-      this.activeTools = streamingState.activeTools;
-      if (finished) this.callbacks.emit('tool_end', finished);
-    }
+    this.activeTools = projectToolExecution(
+      this.activeTools,
+      this.histTracker.getHistory(),
+      this.callbacks,
+      (activeTools) => void (this.activeTools = activeTools),
+      event,
+    );
   }
 
   emitExecutionWorkspaceUpdated(cause: TExecutionWorkspaceUpdateCause, entryId?: string): void {
@@ -193,12 +187,10 @@ export class SessionExecutionController {
       try {
         resumed = resumeQueuedTurn(head);
       } catch (error) {
-        this.executing = false;
         this.turns.fail(head.turnId, error instanceof Error ? error : new Error(String(error)));
         return;
       }
       void resumed.catch((error: unknown) => {
-        this.executing = false;
         this.turns.fail(head.turnId, error instanceof Error ? error : new Error(String(error)));
       });
     }
@@ -217,12 +209,18 @@ export class SessionExecutionController {
     turnOptions: ITurnOptions = {},
   ): Promise<void> {
     // RUNTIME-12: claim the turn SYNCHRONOUSLY at entry. The caller's `if (execCtrl.executing)` gate
-    // (interactive-session.submit) and this assignment are synchronous, so a second concurrent submit
+    // (interactive-session.submit) and this claim are synchronous, so a second concurrent submit
     // observes `executing` and coalesces to the pending queue instead of BOTH starting a turn. (Previously
     // set only AFTER the awaited checkAndRefreshContextIfStale below, leaving a two-await window where both
     // entries saw idle.) The `finally` always releases it — including if the refresh throws, which is why
     // checkAndRefreshContextIfStale now runs INSIDE the try.
-    this.executing = true;
+    let executionClaim: IExecutionClaim;
+    try {
+      executionClaim = this.executionClaim.acquire('prompt');
+    } catch (error) {
+      this.turns.fail(turnId, error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
     // RUNTIME-003: which submission this turn belongs to; the handle minted then settles here.
     // REMOTE-014 E5: capture the ACTIVE turn's driver so event/prompt emitters can attribute to it.
     this.activeDriverId = turnOptions.driverId ?? null;
@@ -323,18 +321,14 @@ export class SessionExecutionController {
         record: (event) => this.histTracker.recordMemoryEvent(event),
         onError: (error) => this.callbacks.emit('error', error),
       });
-      this.callbacks.persistSession();
       // RUNTIME-003: settled BEFORE draining, in the `finally` that always runs — so a caller is
       // answered by ITS turn, and a turn that threw where onError never saw still settles.
       if (terminalResult !== undefined) this.turns.settle(turnId, terminalResult);
       else this.turns.fail(turnId, turnError ?? new Error('the turn ended without a result'));
-      this.executing = false;
       this.activeDriverId = null; // REMOTE-014 E5: turn ended — events after this are not turn-authored
-      this.callbacks.emit('thinking', false);
       // FLOW-002: the wake for this task id is no longer in flight; allow future wakes to inject.
       if (turnOptions.wakeTaskId !== undefined) this.wakeTaskIds.delete(turnOptions.wakeTaskId);
-      this.emitExecutionWorkspaceUpdated('main_thread');
-      this.drainPendingQueue(resumeQueuedTurn);
+      this.executionClaim.complete(executionClaim, () => this.drainPendingQueue(resumeQueuedTurn));
     }
   }
 
@@ -349,15 +343,15 @@ export class SessionExecutionController {
     if (this.executing) {
       throw new Error('Cannot execute fork skill while another prompt is running.');
     }
-    this.executing = true;
-    this.clearStreaming();
-    this.callbacks.emit('thinking', true);
-    this.histTracker.append(
-      messageToHistoryEntry(createUserMessage(displayInput ?? `/${skill.name}`)),
-    );
-    this.emitExecutionWorkspaceUpdated('main_thread');
+    const executionClaim = this.executionClaim.acquire('fork-skill');
 
     try {
+      this.clearStreaming();
+      this.callbacks.emit('thinking', true);
+      this.histTracker.append(
+        messageToHistoryEntry(createUserMessage(displayInput ?? `/${skill.name}`)),
+      );
+      this.emitExecutionWorkspaceUpdated('main_thread');
       const result = await this.skillRouter.executeSkillWithActivation(
         skill,
         args,
@@ -375,11 +369,7 @@ export class SessionExecutionController {
       this.callbacks.emit('error', error);
       return { mode: 'fork', result: '' };
     } finally {
-      this.executing = false;
-      this.callbacks.emit('thinking', false);
-      this.emitExecutionWorkspaceUpdated('main_thread');
-      this.callbacks.persistSession();
-      this.drainPendingQueue(resumeQueuedTurn);
+      this.executionClaim.complete(executionClaim, () => this.drainPendingQueue(resumeQueuedTurn));
     }
   }
 
@@ -387,11 +377,19 @@ export class SessionExecutionController {
     execute: () => Promise<ICommandResult>,
     resumeQueuedTurn: TResumeQueuedTurnFn,
   ): Promise<ICommandResult> {
-    this.executing = true;
-    this.clearStreaming();
-    this.callbacks.emit('thinking', true);
-    this.emitExecutionWorkspaceUpdated('main_thread');
+    let executionClaim: IExecutionClaim;
     try {
+      executionClaim = this.executionClaim.acquire('foreground-command');
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    try {
+      this.clearStreaming();
+      this.callbacks.emit('thinking', true);
+      this.emitExecutionWorkspaceUpdated('main_thread');
       const result = await execute();
       this.callbacks.emit('context_update', this.callbacks.getContextState());
       return result;
@@ -399,29 +397,18 @@ export class SessionExecutionController {
       const errMsg = err instanceof Error ? err.message : String(err);
       return { success: false, message: `Error: ${errMsg}` };
     } finally {
-      this.executing = false;
-      this.callbacks.emit('thinking', false);
-      this.emitExecutionWorkspaceUpdated('main_thread');
-      this.callbacks.persistSession();
-      this.drainPendingQueue(resumeQueuedTurn);
+      this.executionClaim.complete(executionClaim, () => this.drainPendingQueue(resumeQueuedTurn));
     }
   }
 
   async applyForkSkillResult(result: string): Promise<void> {
-    this.flushStreaming();
-    pushToolSummaryToHistory({
-      activeTools: this.activeTools,
-      history: this.histTracker.getHistory(),
-    });
-    this.clearStreaming();
-    const executionResult = {
-      response: result,
-      history: this.histTracker.getHistory(),
-      toolSummaries: [],
-      contextState: this.callbacks.getContextState(),
-    };
-    this.histTracker.append(messageToHistoryEntry(createAssistantMessage(result)));
-    this.callbacks.emit('complete', executionResult);
-    this.callbacks.emit('context_update', this.callbacks.getContextState());
+    projectForkSkillResult(
+      result,
+      this.activeTools,
+      this.histTracker,
+      this.callbacks,
+      () => this.flushStreaming(),
+      () => this.clearStreaming(),
+    );
   }
 }

--- a/packages/agent-framework/src/interactive/interactive-session-execution-events.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-execution-events.ts
@@ -1,0 +1,85 @@
+import {
+  createAssistantMessage,
+  createSystemMessage,
+  messageToHistoryEntry,
+} from '@robota-sdk/agent-core';
+
+import {
+  applyToolEnd,
+  applyToolStart,
+  pushToolSummaryToHistory,
+} from './interactive-session-streaming.js';
+
+import type { IExecutionControllerCallbacks } from './interactive-session-execution-contracts.js';
+import type { SessionHistoryTracker } from './interactive-session-history-tracker.js';
+import type { IToolState } from './types.js';
+import type { TToolArgs } from '@robota-sdk/agent-core';
+import type { ICompactEvent } from '@robota-sdk/agent-interface-transport';
+
+export function projectCompactEvent(
+  histTracker: SessionHistoryTracker,
+  callbacks: IExecutionControllerCallbacks,
+  event: ICompactEvent,
+): void {
+  if (event.trigger === 'auto') {
+    histTracker.append(
+      messageToHistoryEntry(
+        createSystemMessage(
+          `Auto compacted context: ${Math.round(event.before.usedPercentage)}% -> ${Math.round(event.after.usedPercentage)}%`,
+        ),
+      ),
+    );
+  }
+  callbacks.emit('compact', event);
+  callbacks.emit('context_update', event.after);
+}
+
+export function projectToolExecution(
+  activeTools: IToolState[],
+  history: ReturnType<SessionHistoryTracker['getHistory']>,
+  callbacks: IExecutionControllerCallbacks,
+  commitActiveTools: (tools: IToolState[]) => void,
+  event: {
+    type: 'start' | 'end';
+    toolName: string;
+    toolArgs?: TToolArgs;
+    success?: boolean;
+    denied?: boolean;
+    toolResultData?: string;
+    executionId?: string;
+  },
+): IToolState[] {
+  const streamingState = { activeTools, history };
+  if (event.type === 'start') {
+    const toolState = applyToolStart(streamingState, event);
+    commitActiveTools(streamingState.activeTools);
+    callbacks.emit('tool_start', toolState);
+  } else {
+    const finished = applyToolEnd(streamingState, event);
+    commitActiveTools(streamingState.activeTools);
+    if (finished) callbacks.emit('tool_end', finished);
+  }
+  return streamingState.activeTools;
+}
+
+export function projectForkSkillResult(
+  result: string,
+  activeTools: IToolState[],
+  histTracker: SessionHistoryTracker,
+  callbacks: IExecutionControllerCallbacks,
+  flushStreaming: () => void,
+  clearStreaming: () => void,
+): void {
+  flushStreaming();
+  pushToolSummaryToHistory({ activeTools, history: histTracker.getHistory() });
+  clearStreaming();
+  const executionResult = {
+    response: result,
+    history: histTracker.getHistory(),
+    toolSummaries: [],
+    contextState: callbacks.getContextState(),
+  };
+  histTracker.append(messageToHistoryEntry(createAssistantMessage(result)));
+  callbacks.emit('complete', executionResult);
+  callbacks.emit('context_update', callbacks.getContextState());
+}

--- a/packages/agent-framework/src/testing/__tests__/execution-claim-functional.test.ts
+++ b/packages/agent-framework/src/testing/__tests__/execution-claim-functional.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { scriptedSession, type ScriptedSessionHarness } from '../index.js';
+
+import type { ICommandModule } from '../../command-api/command-module.js';
+import type { IInteractiveSessionEvents } from '@robota-sdk/agent-interface-transport';
+
+const TEST_TIMEOUT = 20_000;
+
+let harness: ScriptedSessionHarness | undefined;
+
+afterEach(async () => {
+  await harness?.dispose();
+  harness = undefined;
+});
+
+function bounded<T>(promise: Promise<T>, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(`${label} timed out`)), 5_000);
+    }),
+  ]);
+}
+
+describe('interactive execution claim (framework functional)', () => {
+  it(
+    'keeps a queued prompt through public command refusal and settles it exactly once',
+    async () => {
+      const commandExecute = vi.fn().mockResolvedValue({ success: true, message: 'must not run' });
+      const blockingCommandModule: ICommandModule = {
+        name: 'execution-claim-test',
+        systemCommands: [
+          {
+            name: 'blocked-command',
+            description: 'Must remain blocked while a prompt owns execution',
+            lifecycle: 'blocking',
+            execute: commandExecute,
+          },
+        ],
+      };
+      harness = scriptedSession({
+        permissionMode: 'default',
+        commandModules: [blockingCommandModule],
+        turns: [
+          {
+            toolCalls: [
+              { name: 'Bash', args: { command: 'echo denied > {{cwd}}/must-not-exist.txt' } },
+            ],
+          },
+          { text: 'FIRST_DONE' },
+          { text: 'QUEUED_DONE' },
+        ],
+      });
+      const permissionRequest = new Promise<{ id: string }>((resolve) => {
+        harness!.session.on('permission_request', ((event: { id: string }) =>
+          resolve(event)) as IInteractiveSessionEvents['permission_request']);
+      });
+      const thinkingStates: boolean[] = [];
+      harness.session.on('thinking', (thinking) => thinkingStates.push(thinking));
+
+      const firstSubmission = harness.session.submit('first prompt');
+      const permission = await bounded(permissionRequest, 'permission request');
+      const queued = await harness.session.submit('queued prompt');
+      let queuedSettlements = 0;
+      void queued.completed.then(
+        () => {
+          queuedSettlements += 1;
+        },
+        () => {
+          queuedSettlements += 1;
+        },
+      );
+      const thinkingBeforeCommand = [...thinkingStates];
+
+      const blocked = await bounded(
+        harness.session.executeCommand('blocked-command', ''),
+        'public command refusal',
+      );
+
+      expect(blocked).toMatchObject({ success: false });
+      expect(blocked?.message).toMatch(/already running/i);
+      expect(commandExecute).not.toHaveBeenCalled();
+      expect(thinkingStates).toEqual(thinkingBeforeCommand);
+      expect(harness.session.getPendingPrompt()).toBe('queued prompt');
+
+      harness.session.resolvePermission(permission.id, false);
+      const first = await bounded(firstSubmission, 'first submission');
+      await expect(bounded(first.completed, 'first turn')).resolves.toMatchObject({
+        response: 'FIRST_DONE',
+      });
+      await expect(bounded(queued.completed, 'queued turn')).resolves.toMatchObject({
+        response: 'QUEUED_DONE',
+      });
+
+      expect(queuedSettlements).toBe(1);
+      expect(harness.session.getPendingPrompt()).toBeNull();
+      expect(harness.exists('must-not-exist.txt')).toBe(false);
+      expect(JSON.stringify(harness.session.getFullHistory())).not.toContain('SessionBusyError');
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/packages/agent-session/docs/SPEC.md
+++ b/packages/agent-session/docs/SPEC.md
@@ -373,14 +373,14 @@ The contract this package now publishes:
 - `isRunning()` is therefore authoritative for the session, and a consumer does not need to maintain
   a parallel busy flag.
 
-The one caveat, stated because the recipe above is not unconditional: a turn that never OBSERVES the
-signal is never cut, and its claim is held until it unwinds. A provider that hangs is cut by
-agent-core's upstream-abort path, but a turn parked on a consumer-supplied `permissionHandler` is
-not — `PermissionEnforcer` awaits it with no signal and no timeout — so `abort()` returns, the await
-never does, and every later `run()` on that session is refused. Recovery is `shutdown()`, which does
-not consult the claim, and then a fresh session. `agent-framework` avoids the case by draining its
-prompt registry before aborting; a direct `agent-session` consumer has no equivalent, which is
-RUNTIME-004's subject, not this contract's.
+Every wait owned by this package that can park a turn observes the turn signal. In particular,
+`PermissionEnforcer` races both a consumer `permissionHandler` and an injected approval prompt against
+the signal. Abort resolves that approval decision as **deny** (fail closed), allowing the turn to
+unwind and its matching claim to release; it can never convert cancellation into approval.
+`isRunning()` remains true between `abort()` and that unwind. A consumer must await the active run
+before starting the next one. Long-running tools receive the same signal in their execution context
+and are contractually responsible for observing it; tool-cooperation conformance is a separate
+cross-tool concern rather than a second cancellation channel.
 
 Concurrency ACROSS transports (MCP request correlation, the HTTP `POST /submit` TOCTOU) rides
 `InteractiveSession` in `agent-framework`, a different object, and is not covered by this contract —
@@ -502,6 +502,9 @@ No formal interface implementations. `PermissionEnforcer`, `ContextWindowTracker
 
 - **Session system prompt delivery** -- tests verifying the system prompt is passed to Robota as the single-source top-level `config.systemMessage`, and that `updateSystemMessage` propagates a live change to the next provider request via `Robota.updateSystemPrompt`.
 - **Session provider callback isolation** -- 1 regression test verifying two sessions sharing one provider keep `onTextDelta` output isolated per run.
+- **Approval abort recovery** -- bounded tests cover both approval adapters, wrapper signal wiring,
+  fail-closed denial, listener cleanup, and a full `Session.run()` parked on approval through
+  `abort()` → rejected turn → `isRunning() === false`.
 
 ### Gaps
 

--- a/packages/agent-session/src/__tests__/approval-wait-honours-abort.test.ts
+++ b/packages/agent-session/src/__tests__/approval-wait-honours-abort.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
+import { FunctionTool } from '@robota-sdk/agent-core';
+import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
 
 import { PermissionEnforcer } from '../permission-enforcer.js';
+import { Session } from '../session.js';
 
 import type { IPermissionEnforcerOptions, TPermissionResult } from '../permission-types.js';
 import type { IToolWithEventService, ITerminalOutput, TToolArgs } from '@robota-sdk/agent-core';
@@ -192,5 +195,61 @@ describe('the turn signal reaches the prompt through the tool wrapper (RUNTIME-0
       signal: new AbortController().signal,
     });
     expect(tool.execute).toHaveBeenCalled();
+  });
+});
+
+describe('Session abort releases a turn parked on approval (RUNTIME-005)', () => {
+  it('rejects the real run, releases its claim, and never invokes the unapproved tool', async () => {
+    let markApprovalEntered!: () => void;
+    const approvalEntered = new Promise<void>((resolve) => {
+      markApprovalEntered = resolve;
+    });
+    const executeTool = vi.fn().mockResolvedValue('should not run');
+    const tool = new FunctionTool(
+      {
+        name: 'DestructiveAction',
+        description: 'permission-gated test tool',
+        parameters: { type: 'object', properties: {}, required: [] },
+      },
+      executeTool,
+    );
+    const { provider } = createScriptedProvider([
+      { toolCalls: [{ name: 'DestructiveAction', args: {} }] },
+      { text: 'tool was denied' },
+    ]);
+    const session = new Session({
+      cwd: process.cwd(),
+      tools: [tool],
+      provider,
+      systemMessage: 'test',
+      terminal: makeNoopTerminal(),
+      permissionHandler: () => {
+        markApprovalEntered();
+        return new Promise<TPermissionResult>(() => undefined);
+      },
+    });
+
+    const run = session.run('use the tool');
+    await approvalEntered;
+    expect(session.isRunning()).toBe(true);
+
+    session.abort();
+    const outcome = await Promise.race([
+      run.then(
+        (value) => ({ status: 'resolved' as const, value }),
+        (error: unknown) => ({ status: 'rejected' as const, error }),
+      ),
+      new Promise<{ status: 'pending' }>((resolve) =>
+        setTimeout(() => resolve({ status: 'pending' }), 250),
+      ),
+    ]);
+
+    expect(outcome.status).toBe('rejected');
+    if (outcome.status === 'rejected') {
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect((outcome.error as Error).name).toBe('AbortError');
+    }
+    expect(session.isRunning()).toBe(false);
+    expect(executeTool).not.toHaveBeenCalled();
   });
 });

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -25,7 +25,7 @@
   "packages/agent-framework/src/index.ts": 670,
   "packages/agent-framework/src/interactive/interactive-session-background-tracker.ts": 334,
   "packages/agent-framework/src/interactive/interactive-session-base.ts": 387,
-  "packages/agent-framework/src/interactive/interactive-session-execution-controller.ts": 428,
+  "packages/agent-framework/src/interactive/interactive-session-execution-controller.ts": 415,
   "packages/agent-framework/src/interactive/interactive-session-execution.ts": 313,
   "packages/agent-framework/src/interactive/interactive-session-history-tracker.ts": 355,
   "packages/agent-framework/src/interactive/interactive-session-skill-router.ts": 341,


### PR DESCRIPTION
## Summary
- replace the shared interactive execution boolean with identity-bound claims across prompt, fork, and foreground command paths
- preserve claim ownership through persistence, lifecycle events, and queued-turn handoff
- make approval waits abortable and archive BEHAVIOR-008 / RUNTIME-005 with durable scenario evidence

## Verification
- `pnpm harness:verify-like-ci` (11/11 stages, 6m42s)
- agent-framework: 1,334 tests
- agent-session: 193 tests
- runtime-005 durable user scenario: exit 0
- pre-push scoped verification and 3,223 harness tests