### PR TITLE
docs(arch): activate AGREEMENT-002 implementation

### DIFF
--- a/.agents/spec-docs/active/AGREEMENT-002-complete-august-13-agent-architecture-findings.md
+++ b/.agents/spec-docs/active/AGREEMENT-002-complete-august-13-agent-architecture-findings.md
@@ -1,5 +1,5 @@
 ---
-status: review-ready
+status: in-progress
 type: AGREEMENT
 tags: [typescript, async, cli, websocket]
 ---
@@ -305,6 +305,8 @@ adversarial review before code changes.
 
 ## Tasks
 
+Active initiative Task: `.agents/tasks/AGREEMENT-002-complete-august-13-agent-architecture-findings.md`.
+
 - [ ] ARCH-014 — todo — `.agents/tasks/ARCH-014-session-log-external-payloads-have-no-dereferencer.md`
 - [ ] ARCH-015 — todo — `.agents/tasks/ARCH-015-two-writers-one-record-contract-session-save-destroys-fields.md`
 - [ ] ARCH-016 — todo — `.agents/tasks/ARCH-016-session-log-event-vocabulary-and-compaction-trigger-split-brain.md`
@@ -383,3 +385,40 @@ ARCH-020+028 event-delivery work unit and ARCH-021 parent-side capability broker
   correction for ownership fields and extension-value serialization.
 
 REVIEW VERDICT: ENDORSE
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-15
+
+**Status upgrade:** review-ready → approved
+
+- Explicit user approval: the current user-provided active goal states verbatim,
+  “ARCH-014~028 을 모두 진행해줘.”
+- Approval scope: the instruction directly authorizes implementation of the full ARCH child set governed
+  by this AGREEMENT-002 document; “모두 진행해줘” is an unambiguous instruction to proceed with that design.
+- Post-approval integrity: the document is clean at committed HEAD `657aca3cc`; no Architecture Review,
+  `type`, or `tags` change exists after the current approval statement.
+- Independent architecture validation: the preceding `[proposal-review]` entry records
+  `REVIEW VERDICT: ENDORSE` and specifically endorses the new parent-side broker placement in the existing
+  `agent-subagent-runner` IPC family, with live endpoints retained in the parent and no sibling-PRODUCT
+  dependency introduced.
+- Pre-implementation ordering: the worktree was clean at the approval check and remains at the
+  documentation-only AGREEMENT-002 commit; no ARCH-014–028 implementation edit or commit preceded this gate.
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-15
+
+**Status upgrade:** approved → in-progress
+
+- Tasks file: `.agents/tasks/AGREEMENT-002-complete-august-13-agent-architecture-findings.md` exists and is
+  recorded in the spec document's `## Tasks` section as the active initiative execution record.
+- Completion-criteria correspondence: the Tasks file `## Plan` contains one explicit task for each
+  agreement criterion, `TC-01` through `TC-16`, covering all fourteen child findings, child lifecycle
+  completion, and assembled-base verification.
+- Tasks created: `TC-01` ARCH-014 external payload replay; `TC-02` ARCH-015 record preservation/store port;
+  `TC-03` ARCH-016 event vocabulary/compact trigger; `TC-04` ARCH-017 prompt-registry permission cleanup;
+  `TC-05` ARCH-018 interaction-channel contract; `TC-06` ARCH-020 transition matrix; `TC-07` ARCH-028
+  TUI/protocol delivery; `TC-08` ARCH-021 parent-side worker broker; `TC-09` ARCH-023 default session store;
+  `TC-10` ARCH-024 semantic command roles; `TC-11` ARCH-027 provider override/pack collisions; `TC-12`
+  ARCH-022 public-surface guard; `TC-13` ARCH-025 total executor projections; `TC-14` ARCH-026 shared shell
+  resolver; `TC-15` child done gates/archive; and `TC-16` assembled verification.
+- Task test plan: the Tasks file contains a substantive `## Test Plan` section specifying per-child
+  red-green tests and builds, applicable user-execution scenarios, assembled conformance/scoped/CI-equivalent
+  verification, and task/spec lifecycle projection checks; it exceeds the required 50 characters.

--- a/.agents/tasks/AGREEMENT-002-complete-august-13-agent-architecture-findings.md
+++ b/.agents/tasks/AGREEMENT-002-complete-august-13-agent-architecture-findings.md
@@ -1,6 +1,6 @@
 ---
 title: 'AGREEMENT-002: complete the 2026-08-13 agent architecture findings'
-status: todo
+status: in-progress
 created: 2026-08-15
 priority: critical
 urgency: now
@@ -33,19 +33,31 @@ Track the fourteen open agent-architecture findings created on 2026-08-13 as one
 initiative. The source Task files remain authoritative for each problem and its implementation
 evidence; the paired agreement owns the proposed integration order and assembled completion gate.
 
-This record does not grant implementation approval. The paired spec remains `review-ready`, and work
-must not begin until GATE-APPROVAL records the user's explicit approval.
+The paired spec passed GATE-APPROVAL on 2026-08-15. The user's instruction
+“ARCH-014~028 을 모두 진행해줘.” authorizes implementation of the complete child set.
 
 ## Spec
 
-`.agents/spec-docs/backlog/AGREEMENT-002-complete-august-13-agent-architecture-findings.md`
+`.agents/spec-docs/active/AGREEMENT-002-complete-august-13-agent-architecture-findings.md`
 
 ## Plan
 
-- [ ] Obtain explicit user approval for the paired agreement before implementation.
-- [ ] Apply the agreement's foundational scope corrections before running the affected child gates.
-- [ ] Execute every child through its own implementation and verification lifecycle in dependency order.
-- [ ] Run the initiative-level architecture conformance and CI-equivalent assembled-base gates.
+- [ ] TC-01 — preserve full-fidelity external session payloads in ARCH-014.
+- [ ] TC-02 — preserve unknown session-record fields and reconcile the canonical store port in ARCH-015.
+- [ ] TC-03 — unify the session-log vocabulary and compact trigger in ARCH-016.
+- [ ] TC-04 — remove obsolete permission/ask seams and retain the prompt-registry SSOT in ARCH-017.
+- [ ] TC-05 — make the interaction-channel charter and implementer set agree in ARCH-018.
+- [ ] TC-06 — implement the complete committed checkpoint/branch transition matrix in ARCH-020.
+- [ ] TC-07 — deliver the shared event contract through exhaustive TUI/protocol mappings in ARCH-028.
+- [ ] TC-08 — preserve live product composition through a parent-side worker broker in ARCH-021.
+- [ ] TC-09 — forward runtime-owned default session persistence in ARCH-023.
+- [ ] TC-10 — inject semantic command roles from composition in ARCH-024.
+- [ ] TC-11 — remove the dead provider override and add whole-pack duplicate diagnostics in ARCH-027.
+- [ ] TC-12 — remove framework public-surface laundering and recursively enforce the boundary in ARCH-022.
+- [ ] TC-13 — make executor projections total and mechanically exhaustive in ARCH-025.
+- [ ] TC-14 — share one shell executable/argument-family resolver in ARCH-026.
+- [ ] TC-15 — run every child done gate and archive all fourteen Task records atomically.
+- [ ] TC-16 — pass assembled conformance, scoped verification, and the CI-equivalent gate.
 
 These Plan rows are initiative-level work, not a second child lifecycle ledger. The canonical child
 projection is the section below.
@@ -87,16 +99,19 @@ user-execution scenario owned by its source child Task.
 - The paired agreement passed GATE-WRITE and independent proposal review.
 - Finding-depth review classified all fourteen proposed child scopes as LOCAL after incorporating four
   foundational scope corrections.
-- Explicit implementation approval remains pending.
+- GATE-APPROVAL passed with the user's explicit instruction to proceed with all fourteen children.
+- GATE-IMPLEMENT passed; the paired spec is active and the initiative Task tracks TC-01 through TC-16.
+- Foundational scopes for ARCH-020/021/025/028 and current-SSOT decisions for ARCH-017/027 were
+  recorded before any child recommendation gate.
 
 ## Decisions
 
-- Preserve the paired spec at `review-ready` until the user explicitly approves implementation.
+- Advance the paired spec to `approved` and execute on a dedicated integration base.
 - Keep child behavior, test, and evidence ownership in the source Task records.
 
 ## Blockers
 
-- GATE-APPROVAL requires explicit user approval before implementation begins.
+- None.
 
 ## Result
 

--- a/.agents/tasks/ARCH-014-session-log-external-payloads-have-no-dereferencer.md
+++ b/.agents/tasks/ARCH-014-session-log-external-payloads-have-no-dereferencer.md
@@ -41,11 +41,34 @@ passes the log as well-formed.
 
 ## Direction
 
-Add a shared dereference helper (read `relativePath`, verify sha256) used by
-`loadSessionLogEntries`/`replaySessionLogEntries` and `ReplayProvider.normalizeRecordedMessage`,
-resolving refs back to their values before normalization. Until that lands, the validator must flag an
-externalized `message`/`response` on the replay substrate as a replay-blocking issue rather than
-passing it.
+Own one bounded, fail-closed external-payload hydrator in `agent-session` at the persistence read
+boundary. It recursively validates reference shape, lexical and real-path containment, declared byte
+length, sha256, JSON content, cycle/depth, and aggregate-byte limits before returning values.
+`loadSessionLogEntries` hydrates relative to the log directory. Raw-entry validation rejects unresolved
+history messages and normalized provider responses and does not count an unresolved response as complete.
+
+`ReplayProvider` reuses that resolver only for normalized responses it consumes. Direct construction
+must supply an explicit base directory for unresolved values or receive a typed `UNRESOLVED_REFERENCE`;
+unrelated observability/tool events remain ignored. The file factory partitions limits to the loader and
+never hydrates twice.
+
+## Recommendation Gate
+
+### 2026-08-15 — endorsed after one revision
+
+- Placement: the format writer and hydrator remain in `@robota-sdk/agent-session`; replay-provider gains
+  no second filesystem reader or new production dependency.
+- Public contract: a typed `SessionLogPayloadResolutionError` exposes stable invalid-limit/reference,
+  unresolved, containment, I/O, integrity, JSON, depth, aggregate-byte, and cycle codes with structured
+  metadata.
+- Verification: unit matrices cover fidelity, corruption, containment, bounds, validator behavior, and
+  direct-provider capability preservation. A mandatory scripted `InteractiveSession` functional test
+  drives the real logger, replays a >32KiB response plus sentinel response, and is registered in the
+  functional-coverage manifest.
+- Scenario: deterministic and agent-executable with no network or provider key; the real JSONL artifact
+  and replayed conversation are the observable product outputs.
+
+REVIEW VERDICT: ENDORSE
 
 ## Test Plan
 
@@ -54,20 +77,110 @@ passing it.
   (message present with real content; responses aligned to calls). Fails today.
 - Red-first: `validateSessionReplayLogEntries` flags an externalized replay-substrate payload when no
   dereferencer is available.
+- Framework functional red/green: add
+  `packages/agent-provider-replay/src/__tests__/session-log-external-payload-replay-functional.test.ts` <!-- allow-missing-artifact: ARCH-014 will add this functional test during implementation. -->
+  using `scriptedSession`, and register it as `session-log-external-payload-replay` in
+  `scripts/harness/functional-coverage-manifest.json`.
 - `pnpm harness:verify -- --scope packages/agent-session` and `--scope packages/agent-provider-replay`
   green.
 
 ## User Execution Test Scenarios
 
-**Applies** (session-log replay is a product surface: `robota --session-log`).
+### Scenario 1 — a real session log replays a large response without corrupting the next response
 
-- Prerequisites: built CLI + a provider key; a session that produces at least one assistant message
-  or tool result over 32KiB (a long file read — the fixture prompt is authored by this work).
-- Steps: run a session with logging that emits a large message; then start a replay run from that log
-  (`--session-log replay`) and compare the replayed conversation to the original.
-- Expected (after fix): the large message/response replays intact and provider responses stay aligned
-  to their calls.
-- Expected (before fix, contrast): the large message is missing or shows a `{ external: … }` ref, and
-  later responses are shifted.
-- Cleanup: delete the log + `.payloads/` dir.
-- Evidence (fill in after implementation): the original vs replayed transcript diff.
+- **Agent executability:** `agent-executable`. This is a standalone public-SDK command, not a test
+  runner. It injects the deterministic scripted provider into a real `InteractiveSession`, then injects
+  the public replay provider into a second real `InteractiveSession`. It needs no TTY, network, external
+  service, or provider key.
+- **Prerequisite state and fixture:** install workspace dependencies with the repository's pinned Node
+  and pnpm versions. This work must add the maintained owner-verification example
+  `packages/agent-provider-replay/examples/verify-session-log-external-payload-replay.ts` <!-- allow-missing-artifact: ARCH-014 will add this standalone public-SDK example during implementation. -->
+  and add `@robota-sdk/agent-framework` plus `tsx` as development-only dependencies of
+  `agent-provider-replay`. The example creates two isolated temporary workspaces. Its only injected
+  source provider is `createScriptedProvider` with response 1 equal to `ARCH_014_LARGE:` followed by
+  40 KiB of `x`, and response 2 exactly `ARCH_014_SENTINEL`. No committed transcript or credential is
+  required.
+- **Exact command and ordered steps:**
+
+  ```bash
+  pnpm --filter @robota-sdk/agent-provider-replay build
+  pnpm --filter @robota-sdk/agent-provider-replay exec tsx --conditions=source examples/verify-session-log-external-payload-replay.ts
+  ```
+
+  The standalone example must (1) create the source `InteractiveSession` with the scripted provider,
+  submit two prompts, and await both public turn handles; (2) locate that session's real JSONL under its
+  `.robota/logs/` directory; (3) recursively find the external-payload reference in the parsed JSONL and
+  prove its relative path names an existing sidecar inside the log directory; (4) load the transcript
+  through public `createReplayProviderFromLogFile`; (5) drive a second real `InteractiveSession` for two
+  awaited turns; (6) compare the replayed assistant messages with both original values in order; (7)
+  shut down both sessions, remove both temporary workspaces, prove both paths are absent; and only then
+  print its result. Every mismatch throws and makes the process exit non-zero.
+
+- **Expected observable result:** both commands exit `0`. After the first command's build output, the
+  second command prints exactly one JSON document with this directly observable shape (the source
+  session id portion of `relativePath` is dynamic):
+
+  ```json
+  {
+    "externalPayload": {
+      "present": true,
+      "relativePath": "<source-session-id>.payloads/f41be56583d387c7fd3a79676507aea00115f6d3809e3eb8fd49bd3bc39a2879.json",
+      "sidecarExists": true
+    },
+    "largeResponse": {
+      "byteLength": 40975,
+      "sha256": "42bc9897b0c5ebe94994f5ef0b494461e1133116821ed9141c0d2043a0168193",
+      "matchesOriginal": true
+    },
+    "sentinel": {
+      "callIndex": 2,
+      "value": "ARCH_014_SENTINEL",
+      "aligned": true
+    },
+    "cleanup": {
+      "sourceWorkspaceRemoved": true,
+      "replayWorkspaceRemoved": true
+    }
+  }
+  ```
+
+  This proves the first replayed assistant content is the full value rather than a reference or missing
+  message, and the second recorded response remains aligned with replay call 2.
+
+- **Cleanup/reset:** the example owns cleanup in a `finally` path as well as the success path, restricts
+  deletion to the two exact temporary directories it created, shuts both sessions down, and removes the
+  JSONL, `.payloads/`, and replay logs with those directories. The success output itself confirms both
+  directories no longer exist.
+- **Evidence:**
+
+### [DONE-GATE-STAGE-1] — ❌ FAIL | 2026-08-15
+
+**Status remains:** scenario drafted
+**Failed criteria:**
+
+- Product-surface scenario: the exact command is `pnpm --filter @robota-sdk/agent-provider-replay exec
+vitest run src/__tests__/session-log-external-payload-replay-functional.test.ts`, and its observable is
+  the Vitest result plus assertions made inside that test. The gate catalogue explicitly excludes a
+  test run as a user-execution scenario, even when the test internally calls public SDK objects.
+  **Required action:** provide an exact non-test product command or public SDK/example invocation whose
+  process-visible output directly reports the durable JSONL reference, full hydrated large response,
+  aligned sentinel response, exit code, and cleanup result; keep Vitest in the engineering test plan.
+
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-15
+
+**Status upgrade:** scenario drafted → scenario written
+
+- Scenario completeness: PASS — Scenario 1 supplies explicit prerequisites and fixture values, exact
+  ordered Bash commands and SDK steps, precise exit/output observables, bounded cleanup, and an evidence
+  field reserved for post-implementation execution.
+- Executability: PASS — the scenario is explicitly `agent-executable`, non-interactive, and invokes a
+  maintained standalone example rather than a test runner.
+- Product surface: PASS — the second command drives the public `InteractiveSession` and
+  `createReplayProviderFromLogFile` SDK surfaces and directly emits the durable sidecar, hydrated large
+  response, aligned sentinel, and cleanup observations as process-visible JSON; the build command only
+  establishes its prerequisite artifact.
+- Credentials and external services: PASS — the prerequisites explicitly state that the scripted
+  provider requires no TTY, network, external service, provider key, or committed transcript.
+- Expected-value consistency: PASS — independent calculation confirmed the specified 40 KiB payload is
+  40975 bytes and has SHA-256
+  `42bc9897b0c5ebe94994f5ef0b494461e1133116821ed9141c0d2043a0168193`.

--- a/.agents/tasks/ARCH-017-injected-permission-ask-handlers-are-dead-surface.md
+++ b/.agents/tasks/ARCH-017-injected-permission-ask-handlers-are-dead-surface.md
@@ -5,7 +5,7 @@ created: 2026-08-13
 priority: high
 urgency: soon
 area: packages/agent-framework, packages/agent-interface-transport
-depends_on: []
+depends_on: [ARCH-018]
 ---
 
 # ARCH-017: permission/ask handler seams are dead
@@ -40,36 +40,26 @@ says is emitted has no emitter, so a channel that renders it gets nothing.
 
 ## Direction
 
-Decide (one design fact, both symptoms):
-
-- **Honor injection:** make the prompt registry fall back to a caller-supplied `permissionHandler`/
-  `askHandler` when one is provided (both paths), OR
-- **Remove the dead fields** from `TInteractiveSessionOptions`/`IInteractiveSessionInjectedOptions`
-  and rewrite the SPEC's Extension Points / ask-seam / Permission System sections around the real
-  mechanism (`permission_request`/`ask_request` + `resolvePermission`/`resolveAsk`).
-
-Then either emit `permission-resolved` from the prompt-registry settle path (it carries exactly
-`id`/`granted`) or remove the union member and the SPEC row. Today both halves are false.
+Remove `permissionHandler` and `askHandler` from the session option contracts and remove the stale
+`InteractionEvent.permission-resolved` member. REMOTE-007's prompt registry is the sole settlement
+owner: requests are `permission_request` / `ask_request`, drivers settle them through
+`resolvePermission` / `resolveAsk`, and `prompt_resolved` is the only settlement event. Leaf convenience
+factories may preserve callback ergonomics by subscribing to request events and resolving through that
+same registry; they must not introduce a second session-level settlement path.
 
 ## Test Plan
 
-- Red-first: a session constructed with a custom `permissionHandler` — assert it is invoked on a tool
-  permission request (fails today; the registry default runs instead). If the remove-fields option is
-  chosen, a typecheck asserting the fields are gone + SPEC updated.
-- Red-first: assert `permission-resolved` is either emitted on resolution or absent from the union.
+- Red-first type tests assert the obsolete session option fields and `permission-resolved` event are gone.
+- Prompt-registry integration asserts leaf callback convenience subscribes to a request and settles it
+  through `resolvePermission` / `resolveAsk`, producing exactly one `prompt_resolved` event.
 - `pnpm harness:verify -- --scope packages/agent-framework` green.
 
 ## User Execution Test Scenarios
 
-**Applies** (via the public SDK — a consumer supplying a custom permission handler).
+**Applies** through the documented prompt-request SDK surface.
 
-- Prerequisites: built workspace; a scratch SDK consumer constructing an interactive session with a
-  custom `permissionHandler` that auto-denies a specific tool.
-- Steps: run a turn that triggers that tool.
-- Expected (after the "honor" fix): the custom handler decides (the tool is denied by it).
-- Expected (before fix, contrast): the custom handler never runs; the built-in registry prompt (or
-  fail-closed deny) applies instead.
-- If "remove fields" is chosen: Not applicable — record the API removal + SPEC rewrite in the Test
-  Plan; the scenario becomes "consumer uses the documented `permission_request` path".
-- Evidence (fill in after implementation): the consumer source + turn transcript showing which handler
-  decided.
+- Prerequisites: built workspace; a deterministic consumer subscribed to `permission_request`.
+- Steps: trigger a permission request, resolve it with `resolvePermission`, and observe session events.
+- Expected: the consumer receives the request and exactly one canonical `prompt_resolved` settlement;
+  no legacy handler or `permission-resolved` path exists.
+- Evidence (fill in after implementation): the deterministic consumer transcript.

--- a/.agents/tasks/ARCH-020-branch-event-is-declared-and-emitted-by-nothing.md
+++ b/.agents/tasks/ARCH-020-branch-event-is-declared-and-emitted-by-nothing.md
@@ -5,7 +5,7 @@ created: 2026-08-13
 priority: medium
 urgency: soon
 area: packages/agent-interface-transport, packages/agent-framework
-depends_on: []
+depends_on: [ARCH-016]
 ---
 
 # ARCH-020: branch_event is dead wiring
@@ -36,15 +36,19 @@ edit-checkpoint-store.ts:77-101` (createCheckpoint), `:156-199` (restore→forkF
 
 ## Direction
 
-Emit `branch_event` from the checkpoint-store transitions through `InteractiveSession`, mirroring how
-`goal_event`/`plan_event` are emitted — so a GUI/monitor surface can render branch changes. (Small,
-mechanical.) If the event is genuinely not wanted yet, strike the "Emitted on every transition" TSDoc
-and mark it forward-provisioned — but the pointer being wired argues for emitting it.
+Execute with ARCH-028 as one named event-delivery work unit. Define an exhaustive checkpoint/branch
+operation matrix covering create, fork, switch, restore, rollback, and resume-pointer updates. Assign
+each operation one exact declared event kind and payload, or explicitly classify it as a non-event.
+Emit only after checkpoint mutation, history replacement, and persistence succeed. A subscriber failure
+must not retroactively fail committed state: the operation remains successful while the owning TUI or
+protocol adapter reports the delivery failure through its injected error lifecycle. Shared keys and
+payloads belong to `agent-interface-transport`; executable fan-out policy remains in transport packages.
 
 ## Test Plan
 
-- Red-first: subscribe to `branch_event` on a session, fork/switch a checkpoint, assert the event
-  fires with the transition kind — fails today.
+- Red-first: drive every matrix row and assert its exact post-persistence event or explicit non-event.
+- Throwing-subscriber tests assert committed state remains successful and the transport-owned error sink
+  observes the delivery failure.
 - `pnpm harness:verify -- --scope packages/agent-framework` green.
 
 ## User Execution Test Scenarios

--- a/.agents/tasks/ARCH-021-child-process-subagent-worker-bypasses-product-composition.md
+++ b/.agents/tasks/ARCH-021-child-process-subagent-worker-bypasses-product-composition.md
@@ -5,7 +5,7 @@ created: 2026-08-13
 priority: high
 urgency: soon
 area: packages/agent-subagent-runner, packages/agent-cli, packages/pack-coding, packages/agent-product
-depends_on: []
+depends_on: [ARCH-025]
 ---
 
 # ARCH-021: subagent worker ignores the product's composition
@@ -44,19 +44,27 @@ directly contradicts ARCH-006 ("every tool robota runs comes from a pack").
 
 ## Direction
 
-Give `IChildProcessSubagentRunnerOptions` (and the worker start payload) a seam for the product's
-provider-definition module and composed tool surface, threaded from the composition root the same way
-the in-process runner receives `deps.tools` — so a product's declared providers/tools reach
-child-process subagents. Reconcile `project-structure.md:15` vs `:351` (the composition-leaf
-"imported only at composition roots" rule vs the library edge the same document blesses): either name
-the forked-worker entry a sanctioned composition root or move the entry to the composition-root tier.
-Scope ARCH-006's claim to in-process execution in the meantime if the seam lands incrementally.
+Treat the process boundary as a serialization boundary. Keep the exact composed provider definitions,
+tool instances, credentials, and live owner-bound services in the parent, and expose them to the neutral
+worker through a versioned correlated capability broker. The worker uses provider/tool proxies and must
+fail startup when the broker handshake is unavailable; it never imports or reconstructs Robota defaults.
+
+The protocol must preserve provider streaming, cancellation, typed errors, permissions, and settle-once
+lifecycle behavior. Provider profile selection occurs through an injected parent resolver, falling back
+to the invoking runtime provider only when the request omits a profile. Tool calls serialize every
+classifiable `IToolExecutionContext` field, derive `signal`, and reconstruct live event/ask services in
+the parent. Extensions use a bounded recursive tagged codec for `undefined`, finite/special numbers,
+`Date`, `Error`, arrays, and plain records; cycles, invalid dates, unsupported prototypes, malformed tags,
+and depth/byte overflow fail explicitly. Exhaustive fixtures cover every top-level context key and wire
+variant.
 
 ## Test Plan
 
-- Red-first: a product profile with a custom provider definition and a pack-contributed tool whose
-  name is NOT in `createDefaultTools()` — assert a child-process subagent can construct the provider
-  and call the pack tool. Fails today ("Unknown provider" / tool absent).
+- Red-first: a custom provider and uniquely named pack tool execute through the parent broker without
+  credentials or live instances entering the start payload.
+- Forked-worker tests cover requested/default/unknown profiles, streaming, cancellation, typed errors,
+  ownership-field and tagged-extension round trips, malformed/cyclic/over-limit rejection, missing
+  capabilities, broker handshake failure, and settle-once disconnect/error/exit cleanup.
 - Regression: existing in-process subagent tool-surface parity still holds.
 - `pnpm harness:verify -- --scope packages/agent-subagent-runner` green.
 

--- a/.agents/tasks/ARCH-023-createAgentRuntime-default-sessionstore-never-forwarded.md
+++ b/.agents/tasks/ARCH-023-createAgentRuntime-default-sessionstore-never-forwarded.md
@@ -5,7 +5,7 @@ created: 2026-08-13
 priority: medium
 urgency: soon
 area: packages/agent-framework
-depends_on: []
+depends_on: [ARCH-015]
 ---
 
 # ARCH-023: the runtime-level sessionStore is never inherited

--- a/.agents/tasks/ARCH-025-executor-projections-silently-drop-contract-fields.md
+++ b/.agents/tasks/ARCH-025-executor-projections-silently-drop-contract-fields.md
@@ -5,7 +5,7 @@ created: 2026-08-13
 priority: medium
 urgency: soon
 area: packages/agent-executor, packages/agent-framework
-depends_on: []
+depends_on: [ARCH-024, ARCH-027]
 ---
 
 # ARCH-025: executor facade projections lose contract fields
@@ -41,21 +41,17 @@ projections that should carry them, so a caller who sets them gets a no-op with 
 
 ## Direction
 
-1. Map `usage` in `SubagentManager.wait()` (`...(result.usage ? { usage: result.usage } : {})`),
-   mirroring `toBackgroundResult`.
-2. Either thread `providerProfile` through `ISubagentSpawnRequest`/`toSubagentStartRequest`, or
-   retire/annotate the request field as unused (a forward-provisioned field must not be silently
-   dropped by the one bridging projection — owner decision).
-3. Export `IScheduleEditPatch` from agent-executor's public index, document it in the SPEC, and make
-   agent-framework import it instead of re-declaring.
+Create one canonical total mapper for the public task/request/result projection seam. Every public key
+must be mechanically classified as mapped, deliberately derived, or explicitly rejected; adding a key
+must fail a fixture until classified. Preserve `usage`, `providerProfile`, permission policy, schedule
+patch fields, and future public fields rather than relying on recurring hand-written partial objects.
+Export one `IScheduleEditPatch` owner from agent-executor and consume it from agent-framework.
 
 ## Test Plan
 
-- Red-first: an orchestration step whose subagent reports token usage asserts
-  `IOrchestrationStepResult.usage` is populated (fails today).
-- Red-first (if providerProfile is threaded): a background agent task with a `providerProfile` reaches
-  the worker with that profile; (if retired) a scan asserting the field has no setter.
-- Typecheck asserts `agent-framework` imports `IScheduleEditPatch` (no inline duplicate).
+- Red-first projection tests preserve usage, provider profile, permission policy, and schedule edits.
+- A public-key exhaustiveness fixture fails whenever a new field is unclassified.
+- Typecheck asserts `agent-framework` consumes the exported `IScheduleEditPatch` owner.
 - `pnpm harness:verify -- --scope packages/agent-executor` green.
 
 ## User Execution Test Scenarios

--- a/.agents/tasks/ARCH-027-dead-composition-contract-fields.md
+++ b/.agents/tasks/ARCH-027-dead-composition-contract-fields.md
@@ -31,24 +31,22 @@ args.provider })` BEFORE building the profile (`agent-cli/src/cli.ts:262-265`), 
 
 ## Direction
 
-- `providerOverride`: remove it from `IProductProfile` (the shell-side resolution is the actual
-  design), or fold it into `assembleProduct`'s provider resolution and document it in the SPEC's
-  precedence chain. (Contract removal is a published-surface change — semver/changeset gate.)
-- `ICapabilityPack.id`: either implement duplicate-pack detection / add pack provenance to
-  `IRejectedCapability`, or correct the field's doc to "diagnostics" (not duplicate-detection).
+Remove `IProductProfile.providerOverride`: the shell owns provider-name selection and passes already
+resolved `providerSettings` into product composition. Preserve the existing shell override behavior and
+record the published-contract removal with the required changeset. Make `ICapabilityPack.id` effective:
+reject a later duplicate pack as a whole before merging any of its capabilities, and attach `packId`
+provenance to capability-collision diagnostics.
 
 ## Test Plan
 
-- Red-first (providerOverride, if folded): a profile with `providerOverride` set selects that provider;
-  (if removed) the field no longer exists on the contract.
-- Red-first (id, if implemented): merging two packs with the same id produces a rejection naming the
-  duplicate id; (if doc-only) the field's TSDoc no longer claims duplicate detection.
+- Red-first type test asserts `providerOverride` is absent while CLI/shell override behavior remains.
+- Red-first merge tests assert a later duplicate pack is rejected atomically and capability collisions
+  include `packId` provenance.
 - `pnpm harness:verify -- --scope packages/agent-product` and `--scope packages/agent-capability-pack`
   green; changeset present if the profile contract changes.
 
 ## User Execution Test Scenarios
 
-**Applies to providerOverride only if folded** (product assembly is public SDK usage): a scratch
-product profile setting `providerOverride` selects that provider at assembly. If both fields are
-resolved by removal/doc-correction: Not applicable — record the contract change + changeset in the
-Test Plan.
+Not applicable — this item removes a dead profile field and strengthens composition diagnostics without
+changing the shell's already-resolved provider-selection behavior. Record the contract test, regression
+test, and changeset as engineering evidence.

--- a/.agents/tasks/ARCH-028-plan-and-context-refresh-events-emitted-into-a-contract-no-transport-consumes.md
+++ b/.agents/tasks/ARCH-028-plan-and-context-refresh-events-emitted-into-a-contract-no-transport-consumes.md
@@ -5,7 +5,7 @@ created: 2026-08-13
 priority: medium
 urgency: soon
 area: packages/agent-interface-transport, packages/agent-framework, packages/agent-transport-tui, packages/agent-transport-protocol, packages/agent-transport
-depends_on: []
+depends_on: [ARCH-016]
 ---
 
 # ARCH-028: emitted session events no transport consumes
@@ -36,17 +36,18 @@ notifications fire and reach no surface — TUI, WS bridge, or headless.
 
 ## Direction
 
-Decide per member (same shape as ARCH-020): wire a consumer — a TUI notice and/or WS-bridge forwarding
-so a GUI/monitor can render plan-mode transitions and context-file refreshes — or strike the "consumed
-by transports" charter clause for these members and mark them forward-provisioned. Coordinate with
-ARCH-020 (branch_event) and ARCH-016 (session-log vocabulary) so the plan/branch/context event family
-is resolved consistently across emit, transport-forward, and log-record.
+Execute with ARCH-020 as one named event-delivery work unit. Own shared event keys and payloads in
+`agent-interface-transport`, but keep executable subscription and fan-out policy out of that interface
+package. Add separate mechanically-total `Record<event, classification>` mappings in the TUI and protocol
+implementation packages so branch, plan, and context-refresh events are either deterministically rendered,
+forwarded/accepted by clients, or explicitly classified as non-surface events. Delivery failures use each
+transport's existing injected terminal/logger or client error/disconnect lifecycle and are never swallowed.
 
 ## Test Plan
 
-- Red-first: subscribe a transport (TUI channel binding or WS bridge fan-out) to `plan_event` and
-  `context_file_refreshed`, drive a plan-mode transition and a context-file refresh, assert the surface
-  receives them. Fails today.
+- Red-first exhaustive-map fixtures fail when a shared event key has no TUI/protocol classification.
+- Drive plan transitions and context refreshes and assert deterministic TUI rendering plus protocol
+  fan-out/client observation; include owned delivery-failure assertions.
 - `pnpm harness:verify -- --scope packages/agent-transport-tui` (and the WS bridge scope) green.
 
 ## User Execution Test Scenarios


### PR DESCRIPTION
## Summary

- activate the AGREEMENT-002 multi-backlog architecture initiative
- correct the root scopes and dependency order for ARCH-017/020/021/023/025/027/028
- record the endorsed ARCH-014 replay-hydration design and executable scenario gate

## Verification

- `pnpm harness:scan` — 110 passed, 2 skipped
- `pnpm harness:verify-like-ci` — PASS, 12 stages
- harness contracts — 2301/2301 passed
- pre-push scan — 108 passed, 2 skipped
- CLI smoke — `robota 3.0.0-beta.79`

## Scope

Documentation, backlog, and spec-planning artifacts only. No implementation code is included yet.