### PR TITLE
style(tasks): apply prettier formatting to the CORE-036..038 Task files

### DIFF
--- a/.agents/tasks/CORE-036-runstream-never-applies-config-systemmessage.md
+++ b/.agents/tasks/CORE-036-runstream-never-applies-config-systemmessage.md
@@ -1,5 +1,5 @@
 ---
-title: "CORE-036: runStream() never applies config.systemMessage — the streaming path builds provider messages straight off the conversation store and skips the session initialization that the round path uses to attach the system prompt, so the same agent obeys its persona through run() and ignores it through runStream()"
+title: 'CORE-036: runStream() never applies config.systemMessage — the streaming path builds provider messages straight off the conversation store and skips the session initialization that the round path uses to attach the system prompt, so the same agent obeys its persona through run() and ignores it through runStream()'
 status: todo
 created: 2026-08-16
 priority: high
@@ -26,13 +26,18 @@ instructions, which reads as a model-quality problem rather than a dropped promp
 
 - `packages/agent-core/src/services/execution-service-helpers.ts:189-192` — the round path's
   `initializeConversationStore()` attaches the prompt:
-  `const hasSystemMessage = session.getMessages().some((m) => m.role === 'system'); if
-  (config.systemMessage && !hasSystemMessage) { session.setSystemPrompt(config.systemMessage, {
-  executionId }); }`
+
+  ```ts
+  const hasSystemMessage = session.getMessages().some((m) => m.role === 'system');
+  if (config.systemMessage && !hasSystemMessage) {
+    session.setSystemPrompt(config.systemMessage, { executionId });
+  }
+  ```
+
 - `packages/agent-core/src/services/execution-stream.ts:72` — the streaming path never calls that
   helper; it goes straight to `conversationHistory.getConversationStore(context.conversationId)`.
 - `packages/agent-core/src/services/execution-stream.ts:106-114` — provider messages are the store's
-  messages plus, optionally, the *ephemeral* per-run block only:
+  messages plus, optionally, the _ephemeral_ per-run block only:
   `const conversationMessages = conversationStore.getMessages(); … ephemeralSystemContext …`
 - `grep -n "systemMessage" packages/agent-core/src/services/execution-stream.ts` returns no hit —
   the only system-message reference on that path is `ephemeralSystemContext` (SELFHOST-008 P3).
@@ -47,7 +52,7 @@ returns that string from `run('hi')` and an unrelated greeting from `runStream('
 
 Any streaming agent whose behavior is defined by a system prompt behaves as if unconfigured. The
 reporter's multi-agent app renders every persona through `runStream()`; it also explains a workaround
-they had accumulated — duplicating behavioral rules into the *user* prompt because
+they had accumulated — duplicating behavioral rules into the _user_ prompt because
 "system-message-only instructions didn't stick".
 
 `runStream()` is the default surface for interactive/TUI usage, so this is a correctness defect on

--- a/.agents/tasks/CORE-037-zodtojsonschema-drops-nested-object-properties.md
+++ b/.agents/tasks/CORE-037-zodtojsonschema-drops-nested-object-properties.md
@@ -21,7 +21,7 @@ so only **nested** objects lose their `properties`/`required`. The model therefo
 is an object" with no indication of what belongs in it.
 
 ```ts
-zodToJsonSchema(z.object({ inner: z.object({ s: z.string() }) }))
+zodToJsonSchema(z.object({ inner: z.object({ s: z.string() }) }));
 // → { type: 'object', properties: { inner: { type: 'object' } }, required: ['inner'] }
 //                                            ^^^^^^^^^^^^^^^^^^ shape discarded
 ```
@@ -41,11 +41,11 @@ Reporter's measured downstream effect (forced tool call, `toolChoice: { tool: na
 
 | tool input schema                                    | handler invoked |
 | ---------------------------------------------------- | --------------- |
-| `{ a: string, b: string }`                            | yes |
-| `{ items: string[] }`                                 | yes |
-| `{ items: string[] }` with `.max(2)`                  | yes |
-| `{ delivery: { score, evidence[], suggestions[] } }`  | no |
-| 5 × the above nested object + `summary: string`       | no |
+| `{ a: string, b: string }`                           | yes             |
+| `{ items: string[] }`                                | yes             |
+| `{ items: string[] }` with `.max(2)`                 | yes             |
+| `{ delivery: { score, evidence[], suggestions[] } }` | no              |
+| 5 × the above nested object + `summary: string`      | no              |
 
 Flat schemas including arrays and constraints work; one level of nesting is enough to break it.
 

--- a/.agents/tasks/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md
+++ b/.agents/tasks/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md
@@ -1,5 +1,5 @@
 ---
-title: "CORE-038: the structured-output fallback transport re-asks for JSON in prose, which is the path every provider without a native responseFormat surface takes — and, because a native surface is detected per PROVIDER PACKAGE rather than per endpoint, an OpenAI-compatible gateway serving a non-OpenAI model is silently on the prompt path while the enforcement loop believes it enforced early"
+title: 'CORE-038: the structured-output fallback transport re-asks for JSON in prose, which is the path every provider without a native responseFormat surface takes — and, because a native surface is detected per PROVIDER PACKAGE rather than per endpoint, an OpenAI-compatible gateway serving a non-OpenAI model is silently on the prompt path while the enforcement loop believes it enforced early'
 status: todo
 created: 2026-08-16
 priority: medium
@@ -38,11 +38,11 @@ Two things make this worth changing rather than accepting:
    `responseFormat` mapping exists in three provider packages and in neither of the other two
    text-generation packages:
 
-   | provider package                   | native structured-output surface | evidence |
-   | ---------------------------------- | -------------------------------- | -------- |
-   | `agent-provider-anthropic`         | yes — `output_config.format`     | `src/anthropic/provider.ts:349-356` |
+   | provider package                   | native structured-output surface | evidence                                  |
+   | ---------------------------------- | -------------------------------- | ----------------------------------------- |
+   | `agent-provider-anthropic`         | yes — `output_config.format`     | `src/anthropic/provider.ts:349-356`       |
    | `agent-provider-gemini`            | yes — `responseSchema`           | `src/gemini/execution-helpers.ts:142-145` |
-   | `agent-provider-openai`            | yes — `response_format`          | `src/openai/chat-completions-chat.ts` |
+   | `agent-provider-openai`            | yes — `response_format`          | `src/openai/chat-completions-chat.ts`     |
    | `agent-provider-openai-compatible` | **no** — prompt fallback         | `grep -rn responseFormat …/src` → no hits |
    | `agent-provider-bytedance`         | **no** — prompt fallback         | `grep -rn responseFormat …/src` → no hits |
 
@@ -110,7 +110,7 @@ The issue also asks that `llms.txt` mention structured output. On `develop` it a
   returns a validated typed object with provider-native mapping + bounded retry".
 
 So the gap the reporter hit is closed. What is worth checking as part of this Task is whether that
-line conveys the *guarantee* strongly enough for an agent reading `llms.txt` to choose robota's path
+line conveys the _guarantee_ strongly enough for an agent reading `llms.txt` to choose robota's path
 over its own SDK's helper, and whether it should state that non-native providers go through the
 bounded loop rather than degrading silently. Reply to the issue with the correction either way.
 


### PR DESCRIPTION
Follow-up to #1740. That PR was merged while its `format-check` job was red, so `develop` currently carries three markdown files prettier rejects.

## What is wrong on develop

`prettier --check .agents/tasks/CORE-03[678]-*.md` fails on all three: unnormalized table column widths, `*emphasis*` where the config emits `_emphasis_`, and a missing statement semicolon inside a `ts` fence.

## What this changes

Prettier's own output, plus one deliberate edit: the `execution-service-helpers.ts:189-192` evidence bullet in CORE-036 moves into a fenced code block. Inline, prettier wrapped it mid-statement across three lines — a code citation the reader has to re-assemble is not a citation.

No prose claim, file:line citation, priority, or frontmatter field changed.

## Verification

- `prettier --check` with the repo's own 3.9.6 and `.prettierrc.json` — clean.
- `verify-like-ci --base-ref origin/develop` — **PASS, all 12 stages** (format-check, commitlint, harness-self-test 2307/2307, scan-suite-dist-free, build, typecheck, scan-suite, affected-verify, examples-typecheck, tui-e2e; binary-e2e and harness-hermetic-test skipped exactly as ci.yml skips them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177RGmffprxqf66ZLFKfjwD