### PR TITLE
perf(harness): remove duplicate promotion release gate

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -68,7 +68,9 @@ gate, and neither is any narrower command. Which local gate runs at PUSH time â€
 
 **A PR into `main` is a different gate.** `protect-main` requires `promotion ancestry`, `main PR
 source guard` and `release-grade verification`; the entry point that reproduces the last of those is
-`pnpm harness:verify:release`.
+`pnpm harness:verify:release`. Protected CI is the sole automatic owner of that content-verification
+entry point: `promote.mjs` performs the local structural and ancestry checks but does not run the
+release suite a second time. The root command remains available as an explicit local diagnostic.
 
 **Why:** selective commits leave invisible half-states â€” code pushed while dependent files (SPEC.md, README, tests, backlog) are not.
 

--- a/.agents/rules/verification.md
+++ b/.agents/rules/verification.md
@@ -113,8 +113,10 @@ Parent: [process.md](process.md) | Index: [rules/index.md](index.md)
   Working Tree Before Every Commit and Push. What it runs is owned there; it reports which required
   contexts it could not run. Do not substitute a hand-written list of those commands: a second list
   is what drifts.
-- For release prep — a promotion to `main` — run `pnpm harness:verify:release`, which is what the
-  `release-grade verification` required check executes.
+- For release prep — a promotion to `main` — the protected PR's `release-grade verification`
+  required check runs `pnpm harness:verify:release` as the sole automatic content-verification
+  owner. The same root command remains available as an explicit local diagnostic; `promote.mjs`
+  does not duplicate it before the PR.
 - If any stage fails, fix the issue before proceeding.
 - The harness results must be reported with counts (total tests, failures, build status).
 - This is a blocking gate — no merge to `main` or `release/*` without harness pass.

--- a/.agents/spec-docs/done/INFRA-095-single-promotion-verification-owner.md
+++ b/.agents/spec-docs/done/INFRA-095-single-promotion-verification-owner.md
@@ -1,0 +1,227 @@
+---
+status: done
+type: INFRA
+tags: [typescript]
+---
+
+# INFRA-095: Single owner for promotion release verification
+
+## Problem
+
+`scripts/harness/promote.mjs` currently assembles the `develop → main` promotion branch and then runs
+`pnpm harness:verify:release` locally. After the branch is pushed, the protected main PR's required
+`release-grade verification` job runs the same root command again. Recent promotion evidence measured
+the local copy at roughly seven minutes and the protected CI copy at roughly twelve minutes. The two
+runs verify different commits only by construction detail: the local promotion head and the PR head
+carry the same develop tree, while protected CI is the only result that GitHub's ruleset can consume.
+
+The duplicate does not shorten the required critical path and makes every promotion pay the full
+release sweep twice. It also adds a `--skip-release-gate` bypass solely because scratch tests cannot
+run the workspace gate, creating two modes for an action whose protected result still comes only from CI.
+
+## Prior Art Research
+
+[GitHub's status-check documentation](https://docs.github.com/en/pull-requests/reference/status-checks)
+states that required checks must pass before a protected-branch PR can merge, and GitHub Actions
+produces those checks. Its
+[protected-branch documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+adds that a rule may require a specific GitHub App as the accepted status source. Therefore a local
+process result cannot substitute for the protected GitHub check that decides merge eligibility. This
+directly rules out alternative 2 and supports alternative 3: retain the trusted required check and
+remove only the redundant automatic local copy.
+
+The current repository confirms the same ownership: `.github/workflows/ci.yml` names
+`release-grade verification` as the sole substantive main-only release job,
+`.github/required-status-checks.json` requires it, and `scripts/harness/scan-main-required-checks.mjs`
+reconciles the live ruleset. The local release command remains useful for explicit diagnosis, but
+automatically running it immediately before an unavoidable protected copy is duplicate orchestration.
+
+The larger alternative in INFRA-054 is a trusted workflow that verifies exact `origin/develop` and
+fast-forwards `main`. That would remove the synthetic promotion commit and the duplicate completely,
+but it needs a dedicated write identity, protected environment approval, live ruleset changes, and
+owner decisions about hotfix routing and loss of promotion-PR annotations. Those external decisions
+are not required to remove today's local duplicate safely.
+
+## Architecture Review
+
+### Affected Scope
+
+- `scripts/harness/promote.mjs` — deterministic promotion branch assembler.
+- `scripts/harness/__tests__/promote.test.mjs` — scratch repository behavior.
+- `scripts/harness/__tests__/promotion-preflight-parity.test.mjs` — promotion verification ownership.
+- `.agents/rules/git-branch.md` and `.agents/rules/verification.md` — current operator contract.
+- `scripts/harness/README.md` — discoverable command ownership.
+
+### Alternatives Considered
+
+1. Keep both full runs.
+   - Pro: catches a failure before opening the PR.
+   - Con: duplicates the dominant release sweep and cannot replace protected CI.
+2. Keep only the local run and let the main PR trust a local receipt.
+   - Pro: avoids GitHub runner duplication.
+   - Con: local receipts are not trusted remote attestations and do not satisfy branch protection.
+3. Keep the promotion PR and make its required CI job the single automatic release-verification owner.
+   - Pro: removes the duplicate without weakening the protected boundary or requiring external setup.
+   - Con: a release defect is discovered after the PR opens; operators may still run the diagnostic command explicitly.
+4. Complete INFRA-054's trusted fast-forward workflow now.
+   - Pro: removes both duplicate verification and the synthetic PR merge.
+   - Con: materially expands scope into external credentials, environments, rulesets, and unresolved owner policy.
+
+### Decision
+
+Choose alternative 3. `promote.mjs` owns clean-tree validation, fresh refs, merge-tree conflict
+analysis, exact develop-tree equality, promotion ancestry A1/A2/A3, rollback, and next-command output.
+It does not spawn the release sweep and has no skip flag. The required main-PR job remains the only
+automatic owner of `pnpm harness:verify:release`; the root command remains available for explicit local
+diagnosis. This is a repository developer-workflow change, not a product or package API.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — promotion assembler, main required checks, local diagnostic, and INFRA-054 inspected
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Fallback & Degradation Declaration
+
+None. Missing or failed required CI continues to block the main PR; local ancestry and tree failures
+continue to abort and discard the promotion branch.
+
+## Solution
+
+Remove `spawn`, environment path assembly, `--skip-release-gate`, the automatic child process, and
+local-pass/skip output from `promote.mjs`. Replace them with one explicit statement that the branch is
+structurally ready and the protected PR will run `release-grade verification`; print
+`pnpm harness:verify:release` only as an optional diagnostic, never as an automatic prerequisite.
+
+Rewrite scratch tests so every case uses the same production path, assert no release-gate child is spawned,
+and retain all dirty-tree/conflict/drift/rollback checks. Replace the old “local preflight mirrors
+protect-main” test with a parsed ownership contract: the workflow owns exactly one release entrypoint,
+the assembler does not invoke it, the required-check mapping still names the job, and the diagnostic
+root script remains present. Update current rules without rewriting archived historical evidence.
+
+## Affected Files
+
+- `scripts/harness/promote.mjs`
+- `scripts/harness/__tests__/promote.test.mjs`
+- `scripts/harness/__tests__/promotion-preflight-parity.test.mjs`
+- `.agents/rules/git-branch.md`
+- `.agents/rules/verification.md`
+- `scripts/harness/README.md`
+- `.agents/tasks/INFRA-095-single-promotion-verification-owner.md`
+
+## Completion Criteria
+
+- [x] TC-01: `promote.mjs` has no automatic release-gate spawn and accepts no release-gate bypass flag.
+- [x] TC-02: executable scratch tests preserve clean-tree, ref, conflict, tree-equality, A1/A2/A3,
+      rollback, dry-run, and ready-branch behavior.
+- [x] TC-03: parsed workflow/required-check tests prove `release-grade verification` remains required
+      and owns exactly one `pnpm harness:verify:release`; the root diagnostic remains reachable.
+- [x] TC-04: current rules and harness documentation name protected CI as the sole automatic owner and
+      do not instruct automatic local duplication.
+- [x] TC-05: focused tests, `pnpm harness:scan`, and `pnpm harness:verify-like-ci` exit 0.
+
+## Test Plan
+
+| TC-ID | Test Type              | Tool / Approach                                                                                                                                                                | Notes                                                     |
+| ----- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| TC-01 | Unit/source contract   | `scripts/harness/__tests__/promotion-preflight-parity.test.mjs` — `promotion verification has one automatic owner`                                                             | Reject child spawn and bypass tokens.                     |
+| TC-02 | Integration            | `scripts/harness/__tests__/promote.test.mjs > promote.mjs`                                                                                                                     | Real scratch git repositories, no network.                |
+| TC-03 | Workflow contract      | `scripts/harness/__tests__/promotion-preflight-parity.test.mjs` — `promotion verification has one automatic owner`                                                             | Exact job/entrypoint ownership.                           |
+| TC-04 | Documentation contract | `scripts/harness/__tests__/scan-required-check-local-reachability.test.mjs` — `over the declaration this repository actually ships`; plus `pnpm harness:scan`                  | Current rules only; archived evidence remains historical. |
+| TC-05 | Regression             | Test skipped: this criterion directly executes the aggregate root verification commands; wrapping them in another test would duplicate the gate rather than test new behavior. | Record direct exit results; no product scenario.          |
+
+## Tasks
+
+- [x] `.agents/tasks/completed/INFRA-095-single-promotion-verification-owner.md`
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter, concrete duplicate-run symptom and reproduction, official GitHub status-check research,
+four alternatives with trade-offs, the completed architecture checklist, five TC criteria with five
+Test Plan rows, Tasks placeholder, and empty Evidence Log all satisfy the catalogue.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** review-ready → approved
+User approval: “추천 우선순위 대로 전부 진행해서 완료해줘” authorizes priority 2 from the reasoned
+recommendation. Independent proposal review returned `ENDORSE`: protected CI is the only automatic
+result branch protection consumes, structural promotion preparation remains local, and INFRA-054 is
+correctly excluded pending external configuration and owner policy decisions.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** approved → in-progress
+The linked Task exists with TC-01 through TC-05 and a substantive Test Plan. Implementation may begin
+against the approved single-owner boundary.
+
+### Engineering evidence | 2026-08-14
+
+- TC-01/TC-03: `promotion-preflight-parity.test.mjs`, 5/5 PASS, exit 0. The source contract rejects
+  a release child-process seam and bypass tokens while parsing exactly one protected CI entrypoint.
+- TC-02: `promote.test.mjs`, 12/12 PASS, exit 0. Real scratch repositories cover clean/dirty,
+  dry-run, conflict, tree equality, fresh bare-origin fetch, A1/A2/A3, ready branch, and rollback for
+  a distinct branch, checked-out target, and detached HEAD.
+- TC-04: required-check tests plus `pnpm harness:scan`, 50/50 focused tests and 108 scans PASS,
+  exit 0; current rule and README ownership agree with protected CI.
+- TC-05: final `pnpm harness:verify-like-ci`, 12/12 stages PASS, exit 0, 4m 7.3s. The run included
+  repository-contract 2,232/2,232, hermetic 1,055/1,055, typecheck, and both scan suites.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** in-progress → verifying
+Independent fresh verification passed 30/30 focused tests and 108 harness scans. The task has no
+blocked or unchecked criterion; package build scope is not applicable because no package/app changed,
+while the recorded final `verify-like-ci` covered all 12 workspace stages. Spec-to-code inspection
+confirmed no release child or bypass, exactly one protected-CI release entrypoint, and the retained
+root diagnostic.
+
+### [GATE-COMPLETE: TC-01] — ✅ VERIFIED | 2026-08-14
+
+- Command: `pnpm exec vitest run scripts/harness/__tests__/promotion-preflight-parity.test.mjs`.
+- Result: exit 0; 5/5 tests passed. The `promotion verification has one automatic owner` suite
+  rejects child-process execution seams and the retired bypass tokens in `promote.mjs`.
+
+### [GATE-COMPLETE: TC-02] — ✅ VERIFIED | 2026-08-14
+
+- Command: `pnpm exec vitest run scripts/harness/__tests__/promote.test.mjs`.
+- Result: exit 0; 12/12 tests passed. The `promote.mjs (INFRA-051)` suite exercised dirty/ref,
+  dry-run, conflict, exact tree, real bare-origin fetch, A1/A2/A3, ready branch, and exact rollback
+  from distinct-branch, checked-out-target, and detached states.
+
+### [GATE-COMPLETE: TC-03] — ✅ VERIFIED | 2026-08-14
+
+- Commands: the focused parity suite above plus
+  `pnpm exec vitest run scripts/harness/__tests__/scan-main-required-checks.test.mjs scripts/harness/__tests__/scan-required-check-local-reachability.test.mjs`.
+- Result: exit 0; the combined focused run passed 50/50 tests. Parsed CI retained exactly one
+  `pnpm harness:verify:release` entrypoint and the root diagnostic script remained defined.
+
+### [GATE-COMPLETE: TC-04] — ✅ VERIFIED | 2026-08-14
+
+- Actions: inspected `.agents/rules/git-branch.md`, `.agents/rules/verification.md`, and
+  `scripts/harness/README.md`; ran `pnpm harness:scan`.
+- Result: exit 0; 108 scans passed, 2 skipped. Current documents consistently name protected CI as
+  sole automatic owner, while archived historical evidence remains untouched.
+
+### [GATE-COMPLETE: TC-05] — ✅ VERIFIED | 2026-08-14
+
+- Command: `pnpm harness:verify-like-ci`.
+- Result: exit 0; all 12 stages passed in 4m 7.3s, including repository-contract 2,232/2,232,
+  hermetic 1,055/1,055, typecheck, and both scan suites.
+- Test skipped: this criterion is the direct aggregate execution of the authoritative root gates;
+  wrapping them in another automated test would duplicate the gate rather than test new behavior.
+
+### [GATE-COMPLETE EVIDENCE SUMMARY] — READY | 2026-08-14
+
+- TC-01 through TC-05 are checked and each has exact verification output plus a test reference or
+  explicit skip reason. The active task is completion-ready with no blocker.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** verifying → done
+TC-01 through TC-05 each have labelled command/result/exit evidence and an exact test reference or
+explicit skip reason. The linked task had all five Plan items complete with no blocker; this PASS
+authorizes the atomic terminal status and archive transition.

--- a/.agents/tasks/completed/INFRA-095-single-promotion-verification-owner.md
+++ b/.agents/tasks/completed/INFRA-095-single-promotion-verification-owner.md
@@ -1,0 +1,62 @@
+---
+title: 'INFRA-095: make protected CI the single promotion verification owner'
+status: done
+created: 2026-08-14
+completed: 2026-08-14
+priority: high
+urgency: now
+area: scripts/harness/promote.mjs, .agents/rules
+depends_on: []
+---
+
+# INFRA-095: make protected CI the single promotion verification owner
+
+**Spec:** [active design](../spec-docs/active/INFRA-095-single-promotion-verification-owner.md)
+
+## Plan
+
+- [x] TC-01 — Remove automatic local release-grade execution and its bypass flag from promotion assembly.
+- [x] TC-02 — Preserve clean-tree, fetch, merge-tree, ancestry, tree-equivalence, and branch rollback gates.
+- [x] TC-03 — Keep `pnpm harness:verify:release` as the protected main-PR CI owner and explicit diagnostic command.
+- [x] TC-04 — Update promotion tests, current rules, and mirror ownership so they reject duplicate automatic execution.
+- [x] TC-05 — Run focused and full engineering verification and record measured evidence.
+
+## Progress
+
+### 2026-08-14
+
+- Measured the duplicate path: local `promote.mjs` runs `pnpm harness:verify:release`, then the
+  required main-PR `release-grade verification` job runs the byte-identical command again.
+- Chose the bounded repository-only correction: keep the promotion PR and protected CI, while the
+  local assembler owns only deterministic ancestry/tree preparation. The separate INFRA-054
+  fast-forward end state remains open because it requires external ruleset identity and owner policy decisions.
+- Removed the automatic release child and bypass flag. Added real-origin fetch coverage plus
+  post-merge rollback coverage for a distinct branch, the checked-out target branch, and detached HEAD.
+- Focused promotion/required-check tests pass 50/50 and `pnpm harness:scan` passes 108 scans.
+- Final `pnpm harness:verify-like-ci` passed all 12 stages in 4m 7.3s after Prettier auto-fix;
+  repository-contract 2,232/2,232 and hermetic 1,055/1,055 tests passed.
+
+## Blockers
+
+None.
+
+## Test Plan
+
+- RED: current promotion tests and parity test require a local release-gate child and bypass flag.
+- GREEN: scratch repositories prove the assembler still fails closed for dirty, drifted, conflicting,
+  and invalid refs while a ready branch no longer spawns the release command.
+- Regression: parsed workflow tests prove the protected main job still owns exactly one
+  `pnpm harness:verify:release` invocation and the local diagnostic entry remains reachable.
+- Final: `pnpm harness:scan`, focused Vitest, and `pnpm harness:verify-like-ci` exit 0.
+
+## User Execution Test Scenarios
+
+Not applicable — this changes repository-internal release preparation and protected CI ownership,
+not a shipped CLI, TUI, browser, application, or public SDK behavior. Promotion commands and CI
+results are engineering/governance verification and are recorded in the Test Plan.
+
+## Result
+
+Protected main-PR CI is now the sole automatic release-verification owner. Promotion assembly keeps
+all structural and ancestry gates, including exact rollback of pre-existing and detached states;
+the full local release command remains available as an explicit diagnostic.

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -90,7 +90,15 @@ These scripts are the executable layer of the Robota harness.
 - defaults to fast mode, which verifies directly changed scopes and executable repository checks
 - uses `--skip-dependent-scopes` in fast mode so local push latency does not explode on shared package entrypoint changes
 - supports `HARNESS_PRE_PUSH_MODE=full` when dependent scope typechecks should run locally before publishing
-- leaves release-grade verification as an explicit `pnpm harness:verify:release` command
+- leaves `pnpm harness:verify:release` available as an explicit diagnostic; for promotions,
+  protected main-PR CI is the sole automatic release-grade verification owner
+
+### `promote.mjs`
+
+- validates the clean tree, fresh refs, merge tree, exact develop tree, and A1/A2/A3 ancestry
+- assembles or rolls back the promotion branch without running the full release suite locally
+- names protected main-PR CI as the sole automatic owner of `pnpm harness:verify:release`
+- prints the root release command only as an optional local diagnostic
 
 ### `verify-change.mjs`
 

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -52,45 +52,28 @@ async function newRepo() {
   return { root, git };
 }
 
-/** Same as `run`, but WITHOUT `--skip-release-gate`, so the preflight actually executes. */
-async function runWithGate(root, extraArgv = [], spawn, env) {
-  let output = '';
-  const code = await main({
-    argv: [...extraArgv, '--main-ref', 'main', '--develop-ref', 'develop', '--baseline', 'develop'],
-    cwd: root,
-    fetch: false,
-    spawn,
-    env,
-    out: (text) => {
-      output += text;
-    },
-  });
-  return { code, output };
-}
-
 async function run(root, extraArgv = []) {
   let output = '';
   // extraArgv first: `flag()` reads the FIRST occurrence, so a test override must precede the defaults.
   const code = await main({
-    // `--skip-release-gate`: these cases drive promote against a scratch repository to exercise the
-    // ANCESTRY mechanics. The release gate is a full workspace verification that has nothing to
-    // verify there, and running it made one case take 91s and then fail on the empty scratch tree.
-    // The gate's own wiring is pinned separately, by promotion-preflight-parity.
-    argv: [
-      ...extraArgv,
-      '--skip-release-gate',
-      '--main-ref',
-      'main',
-      '--develop-ref',
-      'develop',
-      '--baseline',
-      'develop',
-    ],
+    argv: [...extraArgv, '--main-ref', 'main', '--develop-ref', 'develop', '--baseline', 'develop'],
     cwd: root,
     out: (text) => {
       output += text;
     },
     fetch: false,
+  });
+  return { code, output };
+}
+
+async function runWithOptions(root, options) {
+  let output = '';
+  const code = await main({
+    cwd: root,
+    out: (text) => {
+      output += text;
+    },
+    ...options,
   });
   return { code, output };
 }
@@ -161,6 +144,124 @@ describe('promote.mjs (INFRA-051)', () => {
     );
   });
 
+  it('fetches fresh origin refs before constructing a promotion', async () => {
+    const { root, git } = await newRepo();
+    commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+    const remote = await mkdtemp(path.join(tmpdir(), 'robota-promote-origin-'));
+    roots.push(remote);
+    makeGit(remote)(['init', '--bare', '--quiet']);
+    git(['remote', 'add', 'origin', remote]);
+    git(['push', '--quiet', 'origin', 'main', 'develop']);
+    git(['update-ref', '-d', 'refs/remotes/origin/main']);
+    git(['update-ref', '-d', 'refs/remotes/origin/develop']);
+
+    const { code, output } = await runWithOptions(root, {
+      argv: ['--dry-run', '--baseline', 'origin/develop'],
+    });
+
+    expect(code).toBe(0);
+    expect(output).toMatch(/fetching origin/);
+    expect(git(['rev-parse', '--verify', 'origin/main']).code).toBe(0);
+    expect(git(['rev-parse', '--verify', 'origin/develop']).code).toBe(0);
+  });
+
+  it('restores an existing promotion branch when a post-merge ancestry check fails', async () => {
+    const { root, git } = await newRepo();
+    commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+    git(['branch', 'release/promote', 'main']);
+    const previousPromotionHead = git(['rev-parse', 'release/promote']).stdout;
+
+    const { code, output } = await runWithOptions(root, {
+      argv: [
+        '--branch',
+        'release/promote',
+        '--main-ref',
+        'main',
+        '--develop-ref',
+        'develop',
+        '--baseline',
+        'develop',
+      ],
+      fetch: false,
+      runGitImpl: (args, cwd) => {
+        if (args[0] === 'rev-list' && args.includes('--format=%h %s')) {
+          return { code: 2, stdout: '', stderr: 'injected ancestry failure' };
+        }
+        return makeGit(cwd)(args);
+      },
+    });
+
+    expect(code).toBe(1);
+    expect(output).toMatch(/does NOT satisfy the promotion-ancestry gate/);
+    expect(git(['branch', '--show-current']).stdout).toBe('develop');
+    expect(git(['rev-parse', 'release/promote']).stdout).toBe(previousPromotionHead);
+    expect(git(['status', '--porcelain']).stdout).toBe('');
+  });
+
+  it('resets a checked-out existing promotion branch after a post-merge failure', async () => {
+    const { root, git } = await newRepo();
+    commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+    git(['checkout', '-b', 'release/promote', 'main']);
+    const previousPromotionHead = git(['rev-parse', 'HEAD']).stdout;
+
+    const { code } = await runWithOptions(root, {
+      argv: [
+        '--branch',
+        'release/promote',
+        '--main-ref',
+        'main',
+        '--develop-ref',
+        'develop',
+        '--baseline',
+        'develop',
+      ],
+      fetch: false,
+      runGitImpl: (args, cwd) => {
+        if (args[0] === 'rev-list' && args.includes('--format=%h %s')) {
+          return { code: 2, stdout: '', stderr: 'injected ancestry failure' };
+        }
+        return makeGit(cwd)(args);
+      },
+    });
+
+    expect(code).toBe(1);
+    expect(git(['branch', '--show-current']).stdout).toBe('release/promote');
+    expect(git(['rev-parse', 'HEAD']).stdout).toBe(previousPromotionHead);
+    expect(git(['status', '--porcelain']).stdout).toBe('');
+  });
+
+  it('returns to a detached head and removes a new promotion branch after failure', async () => {
+    const { root, git } = await newRepo();
+    const detachedHead = commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+    git(['checkout', '--detach', detachedHead]);
+
+    const { code } = await runWithOptions(root, {
+      argv: [
+        '--branch',
+        'release/promote',
+        '--main-ref',
+        'main',
+        '--develop-ref',
+        'develop',
+        '--baseline',
+        'develop',
+      ],
+      fetch: false,
+      runGitImpl: (args, cwd) => {
+        if (args[0] === 'rev-list' && args.includes('--format=%h %s')) {
+          return { code: 2, stdout: '', stderr: 'injected ancestry failure' };
+        }
+        return makeGit(cwd)(args);
+      },
+    });
+
+    expect(code).toBe(1);
+    expect(git(['branch', '--show-current']).stdout).toBe('');
+    expect(git(['rev-parse', 'HEAD']).stdout).toBe(detachedHead);
+    expect(git(['rev-parse', '--verify', '--quiet', 'release/promote']).code).toBe(1);
+    expect(git(['status', '--porcelain']).stdout).toBe('');
+  });
+
   it('stops before touching the tree when main carries conflicting content', async () => {
     const { root, git } = await newRepo();
     git(['checkout', '--quiet', 'main']);
@@ -188,58 +289,15 @@ describe('promote.mjs (INFRA-051)', () => {
     expect(output).toMatch(/resolving refs\/heads\/does-not-exist failed/);
   });
 
-  // The release gate itself, driven WITHOUT the skip flag. Every other case opts out, so until this
-  // existed the new preflight had no execution-based coverage at all — the reviewer's point, and a
-  // fair one: `promotion-preflight-parity` pins that promote INVOKES the right command, not that a
-  // failing invocation actually stops the promotion.
-  //
-  // The scratch repository has no `harness:verify:release` script, so the gate fails immediately.
-  // That is the condition under test: a failing gate must abandon the branch rather than declare it
-  // ready.
-  it('abandons the promotion when the release gate fails', async () => {
-    const { root, git } = await newRepo();
-    git(['checkout', 'develop']);
-    commit(root, git, 'feature.md', 'work\n', 'feat: something');
-
-    const { code, output } = await runWithGate(root);
-
-    expect(code).not.toBe(0);
-    expect(output).toMatch(/release gate/i);
-    expect(output).not.toMatch(/is ready/);
-
-    // The branch must not survive a failed gate — a half-built promotion left behind is worse than
-    // none, because the next run would push it.
-    const branches = git(['branch', '--list', 'release/promote-develop-to-main']).stdout.trim();
-    expect(branches).toBe('');
-  });
-
-  it('runs the release gate against the configured develop novelty baseline', async () => {
+  it('declares protected CI as the next release-verification owner', async () => {
     const { root, git } = await newRepo();
     commit(root, git, 'feature.md', 'work\n', 'feat: something');
-    let invocation;
 
-    const childEnv = {
-      ...process.env,
-      PNPM_HOME: undefined,
-      VOLTA_HOME: '/opt/volta',
-      PATH: '/usr/bin',
-    };
-    const { code, output } = await runWithGate(
-      root,
-      [],
-      (command, args, options) => {
-        invocation = { command, args, options };
-        return { status: 0 };
-      },
-      childEnv,
-    );
+    const { code, output } = await run(root);
 
     expect(code).toBe(0);
-    expect(output).toMatch(/release gate PASSED locally/);
-    expect(invocation.command).toBe('pnpm');
-    expect(invocation.args).toEqual(['harness:verify:release']);
-    expect(invocation.options.env.PATH).toBe(`/opt/volta/bin${path.delimiter}/usr/bin`);
-    expect(invocation.options.env.HARNESS_BASE_REF).toBe('develop');
-    expect(invocation.options.env.GITHUB_BASE_REF).toBe(process.env.GITHUB_BASE_REF);
+    expect(output).toMatch(/release-grade verification.*protected CI/is);
+    expect(output).toMatch(/optional diagnostic.*pnpm harness:verify:release/is);
+    expect(output).not.toMatch(/PASSED locally|SKIPPED/);
   });
 });

--- a/scripts/harness/__tests__/promotion-preflight-parity.test.mjs
+++ b/scripts/harness/__tests__/promotion-preflight-parity.test.mjs
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 const CI_WORKFLOW = path.join(WORKSPACE_ROOT, '.github/workflows/ci.yml');
 const PROMOTE_SCRIPT = path.join(WORKSPACE_ROOT, 'scripts/harness/promote.mjs');
+const ROOT_PACKAGE = path.join(WORKSPACE_ROOT, 'package.json');
 
 /**
  * The job name `protect-main` requires. Not a guess — `scan-main-required-checks` pins the ruleset's
@@ -42,23 +43,12 @@ export function harnessEntryPointsOfJob(workflowText, jobDisplayName) {
 }
 
 /**
- * INFRA-056 pinned `verify-like-ci`'s stages against `protect-develop`'s required jobs, and stopped
- * there. `protect-main`'s substantive required context — `release-grade verification` — runs on NO
- * other branch, so nothing local told you what it would say until the promotion PR was already open.
- *
- * Measured 2026-07-27: two consecutive promotions failed on that job, each costing an
- * open-PR → CI → diagnose → fix → re-promote round trip. `pnpm harness:verify:release` is what the
- * job runs, existed the whole time, and was simply never wired to the act of promoting.
- *
- * That is the same defect shape INFRA-056 fixed one level over: an entry point NAMED as a gate's
- * equivalent while nothing connected it to the gate. `verify-like-ci.mjs`'s own header names this
- * command — writing it down was not enough, which is the general lesson here.
- *
- * So the pin is on the CONNECTION, not on a literal: whatever entry point `protect-main`'s required
- * job runs, `promote.mjs` must run the same one before declaring a promotion branch ready. Change
- * the job and this fails until the preflight follows.
+ * Protected CI is the only automatic release-verification result consumed by `protect-main`.
+ * Promotion assembly keeps its deterministic tree and ancestry checks local, while the root release
+ * command remains reachable for explicit diagnosis. These tests pin that ownership boundary so the
+ * full release sweep cannot silently become an automatic local prerequisite again.
  */
-describe('promotion preflight mirrors protect-main', () => {
+describe('promotion verification has one automatic owner', () => {
   const workflowText = readFileSync(CI_WORKFLOW, 'utf8');
   const promoteSource = readFileSync(PROMOTE_SCRIPT, 'utf8');
 
@@ -73,26 +63,18 @@ describe('promotion preflight mirrors protect-main', () => {
     expect(harnessEntryPointsOfJob(workflowText, MAIN_ONLY_JOB)).toHaveLength(1);
   });
 
-  it('runs, before promoting, the same entry point that job runs', () => {
-    const [entryPoint] = harnessEntryPointsOfJob(workflowText, MAIN_ONLY_JOB) ?? [];
-    const [command, script] = entryPoint.split(/\s+/);
-    const invoked = new RegExp(`['"\`]${command}['"\`][\\s\\S]{0,80}?['"\`]${script}['"\`]`).test(
-      promoteSource,
-    );
-
+  it('leaves the required release entry point to protected CI instead of spawning a local duplicate', () => {
+    expect(promoteSource).not.toMatch(/from\s+['"]node:child_process['"]/);
+    expect(promoteSource).not.toMatch(/\b(?:spawn|spawnSync|exec|execFile)\s*[:=(]/);
+    expect(promoteSource).not.toMatch(/\b(?:spawn|env)\s*=/);
     expect(
-      invoked,
-      `promote.mjs must run \`${entryPoint}\` — what \`${MAIN_ONLY_JOB}\` runs — before it declares a ` +
-        "promotion branch ready. Otherwise the first time anyone learns that gate's verdict is on an " +
-        'open promotion PR.',
-    ).toBe(true);
+      JSON.parse(readFileSync(ROOT_PACKAGE, 'utf8')).scripts['harness:verify:release'],
+    ).toBeTruthy();
   });
 
-  it('treats a failing preflight as blocking, not advisory', () => {
-    // A preflight that runs and ignores its exit code is decoration. The script must branch on the
-    // status and abandon the branch rather than print a warning beside a "ready" line.
-    expect(promoteSource).toMatch(/status\s*!==\s*0/);
-    expect(promoteSource).toMatch(/PromoteError/);
+  it('has no local release-gate bypass mode', () => {
+    expect(promoteSource).not.toContain('--skip-release-gate');
+    expect(promoteSource).not.toContain('release gate PASSED locally');
   });
 
   it('compares promotion-local novelty against develop in the main-only release job', () => {

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -30,7 +30,6 @@
  * requires explicit user approval (`.agents/rules/git-branch.md`). It prints the exact next commands.
  */
 
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 import { ADOPTION_BASELINE, evaluatePromotion, runGit } from './scan-promotion-ancestry.mjs';
@@ -59,13 +58,11 @@ export async function main({
   cwd = WORKSPACE_ROOT,
   out = (text) => process.stdout.write(text),
   fetch: shouldFetch = true,
-  spawn = spawnSync,
-  env = process.env,
+  runGitImpl = runGit,
 } = {}) {
-  const git = (args) => runGit(args, cwd);
+  const git = (args) => runGitImpl(args, cwd);
   const branch = flag(argv, '--branch', DEFAULT_BRANCH);
   const dryRun = argv.includes('--dry-run');
-  const skipReleaseGate = argv.includes('--skip-release-gate');
   const mainRef = flag(argv, '--main-ref', 'origin/main');
   const developRef = flag(argv, '--develop-ref', 'origin/develop');
   const baseline = flag(argv, '--baseline', ADOPTION_BASELINE);
@@ -79,10 +76,22 @@ export async function main({
   };
 
   /** Undo a partially-applied merge and put the caller back where they started. */
-  const restore = (previousBranch, branchExisted) => {
+  const restore = (previousBranch, previousHead, branchExisted, previousBranchHead) => {
     git(['merge', '--abort']);
-    if (previousBranch) git(['checkout', '--quiet', previousBranch]);
-    if (!branchExisted) git(['branch', '-D', branch]);
+    if (previousBranch === branch && previousBranchHead) {
+      git(['reset', '--hard', previousBranchHead]);
+      return;
+    }
+    if (previousBranch) {
+      git(['checkout', '--quiet', previousBranch]);
+    } else if (previousHead) {
+      git(['checkout', '--quiet', '--detach', previousHead]);
+    }
+    if (branchExisted && previousBranchHead) {
+      git(['branch', '-f', branch, previousBranchHead]);
+    } else if (!branchExisted) {
+      git(['branch', '-D', branch]);
+    }
   };
 
   try {
@@ -148,8 +157,12 @@ export async function main({
     }
 
     const previousBranch = git(['branch', '--show-current']).stdout;
+    const previousHead = git(['rev-parse', 'HEAD']).stdout;
     const branchExisted =
       git(['rev-parse', '--verify', '--quiet', `${branch}^{commit}`]).code === 0;
+    const previousBranchHead = branchExisted
+      ? git(['rev-parse', `${branch}^{commit}`]).stdout
+      : undefined;
 
     out(`promote: creating ${branch} from ${developRef}…\n`);
     must(['checkout', '-B', branch, developRef], `creating ${branch}`);
@@ -162,7 +175,7 @@ export async function main({
       "chore(release): record main's ancestry into the promotion",
     ]);
     if (merge.code !== 0) {
-      restore(previousBranch, branchExisted);
+      restore(previousBranch, previousHead, branchExisted, previousBranchHead);
       throw new PromoteError(
         `git merge failed after the pre-flight said it would be clean:\n${merge.stderr || merge.stdout}\n` +
           'The merge was aborted and the branch state restored; re-run after fetching.',
@@ -179,65 +192,17 @@ export async function main({
     });
     if (findings.length > 0) {
       const detail = findings.map((finding) => `  - [${finding.id}] ${finding.detail}`).join('\n');
-      restore(previousBranch, branchExisted);
+      restore(previousBranch, previousHead, branchExisted, previousBranchHead);
       throw new PromoteError(
         `the promotion branch does NOT satisfy the promotion-ancestry gate:\n${detail}\n` +
           'The branch was discarded rather than left behind half-built.',
       );
     }
 
-    // The main-only gate, run HERE rather than discovered on the promotion PR.
-    //
-    // `release-grade verification` is required on `protect-main` and runs nowhere else, so a defect
-    // it catches is invisible until the promotion PR is already open. Measured 2026-07-27: two
-    // consecutive promotions failed on it — a timing-flaky test, then a fixture outside a newly
-    // contained root — each costing an open-PR/CI/diagnose/fix/re-promote round trip. The command
-    // below is byte-identical to what that job runs and was available both times.
-    //
-    // Default-on, because the cost of running it is bounded and the cost of skipping it was
-    // measured. `--skip-release-gate` exists for a deliberate bypass and says so in the output, so
-    // a skip is a visible choice rather than an omission.
-    if (!skipReleaseGate) {
-      out('\npromote: running the main-only release gate (pnpm harness:verify:release)…\n');
-      // `cwd` — this function takes the repository as a parameter and passes it to every git call;
-      // the gate must run in the SAME repository or it verifies the wrong tree while reporting on
-      // this one. Omitted at first, which would have made a scratch-root invocation silently verify
-      // the developer's own checkout.
-      // Package-manager homes can be added by an interactive shell without being exported in the
-      // PATH Node passes to children. Add their canonical bin directories explicitly: the first
-      // pnpm process and every nested `pnpm` in the release script then resolve the same pinned
-      // executable instead of failing at a different nesting level.
-      const packageManagerPaths = [
-        env.PNPM_HOME,
-        env.VOLTA_HOME ? path.join(env.VOLTA_HOME, 'bin') : undefined,
-      ].filter(Boolean);
-      const childPath = [...packageManagerPaths, env.PATH].filter(Boolean).join(path.delimiter);
-      const gate = spawn('pnpm', ['harness:verify:release'], {
-        cwd,
-        stdio: 'inherit',
-        shell: false,
-        // The promotion tree is develop's tree. The PR target (`GITHUB_BASE_REF=main`) remains the
-        // promotion-context signal, while this explicit override scopes novelty diffs to content the
-        // promotion step itself introduced. The CI release job declares the same environment.
-        env: { ...env, PATH: childPath, HARNESS_BASE_REF: developRef },
-      });
-      if (gate.status !== 0) {
-        restore(previousBranch, branchExisted);
-        const launchFailure = gate.error
-          ? `\nThe release-gate process could not start (${gate.error.code ?? 'spawn error'}): ${gate.error.message}`
-          : '';
-        throw new PromoteError(
-          'the release gate FAILED, so the promotion branch was discarded rather than pushed.\n' +
-            'This is the same check `release-grade verification` runs on the promotion PR — fixing it\n' +
-            'here costs one local run instead of an open-PR round trip. Re-run promote when green.' +
-            launchFailure,
-        );
-      }
-    }
-
     out(
       `\npromote: ${branch} is ready — A1/A2/A3 hold (non-merge debt on main: ${currentDebt}).` +
-        `${skipReleaseGate ? '\npromote: RELEASE GATE SKIPPED (--skip-release-gate) — `release-grade verification` is unverified.' : '\npromote: release gate PASSED locally.'}\n` +
+        '\npromote: `release-grade verification` runs once in protected CI on the promotion PR.\n' +
+        'promote: optional diagnostic before push: `pnpm harness:verify:release`.\n' +
         `\nNext (promoting to \`main\` is a release-level action needing explicit user approval):\n` +
         `  git push -u origin ${branch}\n` +
         `  gh pr create --base main --head ${branch} --title "chore(release): promote develop to main"\n` +


### PR DESCRIPTION
## Accepted recommendation

Keep the promotion PR and all local structural/ancestry gates, but make the protected main-PR `release-grade verification` job the sole automatic owner of `pnpm harness:verify:release`. Keep the root command as an explicit diagnostic.

**REVIEW VERDICT: ENDORSE — 2026-08-14.** Protected CI is the only result branch protection consumes; INFRA-054 fast-forward promotion remains separate because it requires external credentials, environment/ruleset changes, and owner policy decisions.

## Implementation

- removed the automatic local release child and `--skip-release-gate` mode
- retained clean/ref/merge-tree/tree/A1-A3 preparation and strengthened exact rollback for existing, checked-out, and detached states
- updated current rules and harness documentation to name the single automatic owner
- completed and archived INFRA-095 task/spec through GATE-COMPLETE PASS

## Verification

- focused promotion and required-check suites: 50/50 PASS
- `pnpm harness:scan`: 108 passed, 2 skipped
- `pnpm harness:verify-like-ci`: 12/12 stages PASS, 4m 7.3s; contract 2,232/2,232 and hermetic 1,055/1,055
- pre-push: contract 2,232/2,232, hermetic 1,055/1,055, scans and CLI smoke PASS
- independent local review: ACTIONABLE FINDINGS 0

## User execution scenario

Not applicable: this changes repository-internal release preparation and protected-CI ownership, not a shipped CLI/TUI/browser/public SDK behavior.

## Residual risks

A release defect is now discovered on the protected promotion PR unless an operator explicitly runs the diagnostic command. The required CI remains fail-closed. INFRA-054 remains open for a future trusted fast-forward workflow.