### PR TITLE
docs(tasks): file CI-time reduction backlog (INFRA-093, INFRA-094)

### DIFF
--- a/.agents/tasks/INFRA-093-scope-harness-unit-tests-by-path.md
+++ b/.agents/tasks/INFRA-093-scope-harness-unit-tests-by-path.md
@@ -1,0 +1,62 @@
+---
+title: 'INFRA-093: the 179-file harness unit-test suite runs in full on every develop PR (~180s) even when no harness code changed — gate it on scripts/harness (and workflow/config) paths so product-only PRs skip it'
+status: todo
+created: 2026-08-14
+priority: medium
+urgency: soon
+area: .github/workflows/ci.yml, scripts/harness
+depends_on: []
+---
+
+# INFRA-093: scope the harness unit-test suite by path
+
+## Problem
+
+The `scans` CI job runs `pnpm harness:test` — the full 179-file unit suite that tests the CI harness
+SCRIPTS themselves — unconditionally on every `develop`-targeting PR, with no `needs` and no path
+gate. Measured at ~180s. It is a fixed cost paid on every product change and every docs change, even
+though nothing under `scripts/harness/**` was touched. It is the single largest change-independent
+time sink in the per-PR CI (26% of the promotion gate's 707s, and a big share of the `scans` job's
+234s on develop PRs).
+
+## Evidence (measured from PR #1709 / #1711 / #1712 CI runs, 2026-08-14)
+
+- `.github/workflows/ci.yml` `scans` job: `if: github.base_ref != 'main'` (runs on ALL develop PRs,
+  including docs-only) → step "Harness scan test suite": `run: pnpm harness:test`
+  (`= vitest run scripts/harness/__tests__ --pool=threads --maxWorkers=2`). No path filter, no
+  `needs: changes`.
+- The suite is 179 test files under `scripts/harness/__tests__/` — they exercise the harness scripts
+  (scan logic, promotion, gates), not product code.
+- Timing: docs-only PR #1711's `scans` job = 232s; the same `pnpm harness:test` also accounts for
+  ~181s of the promotion gate's 707s (`release-grade verification`) breakdown.
+- A `changes` classifier job already exists (`classify-changed-paths.mjs`, outputs `code`/`product`/
+  `tui`/`examples`) — the wiring to gate a job on changed paths is present; harness tests just are not
+  gated by it.
+- Prior decision to respect: HARNESS-021 rejected _per-scan_ test selection (choosing WHICH harness
+  tests to run based on which scan changed) and kept "the suite runs in full". This task is a
+  DIFFERENT, coarser axis — skip the ENTIRE suite only when NOTHING under the harness's own source
+  changed — so it does not reopen HARNESS-021's per-scan-selection question.
+
+## Direction
+
+Add a `harness` path signal to the `changes` classifier (`scripts/harness/**`,
+`.github/workflows/**`, `.agents/harness.config.json`, and the harness test dir itself) and gate the
+`pnpm harness:test` step (and the harness-test portion of `release`) on it. When those paths are
+unchanged, skip the ~180s suite; when they ARE changed, run it in full (preserving HARNESS-021).
+Keep the harness SCAN step (`pnpm harness:scan`) always-on — it validates docs/tasks/rules and must
+run on content changes. The gate must fail-safe: an unreadable/failed classifier runs the suite
+(never silently skips), matching the repo's existing fail-safe classifier posture.
+
+## Test Plan
+
+- A product-only PR (no `scripts/harness/**` change) shows the harness-test step SKIPPED and the
+  `scans` job wall-clock drops by ~180s; the harness scan step still runs.
+- A PR touching `scripts/harness/**` runs the full harness-test suite (verify it is NOT skipped).
+- A PR where the classifier fails runs the suite (fail-safe).
+- `pnpm harness:scan` (the ci-mirror / workflow-lint scans) stays green.
+
+## User Execution Test Scenarios
+
+Not applicable — CI-configuration / harness change with no user-facing product runtime behavior.
+Verification is the CI-timing and skip/run assertions in the Test Plan (measured against a product-only
+PR vs a harness-touching PR).

--- a/.agents/tasks/INFRA-094-advisory-patch-coverage-off-pr-critical-path.md
+++ b/.agents/tasks/INFRA-094-advisory-patch-coverage-off-pr-critical-path.md
@@ -1,0 +1,62 @@
+---
+title: 'INFRA-094: the advisory (non-blocking) patch-coverage job runs ~206s on every code PR and rebuilds all deps itself instead of reusing the build job dist — take it off the develop-PR critical path or make it reuse dist'
+status: todo
+created: 2026-08-14
+priority: medium
+urgency: soon
+area: .github/workflows/ci.yml, scripts/harness/check-patch-coverage.mjs
+depends_on: []
+---
+
+# INFRA-094: advisory patch-coverage off the PR critical path
+
+## Problem
+
+`patch-coverage (advisory)` is a non-blocking job — its result does not gate merges — yet it runs
+~206s on every code-changing develop PR, and it performs its OWN `pnpm build:deps` (a full workspace
+build) that duplicates the `build` job's work because the two do not share a dist artifact. It is
+one of the four ~200s parallel jobs that set the develop-PR wall-clock floor at ~4 minutes, and it
+adds Actions billing for advisory data that never blocks anything.
+
+## Evidence (measured from PR #1709 / #1707 CI runs, 2026-08-14)
+
+- `.github/workflows/ci.yml` `patch-coverage` job: `name: patch-coverage (advisory)`; `if:
+!cancelled() && github.base_ref != 'main' && (needs.changes.result != 'success' ||
+needs.changes.outputs.code == 'true')` — advisory, code-gated (correctly skips docs-only), but runs
+  fully on every code PR.
+- Step "Build workspace packages (affected suites import sibling dist)":
+  `if: steps.detect.outputs.affected == 'true'` → `run: pnpm build:deps` — a second full dep build,
+  independent of the `build` job's output (no shared/artifact-restored dist).
+- Timing: patch-coverage = 206s (#1709), 208s (#1707) — comparable to `build` (200s) and `scans`
+  (234s), all running in parallel.
+
+## Direction
+
+Pick one (owner decision), both reduce the develop-PR wall-clock floor:
+
+- **(a) Move it off the per-PR critical path** — run patch-coverage on a schedule (nightly, like
+  INFRA-042's mutation testing) or as a non-blocking post-merge job. Advisory coverage data does not
+  need to be on the PR's wall-clock, and this removes ~206s + a redundant build from every code PR.
+- **(b) Keep it per-PR but stop it rebuilding** — consume the `build` job's dist via
+  `actions/upload-artifact`/`download-artifact` (the `quality` and binary-e2e steps already restore
+  dist this way), so patch-coverage reuses the build instead of running its own `pnpm build:deps`.
+  Cuts the job's time by the build share and removes the duplicate compile.
+
+Coordinate with INFRA-046 ("promote advisory gates") — if that item's direction is to make advisory
+gates blocking, that argues for (b); if it keeps them advisory, (a) is the cheaper win.
+
+## Test Plan
+
+- (a): patch-coverage no longer appears as a check on a code PR (or appears as a non-blocking
+  scheduled run); develop-PR wall-clock floor drops by ~200s; a nightly run produces the coverage
+  report.
+- (b): the patch-coverage job's "Build workspace packages" step is replaced by a dist artifact
+  restore; the job's wall-clock drops by the build share; coverage numbers are unchanged vs the
+  current run on a sample PR.
+- `pnpm harness:scan` (workflow-lint / ci-mirror scans) stays green.
+
+## User Execution Test Scenarios
+
+Not applicable — CI-configuration change with no user-facing product runtime behavior. Verification is
+the CI-timing / check-presence comparison in the Test Plan (before vs after on a sample code PR, and
+the nightly run for option a).


### PR DESCRIPTION
Two CI-time improvement tasks from a timing analysis of recent PRs (#1709/#1711/#1712). Documentation/backlog only.

- **INFRA-093**: the 179-file harness unit-test suite runs in full (~180s) on every develop PR with no path gate — scope it to `scripts/harness/**`/workflow/config changes so product-only PRs skip it.
- **INFRA-094**: the advisory (non-blocking) `patch-coverage` job runs ~206s per code PR and rebuilds all deps itself — move it off the PR critical path or reuse the build job's dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)