### PR TITLE
docs(tasks): file agent-core issue backlog items (CORE-036, CORE-037, CORE-038)

### DIFF
--- a/.agents/tasks/CORE-036-runstream-never-applies-config-systemmessage.md
+++ b/.agents/tasks/CORE-036-runstream-never-applies-config-systemmessage.md
@@ -1,0 +1,97 @@
+---
+title: "CORE-036: runStream() never applies config.systemMessage — the streaming path builds provider messages straight off the conversation store and skips the session initialization that the round path uses to attach the system prompt, so the same agent obeys its persona through run() and ignores it through runStream()"
+status: todo
+created: 2026-08-16
+priority: high
+urgency: now
+area: packages/agent-core
+depends_on: []
+---
+
+# CORE-036: runStream() drops the configured system prompt
+
+Reported by an external user in [issue #1736](https://github.com/woojubb/robota/issues/1736)
+(`@robota-sdk/agent-core` 3.0.0-beta.78, re-confirmed against `develop`).
+
+## Problem
+
+`Robota.run()` and `Robota.runStream()` receive an identical `executionConfig`, but only the round
+path ever reads `config.systemMessage`. The streaming path takes the conversation store's messages
+as-is, so an agent whose entire behavior is defined by its system prompt streams as if it had none.
+
+The failure is silent and mis-attributable: the model answers fluently, just not under its
+instructions, which reads as a model-quality problem rather than a dropped prompt.
+
+## Evidence (verified against `develop`, 2026-08-16)
+
+- `packages/agent-core/src/services/execution-service-helpers.ts:189-192` — the round path's
+  `initializeConversationStore()` attaches the prompt:
+  `const hasSystemMessage = session.getMessages().some((m) => m.role === 'system'); if
+  (config.systemMessage && !hasSystemMessage) { session.setSystemPrompt(config.systemMessage, {
+  executionId }); }`
+- `packages/agent-core/src/services/execution-stream.ts:72` — the streaming path never calls that
+  helper; it goes straight to `conversationHistory.getConversationStore(context.conversationId)`.
+- `packages/agent-core/src/services/execution-stream.ts:106-114` — provider messages are the store's
+  messages plus, optionally, the *ephemeral* per-run block only:
+  `const conversationMessages = conversationStore.getMessages(); … ephemeralSystemContext …`
+- `grep -n "systemMessage" packages/agent-core/src/services/execution-stream.ts` returns no hit —
+  the only system-message reference on that path is `ephemeralSystemContext` (SELFHOST-008 P3).
+- Both entry points build the config identically (`packages/agent-core/src/core/robota-execution.ts`
+  — `robotaRun` and `robotaRunStream`), so the divergence is entirely in the service layer.
+
+Reporter's reproduction: one `Robota` constructed with a `systemMessage` that demands a fixed string
+returns that string from `run('hi')` and an unrelated greeting from `runStream('hi')`. Passing a
+`signal` makes no difference.
+
+## Impact
+
+Any streaming agent whose behavior is defined by a system prompt behaves as if unconfigured. The
+reporter's multi-agent app renders every persona through `runStream()`; it also explains a workaround
+they had accumulated — duplicating behavioral rules into the *user* prompt because
+"system-message-only instructions didn't stick".
+
+`runStream()` is the default surface for interactive/TUI usage, so this is a correctness defect on
+the most-used path, not an edge case.
+
+## Direction
+
+Do not add a second copy of the prompt-injection logic to `execution-stream.ts` — that is exactly how
+the two paths drifted. Route the streaming path through the same session initialization the round
+path uses (`initializeConversationStore`, or a shared extraction of it), so `config.systemMessage`,
+the "inject once per session" rule (CORE-009/CORE-010) and the ephemeral-block contract are owned in
+one place. Confirm the interaction with `Robota.updateSystemPrompt` (`core/robota.ts:317`) is
+unchanged.
+
+Related but distinct: CORE-032 (`runStream` is a single-round engine) covers the same file; check
+whether the two are better delivered together against one shared session-preparation seam.
+
+## Test Plan
+
+- Unit/integration test asserting the provider receives a `system` message carrying
+  `config.systemMessage` for **both** `run()` and `runStream()` — a shared table-driven test over the
+  two entry points, so a future divergence fails rather than passing quietly.
+- Test covering the resume case: a store that already holds a system message is not given a second
+  one by the streaming path (the round path's `hasSystemMessage` guard must hold identically).
+- Test covering `ephemeralSystemContext` on the streaming path still being appended to the derived
+  provider-message array only, never written to the store.
+- `pnpm harness:verify -- --scope packages/agent-core` green.
+- `packages/agent-core/docs/SPEC.md` § System Prompt states the guarantee holds for both paths.
+
+## User Execution Test Scenarios
+
+Applies — this changes observable SDK behavior.
+
+**Scenario 1 — the same system prompt survives streaming**
+
+- Prerequisites: a provider API key (or an OpenAI-compatible gateway `baseURL`) exported in the
+  environment; a workspace build (`pnpm build`).
+- Environment: uses the existing examples surface — no new fixture required. Confirm at implementation
+  time which example under `apps/`/`examples/` is the shortest streaming path; if none exists, the
+  work adds a minimal script under the examples surface.
+- Steps: construct one `Robota` with
+  `systemMessage: 'Reply with exactly the string OK-APPLIED and nothing else.'`; call `run('hi')`,
+  print the result; construct an identical agent, iterate `runStream('hi')`, concatenate the chunks,
+  print the result.
+- Expected observable result: both prints are `OK-APPLIED`. (Before the fix, only the first is.)
+- Cleanup: none — no state is persisted.
+- Evidence: _to be filled after implementation_ (paste both printed outputs).

--- a/.agents/tasks/CORE-037-zodtojsonschema-drops-nested-object-properties.md
+++ b/.agents/tasks/CORE-037-zodtojsonschema-drops-nested-object-properties.md
@@ -1,0 +1,119 @@
+---
+title: "CORE-037: zodToJsonSchema converts a nested z.object() to a bare { type: 'object' } with no properties or required, so every tool and structured-output schema with one level of nesting reaches the model as an unspecified blob — the handler is then never successfully invoked, sometimes with no error at all"
+status: todo
+created: 2026-08-16
+priority: critical
+urgency: now
+area: packages/agent-core, packages/agent-tools
+depends_on: []
+---
+
+# CORE-037: nested objects lose their fields in Zod → JSON Schema conversion
+
+Reported by an external user in [issue #1737](https://github.com/woojubb/robota/issues/1737)
+(`@robota-sdk/agent-core` 3.0.0-beta.78, re-confirmed against `develop`).
+
+## Problem
+
+`convertZodTypeToProperty` returns `{ type: 'object' }` for `ZodObject` without recursing into the
+shape. The top-level object is handled separately by `zodToJsonSchema` (which does walk the shape),
+so only **nested** objects lose their `properties`/`required`. The model therefore sees "this field
+is an object" with no indication of what belongs in it.
+
+```ts
+zodToJsonSchema(z.object({ inner: z.object({ s: z.string() }) }))
+// → { type: 'object', properties: { inner: { type: 'object' } }, required: ['inner'] }
+//                                            ^^^^^^^^^^^^^^^^^^ shape discarded
+```
+
+## Evidence (verified against `develop`, 2026-08-16)
+
+- `packages/agent-core/src/schema/zod-to-json-schema.ts:96-97` —
+  `case 'ZodObject': return { type: 'object', ...base };` — no recursion.
+- Same file, `case 'ZodArray'` (`:84-94`) **does** recurse via
+  `convertZodTypeToProperty(typeDef.type)`, and `ZodRecord` recurses into `valueType` — so the
+  omission is specific to `ZodObject`, not a deliberate depth limit.
+- Consequence for `z.array(z.object(...))`: the array recurses into `ZodObject`, which then returns
+  the bare form — so arrays-of-objects are affected through the same case.
+
+Reporter's measured downstream effect (forced tool call, `toolChoice: { tool: name }`,
+`maxExecutionRounds: 1`, same model and prompt, only the schema shape varied):
+
+| tool input schema                                    | handler invoked |
+| ---------------------------------------------------- | --------------- |
+| `{ a: string, b: string }`                            | yes |
+| `{ items: string[] }`                                 | yes |
+| `{ items: string[] }` with `.max(2)`                  | yes |
+| `{ delivery: { score, evidence[], suggestions[] } }`  | no |
+| 5 × the above nested object + `summary: string`       | no |
+
+Flat schemas including arrays and constraints work; one level of nesting is enough to break it.
+
+## A shipped built-in tool is already affected
+
+This is not confined to user-authored tools. `packages/agent-tools/src/implementations/function-tool.ts:40`
+calls `zodToJsonSchema(zodSchema)` for every `createZodFunctionTool`, and the built-in computer-use
+tool nests:
+
+- `packages/agent-tools/src/computer-use/computer-tool.ts:72-74` —
+  `const ComputerSchema = z.object({ action: ActionSchema.describe(…) })`, where `ActionSchema` is a
+  13-field `z.object`. The model therefore receives `action` as `{ type: 'object' }` with **no
+  fields at all** — the action vocabulary, the coordinates, the key list, none of it.
+- Same file `:64` — `path: z.array(PointSchema)` is an array-of-objects, stripped through the same
+  `ZodArray` → `ZodObject` route.
+
+The comment above `ActionSchema` ("A flat object (not a discriminated union) so it converts to JSON
+schema") shows the converter's limits were already being worked around one level down, while the
+level above still nests. Whether the `Computer` tool is currently invocable at all should be checked
+as part of this work; if it is not, that raises the severity and may overlap TOOL-004 (built-in tool
+descriptions name parameters the schema rejects).
+
+## Impact
+
+- Any `createZodFunctionTool` tool whose input has a sub-object is effectively uncallable. The
+  failure is quiet: sometimes the run completes with the handler never called and no error raised,
+  sometimes it surfaces as `Validation Error: Failed to parse arguments for tool "<name>"` — neither
+  points at schema conversion.
+- The same converter feeds `IStructuredOutputSpec.jsonSchema`, so `run(input, { output })` (CORE-015)
+  hands providers the same truncated schema on both the native and the fallback transport.
+- The reporter's domain object (five scored axes, each `{ score, evidence[], suggestions[] }`) cannot
+  be expressed flatly without exploding into ~16 sibling fields.
+
+## Direction
+
+Recurse for `ZodObject`, mirroring `ZodArray`. `zodToJsonSchema` already contains the
+"object shape → `properties`/`required`" walk for the top level; extract it into a shared helper so
+the entry point and the nested case cannot diverge again. Check the interaction with `ZodOptional`
+inside a nested shape (an optional nested field must stay out of `required`) and confirm the
+`IParameterSchema` type actually carries nested `properties`/`required` — if it does not, widening
+it is part of this work.
+
+## Test Plan
+
+- Converter tests for: two levels of nesting; an optional field inside a nested object (absent from
+  that object's `required`); `z.array(z.object(...))`; a nested object carrying a `.describe()`.
+- A round-trip test asserting the emitted schema validates a conforming payload and rejects one
+  missing a nested required field, so the fix is pinned by behavior and not only by shape.
+- Check the other `IParameterSchema` producers/consumers (provider adapters that forward tool
+  schemas) accept the now-deeper shape.
+- A test pinning the built-in `Computer` tool's emitted parameter schema, so the regression that
+  silently emptied its `action` field cannot recur unnoticed.
+- `pnpm harness:verify -- --scope packages/agent-core` and `--scope packages/agent-tools` green.
+
+## User Execution Test Scenarios
+
+Applies — this changes observable SDK behavior.
+
+**Scenario 1 — a tool with a nested-object input is actually invoked**
+
+- Prerequisites: a provider API key (or OpenAI-compatible gateway `baseURL`) exported; `pnpm build`.
+- Environment: uses the existing examples surface; confirm at implementation time which example
+  registers a Zod tool, and extend it (or add a minimal script there) with a nested-object input.
+- Steps: define a tool via `createZodFunctionTool` whose input is
+  `z.object({ report: z.object({ score: z.number(), notes: z.array(z.string()) }) })` with a handler
+  that prints its received argument; run the agent with `toolChoice` forcing that tool and a prompt
+  that supplies the values.
+- Expected observable result: the handler prints a fully populated `report` object. (Before the fix,
+  the handler is not called, or the run reports `Failed to parse arguments`.)
+- Cleanup: none.
+- Evidence: _to be filled after implementation_ (paste the handler output and the run result).

--- a/.agents/tasks/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md
+++ b/.agents/tasks/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md
@@ -1,0 +1,146 @@
+---
+title: "CORE-038: the structured-output fallback transport re-asks for JSON in prose, which is the path every provider without a native responseFormat surface takes — and, because a native surface is detected per PROVIDER PACKAGE rather than per endpoint, an OpenAI-compatible gateway serving a non-OpenAI model is silently on the prompt path while the enforcement loop believes it enforced early"
+status: todo
+created: 2026-08-16
+priority: medium
+urgency: soon
+area: packages/agent-core, packages/agent-provider-openai-compatible, packages/agent-provider-bytedance
+depends_on: [CORE-037]
+---
+
+# CORE-038: forced tool call as the structured-output fallback transport
+
+Proposed by an external user in [issue #1738](https://github.com/woojubb/robota/issues/1738), as a
+follow-up to CORE-015 (first-class structured output). The reporter offered to open a PR for either
+piece if the direction is agreed.
+
+## Problem
+
+CORE-015's validate-and-retry loop is not in question — it is what guarantees correctness. What is in
+question is the **transport** used on the attempt the loop wraps. Today, when a provider has no
+native structured-output surface, the fallback re-prompts in prose:
+
+```ts
+// packages/agent-core/src/core/robota-execution.ts:179
+function buildRetryFeedbackInput(spec: IStructuredOutputSpec, issues: string[]): string {
+  return [
+    'Your previous response did not match the required JSON schema.',
+    …
+    'Respond with ONLY a JSON object (no prose, no code fences) matching this JSON schema:',
+    JSON.stringify(spec.jsonSchema),
+  ].join('\n');
+}
+```
+
+Two things make this worth changing rather than accepting:
+
+1. **The fallback is not a rare path.** Verified against `develop`, 2026-08-16 — the native
+   `responseFormat` mapping exists in three provider packages and in neither of the other two
+   text-generation packages:
+
+   | provider package                   | native structured-output surface | evidence |
+   | ---------------------------------- | -------------------------------- | -------- |
+   | `agent-provider-anthropic`         | yes — `output_config.format`     | `src/anthropic/provider.ts:349-356` |
+   | `agent-provider-gemini`            | yes — `responseSchema`           | `src/gemini/execution-helpers.ts:142-145` |
+   | `agent-provider-openai`            | yes — `response_format`          | `src/openai/chat-completions-chat.ts` |
+   | `agent-provider-openai-compatible` | **no** — prompt fallback         | `grep -rn responseFormat …/src` → no hits |
+   | `agent-provider-bytedance`         | **no** — prompt fallback         | `grep -rn responseFormat …/src` → no hits |
+
+   `openai-compatible` is the path for DeepSeek, Groq, Together, OpenRouter, vLLM/Ollama and any
+   gateway — a large share of real deployments.
+
+2. **"Native surface" is per-endpoint, not per-model.** `agent-provider-openai` accepts a `baseURL`.
+   Pointed at a gateway serving a non-OpenAI model, the request still carries
+   `response_format: json_schema`, the endpoint accepts it, and the underlying model may ignore it.
+   The provider cannot tell the difference, so the enforcement loop believes it is on the
+   "enforce early" path while it is effectively on the prompt path.
+
+Reporter's measurement outside robota — same schema, same prompt, one OpenAI-compatible gateway:
+
+| transport                   | DeepSeek v4-flash | Claude haiku-4.5 |
+| --------------------------- | ----------------- | ---------------- |
+| JSON-schema response format | 0/4               | 4/4              |
+| forced tool call            | 4/4               | 4/4              |
+
+The failures were not quality failures: the model produced good content under an invented key
+(`{"feedback": …}` instead of `{"hint": …}`), and once returned the JSON schema definition itself.
+
+## Impact
+
+The loop still returns a schema-conforming object or exhausts its retries, so this is a **cost,
+latency and failure-rate** problem rather than a correctness hole: every first-attempt miss is a full
+extra turn. On the providers most likely to miss, the reporter measured a 0% first-attempt rate.
+
+## Direction (proposal — needs a decision before implementation)
+
+Suggested shape from the reporter:
+
+1. Add a tool-call transport used when no native surface is available: register one tool built from
+   `spec.jsonSchema` (name from `spec.name`), send `tool_choice: required`, and validate the tool
+   arguments with the existing validator.
+2. Keep `buildRetryFeedbackInput` for the case where even the forced tool call fails validation — a
+   good last resort, just not a good first resort.
+3. Optionally make the transport selectable for deployments that know their endpoint honors
+   `response_format`.
+
+Nothing about the enforcement loop, the validator, or the public `run(input, { output })` surface
+changes.
+
+Open questions this Task does **not** decide — they belong to the paired spec-doc and the
+recommendation gate:
+
+- Is the tool-call transport the default for the two non-native packages only, or for any endpoint
+  whose native support cannot be established (which would change `agent-provider-openai` behavior
+  when `baseURL` is set)?
+- Where does transport selection live — provider capability declaration, agent config, or
+  `IRunOptions`? Note PROV-006 (per-model capability flags declared but read by nothing) covers the
+  neighbouring capability-declaration surface and should be reconciled, not duplicated.
+- Does injecting a schema tool interact with an agent's own tool set (name collisions, a model
+  choosing a real tool instead of the schema tool under `tool_choice: required`)?
+
+**Blocked in effect by CORE-037.** While `zodToJsonSchema` drops nested object properties, both
+transports receive a truncated schema, so any before/after measurement of this change is
+uninterpretable for nested schemas.
+
+## Secondary item from the issue — already closed, verify sufficiency
+
+The issue also asks that `llms.txt` mention structured output. On `develop` it already does:
+
+- `llms.txt:24` — "**Schema-enforced structured output** — `run(prompt, { output: zodSchema })`
+  returns a validated typed object with provider-native mapping + bounded retry".
+
+So the gap the reporter hit is closed. What is worth checking as part of this Task is whether that
+line conveys the *guarantee* strongly enough for an agent reading `llms.txt` to choose robota's path
+over its own SDK's helper, and whether it should state that non-native providers go through the
+bounded loop rather than degrading silently. Reply to the issue with the correction either way.
+
+## Test Plan
+
+- The spec-doc's decision is recorded and passes the recommendation gate before any code is written
+  (this is a proposal, not a defect).
+- Provider-level tests asserting the forced-tool-call transport is used on the non-native packages
+  and that its arguments go through the same validator as the native path.
+- A test asserting the prose retry still fires when the forced tool call itself fails validation.
+- A replay-provider (`agent-provider-replay`) test pinning the transport chosen per provider, so a
+  future provider gaining a native surface flips one recorded expectation rather than silently
+  changing behavior.
+- `pnpm harness:verify -- --scope packages/agent-core` and the affected provider scopes green.
+- `packages/agent-core/docs/SPEC.md` § Structured Output Contract documents the transport choice.
+
+## User Execution Test Scenarios
+
+Applies — this changes observable SDK behavior on non-native providers.
+
+**Scenario 1 — a structured run succeeds first-attempt through an OpenAI-compatible endpoint**
+
+- Prerequisites: an OpenAI-compatible gateway `baseURL` plus key exported, serving a non-OpenAI model
+  (the reporter used DeepSeek through such a gateway); `pnpm build`.
+- Environment: requires a user-provided gateway endpoint — state at implementation time whether the
+  repo's existing example configuration covers it or the user must supply their own. This is the one
+  environment dependency the scenario cannot create for itself.
+- Steps: call `run(prompt, { output: <a Zod schema with a nested object> })` against that endpoint
+  with `outputRetries: 0`, and print the returned object.
+- Expected observable result: a schema-conforming object is returned with zero retries. (Before the
+  change, the same call with `outputRetries: 0` fails validation on such an endpoint.)
+- Cleanup: none.
+- Evidence: _to be filled after implementation_ (paste the returned object and the attempt count).


### PR DESCRIPTION
Files three Tasks from the three most recent GitHub issues. Each claim was re-verified against `develop` rather than transcribed from the report.

| Issue | Task | Priority |
| --- | --- | --- |
| #1736 — `runStream()` drops `config.systemMessage` | `CORE-036` | high / now |
| #1737 — `zodToJsonSchema` drops nested object properties | `CORE-037` | critical / now |
| #1738 — forced tool call as the structured-output fallback | `CORE-038` (`depends_on: [CORE-037]`) | medium / soon |

## What the verification changed

- **CORE-036** — the streaming path (`execution-stream.ts:72`) never calls `initializeConversationStore` (`execution-service-helpers.ts:189-192`), which is where the round path attaches the system prompt. The Direction is therefore "route both paths through one session initialization", not "copy the injection into the streaming file" — copying is what let them drift.
- **CORE-037** — `case 'ZodObject'` (`zod-to-json-schema.ts:96-97`) is the only non-recursing case; `ZodArray` (`:84-94`) and `ZodRecord` both recurse, so `z.array(z.object(...))` breaks through the same route. **Finding the issue did not report:** the built-in computer-use tool nests (`computer-tool.ts:72-74`), so the shipped `Computer` tool already emits its `action` argument as a fieldless `{ type: 'object' }`.
- **CORE-038** — the reporter's provider table was re-derived by grep and holds (anthropic/gemini/openai map `responseFormat`; openai-compatible and bytedance have no reference to it). **One secondary request is already satisfied:** `llms.txt:24` documents schema-enforced structured output, so the Task records that correction instead of filing the addition. Because this is a proposal rather than a defect, the open questions (default transport scope, where transport selection lives vs. PROV-006, schema-tool name collisions) are routed to a spec-doc and the recommendation gate rather than decided here.

## Verification

- `task-lifecycle.mjs classify` → `open` for all three.
- `backlog-placement` scan passes.
- `run-all-scans` is 110/112; the two failures (`doc-examples`, `dist`) are environmental on this machine — `tsc` is not installed and there is no `dist/` — and are unrelated to a docs-only diff.

Docs-only: no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177RGmffprxqf66ZLFKfjwD