### PR TITLE
fix(transport): mint unique test turn identities

### DIFF
--- a/.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
+++ b/.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
@@ -35,7 +35,10 @@ scenario_root="$(mktemp -d "${TMPDIR:-/tmp}/robota-arch019.XXXXXX")"
 
 cleanup() {
   case "$(basename -- "$scenario_root")" in
-    robota-arch019.*) rm -rf -- "$scenario_root" ;;
+    robota-arch019.*)
+      node -e "require('node:fs').rmSync(process.argv[1], { recursive: true, force: true })" \
+        "$scenario_root"
+      ;;
     *) printf 'refusing unexpected cleanup path: %s\n' "$scenario_root" >&2; return 1 ;;
   esac
 }
@@ -72,19 +75,28 @@ test "${#observed[@]}" -eq 3
 test "${observed[0]}" = 'test-session-1-turn-1'
 test "${observed[1]}" = 'test-session-1-turn-2'
 test "${observed[2]}" = 'DISTINCT'
+
+completed_root="$scenario_root"
+cleanup
+trap - EXIT
+test ! -e "$completed_root"
+printf 'CLEANUP_OK\n'
 ```
 
 ## Expected observable result
 
 - The complete Bash block exits with status `0` within the stated 120-second build and 15-second
   execution bounds.
-- The one fresh Node.js process prints exactly:
+- In addition to package-build setup output, the one fresh consumer Node.js process prints exactly:
 
   ```text
   test-session-1-turn-1
   test-session-1-turn-2
   DISTINCT
   ```
+
+- After the consumer output, Bash proves the temporary directory is absent and prints exactly one
+  cleanup marker: `CLEANUP_OK`.
 
 - Inside that process, each printed id is derived from the session's own public `getSessionId()`
   value, both `completed` promises settle, and the two ids differ.
@@ -93,9 +105,10 @@ test "${observed[2]}" = 'DISTINCT'
 
 ## Cleanup
 
-The `EXIT` trap removes only the validated `robota-arch019.*` temporary consumer directory,
-including its package symlink, script, and result log. No tracked repository file is created or
-modified.
+The explicit cleanup and fallback `EXIT` trap remove only the validated `robota-arch019.*` temporary
+consumer directory through Node's filesystem API, including its package symlink, script, and result
+log. The command then proves the path no longer exists and prints `CLEANUP_OK`. No tracked repository
+file is created or modified.
 
 ## Observed evidence
 

--- a/.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
+++ b/.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
@@ -112,4 +112,18 @@ file is created or modified.
 
 ## Observed evidence
 
-EMPTY
+Executed from the repository root with `/bin/bash` on 2026-08-14 against commit `e519f7e3c` plus the
+current evidence-only working-tree update. The package build completed successfully; the public
+bare-specifier consumer exited `0` and printed exactly:
+
+```text
+test-session-1-turn-1
+test-session-1-turn-2
+DISTINCT
+```
+
+Both handle completion promises settled before consumer output. After explicit cleanup, Bash proved
+the temporary path absent and printed the separate marker `CLEANUP_OK`; no `robota-arch019.*`
+directory remained. An earlier diagnostic invocation under the tool's default zsh reached the three
+correct product lines but stopped at Bash-only `mapfile`; it is not completion evidence. The recorded
+successful run explicitly selected `/bin/bash`, matching this scenario's prerequisite.

--- a/.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
+++ b/.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
@@ -1,0 +1,102 @@
+# ARCH-019 — published test session mints one identity per submission (agent-run)
+
+This scenario exercises the shipped `@robota-sdk/agent-interface-transport/testing` export from a
+disposable external-style consumer. One fresh Node.js process creates one sanctioned test session,
+derives its runtime session id, submits twice, and proves the two default handles are exactly
+`<session-id>-turn-1` and `<session-id>-turn-2`.
+
+## Executability
+
+`agent-executable` — the flow is non-interactive Bash over the built public testing subpath. It uses
+no provider, credential, network service, test runner, private source import, or repository-internal
+factory path.
+
+## Prerequisites
+
+- Run from the repository root with workspace dependencies installed.
+- Bash, Node.js 22+, pnpm, GNU coreutils `timeout`, `mktemp`, and permission to create a local symbolic
+  link must be available.
+- `packages/agent-interface-transport` must be buildable; the exact command below builds it before
+  executing the consumer.
+- The system temporary directory (`${TMPDIR:-/tmp}`) must be writable.
+- No model-provider key or network access is required.
+
+The existing `scratch/` workspace is intentionally not used: it does not directly declare the
+interface-transport package, and its source-condition runner would not prove the built public export.
+The command creates and removes its own isolated consumer.
+
+## Exact command
+
+```bash
+set -euo pipefail
+
+repo_root="$(pwd -P)"
+scenario_root="$(mktemp -d "${TMPDIR:-/tmp}/robota-arch019.XXXXXX")"
+
+cleanup() {
+  case "$(basename -- "$scenario_root")" in
+    robota-arch019.*) rm -rf -- "$scenario_root" ;;
+    *) printf 'refusing unexpected cleanup path: %s\n' "$scenario_root" >&2; return 1 ;;
+  esac
+}
+trap cleanup EXIT
+
+timeout 120s pnpm --filter @robota-sdk/agent-interface-transport build
+
+mkdir -p "$scenario_root/node_modules/@robota-sdk"
+ln -s "$repo_root/packages/agent-interface-transport" \
+  "$scenario_root/node_modules/@robota-sdk/agent-interface-transport"
+
+tee "$scenario_root/scenario.mjs" >/dev/null <<'JAVASCRIPT'
+import assert from 'node:assert/strict';
+
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+
+const session = createTestInteractiveSession();
+const sessionId = session.getSession().getSessionId();
+const first = await session.submit('first');
+const second = await session.submit('second');
+
+assert.equal(first.turnId, `${sessionId}-turn-1`);
+assert.equal(second.turnId, `${sessionId}-turn-2`);
+assert.notEqual(first.turnId, second.turnId);
+await Promise.all([first.completed, second.completed]);
+
+process.stdout.write(`${first.turnId}\n${second.turnId}\nDISTINCT\n`);
+JAVASCRIPT
+
+timeout 15s node "$scenario_root/scenario.mjs" | tee "$scenario_root/result.log"
+
+mapfile -t observed < "$scenario_root/result.log"
+test "${#observed[@]}" -eq 3
+test "${observed[0]}" = 'test-session-1-turn-1'
+test "${observed[1]}" = 'test-session-1-turn-2'
+test "${observed[2]}" = 'DISTINCT'
+```
+
+## Expected observable result
+
+- The complete Bash block exits with status `0` within the stated 120-second build and 15-second
+  execution bounds.
+- The one fresh Node.js process prints exactly:
+
+  ```text
+  test-session-1-turn-1
+  test-session-1-turn-2
+  DISTINCT
+  ```
+
+- Inside that process, each printed id is derived from the session's own public `getSessionId()`
+  value, both `completed` promises settle, and the two ids differ.
+- Any reused id, wrong prefix or sequence, unsettled completion, extra output, import failure, build
+  failure, or timeout makes the command exit non-zero.
+
+## Cleanup
+
+The `EXIT` trap removes only the validated `robota-arch019.*` temporary consumer directory,
+including its package symlink, script, and result log. No tracked repository file is created or
+modified.
+
+## Observed evidence
+
+EMPTY

--- a/.agents/spec-docs/active/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
+++ b/.agents/spec-docs/active/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
@@ -188,7 +188,7 @@ Execute the twelve existing records without redefining their scope:
 - [ ] ARCH-011 — in-progress — `.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md`
 - [ ] ARCH-012 — in-progress — `.agents/tasks/ARCH-012-interactive-session-god-contract.md`
 - [ ] ARCH-013 — in-progress — `.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md`
-- [ ] ARCH-019 — todo — `.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md`
+- [x] ARCH-019 — done — `.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md`
 - [ ] ARCH-029 — todo — `.agents/tasks/ARCH-029-command-host-capability-contracts.md`
 - [x] DAG-001 — done — `.agents/tasks/completed/DAG-001-running-is-a-terminal-trap.md`
 - [ ] DAG-004 — todo — `.agents/tasks/DAG-004-eight-cli-commands-open-code-the-import-adapter.md`

--- a/.agents/spec-docs/active/ARCH-019-interactive-session-getSession-contract-understated.md
+++ b/.agents/spec-docs/active/ARCH-019-interactive-session-getSession-contract-understated.md
@@ -1,0 +1,221 @@
+---
+status: in-progress
+type: DATA
+tags: [typescript, async]
+capability: true
+user_execution: agent-run
+user_execution_scenario: .agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md
+---
+
+# ARCH-019: make the sanctioned session double honest about turn identity
+
+## Problem
+
+`createTestInteractiveSession().submit()` returns the fixed turn id `test-turn` for every call. Two
+submissions through the published contract double are therefore indistinguishable even though the
+public turn-handle contract identifies each submission separately. The defect reproduces by creating
+one test session, calling `submit` twice, and comparing the two returned `turnId` values: they are equal.
+
+The Task also questioned whether `IInteractiveSession.getSession()` understates a required event-service
+surface. Current source disproves that broader claim: transport-typed consumers use only
+`getSessionId()`, while framework prompt execution receives a concrete framework `Session` through its
+own `IPromptTurnContext`. The double's nested `getEventService` member is defensive extra shape, not a
+demonstrated transport-contract requirement. This work keeps the public nested-session contract narrow
+and removes the unowned extra stub.
+
+There is also a concrete owner-document contradiction: the interface-transport SPEC says
+`agent-framework` re-exports `createTestInteractiveSession`, while framework source and its SPEC say
+the opposite. The `agent-interface-transport/testing` subpath is the sole public owner; both SPECs
+must state that fact.
+
+## Prior Art Research
+
+Vitest's official mock API documents that successive calls may deliberately produce different values
+through `mockImplementationOnce`/`mockReturnValueOnce`, while TypeScript checks those values against the
+original function's return type: [Vitest Mocks](https://vitest.dev/api/mock). The relevant principle is
+not to use Vitest mocks inside the published factory; it is that a test double for an identity-producing
+operation must be able to represent successive distinct identities while remaining type-conformant.
+
+Robota already applies the same rule to this factory's session identity: every factory instance gets a
+deterministic counter-suffixed session id so multi-session tests do not collapse into one identity. The
+turn identity needs the per-call equivalent. A deterministic per-double counter is preferable to random
+data because failures remain reproducible while separate submissions remain representable.
+
+## Architecture Review
+
+### Affected Scope
+
+- `packages/agent-interface-transport/src/testing/index.ts`: published testing-subpath factory.
+- `packages/agent-interface-transport/src/__tests__`: per-call identity and nested-session shape tests.
+- `packages/agent-interface-transport/docs/SPEC.md`: test-double fidelity and nested-session boundary.
+- `packages/agent-framework/docs/SPEC.md`: remove the stale framework-export claim.
+- `.changeset/`: additive/fix release note for the published testing subpath.
+- `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`: public SDK evidence.
+
+### Alternatives Considered
+
+1. Retain one fixed `test-turn` id.
+   - Pro: fully deterministic and zero implementation change.
+   - Con: cannot model two submissions, contradicting the public turn-handle identity semantics.
+2. Generate a random UUID per call.
+   - Pro: identities are practically unique across every double and process.
+   - Con: nondeterministic failure output is unnecessary for an in-process test fixture.
+3. Generate a deterministic id from the double's session id and a per-call counter, and keep
+   `getSession()` at its proven narrow transport surface.
+   - Pro: distinct, reproducible, coherent identities with no production/runtime dependency; avoids
+     widening a public contract for a framework-only concrete-session need.
+   - Con: the factory becomes stateful across submissions and exact literal expectations must migrate.
+
+### Decision
+
+Choose alternative 3. Each factory instance owns a submission counter. Its default `submit` returns a
+turn id derived from that instance's resolved session id plus the next counter value; custom `submit`
+overrides retain full control. Keep `IInteractiveSession.getSession()` as
+`{ getSessionId(): string }`, because all consumers typed against that contract require only identity.
+Remove `getEventService` from the default nested object and add a type-level exactness assertion so the
+published double does not silently grow a framework-only surface again.
+
+Compatibility classification: this is a **PATCH** changeset for
+`@robota-sdk/agent-interface-transport`. It changes default behavior of a published testing fixture but
+does not change a TypeScript signature or production contract. Removing an extra property that was not
+part of the declared nested-session return type is not a public API removal.
+
+This remains in `agent-interface-transport/testing`, mirroring the existing `agent-core/testing`
+fixture family. It adds no product, presentation, package, or sibling dependency. ARCH-012 consumes this
+honest full double as its capability-conformance foundation; it does not widen ARCH-019 into the later
+capability migration.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — `agent-core/testing` and the existing per-double session-id strategy examined
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+Create the default `submit` implementation after the factory's resolved-session-id helper exists. On
+each call it increments a counter and returns a handle whose `turnId` is
+`<resolved-session-id>-turn-<n>`. The completed result remains the existing immediate empty result.
+Overrides are spread after the default and therefore preserve existing customization semantics.
+
+The first two default ids from one double are exactly `${sessionId}-turn-1` and
+`${sessionId}-turn-2`. A second double starts its own counter at 1 under its distinct session id. An
+overridden `getSession()` supplies the prefix when it returns a non-empty id; the existing deterministic
+fallback session id supplies it when that override throws or returns empty. An overridden `submit`
+remains authoritative and does not expose or depend on the default counter.
+
+Return only `getSessionId` from the default `getSession`. Add a compile-time exact nested-session shape
+test plus runtime identity regressions. Update both package SPECs to state that the testing factory is
+owned/exported only by `agent-interface-transport/testing`, models distinct submissions, and keeps the
+transport nested-session contract identity-only. Record the observable testing-subpath fix in a PATCH
+changeset.
+
+## Affected Files
+
+- `packages/agent-interface-transport/src/testing/index.ts`
+- `packages/agent-interface-transport/src/__tests__/test-double-turn-identity.test.ts`
+- `packages/agent-interface-transport/docs/SPEC.md`
+- `packages/agent-framework/docs/SPEC.md`
+- `.changeset/arch-019-test-session-turn-identity.md`
+- `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`
+- `.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md`
+
+## Completion Criteria
+
+- [ ] TC-01: For one default double, two calls return exactly `${sessionId}-turn-1` and
+      `${sessionId}-turn-2` and both complete; a second double starts at `<its-session-id>-turn-1`.
+- [ ] TC-02: The default `getSession()` result contains exactly the public `getSessionId` capability;
+      transport consumers typecheck and framework prompt collection continues through its concrete
+      `Session` contract.
+- [ ] TC-03: A non-empty overridden session id prefixes default turn ids; throwing/empty session-id
+      overrides use the deterministic fallback; an overridden `submit` remains authoritative.
+- [ ] TC-04: Interface-transport and framework SPEC/export surfaces agree that only
+      `@robota-sdk/agent-interface-transport/testing` exports the factory, and the PATCH changeset records
+      the compatible testing-fixture behavior correction.
+- [ ] TC-05: The durable public-SDK scenario imports only
+      `@robota-sdk/agent-interface-transport/testing`, submits twice, prints two distinct deterministic ids
+      and `DISTINCT`, exits 0, and removes its scratch directory.
+- [ ] TC-06: package build, typecheck, tests, scoped harness verification, and
+      `pnpm harness:verify-like-ci` exit 0.
+
+## Test Plan
+
+| TC-ID | Test Type                | Tool / Approach                                                            | Notes                                                                                |
+| ----- | ------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| TC-01 | Unit + async contract    | Vitest two-submit regression in `test-double-turn-identity.test.ts`        | First RED expects unequal ids against the current fixed literal.                     |
+| TC-02 | Type + regression        | exact nested-session shape assertion and affected package typecheck/tests  | No framework-only event-service member on the transport fixture.                     |
+| TC-03 | Unit + async contract    | table-driven override/fallback/custom-submit cases                         | Preserve all documented factory override semantics.                                  |
+| TC-04 | Contract/docs            | export-surface and SPEC assertions plus PATCH changeset inspection         | Pin the sole testing-subpath owner.                                                  |
+| TC-05 | Public SDK scenario      | `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md` | Fresh process prints exact ids derived from its runtime session id, then `DISTINCT`. |
+| TC-06 | Engineering verification | package and harness/CI-mirror commands                                     | Run targeted checks before the broad gate.                                           |
+
+## Tasks
+
+- [ ] `.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md`
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter is valid with draft status, allowed DATA type, and tags. The Problem gives the exact
+fixed-turn-id symptom and two-submit reproduction while explicitly excluding the disproved
+`getSession()` widening premise. Prior Art Research cites official Vitest documentation and the
+repository's deterministic session-id precedent; both feed three pro/con alternatives and the
+counter-based Decision. All four architecture checklist items are checked; no new surface is
+introduced, and the existing testing-subpath placement is justified against the `agent-core/testing`
+sibling without product dependency. Completion Criteria TC-01 through TC-04 are observable and match
+four substantive Test Plan rows exactly. Tasks and an empty first-run Evidence Log were present, with
+no forbidden body status/classification sections.
+
+### [GATE-WRITE] — 🔴 NON-COMPLIANCE | 2026-08-14
+
+**Status remains:** review-ready
+**Violation:** GATE-WRITE was requested against a document whose frontmatter already said
+`review-ready`, while the file remained in `.agents/spec-docs/draft/`; the gate expected `draft`
+input, and the retained PASS evidence covered the superseded four-TC version rather than the current
+six-TC document.
+**Required action:** Restore the document to coherent `status: draft` in `draft/`, retain this
+ordering record, and invoke a fresh GATE-WRITE for the TC-01..06 content. On PASS, move it to
+`.agents/spec-docs/backlog/` while setting `status: review-ready`.
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** draft → review-ready
+Frontmatter and draft-folder input state were coherent. The Problem records the exact fixed-turn-id
+symptom, two-call reproduction, sole-owner SPEC contradiction, and the invalid `getSession`-widening
+premise excluded from scope. Official Vitest documentation and the repository's deterministic
+session-id precedent feed three pro/con alternatives and the deterministic per-double counter
+Decision, including override semantics and PATCH compatibility. All four architecture items are
+checked; no new surface is introduced, and the retained testing subpath is placed against the
+`agent-core/testing` sibling without product dependency. Completion Criteria TC-01 through TC-06
+are observable and match six substantive Test Plan rows exactly. The Tasks placeholder exists;
+prior GATE-WRITE/NON-COMPLIANCE history is preserved; no forbidden body status/classification
+sections exist.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** review-ready → approved
+User standing approval, verbatim: “타당한 이유와 함께 추천안을 제시하면 타당할 경우 자동으로
+승인하겠습니다.” The exact revised ARCH-019 recommendation was independently reviewed and returned
+`ENDORSE`, satisfying the user's stated validity condition; the user's subsequent “진행하세요” and
+“승인함” plus the active initiative instruction confirm execution authority. The endorsed
+Architecture Review and frontmatter (`type: DATA`, `tags: [typescript, async]`) are unchanged in the
+current six-TC document. No new-surface independent-review requirement applies, and no implementation
+work predates this gate.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** approved → in-progress
+Task `.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md` exists and is
+named exactly in the spec's Tasks section. Its revised Plan maps TC-01 through TC-06 one-to-one across
+deterministic turn identity, exact nested-session shape, override/fallback behavior, owner SPECs and
+PATCH changeset, the public SDK scenario, and broad verification/archive. Its substantive Revised Test
+Plan covers red-first, type/regression, public scenario, package/scoped-harness, and CI-equivalent
+checks, with no blockers. Planned implementation/test/scenario/changeset artifacts had not been created
+or modified, so no implementation predated this gate.

--- a/.agents/spec-docs/done/ARCH-019-interactive-session-getSession-contract-understated.md
+++ b/.agents/spec-docs/done/ARCH-019-interactive-session-getSession-contract-understated.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: DATA
 tags: [typescript, async]
 capability: true
@@ -127,36 +127,36 @@ changeset.
 
 ## Completion Criteria
 
-- [ ] TC-01: For one default double, two calls return exactly `${sessionId}-turn-1` and
+- [x] TC-01: For one default double, two calls return exactly `${sessionId}-turn-1` and
       `${sessionId}-turn-2` and both complete; a second double starts at `<its-session-id>-turn-1`.
-- [ ] TC-02: The default `getSession()` result contains exactly the public `getSessionId` capability;
+- [x] TC-02: The default `getSession()` result contains exactly the public `getSessionId` capability;
       transport consumers typecheck and framework prompt collection continues through its concrete
       `Session` contract.
-- [ ] TC-03: A non-empty overridden session id prefixes default turn ids; throwing/empty session-id
+- [x] TC-03: A non-empty overridden session id prefixes default turn ids; throwing/empty session-id
       overrides use the deterministic fallback; an overridden `submit` remains authoritative.
-- [ ] TC-04: Interface-transport and framework SPEC/export surfaces agree that only
+- [x] TC-04: Interface-transport and framework SPEC/export surfaces agree that only
       `@robota-sdk/agent-interface-transport/testing` exports the factory, and the PATCH changeset records
       the compatible testing-fixture behavior correction.
-- [ ] TC-05: The durable public-SDK scenario imports only
+- [x] TC-05: The durable public-SDK scenario imports only
       `@robota-sdk/agent-interface-transport/testing`, submits twice, prints two distinct deterministic ids
       and `DISTINCT`, exits 0, and removes its scratch directory.
-- [ ] TC-06: package build, typecheck, tests, scoped harness verification, and
+- [x] TC-06: package build, typecheck, tests, scoped harness verification, and
       `pnpm harness:verify-like-ci` exit 0.
 
 ## Test Plan
 
-| TC-ID | Test Type                | Tool / Approach                                                            | Notes                                                                                |
-| ----- | ------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| TC-01 | Unit + async contract    | Vitest two-submit regression in `test-double-turn-identity.test.ts`        | First RED expects unequal ids against the current fixed literal.                     |
-| TC-02 | Type + regression        | exact nested-session shape assertion and affected package typecheck/tests  | No framework-only event-service member on the transport fixture.                     |
-| TC-03 | Unit + async contract    | table-driven override/fallback/custom-submit cases                         | Preserve all documented factory override semantics.                                  |
-| TC-04 | Contract/docs            | export-surface and SPEC assertions plus PATCH changeset inspection         | Pin the sole testing-subpath owner.                                                  |
-| TC-05 | Public SDK scenario      | `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md` | Fresh process prints exact ids derived from its runtime session id, then `DISTINCT`. |
-| TC-06 | Engineering verification | package and harness/CI-mirror commands                                     | Run targeted checks before the broad gate.                                           |
+| TC-ID | Test Type                | Tool / Approach                                                                                                                                                                                                                                 | Notes                                                                                      |
+| ----- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| TC-01 | Unit + async contract    | `packages/agent-interface-transport/src/__tests__/test-double-turn-identity.test.ts` — `createTestInteractiveSession turn identity (ARCH-019) > mints deterministic per-call ids and settles each handle`                                       | RED failed on the fixed literal; GREEN proves exact IDs, per-double reset, and settlement. |
+| TC-02 | Type + regression        | `packages/agent-interface-transport/src/__tests__/test-double-turn-identity.test.ts` — `createTestInteractiveSession turn identity (ARCH-019) > keeps the nested transport session identity-only`                                               | Exact type and runtime keys exclude the framework-only event service.                      |
+| TC-03 | Unit + async contract    | `packages/agent-interface-transport/src/__tests__/test-double-turn-identity.test.ts` — `createTestInteractiveSession turn identity (ARCH-019) > uses the resolved session id and preserves submit overrides`                                    | Covers named, empty, throwing, and custom-submit paths.                                    |
+| TC-04 | Contract/docs            | Test skipped: owner SPEC/export and PATCH changeset agreement is a documentation/package-metadata inspection criterion; it is verified by focused package build/typecheck plus `pnpm harness:scan`, not wrapped in a duplicative unit test.     | Pin the sole testing-subpath owner and compatibility classification.                       |
+| TC-05 | Public SDK scenario      | Test skipped: the authoritative executable check is `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`, independently executed by DONE-GATE-STAGE-2 rather than duplicated in Vitest.                                   | Fresh process prints exact runtime-derived ids, `DISTINCT`, and the Bash cleanup marker.   |
+| TC-06 | Engineering verification | Test skipped: this criterion is the aggregate execution of package build/typecheck/tests, scoped verification, scans, and `pnpm harness:verify-like-ci`; wrapping those commands in another test would only invoke the same owners recursively. | Targeted checks precede the broad 12-stage gate.                                           |
 
 ## Tasks
 
-- [ ] `.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md`
+- [x] `.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md`
 
 ## Evidence Log
 
@@ -219,3 +219,96 @@ PATCH changeset, the public SDK scenario, and broad verification/archive. Its su
 Plan covers red-first, type/regression, public scenario, package/scoped-harness, and CI-equivalent
 checks, with no blockers. Planned implementation/test/scenario/changeset artifacts had not been created
 or modified, so no implementation predated this gate.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** in-progress → verifying
+The active ARCH-019 task is 6/6 complete with no blockers. Independent code/spec review confirmed
+deterministic per-call/per-double IDs, resolved-session fallback and override semantics, the
+identity-only nested session, synchronized owner SPECs, and PATCH metadata. Fresh affected-package
+builds and typechecks exited 0; fresh tests passed 7 files / 27 tests for interface-transport and 162
+files / 1,334 tests for framework, including the three ARCH-019 regressions. DONE-GATE-STAGE-2
+independently passed the public testing-subpath scenario with exact identity and cleanup output. The
+task also records current scoped verification and `harness:verify-like-ci` 12/12 in 6m00.8s.
+
+### [GATE-COMPLETE] — ❌ FAIL | 2026-08-14
+
+**Status remains:** verifying
+Readiness passed, but the Evidence Log did not yet contain one labelled completion entry per TC or a
+final summary. Checked criteria, Test Plan references, GATE-VERIFY, and DONE-GATE-STAGE-2 do not
+replace the catalogue-mandated TC evidence records.
+
+### [GATE-COMPLETE: TC-01] — ✅ PASS | 2026-08-14
+
+**Status remains:** verifying
+`pnpm --filter @robota-sdk/agent-interface-transport test` exited 0 with 7 files / 27 tests. The exact
+test `createTestInteractiveSession turn identity (ARCH-019) > mints deterministic per-call ids and
+settles each handle` observed `<session-id>-turn-1`, `<session-id>-turn-2`, independent second-double
+restart at 1, and both completed handles settling. Its pre-implementation RED failed on the fixed
+`test-turn` literal.
+
+### [GATE-COMPLETE: TC-02] — ✅ PASS | 2026-08-14
+
+**Status remains:** verifying
+The exact test `createTestInteractiveSession turn identity (ARCH-019) > keeps the nested transport
+session identity-only` passed in the same exit-0 package run, proving type equality and runtime keys
+exactly `['getSessionId']`. Fresh interface-transport and framework builds, typechecks, and framework
+tests (162 files / 1,334 tests) all exited 0, proving the concrete framework Session path remains green.
+
+### [GATE-COMPLETE: TC-03] — ✅ PASS | 2026-08-14
+
+**Status remains:** verifying
+The exact test `createTestInteractiveSession turn identity (ARCH-019) > uses the resolved session id
+and preserves submit overrides` passed in the exit-0 27-test package run. It observed the named prefix,
+deterministic empty/throwing fallback, and byte-authoritative `custom-turn` submit override.
+
+### [GATE-COMPLETE: TC-04] — ✅ PASS | 2026-08-14
+
+**Status remains:** verifying
+Exact inspection of `packages/agent-interface-transport/docs/SPEC.md` found
+`@robota-sdk/agent-interface-transport/testing` named as sole published owner and framework explicitly
+not re-exporting it; exact inspection of `packages/agent-framework/docs/SPEC.md` records the same
+moved/not-re-exported surface. Exact inspection of
+`.changeset/arch-019-test-session-turn-identity.md` found a PATCH for
+`@robota-sdk/agent-interface-transport`. The commands
+`pnpm --filter @robota-sdk/agent-interface-transport --filter @robota-sdk/agent-framework build`,
+`pnpm --filter @robota-sdk/agent-interface-transport --filter @robota-sdk/agent-framework typecheck`,
+and `pnpm harness:scan` each exited 0.
+Test skipped: this is documentation/package-metadata agreement already checked by those authoritative
+owners and scans; a duplicative prose-snapshot unit test would create a second owner.
+
+### [GATE-COMPLETE: TC-05] — ✅ PASS | 2026-08-14
+
+**Status remains:** verifying
+DONE-GATE-STAGE-2 freshly ran the exact `/bin/bash` block from
+`.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`. The public bare-specifier
+consumer printed `test-session-1-turn-1`, `test-session-1-turn-2`, and `DISTINCT`; Bash printed
+`CLEANUP_OK`, the unified command exited 0, and no temporary path remained. Test skipped: this public
+SDK scenario is independently executed by the scenario gate rather than duplicated in Vitest.
+
+### [GATE-COMPLETE: TC-06] — ✅ PASS | 2026-08-14
+
+**Status remains:** verifying
+`pnpm --filter @robota-sdk/agent-interface-transport --filter @robota-sdk/agent-framework build`,
+`pnpm --filter @robota-sdk/agent-interface-transport --filter @robota-sdk/agent-framework typecheck`,
+and `pnpm --filter @robota-sdk/agent-interface-transport --filter @robota-sdk/agent-framework test`
+each exited 0; interface-transport passed 7 files / 27 tests and framework passed 162 files / 1,334
+tests. `pnpm harness:verify -- --scope packages/agent-interface-transport` exited 0 after its root
+build and scoped build/test/lint/typecheck checks. `pnpm harness:scan` exited 0, and
+`pnpm harness:verify-like-ci` exited 0 with all 12 stages passing in 6m00.8s. Test skipped: this
+criterion aggregates the repository's owning verification commands, so wrapping them in another test
+would recursively duplicate the same owners.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** verifying → done
+TC-01 through TC-06 are checked and each has a labelled evidence entry containing the exact
+verification action or command, observed result, and exit code where applicable. TC-01 through TC-03
+name exact Vitest file and test identities; TC-04 through TC-06 record explicit `Test skipped:` reasons
+tied respectively to owner metadata inspection, the independently executed durable public-SDK
+scenario, and aggregate engineering verification. The affected package build, typecheck, and test
+commands passed; scoped `pnpm harness:verify -- --scope packages/agent-interface-transport` exited 0;
+`pnpm harness:scan` exited 0; and `pnpm harness:verify-like-ci` passed all 12 stages. The exact active
+task is completion-ready with all six Plan items checked and no blockers. GATE-COMPLETE therefore
+passes; task terminalization/archive and the spec's active/verifying → done/done transition are the
+atomic post-PASS handoff.

--- a/.agents/tasks/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
+++ b/.agents/tasks/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
@@ -56,7 +56,7 @@ projection is the section below.
 - [ ] ARCH-011 — in-progress — `.agents/tasks/ARCH-011-transport-adapter-is-a-lifecycle-stub.md`
 - [ ] ARCH-012 — in-progress — `.agents/tasks/ARCH-012-interactive-session-god-contract.md`
 - [ ] ARCH-013 — in-progress — `.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md`
-- [ ] ARCH-019 — todo — `.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md`
+- [x] ARCH-019 — done — `.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md`
 - [ ] ARCH-029 — todo — `.agents/tasks/ARCH-029-command-host-capability-contracts.md`
 - [x] DAG-001 — done — `.agents/tasks/completed/DAG-001-running-is-a-terminal-trap.md`
 - [ ] DAG-004 — todo — `.agents/tasks/DAG-004-eight-cli-commands-open-code-the-import-adapter.md`

--- a/.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md
+++ b/.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARCH-019: the IInteractiveSession getSession() return contract is narrower than the surface the framework and its sanctioned test double actually use, and the double mints one fixed turnId for every submission'
+title: 'ARCH-019: the sanctioned session double reuses one turn identity across distinct submissions'
 status: todo
 created: 2026-08-13
 priority: medium
@@ -8,7 +8,19 @@ area: packages/agent-interface-transport, packages/agent-framework
 depends_on: []
 ---
 
-# ARCH-019: the sanctioned session double is dishonest about the contract surface
+# ARCH-019: the sanctioned session double collapses distinct submissions into one identity
+
+## Current finding-depth disposition
+
+- **LOCAL:** the default double returns `turnId: 'test-turn'` for every submission. This Task owns
+  the per-call deterministic identity fix and its public testing-subpath proof.
+- **INVALID:** the original claim that transport-facing `getSession()` must expose
+  `getEventService()`. The framework caller is typed against concrete `Session`; transport-typed
+  production consumers use only `getSessionId()`. The contract stays narrow. The extra defensive
+  stub may be removed as local cleanup, without widening the public contract.
+
+The historical report below is preserved as provenance; its first numbered claim is not current
+acceptance scope.
 
 ## Problem
 
@@ -42,7 +54,20 @@ string }`. `packages/agent-framework/src/interactive/interactive-session-prompt.
 turnId: 'test-turn', … })` — every submission of every double shares one identity, contrasting the
   package's own rationale for per-double session ids (`:117-124`, `test-double-id-coherence.test.ts`).
 
-## Direction
+## Revised Direction
+
+1. Mint a deterministic per-call `turnId` from the double's session id and a submission counter.
+2. Add a red-first two-submit regression proving distinct ids and separately settled handles.
+3. Keep `getSession(): { getSessionId(): string }`; remove the unowned `getEventService` extra stub.
+4. Correct stale package SPEC claims about which package exports the testing double.
+
+The exact default contract is per factory and per call: `${sessionId}-turn-1`, then
+`${sessionId}-turn-2`; another double restarts at 1 under its own session id. A non-empty overridden
+session id controls the prefix, a throwing/empty override uses the existing deterministic fallback,
+and an overridden `submit` stays authoritative. This is a PATCH behavior correction to the published
+testing subpath, not a production signature change.
+
+## Historical Direction (partially invalid)
 
 1. Decide the `getSession()` surface honestly: either widen the contract's return type to include the
    event-service member (or an explicit narrow port), or stop framework internals from reaching
@@ -53,7 +78,29 @@ turnId: 'test-turn', … })` — every submission of every double shares one ide
    as the per-double session id), so RUNTIME-003 two-submission behavior is testable through the SSOT
    double.
 
-## Test Plan
+## Revised Test Plan
+
+- Red-first: submit twice through one `createTestInteractiveSession` and assert different,
+  deterministic ids plus successful completion for each handle.
+- Type/regression: the default nested session exposes only `getSessionId`; affected consumers compile.
+- Public SDK scenario: import the published `./testing` subpath, submit twice, print ids and
+  `DISTINCT`, exit 0, and clean up scratch files.
+- Package build/typecheck/tests, scoped harness verification, and CI-equivalent verification green.
+
+## Plan
+
+- [ ] TC-01: add red-first exact per-call/per-double turn identity and settlement regressions.
+- [ ] TC-02: remove the undeclared nested event-service stub and prove the identity-only shape.
+- [ ] TC-03: cover session-id override, throwing/empty fallback, and authoritative submit override.
+- [ ] TC-04: synchronize both owner SPECs and add the PATCH changeset.
+- [ ] TC-05: author, gate, execute, and record the durable public testing-subpath scenario.
+- [ ] TC-06: run affected package and broad harness verification, completion gates, and atomic archive.
+
+## Blockers
+
+- None.
+
+## Historical Test Plan
 
 - Red-first: a test submitting twice through `createTestInteractiveSession` asserts two distinct
   `turnId`s (fails today — both `'test-turn'`).
@@ -64,7 +111,10 @@ turnId: 'test-turn', … })` — every submission of every double shares one ide
 
 ## User Execution Test Scenarios
 
-**Applies — via the public SDK surface** (a consumer using `@robota-sdk/agent-interface-transport/testing`).
+**Applies — via the public SDK surface** (a consumer using
+`@robota-sdk/agent-interface-transport/testing`). Exact agent-executable commands, prerequisites,
+observable output, bounds, cleanup, and the evidence field live in
+[`arch-019-test-session-turn-identity-agent-run.md`](../evals/scenarios/arch-019-test-session-turn-identity-agent-run.md).
 
 - Prerequisites: built workspace; a scratch consumer that constructs the double and submits two
   prompts.
@@ -73,3 +123,14 @@ turnId: 'test-turn', … })` — every submission of every double shares one ide
 - Expected (before fix, contrast): both ids are `'test-turn'`.
 - Cleanup: delete the scratch project.
 - Evidence (fill in after implementation): the two distinct turn ids printed by the consumer.
+
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** scenario drafted → scenario written
+Scenario `ARCH-019 — published test session mints one identity per submission (agent-run)` is fully
+written at `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`. It is explicitly
+agent-executable; states complete local prerequisites and the absence of credential/network needs;
+supplies an exact bounded Bash/Node command driving the built public
+`@robota-sdk/agent-interface-transport/testing` export; requires exit 0 and exact deterministic
+two-turn output plus settled completions; validates failure modes; provides path-bounded cleanup; and
+carries an intentionally empty pre-implementation Observed evidence field for Stage 2.

--- a/.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md
+++ b/.agents/tasks/ARCH-019-interactive-session-getSession-contract-understated.md
@@ -134,3 +134,25 @@ supplies an exact bounded Bash/Node command driving the built public
 `@robota-sdk/agent-interface-transport/testing` export; requires exit 0 and exact deterministic
 two-turn output plus settled completions; validates failure modes; provides path-bounded cleanup; and
 carries an intentionally empty pre-implementation Observed evidence field for Stage 2.
+
+### [DONE-GATE-STAGE-1] — ❌ FAIL | 2026-08-14
+
+**Status remains:** scenario drafted
+**Failed criteria:**
+
+- Expected observable result: the revised document attributed `CLEANUP_OK` to the consumer Node
+  process and called four displayed lines exact output, but the consumer prints the first three,
+  Bash prints `CLEANUP_OK` after cleanup, and the build may also emit setup output.
+  **Required action:** Correct output provenance and define the three consumer lines plus the Bash
+  cleanup marker separately from build output.
+
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** scenario drafted → scenario written
+Scenario `ARCH-019 — published test session mints one identity per submission (agent-run)` is fully
+written at `.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`. It declares
+agent executability and complete credential-free prerequisites; provides an exact bounded Bash/Node
+command against the built public testing subpath; separates package-build setup output from the exact
+three consumer lines and the single Bash `CLEANUP_OK` marker; asserts distinct deterministic IDs and
+settled handles; uses validated explicit cleanup with an EXIT fallback and absence proof; and retains
+an empty Observed evidence field for post-implementation Stage 2.

--- a/.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md
+++ b/.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-019: the sanctioned session double reuses one turn identity across distinct submissions'
-status: todo
+status: done
 created: 2026-08-13
+completed: 2026-08-14
 priority: medium
 urgency: soon
 area: packages/agent-interface-transport, packages/agent-framework
@@ -89,16 +90,36 @@ testing subpath, not a production signature change.
 
 ## Plan
 
-- [ ] TC-01: add red-first exact per-call/per-double turn identity and settlement regressions.
-- [ ] TC-02: remove the undeclared nested event-service stub and prove the identity-only shape.
-- [ ] TC-03: cover session-id override, throwing/empty fallback, and authoritative submit override.
-- [ ] TC-04: synchronize both owner SPECs and add the PATCH changeset.
-- [ ] TC-05: author, gate, execute, and record the durable public testing-subpath scenario.
-- [ ] TC-06: run affected package and broad harness verification, completion gates, and atomic archive.
+- [x] TC-01: add red-first exact per-call/per-double turn identity and settlement regressions.
+- [x] TC-02: remove the undeclared nested event-service stub and prove the identity-only shape.
+- [x] TC-03: cover session-id override, throwing/empty fallback, and authoritative submit override.
+- [x] TC-04: synchronize both owner SPECs and add the PATCH changeset.
+- [x] TC-05: author, gate, execute, and record the durable public testing-subpath scenario.
+- [x] TC-06: run affected package and broad harness verification; completion gates and atomic archive
+      follow only after this plan is complete.
 
 ## Blockers
 
 - None.
+
+## Progress
+
+### 2026-08-14
+
+- Added deterministic per-factory submission identities and removed the undeclared nested event-service
+  fixture member under red-first regression coverage.
+- Synchronized the two owner SPECs and recorded a PATCH changeset for the published testing subpath.
+- Executed the public SDK scenario successfully with exact identity and cleanup markers.
+- Verified the affected packages and completed `pnpm harness:verify-like-ci` with 12/12 stages passing
+  in 6m 0.8s.
+
+## Result
+
+The sanctioned public testing double now mints deterministic, distinct submission identities per
+factory, preserves every override/fallback path, and exposes only its declared nested identity surface.
+Both owner SPECs and the PATCH changeset agree on the sole testing-subpath owner. The durable public
+SDK scenario, affected-package checks, scoped harness verification, scans, and the 12-stage CI mirror
+all passed; DONE-GATE-STAGE-2 and GATE-COMPLETE independently passed before archival.
 
 ## Historical Test Plan
 
@@ -114,7 +135,7 @@ testing subpath, not a production signature change.
 **Applies — via the public SDK surface** (a consumer using
 `@robota-sdk/agent-interface-transport/testing`). Exact agent-executable commands, prerequisites,
 observable output, bounds, cleanup, and the evidence field live in
-[`arch-019-test-session-turn-identity-agent-run.md`](../evals/scenarios/arch-019-test-session-turn-identity-agent-run.md).
+[`arch-019-test-session-turn-identity-agent-run.md`](../../evals/scenarios/arch-019-test-session-turn-identity-agent-run.md).
 
 - Prerequisites: built workspace; a scratch consumer that constructs the double and submits two
   prompts.
@@ -122,7 +143,8 @@ observable output, bounds, cleanup, and the evidence field live in
 - Expected (after fix): the two ids differ.
 - Expected (before fix, contrast): both ids are `'test-turn'`.
 - Cleanup: delete the scratch project.
-- Evidence (fill in after implementation): the two distinct turn ids printed by the consumer.
+- Evidence: the durable scenario records the two distinct turn ids, settled handles, exit 0, and
+  successful cleanup from the independent Stage-2 execution.
 
 ### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-14
 
@@ -156,3 +178,14 @@ command against the built public testing subpath; separates package-build setup 
 three consumer lines and the single Bash `CLEANUP_OK` marker; asserts distinct deterministic IDs and
 settled handles; uses validated explicit cleanup with an EXIT fallback and absence proof; and retains
 an empty Observed evidence field for post-implementation Stage 2.
+
+### [DONE-GATE-STAGE-2] — ✅ PASS | 2026-08-14
+
+**Status upgrade:** scenario written → scenario verified
+The agent freshly ran the sole durable scenario from repository root with `/bin/bash` against HEAD
+`e519f7e3c`. The built public `@robota-sdk/agent-interface-transport/testing` consumer exited 0 and
+printed exactly `test-session-1-turn-1`, `test-session-1-turn-2`, and `DISTINCT`; both completion
+promises settled. Explicit cleanup succeeded, Bash printed `CLEANUP_OK`, and a post-run temp-directory
+probe found no `robota-arch019.*` directory. The matching concrete evidence is recorded in
+`.agents/evals/scenarios/arch-019-test-session-turn-identity-agent-run.md`; build output is setup, not
+substituted user-execution evidence.

--- a/.changeset/arch-019-test-session-turn-identity.md
+++ b/.changeset/arch-019-test-session-turn-identity.md
@@ -1,0 +1,7 @@
+---
+'@robota-sdk/agent-interface-transport': patch
+---
+
+Fix the published test session factory so each default submission receives a deterministic identity
+derived from its session id and per-session submission sequence. The testing fixture now models
+multiple correlated turns without changing production contracts or public TypeScript signatures.

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -35,8 +35,9 @@ This package does NOT own: provider implementations, generic session run loop, t
 - Path helpers: `projectPaths()`, `userPaths()`
 - User-local storage: `resolveUserLocalStorageRoot()`, user-local memory APIs
 - Testing utilities: exported from the `@robota-sdk/agent-framework/testing` subpath (not the
-  runtime entry) — `scriptedSession()` / `ScriptedSessionHarness` (functional harness) and
-  `createTestInteractiveSession()` (stub). See Test Strategy → Functional test harness.
+  runtime entry) — `scriptedSession()` / `ScriptedSessionHarness` (functional harness). The lightweight
+  `createTestInteractiveSession()` stub is owned and exported only by
+  `@robota-sdk/agent-interface-transport/testing`. See Test Strategy → Functional test harness.
 - Update check: `checkForCliUpdate()`, related helpers
 - Git utilities: `resolveGitBranch()`
 - Semver utilities: `compareSemverVersions()`, `isNewerSemverVersion()`
@@ -596,8 +597,9 @@ forkSession?, model?, commandModules?, ... })` / `ScriptedSessionHarness` builds
   `session_init` / `provider_request` / `tool_call` / `tool_result` / `assistant` records), and
   `readFile()`/`exists()`/`files()` (workspace side effects). Lifecycle: `dispose()` tears down the
   workspace. Scripted tool-call args may use the `{{cwd}}` placeholder for absolute workspace paths.
-- `createTestInteractiveSession()` (same subpath) remains a lightweight **stub** for wiring/type tests
-  that do not need the real loop.
+- `createTestInteractiveSession()` is a lightweight **stub** for wiring/type tests that do not need the
+  real loop, owned and exported only by `@robota-sdk/agent-interface-transport/testing`; this framework
+  testing subpath does not re-export it.
 
 ### Approach
 

--- a/packages/agent-interface-transport/docs/SPEC.md
+++ b/packages/agent-interface-transport/docs/SPEC.md
@@ -162,8 +162,16 @@ contract, so `null` from `getActiveDriverId()` means exactly one thing.
 from `@robota-sdk/agent-framework` and documented in its SPEC — with zero consumers, because every
 transport package sits BELOW `agent-framework` and could not import it. The 41 hand-rolled
 `as unknown as IInteractiveSession` partials were not an oversight; they were the only thing those
-packages could reach. `agent-framework` re-exports this one rather than keeping a second: two doubles
-for one contract can disagree, which is this defect one level down.
+packages could reach. The sole published owner is
+`@robota-sdk/agent-interface-transport/testing`; `agent-framework` intentionally does not re-export it,
+because pass-through re-exports would create two apparent owners for one contract.
+
+The default double preserves identity semantics rather than only type shape. Each factory instance has
+one deterministic session id, and its successive default submissions return
+`<session-id>-turn-1`, `<session-id>-turn-2`, and so on. Another double restarts its own counter under
+its distinct session id. A custom `submit` override remains authoritative. The nested object returned
+from default `getSession()` exposes only the transport contract's `getSessionId`; framework-only
+`Session` services do not leak into this lower contract fixture.
 
 The remaining casts are held by a ratchet (`scan-contract-cast-ratchet`) that may fall and never
 rise, so the debt cannot grow while the capability-scoped ports are designed.

--- a/packages/agent-interface-transport/src/__tests__/test-double-turn-identity.test.ts
+++ b/packages/agent-interface-transport/src/__tests__/test-double-turn-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { IInteractiveSession } from '../session-contracts.js';
+import { createTestInteractiveSession } from '../testing/index.js';
+
+describe('createTestInteractiveSession turn identity (ARCH-019)', () => {
+  it('mints deterministic per-call ids and settles each handle', async () => {
+    const firstSession = createTestInteractiveSession();
+    const sessionId = firstSession.getSession().getSessionId();
+
+    const first = await firstSession.submit('first');
+    const second = await firstSession.submit('second');
+
+    expect(first.turnId).toBe(`${sessionId}-turn-1`);
+    expect(second.turnId).toBe(`${sessionId}-turn-2`);
+    await expect(first.completed).resolves.toMatchObject({ response: '' });
+    await expect(second.completed).resolves.toMatchObject({ response: '' });
+
+    const secondSession = createTestInteractiveSession();
+    const secondSessionId = secondSession.getSession().getSessionId();
+    const secondSessionFirst = await secondSession.submit('first');
+    expect(secondSessionFirst.turnId).toBe(`${secondSessionId}-turn-1`);
+  });
+
+  it('uses the resolved session id and preserves submit overrides', async () => {
+    const named = createTestInteractiveSession({
+      getSession: () => ({ getSessionId: () => 'named-session' }),
+    });
+    expect((await named.submit('named')).turnId).toBe('named-session-turn-1');
+
+    const empty = createTestInteractiveSession({
+      getSession: () => ({ getSessionId: () => '' }),
+    });
+    expect((await empty.submit('empty')).turnId).toMatch(/^test-session-\d+-turn-1$/);
+
+    const throwing = createTestInteractiveSession({
+      getSession: () => {
+        throw new Error('deliberate test override');
+      },
+    });
+    expect((await throwing.submit('throwing')).turnId).toMatch(/^test-session-\d+-turn-1$/);
+
+    const completed = Promise.resolve({
+      response: 'custom',
+      history: [],
+      toolSummaries: [],
+      contextState: {
+        usedTokens: 0,
+        maxTokens: 1,
+        usedPercentage: 0,
+        remainingPercentage: 100,
+      },
+    });
+    const custom = createTestInteractiveSession({
+      submit: async () => ({ turnId: 'custom-turn', completed }),
+    });
+    expect((await custom.submit('custom')).turnId).toBe('custom-turn');
+  });
+
+  it('keeps the nested transport session identity-only', () => {
+    const session = createTestInteractiveSession();
+    expectTypeOf(session.getSession).returns.toEqualTypeOf<
+      ReturnType<IInteractiveSession['getSession']>
+    >();
+    expect(Object.keys(session.getSession())).toEqual(['getSessionId']);
+  });
+});

--- a/packages/agent-interface-transport/src/testing/index.ts
+++ b/packages/agent-interface-transport/src/testing/index.ts
@@ -65,6 +65,7 @@ export function createTestInteractiveSession(
   overrides?: Partial<IInteractiveSession>,
 ): IInteractiveSession {
   const fallbackId = `test-session-${(doublesCreated += 1)}`;
+  let submissionsAccepted = 0;
   /**
    * The id EVERY surface of this double names — including when a caller overrides `getSession`.
    *
@@ -96,7 +97,7 @@ export function createTestInteractiveSession(
     // stands in for hangs. The default turn ends at once with an empty result.
     submit: () =>
       Promise.resolve({
-        turnId: 'test-turn',
+        turnId: `${sessionId()}-turn-${(submissionsAccepted += 1)}`,
         completed: Promise.resolve({
           response: '',
           history: [],
@@ -122,8 +123,6 @@ export function createTestInteractiveSession(
       // A counter, not a random: the value stays stable within one double and reproducible across
       // runs, so a failure message names the same session twice.
       getSessionId: () => fallbackId,
-      // SELFHOST-004: the span collector subscribes to the session bus each turn.
-      getEventService: () => ({ subscribe: () => {}, unsubscribe: () => {} }),
     }),
     getCwd: () => '/workspace',
     executeCommand: () => Promise.resolve(null),


### PR DESCRIPTION
## Accepted recommendation

Keep the transport-facing nested session identity-only and correct the published testing double locally: mint deterministic per-factory submission IDs, preserve override authority, remove the undeclared event-service fixture member, and synchronize the owner SPECs. Independent proposal review: REVIEW VERDICT: ENDORSE.

## Why

The original getSession widening premise was invalid: framework event collection uses the concrete Session contract. The real defect was the sanctioned public double returning the same test-turn identity for every accepted submission, which prevents faithful multi-turn correlation tests.

## Implementation

- mint <session-id>-turn-<n> per factory and submission
- preserve named, empty, throwing, and custom-submit overrides
- prove the nested transport session exposes only getSessionId
- synchronize interface-transport/framework SPEC ownership
- add a PATCH changeset and durable public-SDK scenario
- complete and archive ARCH-019 atomically, including AGREEMENT projections

## Verification

- red-first ARCH-019 suite, then 3/3 green
- interface-transport: 7 files / 27 tests
- framework: 162 files / 1,334 tests
- affected builds and typechecks: exit 0
- scoped harness verify: exit 0
- harness scan: exit 0
- harness:verify-like-ci: 12/12 in 6m00.8s
- DONE-GATE-STAGE-2 public SDK scenario: exact two IDs, DISTINCT, CLEANUP_OK, exit 0
- final local review: ACTIONABLE FINDINGS: 0

## Residual risk

CI-only Windows and CodeQL checks require this real PR. ARCH-012 remains separate downstream capability-decomposition work; this PR does not widen or replace the public session contract.