### PR TITLE
fix(protocol): unify outbound reply delivery behind one carrier boundary (ARCH-030)

### DIFF
--- a/.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
+++ b/.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
@@ -53,9 +53,121 @@ mistake.
 
 ## User Execution Test Scenarios
 
-Applies. At scenario planning, author a maintained public-SDK example that starts a deterministic delayed
-remote command, disconnects its local carrier, resolves the command, and prints structured evidence for
-exactly one delivery error, committed operation success, cleanup, and zero unhandled rejections.
+**Applies.** The change alters runnable behavior of a published SDK surface — `WsTransport` and
+`createWsTransport` from `@robota-sdk/agent-transport-ws` — so the gate is a public-SDK example run, not
+an engineering check.
+
+**Scenario home decision.** The scenario lives in **`packages/agent-transport-ws`**, which owns the real
+`WsSessionDelivery` carrier and a real `ws` socket and currently has **no** scenario script.
+`scripts/harness/scenario-owner-map.mjs` takes the FIRST matching script name per package, and
+`@robota-sdk/agent-transport` already owns `scenario:verify` for ARCH-020/028
+(`examples/verify-session-event-delivery.ts`). Extending that script was rejected: it would re-record
+ARCH-028's canonical `examples/scenarios/session-event-delivery.record.json`, replacing evidence for a
+completed item with evidence for this one. Adding a second owner package leaves ARCH-020/028's record
+untouched and puts the scenario in the package that holds the carrier.
+
+**Surface preference level 1 (self-contained product observables).** No credentials, no external service,
+no provider call, no SQLite: the scenario starts a loopback WS server the product itself owns, connects a
+real client, and reads exit code plus one JSON line from stdout. Levels 2 and 3 were not needed.
+
+### Scenario 1 — a reply that resolves after the carrier disconnected is reported, not thrown
+
+**Agent-executability decision:** `agent-executable`. Non-interactive, no TTY, no network beyond
+`127.0.0.1`. The invocation shape was executed against current `develop` before this section was written
+(see RED baseline below), so the command, the module resolution, and the observables are proven real —
+only the values change once the boundary lands.
+
+**Prerequisites**
+
+- Node ≥ 22 and `pnpm install` completed at the repo root. `volta` is not required.
+- No provider credentials, no `.env`, no network egress. The WS transport auto-mints its own admission
+  token (`WsTransport.resolvedToken`) — the scenario reads it from the object it just constructed.
+- Loopback TCP ports `43117`–`43142` available (the scenario binds `43117` with `maxRetries: 25`).
+- Artifacts this backlog must create as part of the implementation slice:
+  - `packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts` — the maintained example.
+  - `packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json` — canonical
+    record, produced by `pnpm scenario:record`.
+  - `packages/agent-transport-ws/package.json` scripts:
+    - `"scenario:verify": "pnpm exec tsx --conditions=source examples/verify-outbound-delivery-boundary.ts"`
+    - `"scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-transport-ws --output examples/scenarios/outbound-delivery-boundary.record.json -- pnpm scenario:verify"`
+  - **Dependency to ADD (stated, not discovered later):** `tsx: "^4.23.1"` in
+    `packages/agent-transport-ws` `devDependencies`. It currently resolves only by root hoisting;
+    `@robota-sdk/agent-transport` declares it explicitly and this package must too. **No other dependency
+    is added and no new package edge is created** — `ws`, `@types/ws`,
+    `@robota-sdk/agent-interface-transport` (for the `./testing` conformant double) and
+    `@robota-sdk/agent-transport-protocol` are already declared. The example imports the package under its
+    own name (`@robota-sdk/agent-transport-ws`) via Node self-referencing through `exports`, which is
+    verified working under `--conditions=source`; it does not need a self-dependency entry.
+- Fixture shape the example must build (no live model, no session store): the conformant
+  `createTestInteractiveSession` double from `@robota-sdk/agent-interface-transport/testing`, overriding
+  `executeCommand` to (1) signal that it started, (2) await a release gate the scenario controls,
+  (3) write a "committed" marker file, (4) resolve — and counting `on`/`off` calls so carrier cleanup is
+  externally countable.
+
+**Exact Bash command**
+
+```bash
+cd /home/ubunutu/dev/robota-2/packages/agent-transport-ws && pnpm scenario:verify
+```
+
+(equivalently, without the package script: `pnpm exec tsx --conditions=source examples/verify-outbound-delivery-boundary.ts`)
+
+**Expected observable result**
+
+- Exit code `0`.
+- stdout contains exactly one JSON line. Required substrings:
+  - `"scenario":"ARCH-030-outbound-delivery-boundary"`
+  - Phase A — real carrier (`WsTransport`, real `ws` server + real client socket, real
+    `WsSessionDelivery`): `"carrier":"WsTransport(real ws socket)"`, `"operationCommitted":true`,
+    `"cleanupRuns":1`, **`"unhandledRejections":0`**.
+  - Phase B — observable carrier (`createWsTransport`, whose `send`/`onDeliveryError` are public options):
+    `"carrier":"createWsTransport(observable delivery callbacks)"`,
+    **`"deliveryErrors":[{"message":"WebSocket is not open","event":"command_result"}]`** (exactly one
+    entry), `"operationCommitted":true`, `"cleanupObserved":true`, **`"latchThrew":null`**,
+    `"unhandledRejections":0`.
+  - `"cleanupRemoved":true`.
+- stderr empty apart from pnpm's own banner.
+- Assertion failures are fatal: any mismatch throws with a named message and exits non-zero. The example
+  must not soften an assertion to make the run pass.
+
+The four claims map to the four observables: (a) exactly one delivery error → Phase B `deliveryErrors`
+length 1 with `event: "command_result"`; (b) the committed operation survives → both phases'
+`operationCommitted` (the marker file written by the command after the disconnect);
+(c) cleanup exactly once → Phase A `cleanupRuns` from the `on`/`off` listener balance and Phase B
+`cleanupObserved` (`transport.onMessage === null`); (d) zero unhandled rejections → both phases'
+`unhandledRejections`. `latchThrew: null` additionally pins the §2 latch: a further frame pushed through
+the retained `onMessage` after the failure must be dropped silently — neither a second `onDeliveryError`
+nor a synchronous throw out of `onMessage`.
+
+**RED baseline captured before implementation (2026-08-16, `main` @ `e828a2925`, same command with the
+assertions temporarily relaxed so both phases run to completion):**
+
+```
+{"scenario":"ARCH-030-outbound-delivery-boundary",
+ "realCarrier":{"carrier":"WsTransport(real ws socket)","operationCommitted":true,"cleanupRuns":1,"unhandledRejections":1},
+ "observedCarrier":{"carrier":"createWsTransport(observable delivery callbacks)","latchThrew":"WebSocket is not open","cleanupObserved":false,"operationCommitted":true,"deliveryErrors":[],"cleanupRuns":1,"unhandledRejections":2},
+ "cleanupRemoved":true}
+```
+
+With the assertions as specified above, the same run on current code exits `1` with
+`Error: real carrier produced unhandled rejections: ["WebSocket is not open"]`. Every expected value was
+therefore authored against observed-failing behavior, not back-fitted to output.
+
+**Cleanup / reset**
+
+- The example removes its own `mkdtemp` directory in a `finally` block and asserts the directory is gone
+  (`"cleanupRemoved":true`).
+- Both transports are stopped in `finally` (`WsTransport.stop()` closes the WS server and the HTTP
+  listener; the client socket is terminated), so no port stays bound and the process exits on its own.
+- Nothing is written inside the repository. No manual reset step is required.
+
+**Evidence (fill in after implementation, before `status: done`):**
+
+- Command run:
+- Exit code:
+- stdout JSON line:
+- Canonical record path + `stdout.sha256`:
+- Date / branch / commit:
 
 ## Plan
 

--- a/.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
+++ b/.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
@@ -198,13 +198,133 @@ therefore authored against observed-failing behavior, not back-fitted to output.
   `command.rendered: pnpm scenario:verify`.
 - **Date / branch:** 2026-08-16 / `fix/arch-030-outbound-delivery-boundary`.
 
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-16
+
+**Status upgrade:** `todo` → `todo` (Stage 1 authorizes implementation to begin; it transitions no
+frontmatter status — the terminal status change belongs to Completion Steps after Stage 2).
+
+**Ordering check:** exempt — the gate catalogue's prior-gate map records no prior gate for
+`DONE-GATE-STAGE-1`. Write-order was nonetheless confirmed: the scenario section was authored in
+`aac4f983d` ("docs(tasks): plan the ARCH-030 delayed-reply scenario"), which precedes every
+implementation commit on this branch (`235f4e1cc`, `be8ae6288`, `4555962f9`, `874e793fe`, `c7b3fbfc0`,
+`1da64b66c`, `30a2ac51a`), with the evidence field present and empty at write time. No prior
+`DONE-GATE-STAGE-1` entry exists in this section — this is the first run.
+
+**Per-criterion evidence:**
+
+- **Fields complete (exact commands, prerequisites, expected observable, evidence field)** — Scenario 1
+  carries all four. Command: `cd .../packages/agent-transport-ws && pnpm scenario:verify` (plus the
+  script-free equivalent). Prerequisites: Node ≥ 22 + `pnpm install`, no credentials/`.env`/egress,
+  loopback ports `43117`–`43142`, the three artifacts to be created, the `tsx: "^4.23.1"` devDependency
+  to add, and the `createTestInteractiveSession` fixture shape. Expected observable: exit code `0` and
+  one stdout JSON line with named required substrings per phase (`unhandledRejections:0`, a single
+  `deliveryErrors` entry for `command_result`, `cleanupObserved:true`, `latchThrew:null`,
+  `cleanupRemoved:true`). Evidence field present (authored empty; filled 2026-08-16). A cleanup/reset
+  step is also present.
+- **Executability decision** — `agent-executable`, stated explicitly with its justification
+  (non-interactive, no TTY, no network beyond `127.0.0.1`). Verified by the guard, not taken on claim:
+  `pnpm scenario:verify` ran to completion here with `EXIT_CODE=0` and printed exactly the JSON line the
+  document records. No `manual-only` label is claimed, so the specific-technical-reason requirement is
+  N/A.
+- **Drives a product surface** — PASS, not an engineering check. The scenario executes
+  `packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts`, which imports the
+  published entry point `@robota-sdk/agent-transport-ws` by package name (`WsTransport`,
+  `createWsTransport`) and drives a real `ws` server + client socket. Confirmed by reading the example's
+  imports — no deep internal path, and the observable is product behavior over a live carrier, not a
+  build, typecheck, lint, vitest run, `harness:scan`, CI check, or inspection of repository text.
+- **Credential / external-service prerequisite stated** — N/A-with-reason, stated explicitly rather than
+  left to the executor: "No provider credentials, no `.env`, no network egress", with the admission token
+  auto-minted via `WsTransport.resolvedToken`. The one genuine environmental prerequisite (loopback TCP
+  `43117`–`43142`) is named up front, so an executor learns the requirement from the scenario.
+- **Exception clause** — N/A: no scenario is left unwritten, so the write-is-impossible exception is not
+  invoked.
+
+**Notes carried forward (not Stage-1 failures):** (a) the evidence field is already filled, including a
+canonical record at `packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json`
+whose `stdout.sha256` recomputes to the recorded
+`26bbc66703bdc9ba2e7b76d28ca893866ff7c8f380d27d2a7eca3a97491f3bed`; the guard's own run reproduced that
+output, so the recorded evidence is genuine and not fabricated — judging it remains Stage 2's call.
+(b) Scenario 1 covers the WS carrier only; the WebRTC carrier named in `## Direction` is covered by the
+engineering `## Test Plan`, which Stage 1 does not gate.
+
+### [DONE-GATE-STAGE-2] — ✅ PASS | 2026-08-16
+
+**Status upgrade:** `todo` → `todo` (Stage 2 authorizes Completion Steps to run; it sets no frontmatter
+status itself — the terminal status change and the archival move belong to Completion Steps).
+
+**Ordering check:** PASS. `[DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-16` is recorded in this section with
+per-criterion evidence. Expected input state per the gate catalogue's prior-gate map ("scenarios written,
+implementation complete") holds: `## User Execution Test Scenarios` carries a fully written Scenario 1,
+and `## Plan` has every implementation item `[x]` with only the completion-gate item open. Frontmatter is
+`status: todo` in `.agents/tasks/` root — status has not been pre-set to `done` ahead of this gate.
+
+**Per-criterion evidence:**
+
+- **Every scenario directly executed against the completed implementation** — PASS, executed by the guard,
+  not accepted on claim. `cd packages/agent-transport-ws && pnpm scenario:verify` was run at current HEAD
+  `30a2ac51a`, which is two commits AFTER the record was committed (`c7b3fbfc0`), so the run also proves the
+  later `1da64b66c`/`30a2ac51a` refactors did not regress the observable. `EXIT_CODE=0`. Scenario 1 is the
+  only scenario in this section; there is no unexecuted scenario.
+- **Observed result matched the expected observable result** — PASS, every named observable, not a summary.
+  Exactly one stdout JSON line; `realCarrier`: `"carrier":"WsTransport(real ws socket)"`,
+  `operationCommitted:true`, `cleanupRuns:1`, `unhandledRejections:0`; `observedCarrier`:
+  `"carrier":"createWsTransport(observable delivery callbacks)"`, `operationCommitted:true`,
+  `cleanupObserved:true`, `deliveryErrors` exactly one entry
+  `{"message":"WebSocket is not open","event":"command_result"}`, `latchThrew:null`,
+  `unhandledRejections:0`; `cleanupRemoved:true`. stderr held only pnpm's own `pnpm.overrides` banner, as
+  the scenario allows. The guard's normalized stdout is **byte-identical** to the recorded
+  `stdout.normalized`, and `sha256(stdout.normalized)` recomputes to the recorded
+  `26bbc66703bdc9ba2e7b76d28ca893866ff7c8f380d27d2a7eca3a97491f3bed` — the recorded evidence is reproducible,
+  not transcribed. Expectation-rewriting was checked and not found: assertions in
+  `examples/verify-outbound-delivery-boundary.ts` are fatal `throw`s pinning the exact values
+  (`rejections.length === 0`, `deliveryErrors.length === 1`, `deliveryErrors[0].event === 'command_result'`,
+  `cleanupObserved`, `latchThrew === null`), so a mismatch exits non-zero rather than printing a softer line.
+- **Concrete evidence recorded under the scenario's evidence field** — PASS. The `**Evidence (2026-08-16):**`
+  block under Scenario 1 carries the command run, exit code `0`, the full stdout JSON line, the per-value
+  RED→GREEN deltas (`unhandledRejections` `1→0` and `2→0`, `deliveryErrors` `[]→` one `command_result` entry,
+  `cleanupObserved` `false→true`, `latchThrew` `"WebSocket is not open"→null`), the canonical record path,
+  and date/branch.
+- **Engineering verification cited as evidence (FAIL check)** — clean. The evidence block cites only the
+  product-surface run and its canonical record. No build, typecheck, lint, vitest, `harness:scan`,
+  `harness:verify-like-ci`, or CI output appears as gate evidence; those remain confined to the engineering
+  `## Test Plan`, where they belong.
+- **Unprobed capability-absence claim (FAIL check)** — N/A, and not by omission: no capability-absence
+  exception is invoked anywhere in the section. The prerequisite statement is affirmative ("no provider
+  credentials, no `.env`, no network egress"; admission token auto-minted via `WsTransport.resolvedToken`)
+  and was proven by execution — the guard's run succeeded with no credentials supplied.
+- **Durable repository artifacts (code-changing item)** — PASS, each referenced path verified present:
+  `packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts`,
+  `packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json`,
+  `packages/agent-transport-protocol/docs/SPEC.md`,
+  `.changeset/arch-030-outbound-delivery-boundary.md`, and the declared
+  `scenario:verify` / `scenario:record` scripts plus `tsx: "^4.23.1"` in
+  `packages/agent-transport-ws/package.json`.
+- **Exception clause** — N/A: execution was possible and performed, no scenario is labeled `manual-only`,
+  so the execution-is-impossible exception is not invoked.
+- **Mechanical floors** — all three green at HEAD: `check-done-evidence.mjs` exit `0`
+  ("done-evidence scan passed (14 superseded reference(s))"), `check-backlog-placement.mjs` exit `0`,
+  `scan-capability-reachability.mjs` exit `0`.
+
+**Not verified (out of this gate's reach, not counted as evidence):** the RED baseline attributed to `main`
+@ `e828a2925` was not reproduced — doing so needs a working-tree checkout the guard may not perform. It is
+supporting narrative; the verdict rests on the GREEN run above.
+
 ## Plan
 
-- [ ] Author and approve a BEHAVIOR spec for the single outbound delivery boundary.
-- [ ] Plan and gate the public-SDK delayed-reply scenario.
-- [ ] Add the protocol RED proof and implement the shared delivery boundary.
-- [ ] Wire WS, WebRTC, and resume paths through the boundary with lifecycle regressions.
-- [ ] Synchronize package SPECs, README/content guidance, and changesets.
+- [x] Author and approve a BEHAVIOR spec for the single outbound delivery boundary — the recommendation
+      went through two independent review rounds (`REVISE` → `ENDORSE`, 2026-08-16); the boundary's
+      contract now lives in `packages/agent-transport-protocol/docs/SPEC.md`.
+- [x] Plan and gate the public-SDK delayed-reply scenario — written before implementation
+      (`aac4f983d`), `DONE-GATE-STAGE-1` PASS 2026-08-16.
+- [x] Add the protocol RED proof and implement the shared delivery boundary — `createOutboundDelivery`
+      plus `src/__tests__/outbound-delivery.test.ts` covering all eleven reply families, the latch, and
+      the `@ts-expect-error` type floor.
+- [x] Wire WS, WebRTC, and resume paths through the boundary with lifecycle regressions —
+      `WsSessionDelivery` (raw sink now private), `createWsTransport`, `PairingGate`,
+      `WebRtcTransport`, and `SessionResumeBridge` (per-attachment boundary), each with a carrier
+      regression.
+- [x] Synchronize package SPECs, README/content guidance, and changesets — the three transport SPECs and
+      `.changeset/arch-030-outbound-delivery-boundary.md` (protocol `major`, ws/webrtc `patch`).
 - [ ] Pass completion gates, archive the Task, and close issue #1734.
 
 ## Blockers

--- a/.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
+++ b/.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
@@ -161,13 +161,42 @@ therefore authored against observed-failing behavior, not back-fitted to output.
   listener; the client socket is terminated), so no port stays bound and the process exits on its own.
 - Nothing is written inside the repository. No manual reset step is required.
 
-**Evidence (fill in after implementation, before `status: done`):**
+**Evidence (2026-08-16):**
 
-- Command run:
-- Exit code:
-- stdout JSON line:
-- Canonical record path + `stdout.sha256`:
-- Date / branch / commit:
+- **Command run:** `cd packages/agent-transport-ws && pnpm scenario:verify`
+- **Exit code:** `0`
+- **stdout JSON line:**
+
+  ```json
+  {
+    "scenario": "ARCH-030-outbound-delivery-boundary",
+    "realCarrier": {
+      "carrier": "WsTransport(real ws socket)",
+      "operationCommitted": true,
+      "cleanupRuns": 1,
+      "unhandledRejections": 0
+    },
+    "observedCarrier": {
+      "carrier": "createWsTransport(observable delivery callbacks)",
+      "operationCommitted": true,
+      "cleanupObserved": true,
+      "deliveryErrors": [{ "message": "WebSocket is not open", "event": "command_result" }],
+      "latchThrew": null,
+      "unhandledRejections": 0
+    },
+    "cleanupRemoved": true
+  }
+  ```
+
+- **Every expected observable matched**, each against the RED value recorded before implementation:
+  `realCarrier.unhandledRejections` `1 → 0`; `observedCarrier.deliveryErrors` `[] →` exactly one entry
+  naming `command_result`; `observedCarrier.cleanupObserved` `false → true`;
+  `observedCarrier.latchThrew` `"WebSocket is not open" → null`;
+  `observedCarrier.unhandledRejections` `2 → 0`. No expectation was rewritten after the run.
+- **Canonical record:** `packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json`
+  — `status: 0`, `stdout.sha256: 26bbc66703bdc9ba2e7b76d28ca893866ff7c8f380d27d2a7eca3a97491f3bed`,
+  `command.rendered: pnpm scenario:verify`.
+- **Date / branch:** 2026-08-16 / `fix/arch-030-outbound-delivery-boundary`.
 
 ## Plan
 

--- a/.agents/tasks/REL-024-changeset-fixed-group-covers-13-of-30-packages.md
+++ b/.agents/tasks/REL-024-changeset-fixed-group-covers-13-of-30-packages.md
@@ -1,0 +1,84 @@
+---
+title: 'REL-024: the changesets `fixed` group holds 13 packages while the version rule says every `@robota-sdk/*` package is in it — the next major bump splits the workspace into two version lines'
+status: todo
+created: 2026-08-16
+priority: high
+urgency: before-next-publish
+area: .changeset/, .agents/skills/version-management
+depends_on: []
+---
+
+# REL-024: the fixed group and the version rule disagree
+
+## Problem
+
+`.agents/skills/version-management/SKILL.md` states two rules as invariants:
+
+- rule 1 — "all `@robota-sdk/*` packages have the same version — no exceptions";
+- rule 4 — "all packages are in the same `fixed` group in `.changeset/config.json`".
+
+`.changeset/config.json` contains **13 packages**: `agent-cli`, `agent-command`, `agent-core`,
+`agent-executor`, `agent-framework`, `agent-interface-transport`, `agent-interface-tui`, `agent-plugin`,
+`agent-preset`, `agent-session`, `agent-subagent-runner`, `agent-tools`, `agent-transport`. The workspace
+publishes roughly thirty. Every transport implementation is outside it —
+`agent-transport-protocol`, `agent-transport-ws`, `agent-transport-webrtc`, `agent-transport-http`,
+`agent-transport-tui`, `agent-transport-gui`, `agent-transport-webrtc-web` — as are the provider packages.
+
+Today every package sits at `3.0.0-beta.79`, so the disagreement is invisible. It stops being invisible at
+the next `changeset version`: there are already major changesets pending against the fixed group, which
+takes those 13 to `4.0.0-beta.N` while an outside package moves only when it has a changeset of its own.
+The workspace then holds two version lines, which rule 1 says cannot happen — and nothing fails when it
+does, because no scan reads the config against the rule.
+
+## Why this is filed rather than fixed in passing
+
+Found while classifying the release impact of ARCH-030
+(`.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md`), whose changeset
+classifies `agent-transport-protocol` as `major` and its two dependents as `patch`. That classification is
+what the semver table forces once the config is taken as the operative artifact, and it is correct for that
+item. The disagreement it exposes is monorepo-wide and pre-existing: ARCH-030 neither caused it nor is the
+right place to resolve it, because resolving it changes what the NEXT release publishes for roughly
+seventeen packages.
+
+## What
+
+Decide which of the two is authoritative, then make the other match, and add the mechanical floor that
+would have caught the drift:
+
+1. **If rule 4 is authoritative** — add every published `@robota-sdk/*` package to the `fixed` group, and
+   accept that any package's major takes the whole workspace major. State the cost in the skill: an
+   unrelated package's breaking change bumps every package a consumer has installed.
+2. **If the current config is authoritative** — rewrite rules 1 and 4 to describe per-package versioning,
+   and say how a consumer is expected to reason about mixed versions across `@robota-sdk/*`.
+
+Either way: a scan that fails when a published workspace package is absent from the `fixed` group (option
+
+1. or when the skill's prose claims a membership the config does not have (option 2). The drift survived
+   because it is stated in prose in one file and configured in another, and nothing compares them.
+
+## Test Plan
+
+- The new scan fails on the current tree before the reconciliation and passes after it.
+- `pnpm changeset version --snapshot` (or a dry run) shows one version line across every published package.
+- `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+Not applicable — this is a release-governance and configuration change that delivers no runnable
+user-facing behavior. Verification evidence belongs in the Test Plan above.
+
+## Plan
+
+- [ ] Get the owner's decision between the two options (this is product/release policy, not agent authority).
+- [ ] Apply the chosen reconciliation to `.changeset/config.json` and/or `version-management/SKILL.md`.
+- [ ] Add the scan that compares the two and wire it into `run-all-scans`.
+- [ ] Verify one version line across the workspace on a dry-run version bump.
+
+## Blockers
+
+- Needs an owner decision: which of the two rules holds. Both are defensible and the choice changes what
+  every future release publishes.
+
+## Result
+
+Pending.

--- a/.agents/tasks/completed/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
+++ b/.agents/tasks/completed/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
@@ -1,7 +1,8 @@
 ---
 title: 'ARCH-030: outbound protocol replies bypass the carrier delivery boundary'
-status: todo
+status: done
 created: 2026-08-16
+completed: 2026-08-16
 priority: critical
 urgency: now
 area: packages/agent-transport-protocol, packages/agent-transport-ws, packages/agent-transport-webrtc
@@ -325,12 +326,34 @@ supporting narrative; the verdict rests on the GREEN run above.
       regression.
 - [x] Synchronize package SPECs, README/content guidance, and changesets — the three transport SPECs and
       `.changeset/arch-030-outbound-delivery-boundary.md` (protocol `major`, ws/webrtc `patch`).
-- [ ] Pass completion gates, archive the Task, and close issue #1734.
+- [x] Pass completion gates, archive the Task, and close issue #1734.
 
 ## Blockers
 
-- ARCH-020 and ARCH-028 must land so the carrier failure lifecycle being unified is stable.
+- None. ARCH-020 and ARCH-028 both landed (PR #1735) before this item started, so the carrier failure
+  lifecycle being unified was already stable.
 
 ## Result
 
-Pending.
+One connection-scoped outbound delivery boundary now carries every outbound `TServerMessage` on a
+connection — the session-event fan-out and all eleven reply families alike. The **carrier** builds it
+from its own sink and its own failure policy and passes it down; `TOutboundDeliver` is branded and
+`createOutboundDelivery` is its only producer, so a raw `send` is refused by the compiler wherever a
+boundary is required, and `WsSessionDelivery`'s raw sink is private with `deliver` as its only public
+exit. A reply that resolves after a disconnect is now reported once through the carrier's own cleanup
+instead of escaping as an unhandled rejection.
+
+Two corrections to this item's own text, both confirmed by independent review: the WebRTC path named
+here was already guarded through `SessionResumeBridge` — the unguarded WebRTC exposure was the bare
+`createWsHandler` the pairing gate and transport build when no resume bridge is supplied; and six
+SYNCHRONOUS reply families escaped too, throwing into the carrier's inbound listener rather than as
+rejections, so guarding only the five Promise continuations the title names would have left them.
+
+Verification: `harness:verify-like-ci` PASS (12/12 stages), transport suites 204 green, the
+user-execution scenario green with both done-gate stages independently PASSed, and the pre-PR review's
+own worktree run at the merge base reproducing the RED baseline byte for byte.
+
+Three review findings were upheld and fixed rather than argued away — the bridge held its channel in a
+closure `dispose()` never cleared, the scenario's latch observable measured a property the cleanup had
+already nulled, and no commit was typed `fix:` so the repository's regression red-proof floor had never
+evaluated this defect fix. The floor now runs and returns `red-proof-ok`.

--- a/.agents/tasks/completed/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
+++ b/.agents/tasks/completed/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md
@@ -74,9 +74,10 @@ real client, and reads exit code plus one JSON line from stdout. Levels 2 and 3 
 ### Scenario 1 — a reply that resolves after the carrier disconnected is reported, not thrown
 
 **Agent-executability decision:** `agent-executable`. Non-interactive, no TTY, no network beyond
-`127.0.0.1`. The invocation shape was executed against current `develop` before this section was written
-(see RED baseline below), so the command, the module resolution, and the observables are proven real —
-only the values change once the boundary lands.
+`127.0.0.1`. The invocation shape was executed against `main` @ `e828a2925` before this section was
+written — it exited `1` with `Error: real carrier produced unhandled rejections: ["WebSocket is not
+open"]` — so the command, the module resolution, and the observables were proven real before any
+expectation was set here; only the values change once the boundary lands.
 
 **Prerequisites**
 

--- a/.changeset/arch-030-outbound-delivery-boundary.md
+++ b/.changeset/arch-030-outbound-delivery-boundary.md
@@ -1,0 +1,52 @@
+---
+'@robota-sdk/agent-transport-protocol': major
+'@robota-sdk/agent-transport-ws': patch
+'@robota-sdk/agent-transport-webrtc': patch
+---
+
+**BREAKING — ARCH-030: `createWsHandler` takes the carrier's delivery boundary, not a raw `send`.**
+
+`createWsHandler` had two outbound semantics on one connection. The session-event fan-out went through
+a guard that reported carrier failures through `onDeliveryError`; every reply to an inbound frame got
+the raw `send`. Eleven reply families were unguarded — five resolving from a Promise continuation, so a
+reply landing after a disconnect escaped as an **unhandled rejection** while the carrier's cleanup was
+never notified, and six synchronous ones that threw into the carrier's inbound listener instead.
+
+`IWsHandlerOptions` now takes a single `deliver: TOutboundDeliver` in place of `send` and
+`onDeliveryError`. **The carrier builds the boundary** from its own sink and its own failure policy and
+passes it down — not the reverse, because a protocol layer handed a raw sink so it can hand a wrapper
+back leaves the raw sink reachable, which is how the twelfth reply family gets added unguarded.
+
+```ts
+// before
+const { onMessage, cleanup } = createWsHandler({
+  session,
+  send: (msg) => ws.send(JSON.stringify(msg)),
+  onDeliveryError: (error) => ws.close(1011, error.message),
+});
+
+// after
+const deliver = createOutboundDelivery(
+  (msg) => ws.send(JSON.stringify(msg)),
+  (error) => ws.close(1011, error.message),
+);
+const { onMessage, cleanup } = createWsHandler({ session, deliver });
+```
+
+`TOutboundDeliver` is branded and `createOutboundDelivery` is its only producer, so a plain
+`(message: TServerMessage) => void` is refused by the compiler wherever a boundary is required.
+
+**The boundary latches:** it reports at most one delivery failure per connection, after which frames are
+dropped without a further report. All three carriers already treated a delivery failure as terminal and
+each had grown its own latch; it belongs upstream of all three. `SessionResumeBridge` builds a fresh
+boundary per `attach`, which is what un-latches the session after a reconnect, and buffers a frame
+before the boundary so a dropped one still replays.
+
+**`ISubscribeSessionEventsOptions` is no longer exported** from the package barrel. It is the options bag
+of `subscribeSessionEvents`, which is package-internal, and it was already absent from the SPEC's public
+API table. Its `onDeliveryError` member is gone regardless — carrier-failure containment is the
+boundary's job now.
+
+`agent-transport-ws` and `agent-transport-webrtc` are `patch`: `WsSessionDelivery` (whose raw `send` is
+now private, with `deliver` the only public sink) and `PairingGate` are not on their packages' barrels,
+and every barrel export of both packages keeps its signature.

--- a/packages/agent-cli/src/__tests__/ws-command-host-action.test.ts
+++ b/packages/agent-cli/src/__tests__/ws-command-host-action.test.ts
@@ -52,12 +52,7 @@ function setup(adapters: ICommandHostAdapters): {
     commandHostAdapters: adapters,
   });
   const sent: TServerMessage[] = [];
-  const { onMessage } = createWsHandler({
-    session,
-    send: (msg) => sent.push(msg),
-    driverId: 'device-e2e-1',
-    onDeliveryError: vi.fn(),
-  });
+  const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId: 'device-e2e-1' });
   return { sent, onMessage };
 }
 

--- a/packages/agent-cli/src/__tests__/ws-command-host-action.test.ts
+++ b/packages/agent-cli/src/__tests__/ws-command-host-action.test.ts
@@ -17,7 +17,7 @@ import {
   createLanguageCommandModule,
   createSettingsCommandModule,
 } from '@robota-sdk/agent-command';
-import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+import { createOutboundDelivery, createWsHandler } from '@robota-sdk/agent-transport-protocol';
 import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
 import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
 
@@ -52,7 +52,11 @@ function setup(adapters: ICommandHostAdapters): {
     commandHostAdapters: adapters,
   });
   const sent: TServerMessage[] = [];
-  const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId: 'device-e2e-1' });
+  const { onMessage } = createWsHandler({
+    session,
+    deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()),
+    driverId: 'device-e2e-1',
+  });
   return { sent, onMessage };
 }
 

--- a/packages/agent-transport-protocol/docs/SPEC.md
+++ b/packages/agent-transport-protocol/docs/SPEC.md
@@ -10,11 +10,11 @@ Owns the **transport-neutral session bridge + wire protocol** shared by transpor
 (`agent-transport-ws`, `agent-transport-webrtc`, …). Extracted from `agent-transport-ws` (REMOTE-002) so a
 non-WebSocket transport can reuse it without a `webrtc → ws` package edge.
 
-- `createWsHandler({ session, send })` — accepts the named `IProtocolSession` role aggregate,
-  subscribes to its events, and pushes them as
-  `TServerMessage`s via the injected `send`; returns `onMessage(data)` (drives `session.submit/executeCommand/
+- `createWsHandler({ session, deliver })` — accepts the named `IProtocolSession` role aggregate and the
+  CARRIER's outbound delivery boundary (ARCH-030), subscribes to the session's events, and pushes them as
+  `TServerMessage`s through that boundary; returns `onMessage(data)` (drives `session.submit/executeCommand/
 abort/...` from inbound `TClientMessage`s) + `cleanup()`. Framework-agnostic: works over any byte/string
-  channel via `send`/`onMessage` callbacks — no `ws`, no `node:` sockets.
+  channel via the carrier's `deliver`/`onMessage` callbacks — no `ws`, no `node:` sockets.
 - `TClientMessage` / `TServerMessage` — the JSON wire protocol (inbound client verbs; outbound server events).
 - **TRANS-001 payload-agnostic channel frame codec** (`src/channel-frames.ts`) — `encodeBinaryFrame`,
   `encodeChannelEventFrame`, `decodeChannelFrame`, `isChannelFrame`, plus `CHANNEL_FRAME_MAGIC` /
@@ -52,11 +52,32 @@ abort/...` from inbound `TClientMessage`s) + `cleanup()`. Framework-agnostic: wo
   `Record<TInteractiveEventName, 'forwarded' | 'requester-routed' | 'non-surface'>`. The actual
   `subscribeSessionEvents` registrations are mechanically compared with every non-`non-surface`
   entry. `plan_event`, `context_file_refreshed`, and `branch_event` are forwarded as identically named
-  `TServerMessage` variants. Each transport-owned listener catches an outbound `send` failure and
-  reports it through the required `onDeliveryError(error, event)` carrier callback without reversing the already-committed session
-  operation; a diagnostic callback failure is isolated too. `SessionResumeBridge` applies the same
-  rule per attachment: `attach` requires the current carrier's callback, and a failure detaches the
-  broken sink while preserving the buffered frame for replay.
+  `TServerMessage` variants.
+- **ARCH-030 one outbound delivery boundary per connection.** Every outbound `TServerMessage` — the
+  session-event fan-out AND every reply to an inbound frame — leaves through one
+  `TOutboundDeliver`, produced by `createOutboundDelivery(send, onDeliveryError)`. The **carrier**
+  builds it, from its own raw sink and its own failure policy, and passes it down as
+  `IWsHandlerOptions.deliver`; the protocol package never receives a raw sink. `TOutboundDeliver` is
+  branded and `createOutboundDelivery` is its only producer, so a plain
+  `(message: TServerMessage) => void` is refused by the compiler wherever a boundary is required —
+  the mechanical floor that keeps a future reply family from reaching the wire unguarded.
+
+  **Semantics.** A carrier failure is reported through `onDeliveryError(error, message.type)` and
+  never thrown at the caller, so a reply resolving after a disconnect cannot escape as an unhandled
+  rejection or out of the carrier's inbound listener, and an already-committed session operation is
+  never reversed. A handler that itself throws is isolated. **The boundary LATCHES:** it reports at
+  most ONE failure, after which every subsequent frame is dropped without a further report — all
+  three carriers treat a delivery failure as terminal and each had grown its own latch to suppress
+  the repeats.
+
+  `SessionResumeBridge` builds a **fresh boundary per `attach`**, which is what un-latches the
+  session after a reconnect; `detach` clears it and buffering continues. A frame is appended to the
+  resume buffer BEFORE the boundary, so a dropped frame stays in the un-acked tail and replays on
+  the next sink, and a failing multi-frame `replay()` reports exactly once.
+
+  Before ARCH-030 the fan-out had its own guard and the eleven reply families had none — five of
+  them resolving from a Promise continuation, which is the shape WS-001 recorded and half-fixed.
+
 - **CMD-004 Phase 2 host-action/UI-intent split.** An inbound `command` verb passes the handler's
   SERVER-ASSIGNED `driverId` (REMOTE-014 E5 — never a client-sent one) into
   `session.executeCommand(name, args, 'remote', driverId)` so the session executes host actions
@@ -107,7 +128,11 @@ they do not rebuild anonymous intersections or require the unrelated lifecycle/g
 | `bearerCredential`                      | Function  | SEC-008: extract a bearer credential from an `Authorization` header value               |
 | `createWsHandler`                       | function  |
 | `IWsHandlerOptions`                     | interface |
+| `createOutboundDelivery`                | function  | ARCH-030: the ONLY producer of a connection's outbound delivery boundary                |
+| `TOutboundDeliver`                      | type      | ARCH-030: the branded boundary a carrier passes down as `IWsHandlerOptions.deliver`     |
+| `TDeliveryErrorHandler`                 | type      | ARCH-030: a carrier's failure policy — required, invoked at most once per boundary      |
 | `PROTOCOL_SESSION_EVENT_CLASSIFICATION` | constant  | Exhaustive protocol surface policy for every shared session-event key                   |
+| `TProtocolSessionEventClassification`   | type      | The classification vocabulary the constant is keyed by                                  |
 | `TClientMessage`                        | type      |
 | `TServerMessage`                        | type      |
 | `TSeqServerMessage`                     | type      |
@@ -128,11 +153,13 @@ they do not rebuild anonymous intersections or require the unrelated lifecycle/g
 
 ## Type Ownership
 
-| Type/Symbol       | Location             | Purpose                                       |
-| ----------------- | -------------------- | --------------------------------------------- |
-| `createWsHandler` | `src/ws-handler.ts`  | Session↔client bridge over `send`/`onMessage` |
-| `TClientMessage`  | `src/ws-protocol.ts` | Inbound client wire messages                  |
-| `TServerMessage`  | `src/ws-protocol.ts` | Outbound server wire messages                 |
+| Type/Symbol              | Location                   | Purpose                                                 |
+| ------------------------ | -------------------------- | ------------------------------------------------------- |
+| `createWsHandler`        | `src/ws-handler.ts`        | Session↔client bridge over `deliver`/`onMessage`        |
+| `createOutboundDelivery` | `src/outbound-delivery.ts` | The one connection-scoped outbound boundary             |
+| `TOutboundDeliver`       | `src/outbound-delivery.ts` | The branded boundary type; only the factory produces it |
+| `TClientMessage`         | `src/ws-protocol.ts`       | Inbound client wire messages                            |
+| `TServerMessage`         | `src/ws-protocol.ts`       | Outbound server wire messages                           |
 
 The TRANS-001 channel frame codec owns the ENVELOPE only; the frame/channel CONTRACT types
 (`IBinaryFrame`, `IChannelEventFrame`, `TChannelReceiveResult`, …) are owned by
@@ -146,7 +173,12 @@ including the REMOTE-007 prompt-event forwarding and the `permission-response` /
 dispatch (TC-06). `src/__tests__/session-event-delivery.test.ts` mechanically compares the real
 subscriptions and teardown handlers with the exhaustive classification, verifies plan/context/branch
 fan-out, and proves a throwing carrier is reported without escaping the session listener.
-`src/__tests__/session-resume-bridge.test.ts` proves sink failure detaches while retaining the frame.
+`src/__tests__/session-resume-bridge.test.ts` proves sink failure detaches while retaining the frame, and
+(ARCH-030) that a failing multi-frame replay reports once, its frames replay on the next sink, and a fresh
+`attach` un-latches the connection. `src/__tests__/outbound-delivery.test.ts` covers the boundary itself:
+all eleven reply families after a disconnect (five Promise continuations asserting zero unhandled
+rejections, six synchronous ones asserting nothing escapes `onMessage`), the latch, observer isolation,
+and a `@ts-expect-error` case that fails typecheck if the brand is ever dropped.
 `src/__tests__/channel-frames.test.ts` (TRANS-001) covers the channel codec: opaque
 round-trip integrity (including non-UTF-8 bytes), chunked reassembly by `seq` from out-of-order delivery,
 multi-byte channel names, encoder input validation, and every malformed-input error result.

--- a/packages/agent-transport-protocol/docs/SPEC.md
+++ b/packages/agent-transport-protocol/docs/SPEC.md
@@ -175,7 +175,8 @@ subscriptions and teardown handlers with the exhaustive classification, verifies
 fan-out, and proves a throwing carrier is reported without escaping the session listener.
 `src/__tests__/session-resume-bridge.test.ts` proves sink failure detaches while retaining the frame, and
 (ARCH-030) that a failing multi-frame replay reports once, its frames replay on the next sink, and a fresh
-`attach` un-latches the connection. `src/__tests__/outbound-delivery.test.ts` covers the boundary itself:
+`attach` un-latches the connection. Those three pass against the PRE-ARCH-030 bridge too and are recorded
+as such: the bridge path was already guarded, so they guard the restructure rather than red-prove a defect. `src/__tests__/outbound-delivery.test.ts` covers the boundary itself:
 all eleven reply families after a disconnect (five Promise continuations asserting zero unhandled
 rejections, six synchronous ones asserting nothing escapes `onMessage`), the latch, observer isolation,
 and a `@ts-expect-error` case that fails typecheck if the brand is ever dropped.

--- a/packages/agent-transport-protocol/src/__tests__/driver-attribution-capability.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/driver-attribution-capability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { createOutboundDelivery } from '../outbound-delivery.js';
 import { subscribeSessionEvents } from '../ws-session-events.js';
 
 import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
@@ -59,7 +60,7 @@ describe('driver attribution is a declared capability, not an optional call (ARC
   it('stamps the active driver onto a turn-authored event', () => {
     const send = vi.fn();
     const session = hostWithAttribution('driver-7');
-    subscribeSessionEvents(session, send, { onDeliveryError: vi.fn() });
+    subscribeSessionEvents(session, createOutboundDelivery(send, vi.fn()));
 
     const handler = vi.mocked(session.on).mock.calls.find(([name]) => name === 'user_message')?.[1];
     (handler as (content: string) => void)('hello');
@@ -72,7 +73,7 @@ describe('driver attribution is a declared capability, not an optional call (ARC
     // "this host cannot answer the question".
     const send = vi.fn();
     const session = hostWithAttribution(null);
-    subscribeSessionEvents(session, send, { onDeliveryError: vi.fn() });
+    subscribeSessionEvents(session, createOutboundDelivery(send, vi.fn()));
 
     const handler = vi.mocked(session.on).mock.calls.find(([name]) => name === 'user_message')?.[1];
     (handler as (content: string) => void)('hello');

--- a/packages/agent-transport-protocol/src/__tests__/outbound-delivery.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/outbound-delivery.test.ts
@@ -1,0 +1,333 @@
+/**
+ * ARCH-030 — the connection-scoped outbound delivery boundary.
+ *
+ * Every case here was RED before the boundary existed. The two escape hatches it closes are different
+ * and both had to be covered: a reply resolving from a Promise continuation escaped as an
+ * `unhandledRejection`, while a synchronous reply threw straight out of `onMessage` into the carrier's
+ * inbound listener. Guarding only the first would have left six families still escaping.
+ */
+
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+import { describe, expect, it } from 'vitest';
+
+import { createOutboundDelivery } from '../outbound-delivery.js';
+import { createWsHandler } from '../ws-handler.js';
+
+import type { TOutboundDeliver } from '../outbound-delivery.js';
+import type { TServerMessage } from '../ws-protocol.js';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+
+interface ICarrierProbe {
+  readonly deliver: TOutboundDeliver;
+  readonly delivered: TServerMessage[];
+  readonly failures: Array<{ message: string; event: TServerMessage['type'] }>;
+  disconnect: () => void;
+}
+
+/** A carrier whose sink starts throwing the real `WsSessionDelivery` error once disconnected. */
+function createCarrierProbe(): ICarrierProbe {
+  const delivered: TServerMessage[] = [];
+  const failures: Array<{ message: string; event: TServerMessage['type'] }> = [];
+  let open = true;
+  const probe: ICarrierProbe = {
+    delivered,
+    failures,
+    disconnect: () => {
+      open = false;
+    },
+    deliver: createOutboundDelivery(
+      (message) => {
+        if (!open) throw new Error('WebSocket is not open');
+        delivered.push(message);
+      },
+      (error, event) => failures.push({ message: error.message, event }),
+    ),
+  };
+  return probe;
+}
+
+/**
+ * Collect unhandled rejections for the duration of `run`. Node reports them on a later tick, so the
+ * helper drains the microtask/macrotask queue before restoring the previous listeners.
+ */
+async function withUnhandledRejectionCapture(run: () => void | Promise<void>): Promise<unknown[]> {
+  const captured: unknown[] = [];
+  const existing = process.listeners('unhandledRejection');
+  for (const listener of existing) process.off('unhandledRejection', listener);
+  const collect = (reason: unknown): void => {
+    captured.push(reason);
+  };
+  process.on('unhandledRejection', collect);
+  try {
+    await run();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } finally {
+    process.off('unhandledRejection', collect);
+    for (const listener of existing)
+      process.on('unhandledRejection', listener as NodeJS.UnhandledRejectionListener);
+  }
+  return captured;
+}
+
+/** A deferred whose resolution the test controls, so "after disconnect" is deterministic. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (e: Error) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (e: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createOutboundDelivery', () => {
+  it('reports a carrier failure instead of throwing at the caller', () => {
+    const probe = createCarrierProbe();
+    probe.disconnect();
+
+    expect(() => probe.deliver({ type: 'history_cleared' })).not.toThrow();
+    expect(probe.failures).toEqual([
+      { message: 'WebSocket is not open', event: 'history_cleared' },
+    ]);
+  });
+
+  it('latches: a connection reports at most one delivery failure', () => {
+    const probe = createCarrierProbe();
+    probe.disconnect();
+
+    probe.deliver({ type: 'history_cleared' });
+    probe.deliver({ type: 'executing', executing: true });
+    probe.deliver({ type: 'protocol_error', message: 'third' });
+
+    expect(probe.failures).toHaveLength(1);
+    // The three carriers each grew their own latch to suppress the repeats; it belongs here instead.
+    expect(probe.failures[0]?.event).toBe('history_cleared');
+  });
+
+  it('isolates an error handler that itself throws', () => {
+    const deliver = createOutboundDelivery(
+      () => {
+        throw new Error('carrier down');
+      },
+      () => {
+        throw new Error('observer exploded');
+      },
+    );
+
+    // A diagnostic cannot reverse a session operation that has already committed.
+    expect(() => deliver({ type: 'history_cleared' })).not.toThrow();
+  });
+
+  it('normalizes a non-Error throw', () => {
+    const failures: Error[] = [];
+    const deliver = createOutboundDelivery(
+      () => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- a carrier can throw anything
+        throw 'data channel is closing';
+      },
+      (error) => failures.push(error),
+    );
+
+    deliver({ type: 'history_cleared' });
+    expect(failures[0]).toBeInstanceOf(Error);
+    expect(failures[0]?.message).toBe('data channel is closing');
+  });
+
+  it('refuses a raw sink where a boundary is required — the mechanical floor', () => {
+    const session = createTestInteractiveSession();
+    const rawSend = (_message: TServerMessage): void => undefined;
+
+    createWsHandler({
+      session,
+      // @ts-expect-error ARCH-030: only `createOutboundDelivery` produces a `TOutboundDeliver`. If this
+      // ever compiles, the brand is gone and a twelfth reply family can reach the wire unguarded.
+      deliver: rawSend,
+    });
+  });
+});
+
+describe('reply families that resolve after the carrier disconnected (ARCH-030)', () => {
+  /** The five families whose reply lands from a Promise continuation. */
+  const asynchronousFamilies: ReadonlyArray<{
+    readonly name: string;
+    readonly frame: Record<string, unknown>;
+    readonly expectedEvent: TServerMessage['type'];
+    readonly session: (release: Promise<never> | Promise<unknown>) => Partial<IInteractiveSession>;
+  }> = [
+    {
+      name: 'command result',
+      frame: { type: 'command', name: 'status' },
+      expectedEvent: 'command_result',
+      session: (release) => ({
+        executeCommand: () => release.then(() => ({ success: true, message: 'done' })),
+      }),
+    },
+    {
+      name: 'submit rejection',
+      frame: { type: 'submit', prompt: 'hello' },
+      expectedEvent: 'protocol_error',
+      session: (release) => ({
+        submit: () => release.then(() => Promise.reject(new Error('submit failed'))),
+      }),
+    },
+    {
+      name: 'background log read',
+      frame: { type: 'read-background-task-log', taskId: 'task_1' },
+      expectedEvent: 'background_task_log',
+      session: (release) => ({
+        readBackgroundTaskLog: () => release.then(() => ({ taskId: 'task_1', lines: [] })),
+      }),
+    },
+    {
+      name: 'job-group wait',
+      frame: { type: 'wait-background-job-group', groupId: 'group_1' },
+      expectedEvent: 'background_job_group',
+      session: (release) => ({
+        waitBackgroundJobGroup: () =>
+          release.then(() => ({
+            id: 'group_1',
+            parentSessionId: 'session_1',
+            waitPolicy: 'wait_all' as const,
+            taskIds: [],
+            status: 'completed' as const,
+            createdAt: '2026-08-16T00:00:00.000Z',
+            updatedAt: '2026-08-16T00:00:00.000Z',
+            results: [],
+          })),
+      }),
+    },
+    {
+      name: 'background control result',
+      frame: { type: 'cancel-background-task', taskId: 'task_1' },
+      expectedEvent: 'background_task_control_result',
+      session: (release) => ({
+        cancelBackgroundTask: () => release.then(() => undefined),
+      }),
+    },
+  ];
+
+  for (const family of asynchronousFamilies) {
+    it(`reports and does not leak an unhandled rejection — ${family.name}`, async () => {
+      const probe = createCarrierProbe();
+      const gate = deferred<void>();
+      const session = createTestInteractiveSession(
+        family.session(gate.promise) as Partial<IInteractiveSession>,
+      );
+      const handler = createWsHandler({ session, deliver: probe.deliver });
+
+      const rejections = await withUnhandledRejectionCapture(async () => {
+        handler.onMessage(JSON.stringify(family.frame));
+        probe.disconnect();
+        gate.resolve();
+      });
+
+      expect(rejections).toEqual([]);
+      expect(probe.failures).toEqual([
+        { message: 'WebSocket is not open', event: family.expectedEvent },
+      ]);
+      handler.cleanup();
+    });
+  }
+
+  /** The six families whose reply is synchronous — they used to throw out of `onMessage` itself. */
+  const synchronousFrames: ReadonlyArray<{
+    name: string;
+    raw: string;
+    event: TServerMessage['type'];
+  }> = [
+    { name: 'parse error', raw: 'not json at all', event: 'protocol_error' },
+    {
+      name: 'unknown message type',
+      raw: JSON.stringify({ type: 'nonsense' }),
+      event: 'protocol_error',
+    },
+    {
+      name: 'submit validation error',
+      raw: JSON.stringify({ type: 'submit', prompt: '' }),
+      event: 'protocol_error',
+    },
+    { name: 'session query', raw: JSON.stringify({ type: 'get-executing' }), event: 'executing' },
+    {
+      name: 'background query snapshot',
+      raw: JSON.stringify({ type: 'get-background-tasks' }),
+      event: 'background_tasks',
+    },
+    {
+      name: 'background validation error',
+      raw: JSON.stringify({ type: 'get-background-task', taskId: '' }),
+      event: 'protocol_error',
+    },
+  ];
+
+  for (const frame of synchronousFrames) {
+    it(`does not throw out of onMessage — ${frame.name}`, () => {
+      const probe = createCarrierProbe();
+      const handler = createWsHandler({
+        session: createTestInteractiveSession(),
+        deliver: probe.deliver,
+      });
+      probe.disconnect();
+
+      expect(() => handler.onMessage(frame.raw)).not.toThrow();
+      expect(probe.failures).toEqual([{ message: 'WebSocket is not open', event: frame.event }]);
+      handler.cleanup();
+    });
+  }
+
+  it('leaves the committed session operation successful and drops later frames silently', async () => {
+    const probe = createCarrierProbe();
+    const gate = deferred<void>();
+    const executed: string[] = [];
+    const session = createTestInteractiveSession({
+      executeCommand: (name: string) =>
+        gate.promise.then(() => {
+          executed.push(name);
+          return { success: true, message: 'done' };
+        }),
+    } as Partial<IInteractiveSession>);
+    const handler = createWsHandler({ session, deliver: probe.deliver });
+
+    const rejections = await withUnhandledRejectionCapture(async () => {
+      handler.onMessage(JSON.stringify({ type: 'command', name: 'status' }));
+      probe.disconnect();
+      gate.resolve();
+    });
+
+    expect(rejections).toEqual([]);
+    expect(executed).toEqual(['status']); // the command ran; delivery failing did not reverse it
+    expect(probe.failures).toHaveLength(1);
+
+    // The latch, observed from outside: a further inbound frame is dropped, neither reported again
+    // nor thrown out of `onMessage`.
+    expect(() => handler.onMessage(JSON.stringify({ type: 'get-executing' }))).not.toThrow();
+    expect(probe.failures).toHaveLength(1);
+    handler.cleanup();
+  });
+
+  it('keeps the session-event fan-out on the same boundary', () => {
+    const emit = new Map<string, (payload: unknown) => void>();
+    const probe = createCarrierProbe();
+    const session = createTestInteractiveSession({
+      on: ((event: string, handler: (payload: unknown) => void) => {
+        emit.set(event, handler);
+      }) as IInteractiveSession['on'],
+      off: ((event: string) => {
+        emit.delete(event);
+      }) as IInteractiveSession['off'],
+    });
+    createWsHandler({ session, deliver: probe.deliver });
+    probe.disconnect();
+
+    expect(() => emit.get('history_cleared')?.(undefined)).not.toThrow();
+    expect(probe.failures).toEqual([
+      { message: 'WebSocket is not open', event: 'history_cleared' },
+    ]);
+    // …and the fan-out shares the reply path's latch rather than having a second one.
+    emit.get('thinking')?.(true);
+    expect(probe.failures).toHaveLength(1);
+  });
+});

--- a/packages/agent-transport-protocol/src/__tests__/session-event-delivery.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/session-event-delivery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { createOutboundDelivery } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 import { PROTOCOL_SESSION_EVENT_CLASSIFICATION } from '../ws-session-events.js';
 
@@ -30,11 +31,7 @@ function createSession(): TEmittingSession {
 describe('protocol session-event delivery policy (ARCH-020/ARCH-028)', () => {
   it('mechanically matches every surface classification to an actual subscription', () => {
     const session = createSession();
-    const { cleanup } = createWsHandler({
-      session,
-      send: vi.fn(),
-      onDeliveryError: vi.fn(),
-    });
+    const { cleanup } = createWsHandler({ session, deliver: createOutboundDelivery(vi.fn(), vi.fn()) });
     const classifiedForSubscription = Object.entries(PROTOCOL_SESSION_EVENT_CLASSIFICATION)
       .filter(([, classification]) => classification !== 'non-surface')
       .map(([event]) => event)
@@ -53,11 +50,7 @@ describe('protocol session-event delivery policy (ARCH-020/ARCH-028)', () => {
   it('forwards plan, context refresh, and branch events as typed protocol frames', () => {
     const session = createSession();
     const sent: TServerMessage[] = [];
-    createWsHandler({
-      session,
-      send: (message) => sent.push(message),
-      onDeliveryError: vi.fn(),
-    });
+    createWsHandler({ session, deliver: createOutboundDelivery((message) => sent.push(message), vi.fn()) });
 
     session.emitForTest('plan_event', { type: 'plan_created', plan: { id: 'plan-1' } });
     session.emitForTest('context_file_refreshed', { filePath: '/repo/AGENTS.md' });
@@ -77,16 +70,12 @@ describe('protocol session-event delivery policy (ARCH-020/ARCH-028)', () => {
   it('isolates a carrier send failure and reports its owning session event', () => {
     const session = createSession();
     const failures: Array<{ message: string; event: string }> = [];
-    createWsHandler({
-      session,
-      send: () => {
+    createWsHandler({ session, deliver: createOutboundDelivery(() => {
         throw new Error('socket closed');
-      },
-      onDeliveryError: (error, event) => {
+      }, (error, event) => {
         failures.push({ message: error.message, event });
         throw new Error('diagnostic callback failed');
-      },
-    });
+      }) });
 
     expect(() =>
       session.emitForTest('branch_event', {

--- a/packages/agent-transport-protocol/src/__tests__/session-event-delivery.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/session-event-delivery.test.ts
@@ -31,7 +31,10 @@ function createSession(): TEmittingSession {
 describe('protocol session-event delivery policy (ARCH-020/ARCH-028)', () => {
   it('mechanically matches every surface classification to an actual subscription', () => {
     const session = createSession();
-    const { cleanup } = createWsHandler({ session, deliver: createOutboundDelivery(vi.fn(), vi.fn()) });
+    const { cleanup } = createWsHandler({
+      session,
+      deliver: createOutboundDelivery(vi.fn(), vi.fn()),
+    });
     const classifiedForSubscription = Object.entries(PROTOCOL_SESSION_EVENT_CLASSIFICATION)
       .filter(([, classification]) => classification !== 'non-surface')
       .map(([event]) => event)
@@ -50,7 +53,10 @@ describe('protocol session-event delivery policy (ARCH-020/ARCH-028)', () => {
   it('forwards plan, context refresh, and branch events as typed protocol frames', () => {
     const session = createSession();
     const sent: TServerMessage[] = [];
-    createWsHandler({ session, deliver: createOutboundDelivery((message) => sent.push(message), vi.fn()) });
+    createWsHandler({
+      session,
+      deliver: createOutboundDelivery((message) => sent.push(message), vi.fn()),
+    });
 
     session.emitForTest('plan_event', { type: 'plan_created', plan: { id: 'plan-1' } });
     session.emitForTest('context_file_refreshed', { filePath: '/repo/AGENTS.md' });
@@ -70,12 +76,18 @@ describe('protocol session-event delivery policy (ARCH-020/ARCH-028)', () => {
   it('isolates a carrier send failure and reports its owning session event', () => {
     const session = createSession();
     const failures: Array<{ message: string; event: string }> = [];
-    createWsHandler({ session, deliver: createOutboundDelivery(() => {
-        throw new Error('socket closed');
-      }, (error, event) => {
-        failures.push({ message: error.message, event });
-        throw new Error('diagnostic callback failed');
-      }) });
+    createWsHandler({
+      session,
+      deliver: createOutboundDelivery(
+        () => {
+          throw new Error('socket closed');
+        },
+        (error, event) => {
+          failures.push({ message: error.message, event });
+          throw new Error('diagnostic callback failed');
+        },
+      ),
+    });
 
     expect(() =>
       session.emitForTest('branch_event', {

--- a/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { createOutboundDelivery } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 import { SessionResumeBridge } from '../session-resume-bridge.js';
 import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
@@ -189,11 +190,7 @@ describe('SessionResumeBridge (REMOTE-013 TC-02)', () => {
   it('regression: the WS createWsHandler path stamps NO seq', () => {
     const { session, fire } = fakeSession();
     const sent: unknown[] = [];
-    const { cleanup } = createWsHandler({
-      session,
-      send: (m) => sent.push(m),
-      onDeliveryError: vi.fn(),
-    });
+    const { cleanup } = createWsHandler({ session, deliver: createOutboundDelivery((m) => sent.push(m), vi.fn()) });
     fire('text_delta', 'a');
     expect(sent).toEqual([{ type: 'text_delta', delta: 'a' }]); // no `seq` field
     cleanup();

--- a/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
@@ -190,7 +190,10 @@ describe('SessionResumeBridge (REMOTE-013 TC-02)', () => {
   it('regression: the WS createWsHandler path stamps NO seq', () => {
     const { session, fire } = fakeSession();
     const sent: unknown[] = [];
-    const { cleanup } = createWsHandler({ session, deliver: createOutboundDelivery((m) => sent.push(m), vi.fn()) });
+    const { cleanup } = createWsHandler({
+      session,
+      deliver: createOutboundDelivery((m) => sent.push(m), vi.fn()),
+    });
     fire('text_delta', 'a');
     expect(sent).toEqual([{ type: 'text_delta', delta: 'a' }]); // no `seq` field
     cleanup();
@@ -221,5 +224,92 @@ describe('SessionResumeBridge (REMOTE-013 TC-02)', () => {
     expect(failures).toEqual([{ message: 'data channel closed', event: 'branch_event' }]);
     expect(bridge.lastSeq).toBe(1); // retained for replay after the carrier reconnects
     bridge.dispose();
+  });
+
+  // ARCH-030: the bridge's own string-level try/catch is gone; its only guard is the per-attachment
+  // outbound boundary. These three pin the semantics that used to be side effects of `detach()`.
+  describe('the attachment boundary (ARCH-030)', () => {
+    it('reports ONCE across a failing multi-frame replay, and the dropped frames survive', () => {
+      const { session, fire } = fakeSession();
+      const failures: Array<{ message: string; event: string }> = [];
+      const bridge = new SessionResumeBridge({ session });
+
+      // Three frames buffered while no channel is attached — the reconnect gap.
+      fire('text_delta', 'a');
+      fire('text_delta', 'b');
+      fire('text_delta', 'c');
+      expect(bridge.lastSeq).toBe(3);
+
+      bridge.attach(
+        () => {
+          throw new Error('data channel closed');
+        },
+        {
+          awaitResume: true,
+          onDeliveryError: (error, event) => failures.push({ message: error.message, event }),
+        },
+      );
+      bridge.onClientMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+
+      // One report for the whole tail. Before the boundary this was one only because
+      // `reportDeliveryError` happened to `detach()` mid-loop; now it is the stated contract.
+      expect(failures).toEqual([{ message: 'data channel closed', event: 'text_delta' }]);
+
+      // Nothing was acked, so every frame is still replayable on the NEXT sink.
+      const healthy = sink();
+      bridge.attach(healthy, { awaitResume: true, onDeliveryError: vi.fn() });
+      bridge.onClientMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+      expect(frames(healthy).map((f) => f.seq)).toEqual([1, 2, 3]);
+      expect(frames(healthy).map((f) => f.delta)).toEqual(['a', 'b', 'c']);
+      bridge.dispose();
+    });
+
+    it('a fresh attach un-latches the connection, and seq stays continuous across the failure', () => {
+      const { session, fire } = fakeSession();
+      const bridge = new SessionResumeBridge({ session });
+      bridge.attach(
+        () => {
+          throw new Error('data channel closed');
+        },
+        { onDeliveryError: vi.fn() },
+      );
+      fire('text_delta', 'a');
+
+      const second = sink();
+      const secondFailures: string[] = [];
+      bridge.attach(second, { onDeliveryError: (error) => secondFailures.push(error.message) });
+      fire('text_delta', 'b');
+
+      // The new attachment delivers: a latched boundary is not carried across `attach`.
+      expect(frames(second).map((f) => f.seq)).toEqual([2]);
+      expect(secondFailures).toEqual([]);
+      expect(bridge.lastSeq).toBe(2); // the failed frame still consumed its seq
+      bridge.dispose();
+    });
+
+    it('routes a reply to an inbound frame through the same boundary as the event fan-out', () => {
+      const handlers = new Map<string, (arg: unknown) => void>();
+      const session = createTestInteractiveSession({
+        on: ((event: string, handler: (arg: unknown) => void) =>
+          handlers.set(event, handler)) as IInteractiveSession['on'],
+        off: ((event: string) => {
+          handlers.delete(event);
+        }) as IInteractiveSession['off'],
+      });
+      const failures: Array<{ message: string; event: string }> = [];
+      const bridge = new SessionResumeBridge({ session });
+      bridge.attach(
+        () => {
+          throw new Error('data channel closed');
+        },
+        { onDeliveryError: (error, event) => failures.push({ message: error.message, event }) },
+      );
+
+      // A synchronous query reply — before ARCH-030 the bridge guarded this at the string level, and
+      // the handler path next to it did not guard it at all.
+      expect(() => bridge.onClientMessage(JSON.stringify({ type: 'get-executing' }))).not.toThrow();
+      expect(failures).toEqual([{ message: 'data channel closed', event: 'executing' }]);
+      bridge.dispose();
+    });
   });
 });

--- a/packages/agent-transport-protocol/src/__tests__/ws-broadcast-events.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-broadcast-events.test.ts
@@ -49,8 +49,16 @@ function setupTwoSurfaces(): {
   const session = createMockSession();
   const sentA: TServerMessage[] = [];
   const sentB: TServerMessage[] = [];
-  createWsHandler({ session, deliver: createOutboundDelivery((m) => sentA.push(m), vi.fn()), driverId: 'device-A' });
-  createWsHandler({ session, deliver: createOutboundDelivery((m) => sentB.push(m), vi.fn()), driverId: 'device-B' });
+  createWsHandler({
+    session,
+    deliver: createOutboundDelivery((m) => sentA.push(m), vi.fn()),
+    driverId: 'device-A',
+  });
+  createWsHandler({
+    session,
+    deliver: createOutboundDelivery((m) => sentB.push(m), vi.fn()),
+    driverId: 'device-B',
+  });
   return { session, sentA, sentB };
 }
 

--- a/packages/agent-transport-protocol/src/__tests__/ws-broadcast-events.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-broadcast-events.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { createOutboundDelivery } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 
 import type { TServerMessage } from '../ws-protocol.js';
@@ -48,18 +49,8 @@ function setupTwoSurfaces(): {
   const session = createMockSession();
   const sentA: TServerMessage[] = [];
   const sentB: TServerMessage[] = [];
-  createWsHandler({
-    session,
-    send: (m) => sentA.push(m),
-    driverId: 'device-A',
-    onDeliveryError: vi.fn(),
-  });
-  createWsHandler({
-    session,
-    send: (m) => sentB.push(m),
-    driverId: 'device-B',
-    onDeliveryError: vi.fn(),
-  });
+  createWsHandler({ session, deliver: createOutboundDelivery((m) => sentA.push(m), vi.fn()), driverId: 'device-A' });
+  createWsHandler({ session, deliver: createOutboundDelivery((m) => sentB.push(m), vi.fn()), driverId: 'device-B' });
   return { session, sentA, sentB };
 }
 

--- a/packages/agent-transport-protocol/src/__tests__/ws-handler-e5.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-handler-e5.test.ts
@@ -2,6 +2,7 @@ import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transp
 
 import { describe, it, expect, vi } from 'vitest';
 
+import { createOutboundDelivery } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 import type { TServerMessage } from '../ws-protocol.js';
 import type {
@@ -35,12 +36,7 @@ function mockSession(activeDriverId: string | null) {
 describe('ws-handler E5 driver attribution (REMOTE-014)', () => {
   it('TC-05: injects the SERVER-ASSIGNED driver id into submit + prompt-response (client cannot forge it)', () => {
     const session = mockSession(null);
-    const { onMessage } = createWsHandler({
-      session,
-      send: () => {},
-      driverId: 'device-42',
-      onDeliveryError: vi.fn(),
-    });
+    const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery(() => {}, vi.fn()), driverId: 'device-42' });
     // A client submit frame carries NO driverId field (structurally — TClientMessage has none); the handler
     // injects the bound server id.
     onMessage(JSON.stringify({ type: 'submit', prompt: 'hi', driverId: 'spoofed' }));
@@ -67,7 +63,7 @@ describe('ws-handler E5 driver attribution (REMOTE-014)', () => {
   it('TC-03: SELECTIVELY stamps turn-authored events with the active driver; background events carry none', () => {
     const session = mockSession('driver-A');
     const sent: TServerMessage[] = [];
-    createWsHandler({ session, send: (m) => sent.push(m), onDeliveryError: vi.fn() });
+    createWsHandler({ session, deliver: createOutboundDelivery((m) => sent.push(m), vi.fn()) });
 
     session._emit('user_message', 'hello');
     session._emit('text_delta', 'chunk');
@@ -84,7 +80,7 @@ describe('ws-handler E5 driver attribution (REMOTE-014)', () => {
   it('TC-03: an unattributed (idle) turn stamps no driverId', () => {
     const session = mockSession(null); // getActiveDriverId → null
     const sent: TServerMessage[] = [];
-    createWsHandler({ session, send: (m) => sent.push(m), onDeliveryError: vi.fn() });
+    createWsHandler({ session, deliver: createOutboundDelivery((m) => sent.push(m), vi.fn()) });
     session._emit('user_message', 'hi');
     expect((sent[0] as { driverId?: string }).driverId).toBeUndefined();
   });

--- a/packages/agent-transport-protocol/src/__tests__/ws-handler-e5.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-handler-e5.test.ts
@@ -36,7 +36,11 @@ function mockSession(activeDriverId: string | null) {
 describe('ws-handler E5 driver attribution (REMOTE-014)', () => {
   it('TC-05: injects the SERVER-ASSIGNED driver id into submit + prompt-response (client cannot forge it)', () => {
     const session = mockSession(null);
-    const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery(() => {}, vi.fn()), driverId: 'device-42' });
+    const { onMessage } = createWsHandler({
+      session,
+      deliver: createOutboundDelivery(() => {}, vi.fn()),
+      driverId: 'device-42',
+    });
     // A client submit frame carries NO driverId field (structurally — TClientMessage has none); the handler
     // injects the bound server id.
     onMessage(JSON.stringify({ type: 'submit', prompt: 'hi', driverId: 'spoofed' }));

--- a/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
@@ -5,6 +5,7 @@
 import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
 
 import { describe, it, expect, vi } from 'vitest';
+import { createOutboundDelivery } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 import { PROTOCOL_SESSION_EVENT_CLASSIFICATION } from '../ws-session-events.js';
 import type { TServerMessage } from '../ws-protocol.js';
@@ -113,11 +114,7 @@ describe('WebSocket Transport Handler', () => {
   function setup() {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
-    const { onMessage, cleanup } = createWsHandler({
-      session,
-      send: (msg) => sent.push(msg),
-      onDeliveryError: vi.fn(),
-    });
+    const { onMessage, cleanup } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()) });
     return { session, sent, onMessage, cleanup };
   }
 
@@ -318,12 +315,7 @@ describe('WebSocket Transport Handler', () => {
   it('command carries the SERVER-ASSIGNED driver id as the command origin (CMD-004 Phase 2)', async () => {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
-    const { onMessage } = createWsHandler({
-      session,
-      send: (msg) => sent.push(msg),
-      driverId: 'device-7',
-      onDeliveryError: vi.fn(),
-    });
+    const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId: 'device-7' });
     onMessage(JSON.stringify({ type: 'command', name: 'settings' }));
     await new Promise((r) => setTimeout(r, 10));
     expect(
@@ -334,12 +326,7 @@ describe('WebSocket Transport Handler', () => {
   it('forwards ui_intent session events to the requesting client (CMD-004 Phase 2)', () => {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
-    createWsHandler({
-      session,
-      send: (msg) => sent.push(msg),
-      driverId: 'device-7',
-      onDeliveryError: vi.fn(),
-    });
+    createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId: 'device-7' });
     session._emit('ui_intent', {
       intent: { type: 'show-settings' },
       requesterDriverId: 'device-7',
@@ -361,18 +348,8 @@ describe('WebSocket Transport Handler', () => {
       const session = createMockSession();
       const sentA: TServerMessage[] = [];
       const sentB: TServerMessage[] = [];
-      createWsHandler({
-        session,
-        send: (msg) => sentA.push(msg),
-        driverId: 'device-A',
-        onDeliveryError: vi.fn(),
-      });
-      createWsHandler({
-        session,
-        send: (msg) => sentB.push(msg),
-        driverId: 'device-B',
-        onDeliveryError: vi.fn(),
-      });
+      createWsHandler({ session, deliver: createOutboundDelivery((msg) => sentA.push(msg), vi.fn()), driverId: 'device-A' });
+      createWsHandler({ session, deliver: createOutboundDelivery((msg) => sentB.push(msg), vi.fn()), driverId: 'device-B' });
       return { session, sentA, sentB };
     }
 

--- a/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
@@ -114,7 +114,10 @@ describe('WebSocket Transport Handler', () => {
   function setup() {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
-    const { onMessage, cleanup } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()) });
+    const { onMessage, cleanup } = createWsHandler({
+      session,
+      deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()),
+    });
     return { session, sent, onMessage, cleanup };
   }
 
@@ -315,7 +318,11 @@ describe('WebSocket Transport Handler', () => {
   it('command carries the SERVER-ASSIGNED driver id as the command origin (CMD-004 Phase 2)', async () => {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
-    const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId: 'device-7' });
+    const { onMessage } = createWsHandler({
+      session,
+      deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()),
+      driverId: 'device-7',
+    });
     onMessage(JSON.stringify({ type: 'command', name: 'settings' }));
     await new Promise((r) => setTimeout(r, 10));
     expect(
@@ -326,7 +333,11 @@ describe('WebSocket Transport Handler', () => {
   it('forwards ui_intent session events to the requesting client (CMD-004 Phase 2)', () => {
     const session = createMockSession();
     const sent: TServerMessage[] = [];
-    createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId: 'device-7' });
+    createWsHandler({
+      session,
+      deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()),
+      driverId: 'device-7',
+    });
     session._emit('ui_intent', {
       intent: { type: 'show-settings' },
       requesterDriverId: 'device-7',
@@ -348,8 +359,16 @@ describe('WebSocket Transport Handler', () => {
       const session = createMockSession();
       const sentA: TServerMessage[] = [];
       const sentB: TServerMessage[] = [];
-      createWsHandler({ session, deliver: createOutboundDelivery((msg) => sentA.push(msg), vi.fn()), driverId: 'device-A' });
-      createWsHandler({ session, deliver: createOutboundDelivery((msg) => sentB.push(msg), vi.fn()), driverId: 'device-B' });
+      createWsHandler({
+        session,
+        deliver: createOutboundDelivery((msg) => sentA.push(msg), vi.fn()),
+        driverId: 'device-A',
+      });
+      createWsHandler({
+        session,
+        deliver: createOutboundDelivery((msg) => sentB.push(msg), vi.fn()),
+        driverId: 'device-B',
+      });
       return { session, sentA, sentB };
     }
 

--- a/packages/agent-transport-protocol/src/index.ts
+++ b/packages/agent-transport-protocol/src/index.ts
@@ -1,10 +1,14 @@
 export { createWsHandler } from './ws-handler.js';
 export type { IWsHandlerOptions } from './ws-handler.js';
+// ARCH-030: the connection-scoped outbound delivery boundary every carrier builds and passes down.
+export { createOutboundDelivery } from './outbound-delivery.js';
+export type { TDeliveryErrorHandler, TOutboundDeliver } from './outbound-delivery.js';
 export { PROTOCOL_SESSION_EVENT_CLASSIFICATION } from './ws-session-events.js';
-export type {
-  ISubscribeSessionEventsOptions,
-  TProtocolSessionEventClassification,
-} from './ws-session-events.js';
+// `ISubscribeSessionEventsOptions` is NOT here (ARCH-030): it is the options bag of
+// `subscribeSessionEvents`, which is package-internal, and a barrel that exports the options of a
+// function it does not export is the "internal implementation detail through the barrel" the
+// version-management skill bans. It was also absent from the SPEC's Public API Surface table.
+export type { TProtocolSessionEventClassification } from './ws-session-events.js';
 export type { IProtocolSession } from './protocol-session.js';
 export type { TClientMessage, TServerMessage, TSeqServerMessage } from './ws-protocol.js';
 export { ResumeBuffer } from './resume-buffer.js';

--- a/packages/agent-transport-protocol/src/outbound-delivery.ts
+++ b/packages/agent-transport-protocol/src/outbound-delivery.ts
@@ -1,0 +1,92 @@
+/**
+ * The connection-scoped outbound delivery boundary (ARCH-030).
+ *
+ * Every outbound `TServerMessage` on one connection — session-event fan-out AND every reply to an
+ * inbound frame — goes through ONE boundary that owns carrier-failure containment. Before this
+ * existed, `subscribeSessionEvents` guarded its sends while the reply paths received the raw carrier
+ * `send`, so a reply resolving after a disconnect threw from a Promise continuation, escaped as an
+ * unhandled rejection, and left the carrier's cleanup — written, idempotent, and waiting — unnotified.
+ *
+ * WHO BUILDS IT. The **carrier**, from its own private sink and its own failure policy, and passes the
+ * result down into the protocol handler. Not the other way round: the raw sink and the "what does a
+ * failed send mean for this connection" decision both belong to the carrier, and handing the protocol
+ * layer a raw sink so it can hand a wrapper back leaves the raw sink reachable — which is the hole a
+ * twelfth reply family walks through next year.
+ *
+ * WHY IT IS BRANDED. {@link createOutboundDelivery} is the only producer of {@link TOutboundDeliver}, so
+ * a plain `(message: TServerMessage) => void` is **refused by the compiler** wherever a boundary is
+ * required. That turns "a new raw-send continuation cannot be added silently" from a scan that a rename
+ * defeats into a type error at the call site. `src/__tests__` is inside this package's `tsconfig.json`
+ * `include`, so the `@ts-expect-error` case pinning it is checked by `tsgo --noEmit`.
+ *
+ * IT LATCHES. A boundary reports AT MOST ONE delivery failure; after the first, it is closed and every
+ * subsequent frame is dropped without a further report. All three carriers already treat a delivery
+ * failure as terminal (`WsSessionDelivery.close` → `socket.close(1011)`, `WebRtcDeliveryLifecycle` →
+ * `channel.close()`, `PairingGate` → `pairingChannel.close`) and each had grown its own latch to
+ * suppress the repeats; the latch belongs upstream of all three. `SessionResumeBridge` already behaved
+ * this way, so the handler path converges onto the bridge's semantics rather than the reverse.
+ *
+ * A boundary is not reusable across carriers: a latched one stays latched. `SessionResumeBridge` builds
+ * a fresh boundary per `attach`, which is what un-latches the session after a reconnect.
+ */
+
+import type { TServerMessage } from './ws-protocol.js';
+
+declare const outboundDeliveryBrand: unique symbol;
+
+/**
+ * Deliver one outbound frame on a connection. A carrier failure is REPORTED through the boundary's
+ * error handler, never thrown at the caller — so a reply resolving after a disconnect cannot escape as
+ * an unhandled rejection or out of the carrier's inbound listener.
+ *
+ * Only {@link createOutboundDelivery} produces one. The brand is the mechanism, not decoration: it is
+ * what makes a raw carrier `send` unusable where a boundary is required.
+ */
+export type TOutboundDeliver = ((message: TServerMessage) => void) & {
+  readonly [outboundDeliveryBrand]: true;
+};
+
+/**
+ * Observe THIS connection's first outbound delivery failure. `event` is the `type` of the frame that
+ * could not be delivered — a session event's own name for the fan-out (they are identical), and the
+ * reply's type for a reply (`command_result`, `protocol_error`, …).
+ *
+ * Required, never optional: a carrier that could opt out of observing its own delivery failures is the
+ * silent-failure shape this boundary exists to remove.
+ */
+export type TDeliveryErrorHandler = (error: Error, event: TServerMessage['type']) => void;
+
+/**
+ * Build the outbound delivery boundary for ONE connection from that connection's raw sink and its
+ * failure policy.
+ *
+ * @param send - the carrier's raw sink. May throw; that is what makes it raw.
+ * @param onDeliveryError - the carrier's failure policy, invoked at most once. A handler that itself
+ *   throws is isolated: a diagnostic cannot reverse an already-committed session operation.
+ */
+export function createOutboundDelivery(
+  send: (message: TServerMessage) => void,
+  onDeliveryError: TDeliveryErrorHandler,
+): TOutboundDeliver {
+  let closed = false;
+  const deliver = (message: TServerMessage): void => {
+    if (closed) return;
+    try {
+      send(message);
+    } catch (error) {
+      // allow-fallback: this IS the boundary — a carrier send failure is a CARRIER lifecycle failure,
+      // reported to the carrier's own policy (which closes the connection). It is never swallowed, and
+      // re-throwing it would fail a session operation that has already committed.
+      closed = true;
+      const normalized = error instanceof Error ? error : new Error(String(error));
+      try {
+        onDeliveryError(normalized, message.type);
+      } catch {
+        // allow-fallback: the carrier-owned diagnostic is the LAST step of a failure already being
+        // reported. A throw from it has nowhere left to go, and letting it out would make a committed
+        // session operation fail for the sake of a diagnostic.
+      }
+    }
+  };
+  return deliver as TOutboundDeliver;
+}

--- a/packages/agent-transport-protocol/src/session-resume-bridge.ts
+++ b/packages/agent-transport-protocol/src/session-resume-bridge.ts
@@ -19,10 +19,12 @@
  * The WS localhost path does NOT use this bridge — it keeps `createWsHandler` unchanged.
  */
 
+import { createOutboundDelivery } from './outbound-delivery.js';
 import { ResumeBuffer, type IResumeBufferOptions } from './resume-buffer.js';
 import { handleClientMessage, parseClientMessage } from './ws-handler.js';
 import { subscribeSessionEvents } from './ws-session-events.js';
 
+import type { TOutboundDeliver } from './outbound-delivery.js';
 import type { IProtocolSession } from './protocol-session.js';
 import type { TSeqServerMessage, TServerMessage } from './ws-protocol.js';
 import type { TDriverId } from '@robota-sdk/agent-interface-transport';
@@ -58,6 +60,18 @@ export class SessionResumeBridge {
   private readonly unsubscribe: () => void;
   private onDeliveryError?: IAttachOptions['onDeliveryError'];
   private sink?: TResumeSink;
+  /**
+   * ARCH-030: the attachment's outbound boundary. Built per `attach` because a boundary LATCHES on its
+   * first failure — a fresh one is exactly what un-latches the session for the next channel. The single
+   * try/catch for this whole class lives inside it; there is no second guard at the string level.
+   */
+  private outbound?: TOutboundDeliver;
+  /**
+   * The session-lifetime entry every frame takes — event fan-out AND every reply to an inbound frame —
+   * before it is seq-stamped and buffered by {@link emit}. Distinct from {@link outbound}, which is the
+   * per-attachment exit to the current channel; this one outlives channels because the subscription does.
+   */
+  private readonly emitBoundary: TOutboundDeliver;
   private disposed = false;
   /** REMOTE-013 E4: while true, live emits are buffered but NOT forwarded — released by `replay()` on reconnect. */
   private holding = false;
@@ -70,9 +84,18 @@ export class SessionResumeBridge {
     // CMD-004 Stage D: `ui_intent` is requester-routed against the LATE-BOUND driver id (bound by
     // `setDriverId` after pairing) — routing happens BEFORE buffering, so a foreign surface's intent
     // consumes no seq and can never leak through a later `resume` replay.
-    this.unsubscribe = subscribeSessionEvents(this.session, (message) => this.emit(message), {
+    //
+    // ARCH-030: built through the factory, never cast — the brand is only worth having if this class
+    // does not spell its way around it. `emit` buffers and then hands the stamped frame to whatever
+    // boundary is currently ATTACHED, so it does not itself throw on a carrier failure; this boundary
+    // exists so that if it ever did, the failure would be reported rather than escaping the session's
+    // event listener.
+    this.emitBoundary = createOutboundDelivery(
+      (message) => this.emit(message),
+      (error, event) => this.reportDeliveryError(error, event),
+    );
+    this.unsubscribe = subscribeSessionEvents(this.session, this.emitBoundary, {
       getSurfaceDriverId: () => this.driverId,
-      onDeliveryError: (error, event) => this.reportDeliveryError(error, event),
     });
   }
 
@@ -81,6 +104,10 @@ export class SessionResumeBridge {
     if (this.disposed) return;
     this.sink = sink;
     this.onDeliveryError = options.onDeliveryError;
+    this.outbound = createOutboundDelivery(
+      (message) => sink(JSON.stringify(message)),
+      (error, event) => this.reportDeliveryError(error, event),
+    );
     // On a reconnect, hold live forwarding until `resume` flushes the buffered tail (avoids the live-vs-replay race).
     this.holding = options.awaitResume === true;
   }
@@ -88,6 +115,7 @@ export class SessionResumeBridge {
   /** Clear the sink (channel drop). Buffering continues so gap output is retained for the next `resume`. */
   public detach(): void {
     this.sink = undefined;
+    this.outbound = undefined;
     this.onDeliveryError = undefined;
   }
 
@@ -102,7 +130,7 @@ export class SessionResumeBridge {
   /** Route one inbound channel frame: `resume`/`ack` handled here; everything else → the session. */
   public onClientMessage(data: string): void {
     if (this.disposed) return;
-    const msg = parseClientMessage(data, (m) => this.emit(m));
+    const msg = parseClientMessage(data, this.emitBoundary);
     if (!msg) return;
     if (msg.type === 'resume') {
       this.replay(msg.lastSeq);
@@ -114,7 +142,7 @@ export class SessionResumeBridge {
     }
     // Session control/query/background/prompt-response — responses funnel back through `emit` (seq'd + buffered).
     // REMOTE-014 E5: inject the server-assigned driver id (submit/prompt-response attribution).
-    handleClientMessage(this.session, (m) => this.emit(m), msg, this.driverId);
+    handleClientMessage(this.session, this.emitBoundary, msg, this.driverId);
   }
 
   /** Unsubscribe from the session (host reconnect-window ceiling / teardown). Idempotent. */
@@ -130,42 +158,47 @@ export class SessionResumeBridge {
     return this.buffer.lastSeq;
   }
 
-  /** Stamp a seq, retain in the buffer, and forward to the current sink — UNLESS holding for a reconnect replay. */
+  /**
+   * Stamp a seq, retain in the buffer, and forward to the current sink — UNLESS holding for a reconnect replay.
+   *
+   * ARCH-030: the `buffer.append` happens BEFORE the boundary, deliberately. The boundary latches on its
+   * first failure and drops everything after it, so a frame appended afterwards would be lost — appending
+   * first means a dropped frame is still in the un-acked tail and still replays on the next `resume`.
+   */
   private emit(message: TServerMessage): void {
     if (this.disposed) return;
     const seq = this.buffer.append(message);
     if (this.holding) return; // buffered only; `replay()` will flush it in order and release the hold
-    this.send({ ...message, seq } as TSeqServerMessage);
+    this.deliverFrame({ ...message, seq } as TSeqServerMessage);
   }
 
   /**
    * Replay the buffered tail after `lastSeq` (or `resume_gap` on overrun), then RELEASE the reconnect hold so
    * subsequent live frames flow in order behind the flushed gap.
+   *
+   * A failing sink reports ONCE across the whole tail: the boundary latches on the first failure and every
+   * remaining frame is dropped silently. Those frames stay un-acked in the buffer and replay on the next
+   * attachment. Before ARCH-030 the single report was a side effect of `detach()` running mid-loop; now it
+   * is the boundary's stated contract.
    */
   private replay(lastSeq: number): void {
     const tail = this.buffer.tailAfter(lastSeq);
     if (tail.kind === 'overrun') {
-      this.rawSend(JSON.stringify({ type: 'resume_gap' }), 'resume_gap');
+      // `resume_gap` is neither stamped nor buffered: the client answers it with a full `get-messages`
+      // refresh, so there is nothing for it to resume from.
+      this.deliverFrame({ type: 'resume_gap' });
       this.holding = false; // client will full-refresh via get-messages; let live frames flow
       return;
     }
     for (const frame of tail.frames) {
-      this.send({ ...frame.message, seq: frame.seq } as TSeqServerMessage);
+      this.deliverFrame({ ...frame.message, seq: frame.seq } as TSeqServerMessage);
     }
     this.holding = false; // gap flushed in order — resume live forwarding
   }
 
-  private send(message: TSeqServerMessage): void {
-    this.rawSend(JSON.stringify(message), message.type);
-  }
-
-  private rawSend(data: string, event: TServerMessage['type']): void {
-    try {
-      this.sink?.(data);
-    } catch (error) {
-      const normalized = error instanceof Error ? error : new Error(String(error));
-      this.reportDeliveryError(normalized, event);
-    }
+  /** The ONE outbound exit from this class. No frame reaches the sink except through the attachment's boundary. */
+  private deliverFrame(message: TServerMessage): void {
+    this.outbound?.(message);
   }
 
   /** Detach the failed sink but retain the frame, then notify its attachment owner. */

--- a/packages/agent-transport-protocol/src/session-resume-bridge.ts
+++ b/packages/agent-transport-protocol/src/session-resume-bridge.ts
@@ -59,17 +59,22 @@ export class SessionResumeBridge {
   private driverId?: TDriverId;
   private readonly unsubscribe: () => void;
   private onDeliveryError?: IAttachOptions['onDeliveryError'];
-  private sink?: TResumeSink;
   /**
-   * ARCH-030: the attachment's outbound boundary. Built per `attach` because a boundary LATCHES on its
-   * first failure — a fresh one is exactly what un-latches the session for the next channel. The single
-   * try/catch for this whole class lives inside it; there is no second guard at the string level.
+   * ARCH-030: the attachment's outbound boundary — and the only reference this class keeps to the current
+   * channel, which is why `dispose()` goes through `detach()` rather than clearing a separate field.
+   * Built per `attach` because a boundary LATCHES on its first failure, so a fresh one is exactly what
+   * un-latches the session for the next channel. It holds the only try/catch on the frame path.
    */
   private outbound?: TOutboundDeliver;
   /**
    * The session-lifetime entry every frame takes — event fan-out AND every reply to an inbound frame —
    * before it is seq-stamped and buffered by {@link emit}. Distinct from {@link outbound}, which is the
    * per-attachment exit to the current channel; this one outlives channels because the subscription does.
+   *
+   * It guards the BUFFERING step, not a carrier, and it latches for the life of the session on purpose: a
+   * resume buffer that cannot accept a frame cannot honour a later `resume` either, so there is nothing a
+   * reconnect could recover. That is the opposite of {@link outbound}, where the next channel is exactly
+   * what recovery looks like — the two scopes differ because the failures do.
    */
   private readonly emitBoundary: TOutboundDeliver;
   private disposed = false;
@@ -102,7 +107,6 @@ export class SessionResumeBridge {
   /** Set the current channel sink (on connect / reconnect). Live messages reach the client; replay is `resume`-driven. */
   public attach(sink: TResumeSink, options: IAttachOptions): void {
     if (this.disposed) return;
-    this.sink = sink;
     this.onDeliveryError = options.onDeliveryError;
     this.outbound = createOutboundDelivery(
       (message) => sink(JSON.stringify(message)),
@@ -114,7 +118,6 @@ export class SessionResumeBridge {
 
   /** Clear the sink (channel drop). Buffering continues so gap output is retained for the next `resume`. */
   public detach(): void {
-    this.sink = undefined;
     this.outbound = undefined;
     this.onDeliveryError = undefined;
   }
@@ -149,7 +152,9 @@ export class SessionResumeBridge {
   public dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.sink = undefined;
+    // Through `detach`, not a field assignment: the boundary's closure is what holds the channel, so
+    // clearing anything else released nothing and left teardown documented but not performed.
+    this.detach();
     this.unsubscribe();
   }
 

--- a/packages/agent-transport-protocol/src/session-resume-bridge.ts
+++ b/packages/agent-transport-protocol/src/session-resume-bridge.ts
@@ -71,10 +71,13 @@ export class SessionResumeBridge {
    * before it is seq-stamped and buffered by {@link emit}. Distinct from {@link outbound}, which is the
    * per-attachment exit to the current channel; this one outlives channels because the subscription does.
    *
-   * It guards the BUFFERING step, not a carrier, and it latches for the life of the session on purpose: a
-   * resume buffer that cannot accept a frame cannot honour a later `resume` either, so there is nothing a
-   * reconnect could recover. That is the opposite of {@link outbound}, where the next channel is exactly
-   * what recovery looks like — the two scopes differ because the failures do.
+   * It guards the BUFFERING step, not a carrier, and it latches for the life of the session on purpose:
+   * the failure it is placed against is the buffer refusing a frame on capacity, and a resume buffer that
+   * cannot accept frames cannot honour a later `resume` either, so there is nothing a reconnect recovers.
+   * That is the opposite of {@link outbound}, where the next channel IS the recovery — the two scopes
+   * differ because the failures do. (A per-frame serialization failure would leave the buffer intact, but
+   * such a frame is undeliverable on every carrier, since each one stringifies it too; it is reported and
+   * the carrier torn down, never silently dropped.)
    */
   private readonly emitBoundary: TOutboundDeliver;
   private disposed = false;

--- a/packages/agent-transport-protocol/src/ws-background-messages.ts
+++ b/packages/agent-transport-protocol/src/ws-background-messages.ts
@@ -1,9 +1,10 @@
+import type { TOutboundDeliver } from './outbound-delivery.js';
 import type { IProtocolSession } from './protocol-session.js';
-import type { TBackgroundControlAction, TClientMessage, TServerMessage } from './ws-protocol.js';
+import type { TBackgroundControlAction, TClientMessage } from './ws-protocol.js';
 
 export function handleBackgroundQueryMessage(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<
     TClientMessage,
     | { type: 'get-background-tasks' | 'get-background-task' | 'read-background-task-log' }
@@ -14,43 +15,43 @@ export function handleBackgroundQueryMessage(
   >,
 ): void {
   if (msg.type === 'get-background-tasks') {
-    send({ type: 'background_tasks', tasks: session.listBackgroundTasks(msg.filter) });
+    deliver({ type: 'background_tasks', tasks: session.listBackgroundTasks(msg.filter) });
     return;
   }
   if (msg.type === 'get-background-task') {
-    sendBackgroundTaskSnapshot(session, send, msg);
+    sendBackgroundTaskSnapshot(session, deliver, msg);
     return;
   }
   if (msg.type === 'get-background-job-groups') {
-    send({ type: 'background_job_groups', groups: session.listBackgroundJobGroups() });
+    deliver({ type: 'background_job_groups', groups: session.listBackgroundJobGroups() });
     return;
   }
   if (msg.type === 'get-background-job-group') {
-    sendBackgroundJobGroupSnapshot(session, send, msg);
+    sendBackgroundJobGroupSnapshot(session, deliver, msg);
     return;
   }
   if (msg.type === 'wait-background-job-group') {
-    sendBackgroundJobGroupWaitResult(session, send, msg);
+    sendBackgroundJobGroupWaitResult(session, deliver, msg);
     return;
   }
-  sendBackgroundTaskLogPage(session, send, msg);
+  sendBackgroundTaskLogPage(session, deliver, msg);
 }
 
 export function handleBackgroundControlMessage(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<
     TClientMessage,
     { type: 'cancel-background-task' | 'close-background-task' | 'send-background-task' }
   >,
 ): void {
   if (!msg.taskId) {
-    send({ type: 'protocol_error', message: 'taskId is required' });
+    deliver({ type: 'protocol_error', message: 'taskId is required' });
     return;
   }
   if (msg.type === 'cancel-background-task') {
     sendBackgroundTaskControlResult(
-      send,
+      deliver,
       'cancel',
       msg.taskId,
       session.cancelBackgroundTask(msg.taskId, msg.reason),
@@ -59,26 +60,26 @@ export function handleBackgroundControlMessage(
   }
   if (msg.type === 'close-background-task') {
     sendBackgroundTaskControlResult(
-      send,
+      deliver,
       'close',
       msg.taskId,
       session.closeBackgroundTask(msg.taskId),
     );
     return;
   }
-  sendBackgroundTaskInput(session, send, msg);
+  sendBackgroundTaskInput(session, deliver, msg);
 }
 
 function sendBackgroundTaskSnapshot(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<TClientMessage, { type: 'get-background-task' }>,
 ): void {
   if (!msg.taskId) {
-    send({ type: 'protocol_error', message: 'taskId is required' });
+    deliver({ type: 'protocol_error', message: 'taskId is required' });
     return;
   }
-  send({
+  deliver({
     type: 'background_task',
     taskId: msg.taskId,
     task: session.getBackgroundTask(msg.taskId) ?? null,
@@ -87,29 +88,29 @@ function sendBackgroundTaskSnapshot(
 
 function sendBackgroundTaskLogPage(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<TClientMessage, { type: 'read-background-task-log' }>,
 ): void {
   if (!msg.taskId) {
-    send({ type: 'protocol_error', message: 'taskId is required' });
+    deliver({ type: 'protocol_error', message: 'taskId is required' });
     return;
   }
   session.readBackgroundTaskLog(msg.taskId, msg.cursor).then(
-    (page) => send({ type: 'background_task_log', taskId: msg.taskId, page }),
-    (error: Error) => send({ type: 'protocol_error', message: error.message }),
+    (page) => deliver({ type: 'background_task_log', taskId: msg.taskId, page }),
+    (error: Error) => deliver({ type: 'protocol_error', message: error.message }),
   );
 }
 
 function sendBackgroundJobGroupSnapshot(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<TClientMessage, { type: 'get-background-job-group' }>,
 ): void {
   if (!msg.groupId) {
-    send({ type: 'protocol_error', message: 'groupId is required' });
+    deliver({ type: 'protocol_error', message: 'groupId is required' });
     return;
   }
-  send({
+  deliver({
     type: 'background_job_group',
     groupId: msg.groupId,
     group: session.getBackgroundJobGroup(msg.groupId) ?? null,
@@ -118,30 +119,30 @@ function sendBackgroundJobGroupSnapshot(
 
 function sendBackgroundJobGroupWaitResult(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<TClientMessage, { type: 'wait-background-job-group' }>,
 ): void {
   if (!msg.groupId) {
-    send({ type: 'protocol_error', message: 'groupId is required' });
+    deliver({ type: 'protocol_error', message: 'groupId is required' });
     return;
   }
   session.waitBackgroundJobGroup(msg.groupId).then(
-    (group) => send({ type: 'background_job_group', groupId: msg.groupId, group }),
-    (error: Error) => send({ type: 'protocol_error', message: error.message }),
+    (group) => deliver({ type: 'background_job_group', groupId: msg.groupId, group }),
+    (error: Error) => deliver({ type: 'protocol_error', message: error.message }),
   );
 }
 
 function sendBackgroundTaskInput(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<TClientMessage, { type: 'send-background-task' }>,
 ): void {
   if (!msg.input) {
-    send({ type: 'protocol_error', message: 'input is required' });
+    deliver({ type: 'protocol_error', message: 'input is required' });
     return;
   }
   sendBackgroundTaskControlResult(
-    send,
+    deliver,
     'send',
     msg.taskId,
     session.sendBackgroundTask(msg.taskId, msg.input),
@@ -149,15 +150,15 @@ function sendBackgroundTaskInput(
 }
 
 function sendBackgroundTaskControlResult(
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   action: TBackgroundControlAction,
   taskId: string,
   operation: Promise<void>,
 ): void {
   operation.then(
-    () => send({ type: 'background_task_control_result', action, taskId, success: true }),
+    () => deliver({ type: 'background_task_control_result', action, taskId, success: true }),
     (error: Error) =>
-      send({
+      deliver({
         type: 'background_task_control_result',
         action,
         taskId,

--- a/packages/agent-transport-protocol/src/ws-handler.ts
+++ b/packages/agent-transport-protocol/src/ws-handler.ts
@@ -14,9 +14,9 @@ import {
 } from './ws-background-messages.js';
 import { subscribeSessionEvents } from './ws-session-events.js';
 
+import type { TOutboundDeliver } from './outbound-delivery.js';
 import type { IProtocolSession } from './protocol-session.js';
-import type { ISubscribeSessionEventsOptions } from './ws-session-events.js';
-import type { TClientMessage, TServerMessage } from './ws-protocol.js';
+import type { TClientMessage } from './ws-protocol.js';
 import type { TDriverId } from '@robota-sdk/agent-interface-transport';
 
 // Outbound session→TServerMessage fan-out (incl. CMD-004 requester-routed `ui_intent`) lives in
@@ -27,16 +27,20 @@ export type { ISubscribeSessionEventsOptions } from './ws-session-events.js';
 export interface IWsHandlerOptions {
   /** IProtocolSession to expose. */
   session: IProtocolSession;
-  /** Send a JSON message to the client. */
-  send: (message: TServerMessage) => void;
+  /**
+   * ARCH-030: the CARRIER's connection-scoped outbound delivery boundary — not a raw `send`, and not a
+   * `send` plus an error callback for this handler to assemble into one. The carrier owns both the sink
+   * and the "what does a failed send mean for this connection" policy, so it builds the boundary and
+   * passes it down; the raw sink never crosses this parameter, which is what stops a future reply family
+   * from reaching the wire unguarded.
+   */
+  deliver: TOutboundDeliver;
   /**
    * REMOTE-014 E5: the SERVER-ASSIGNED driver id for THIS remote surface (the E3 `deviceId`). Injected into
    * every inbound `submit`/`command`/prompt-response so a co-drive turn/answer is attributed to this driver —
    * a client-supplied driver id is NEVER trusted. Absent → unattributed (the session defaults to the owner).
    */
   driverId?: TDriverId;
-  /** Observe a failed outbound session-event delivery and close/clean up the owning carrier. */
-  onDeliveryError: ISubscribeSessionEventsOptions['onDeliveryError'];
 }
 
 /**
@@ -48,11 +52,11 @@ export interface IWsHandlerOptions {
  *
  * Usage:
  * ```typescript
- * const { onMessage, cleanup } = createWsHandler({
- *   session: interactiveSession,
- *   send: (msg) => ws.send(JSON.stringify(msg)),
- *   onDeliveryError: (error) => ws.close(1011, error.message),
- * });
+ * const delivery = createOutboundDelivery(
+ *   (msg) => ws.send(JSON.stringify(msg)),
+ *   (error) => ws.close(1011, error.message),
+ * );
+ * const { onMessage, cleanup } = createWsHandler({ session: interactiveSession, deliver: delivery });
  *
  * ws.on('message', (data) => onMessage(String(data)));
  * ws.on('close', cleanup);
@@ -62,37 +66,35 @@ export function createWsHandler(options: IWsHandlerOptions): {
   onMessage: (data: string) => void;
   cleanup: () => void;
 } {
-  const cleanup = subscribeSessionEvents(options.session, options.send, {
+  const cleanup = subscribeSessionEvents(options.session, options.deliver, {
     getSurfaceDriverId: () => options.driverId,
-    onDeliveryError: options.onDeliveryError,
   });
-  // Contained — ARCH-030. Inbound replies still use the raw send until one outbound boundary owns both paths.
-  const onMessage = createWsMessageHandler(options.session, options.send, options.driverId);
+  const onMessage = createWsMessageHandler(options.session, options.deliver, options.driverId);
 
   return { onMessage, cleanup };
 }
 
 function createWsMessageHandler(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   driverId?: TDriverId,
 ): (data: string) => void {
   return (data: string): void => {
-    const msg = parseClientMessage(data, send);
+    const msg = parseClientMessage(data, deliver);
     if (!msg) return;
-    handleClientMessage(session, send, msg, driverId);
+    handleClientMessage(session, deliver, msg, driverId);
   };
 }
 
 /** Parse a client JSON frame; on invalid JSON it emits `protocol_error` and returns null. Exported for E4. */
-export function parseClientMessage(
-  data: string,
-  send: (message: TServerMessage) => void,
-): TClientMessage | null {
+export function parseClientMessage(data: string, deliver: TOutboundDeliver): TClientMessage | null {
   try {
     return JSON.parse(data) as TClientMessage;
   } catch {
-    send({ type: 'protocol_error', message: 'Invalid JSON' });
+    // allow-fallback: a malformed client frame is answered on the wire with `protocol_error`, which is
+    // the protocol's stated response — not a swallowed failure. Nothing upstream can act on the parse
+    // error itself, and throwing here would take down the carrier's inbound listener.
+    deliver({ type: 'protocol_error', message: 'Invalid JSON' });
     return null;
   }
 }
@@ -103,24 +105,24 @@ export function parseClientMessage(
  */
 export function handleClientMessage(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: TClientMessage,
   driverId?: TDriverId,
 ): void {
   if (isSessionControlMessage(msg)) {
-    handleSessionControlMessage(session, send, msg, driverId);
+    handleSessionControlMessage(session, deliver, msg, driverId);
     return;
   }
   if (isSessionQueryMessage(msg)) {
-    handleSessionQueryMessage(session, send, msg);
+    handleSessionQueryMessage(session, deliver, msg);
     return;
   }
   if (isBackgroundQueryMessage(msg)) {
-    handleBackgroundQueryMessage(session, send, msg);
+    handleBackgroundQueryMessage(session, deliver, msg);
     return;
   }
   if (isBackgroundControlMessage(msg)) {
-    handleBackgroundControlMessage(session, send, msg);
+    handleBackgroundControlMessage(session, deliver, msg);
     return;
   }
   if (isPromptResponseMessage(msg)) {
@@ -128,7 +130,7 @@ export function handleClientMessage(
     return;
   }
   const unknownType = (msg as { type: string }).type;
-  send({ type: 'protocol_error', message: `Unknown message type: ${unknownType}` });
+  deliver({ type: 'protocol_error', message: `Unknown message type: ${unknownType}` });
 }
 
 function isSessionControlMessage(
@@ -214,31 +216,31 @@ function handlePromptResponseMessage(
 
 function handleSessionControlMessage(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<TClientMessage, { type: 'submit' | 'command' | 'abort' | 'cancel-queue' }>,
   driverId?: TDriverId,
 ): void {
   if (msg.type === 'submit') {
     if (!msg.prompt) {
-      send({ type: 'protocol_error', message: 'prompt is required' });
+      deliver({ type: 'protocol_error', message: 'prompt is required' });
       return;
     }
     // REMOTE-014 E5: attribute this remote turn to the SERVER-ASSIGNED driver id (never a client-sent one).
     session
       .submit(msg.prompt, undefined, undefined, driverId ? { driverId } : undefined)
       .catch((error: Error) => {
-        send({ type: 'protocol_error', message: error.message });
+        deliver({ type: 'protocol_error', message: error.message });
       });
   } else if (msg.type === 'command') {
     if (!msg.name) {
-      send({ type: 'protocol_error', message: 'name is required' });
+      deliver({ type: 'protocol_error', message: 'name is required' });
       return;
     }
     // REMOTE-003: a transport-origin command is tagged `'remote'` (optional policy, allow-by-default;
     // REMOTE-006). CMD-004: the SERVER-ASSIGNED driver id (E5) is the command origin — intents route back here.
     session.executeCommand(msg.name, msg.args ?? '', 'remote', driverId).then(
       (result) => {
-        send({
+        deliver({
           type: 'command_result',
           name: msg.name,
           message: result?.message ?? `Unknown command: ${msg.name}`,
@@ -247,7 +249,7 @@ function handleSessionControlMessage(
         });
       },
       (error: Error) => {
-        send({ type: 'protocol_error', message: error.message });
+        deliver({ type: 'protocol_error', message: error.message });
       },
     );
   } else if (msg.type === 'abort') {
@@ -259,7 +261,7 @@ function handleSessionControlMessage(
 
 function handleSessionQueryMessage(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
+  deliver: TOutboundDeliver,
   msg: Extract<
     TClientMessage,
     {
@@ -273,17 +275,17 @@ function handleSessionQueryMessage(
   >,
 ): void {
   if (msg.type === 'get-messages') {
-    send({ type: 'messages', messages: session.getMessages() });
+    deliver({ type: 'messages', messages: session.getMessages() });
   } else if (msg.type === 'get-context') {
-    send({ type: 'context', state: session.getContextState() });
+    deliver({ type: 'context', state: session.getContextState() });
   } else if (msg.type === 'get-executing') {
-    send({ type: 'executing', executing: session.isExecuting() });
+    deliver({ type: 'executing', executing: session.isExecuting() });
   } else if (msg.type === 'get-execution-workspace') {
-    send({
+    deliver({
       type: 'execution_workspace_event',
       snapshot: session.getExecutionWorkspaceSnapshot(),
     });
   } else {
-    send({ type: 'pending', pending: session.getPendingPrompt() });
+    deliver({ type: 'pending', pending: session.getPendingPrompt() });
   }
 }

--- a/packages/agent-transport-protocol/src/ws-session-events.ts
+++ b/packages/agent-transport-protocol/src/ws-session-events.ts
@@ -6,8 +6,8 @@
  * `SessionResumeBridge` (REMOTE-013 E4 — a SINGLE subscription that outlives per-channel handlers).
  */
 
+import type { TOutboundDeliver } from './outbound-delivery.js';
 import type { IProtocolSession } from './protocol-session.js';
-import type { TServerMessage } from './ws-protocol.js';
 import type { TDriverId, TInteractiveEventName } from '@robota-sdk/agent-interface-transport';
 import type {
   IAskRequestEvent,
@@ -57,39 +57,38 @@ export const PROTOCOL_SESSION_EVENT_CLASSIFICATION = {
   history_cleared: 'forwarded',
 } as const satisfies Record<TInteractiveEventName, TProtocolSessionEventClassification>;
 
-/** Options for {@link subscribeSessionEvents}. */
+/**
+ * Options for {@link subscribeSessionEvents}.
+ *
+ * ARCH-030: `onDeliveryError` is NOT here. Carrier-failure containment moved to the one
+ * connection-scoped {@link TOutboundDeliver} boundary this function now receives, so the fan-out and
+ * every reply share a single guard instead of the fan-out having its own.
+ */
 export interface ISubscribeSessionEventsOptions {
   /**
    * CMD-004 Stage D: lazily read the SERVER-ASSIGNED driver id of THIS surface — `ui_intent` is
    * requester-routed against it (lazy because the resume bridge binds the id only after pairing).
    */
   getSurfaceDriverId?: () => TDriverId | undefined;
-  /** Carrier-owned send failures; the handler is isolated from the committed session operation. */
-  onDeliveryError: (error: Error, event: TInteractiveEventName) => void;
 }
 
 /**
- * Subscribe the session's events and forward each as a `TServerMessage` via `send`; returns an unsubscribe.
- * Exported (REMOTE-013 E4) so the persistent `SessionResumeBridge` can own a SINGLE subscription that
- * outlives per-channel handlers.
+ * Subscribe the session's events and forward each as a `TServerMessage` through the connection's
+ * outbound boundary; returns an unsubscribe. Exported (REMOTE-013 E4) so the persistent
+ * `SessionResumeBridge` can own a SINGLE subscription that outlives per-channel handlers.
+ *
+ * ARCH-030: the second parameter is the boundary, not a raw sink — a carrier `send` cannot be passed
+ * here, which is what keeps the fan-out and the reply paths on one guard.
  */
 export function subscribeSessionEvents(
   session: IProtocolSession,
-  send: (message: TServerMessage) => void,
-  options: ISubscribeSessionEventsOptions,
+  deliver: TOutboundDeliver,
+  options: ISubscribeSessionEventsOptions = {},
 ): () => void {
-  const deliver = (event: TInteractiveEventName, message: TServerMessage): void => {
-    try {
-      send(message);
-    } catch (error) {
-      const normalized = error instanceof Error ? error : new Error(String(error));
-      try {
-        options.onDeliveryError(normalized, event);
-      } catch {
-        // The transport-owned diagnostic callback cannot make a committed session operation fail.
-      }
-    }
-  };
+  // ARCH-030: no local guard wrapper any more, and no event name passed alongside the message. The name
+  // existed so the local guard could label a failure with it; the boundary labels with `message.type`,
+  // which is identical for every forwarded event (asserted in `session-event-delivery.test.ts`). Keeping
+  // the argument would have been a parameter that documents nothing and is read by nobody.
   // REMOTE-014 E5: stamp the ACTIVE turn's driver id onto TURN-AUTHORED events (co-drive authorship,
   // display-only), read at emit time. Only these events — background/goal/memory/execution-workspace events
   // are NOT authored by a driver turn and carry no `driverId`. `undefined` when idle or unattributed.
@@ -100,44 +99,39 @@ export function subscribeSessionEvents(
     return driverId ? { driverId } : {};
   };
   const onUserMessage = (content: string): void =>
-    deliver('user_message', { type: 'user_message', content, ...attr() });
-  const onTextDelta = (delta: string): void =>
-    deliver('text_delta', { type: 'text_delta', delta, ...attr() });
+    deliver({ type: 'user_message', content, ...attr() });
+  const onTextDelta = (delta: string): void => deliver({ type: 'text_delta', delta, ...attr() });
   const onToolStart = (state: IToolState): void =>
-    deliver('tool_start', { type: 'tool_start', state, ...attr() });
-  const onToolEnd = (state: IToolState): void =>
-    deliver('tool_end', { type: 'tool_end', state, ...attr() });
+    deliver({ type: 'tool_start', state, ...attr() });
+  const onToolEnd = (state: IToolState): void => deliver({ type: 'tool_end', state, ...attr() });
   const onThinking = (isThinking: boolean): void =>
-    deliver('thinking', { type: 'thinking', isThinking, ...attr() });
+    deliver({ type: 'thinking', isThinking, ...attr() });
   const onComplete = (result: IExecutionResult): void =>
-    deliver('complete', { type: 'complete', result, ...attr() });
+    deliver({ type: 'complete', result, ...attr() });
   const onInterrupted = (result: IExecutionResult): void =>
-    deliver('interrupted', { type: 'interrupted', result, ...attr() });
+    deliver({ type: 'interrupted', result, ...attr() });
   const onError = (error: Error): void =>
-    deliver('error', { type: 'error', message: error.message, ...attr() });
+    deliver({ type: 'error', message: error.message, ...attr() });
   const onBackgroundTaskEvent = (event: TBackgroundTaskEvent): void =>
-    deliver('background_task_event', { type: 'background_task_event', event });
+    deliver({ type: 'background_task_event', event });
   const onBackgroundJobGroupEvent = (event: TBackgroundJobGroupEvent): void =>
-    deliver('background_job_group_event', { type: 'background_job_group_event', event });
+    deliver({ type: 'background_job_group_event', event });
   const onExecutionWorkspace = (event: IExecutionWorkspaceEvent): void =>
-    deliver('execution_workspace_event', {
+    deliver({
       type: 'execution_workspace_event',
       snapshot: event.snapshot,
     });
-  const onPlanEvent = (event: IPlanApprovalEvent): void =>
-    deliver('plan_event', { type: 'plan_event', event });
+  const onPlanEvent = (event: IPlanApprovalEvent): void => deliver({ type: 'plan_event', event });
   const onContextFileRefreshed = (event: IContextFileRefreshedEvent): void =>
-    deliver('context_file_refreshed', { type: 'context_file_refreshed', event });
-  const onBranchEvent = (event: IBranchEvent): void =>
-    deliver('branch_event', { type: 'branch_event', event });
+    deliver({ type: 'context_file_refreshed', event });
+  const onBranchEvent = (event: IBranchEvent): void => deliver({ type: 'branch_event', event });
   // REMOTE-007: forward the transport-neutral prompt events so a remote surface can render + answer the
   // SAME permission/ask prompt; `prompt_resolved` dismisses it when another surface answered first.
   const onPermissionRequest = (event: IPermissionRequestEvent): void =>
-    deliver('permission_request', { type: 'permission_request', event });
-  const onAskRequest = (event: IAskRequestEvent): void =>
-    deliver('ask_request', { type: 'ask_request', event });
+    deliver({ type: 'permission_request', event });
+  const onAskRequest = (event: IAskRequestEvent): void => deliver({ type: 'ask_request', event });
   const onPromptResolved = (event: IPromptResolvedEvent): void =>
-    deliver('prompt_resolved', { type: 'prompt_resolved', event });
+    deliver({ type: 'prompt_resolved', event });
   // CMD-004 Stage D: `ui_intent` is REQUESTER-ROUTED — delivered only to the surface whose
   // server-assigned driver id issued the command. An UNATTRIBUTED intent (no requester id, e.g. an
   // idle model-invoked command) is unroutable and reaches every surface — never a silent drop.
@@ -148,13 +142,13 @@ export function subscribeSessionEvents(
     ) {
       return; // another surface's intent — this surface never sees it (and never buffers it)
     }
-    deliver('ui_intent', { type: 'ui_intent', event });
+    deliver({ type: 'ui_intent', event });
   };
   // CMD-004 Stage E: BROADCAST session-state events — the host executed the rename/clear; EVERY
   // attached surface (co-driving included) reflects it. Never requester-filtered, unlike `ui_intent`.
   const onSessionRenamed = (event: ISessionRenamedEvent): void =>
-    deliver('session_renamed', { type: 'session_renamed', event });
-  const onHistoryCleared = (): void => deliver('history_cleared', { type: 'history_cleared' });
+    deliver({ type: 'session_renamed', event });
+  const onHistoryCleared = (): void => deliver({ type: 'history_cleared' });
 
   session.on('user_message', onUserMessage);
   session.on('text_delta', onTextDelta);

--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -47,11 +47,12 @@ trickle candidates that precede the remote description), creates the `robota-ses
 SDP offer. The data channel is wired **eagerly at creation** (not on `open`): `createWsHandler({ session, send })`
 is built immediately and `onMessage` subscribed at once, because werift does not buffer inbound frames that
 arrive before a subscription and the remote can send its first `TClientMessage` before the host's channel opens.
-Outbound session-event delivery is owned by the carrier. The protocol handler's `onDeliveryError`
-callback routes a data-channel send failure through one idempotent channel/handler cleanup path and an
-optional owner observer; it never escapes back into the committed session operation. The pairing gate
-uses the same rule after acceptance, and a reconnect attachment detaches its failed sink while retaining
-the frame in the resume buffer. `stop()` tears down the handler, signal subscription, and peer.
+Outbound delivery is owned by the carrier — ARCH-030: the transport and the pairing gate each BUILD the
+connection's `TOutboundDeliver` boundary from their own channel sink and their own failure policy and pass
+it into `createWsHandler`, so replies and session events share one guard. A data-channel send failure
+routes through one idempotent channel/handler cleanup path and an optional owner observer; it never
+escapes back into the committed session operation, and the boundary reports it once. A reconnect
+attachment detaches its failed sink while retaining the frame in the resume buffer. `stop()` tears down the handler, signal subscription, and peer.
 
 ARCH-011 classifies this as a frozen `service` lifecycle. Its readiness boundary is publication of
 the local offer/signaling state; it deliberately does not wait for an external answer, data-channel
@@ -120,9 +121,10 @@ reserved for E4). Without `reconnect`, the gate is exactly the B4 first-pair-onl
 - `werift` absent → `loadWerift` throws `WebRTC transport unavailable — install the optional peer dependency
 "werift" …` at point-of-use (never a silent degrade).
 - `start()` before `attach()` → throws `WebRtcTransport: attach() must be called before start()`.
-- A session-event `send` failure on a closing/closed channel closes and detaches that carrier, reports
-  `onDeliveryError`, and leaves the committed session operation successful. It is never silently dropped
-  or partially retried.
+- An outbound `send` failure on a closing/closed channel — a session event OR a reply that resolved after
+  the drop (ARCH-030) — closes and detaches that carrier, reports `onDeliveryError` exactly once, and
+  leaves the committed session operation successful. It is never silently dropped or partially retried,
+  and it never surfaces as an unhandled rejection.
 
 ## Test Strategy
 

--- a/packages/agent-transport-webrtc/src/__tests__/outbound-delivery-carrier.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/outbound-delivery-carrier.test.ts
@@ -135,7 +135,10 @@ describe('PairingGate bare-handler branch + the outbound boundary (ARCH-030)', (
     expect(channelClose).toHaveBeenCalledTimes(1);
   });
 
-  it('latches: a burst of replies after the drop reports once', async () => {
+  // As on the WS side, this is not the boundary latch's own proof — `PairingGate.handleSessionDeliveryError`
+  // returns early once its state is `closed`, so the single report predates ARCH-030. It pins that the
+  // boundary above it did not change what the gate observes. The latch is red-proved in the protocol suite.
+  it('reports once for a burst of replies after the drop', async () => {
     const session = createTestInteractiveSession();
     const { gate, drop, deliveryErrors } = await acceptedGate(session);
     drop();

--- a/packages/agent-transport-webrtc/src/__tests__/outbound-delivery-carrier.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/outbound-delivery-carrier.test.ts
@@ -1,0 +1,149 @@
+/**
+ * ARCH-030 at the WebRTC carrier.
+ *
+ * The item named WebRTC as affected, and its stated reason was wrong in a way worth recording: the
+ * PAIRED-with-resume-bridge path was already guarded (the bridge routed replies through its own
+ * try/catch). The genuinely unguarded WebRTC exposure was the BARE `createWsHandler` — `PairingGate`'s
+ * no-`resumeBridge` branch, taken after the handshake accepts, and `WebRtcTransport`'s no-secret
+ * branch, which is the same construction. This suite drives the gate's branch with a stubbed
+ * handshake, the way `pairing-gate.test.ts` does, because that is the one that ships by default.
+ */
+
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PairingGate } from '../pairing-gate.js';
+
+import type { startPairingHandshake, TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+import type { RTCDataChannel } from 'werift';
+
+/** Collect unhandled rejections while `run` executes, then drain the queue Node reports them on. */
+async function withUnhandledRejectionCapture(run: () => void | Promise<void>): Promise<unknown[]> {
+  const captured: unknown[] = [];
+  const existing = process.listeners('unhandledRejection');
+  for (const listener of existing) process.off('unhandledRejection', listener);
+  const collect = (reason: unknown): void => {
+    captured.push(reason);
+  };
+  process.on('unhandledRejection', collect);
+  try {
+    await run();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } finally {
+    process.off('unhandledRejection', collect);
+    for (const listener of existing)
+      process.on('unhandledRejection', listener as NodeJS.UnhandledRejectionListener);
+  }
+  return captured;
+}
+
+/** A controllable handshake stub: the test decides when pairing accepts. */
+function makeHandshakeStub(): { start: typeof startPairingHandshake; accept: () => void } {
+  let resolveResult!: (value: { sessionKey: string }) => void;
+  const start: typeof startPairingHandshake = (options) => {
+    const controller = {
+      result: new Promise<{ sessionKey: string }>((res) => {
+        resolveResult = res;
+      }),
+      onFrame: (_frame: TPairingFrame) => undefined,
+    };
+    options.send({ t: 'pair-nonce', nonce: 'stub' });
+    return controller;
+  };
+  return { start, accept: () => resolveResult({ sessionKey: 'k' }) };
+}
+
+/** A data channel whose `send` starts throwing once dropped, as werift's does on a closed channel. */
+function createDroppableChannel(): {
+  channel: RTCDataChannel;
+  close: ReturnType<typeof vi.fn>;
+  drop: () => void;
+} {
+  let open = true;
+  const close = vi.fn();
+  const channel = {
+    send: (data: string) => {
+      if (!open) throw new Error('RTCDataChannel is not open');
+      void data;
+    },
+    close,
+  } as unknown as RTCDataChannel;
+  return {
+    channel,
+    close,
+    drop: () => {
+      open = false;
+    },
+  };
+}
+
+/** Build an accepted gate on its bare-handler branch (no `resumeBridge`). */
+async function acceptedGate(session: IInteractiveSession): Promise<{
+  gate: PairingGate;
+  channelClose: ReturnType<typeof vi.fn>;
+  drop: () => void;
+  deliveryErrors: Array<{ message: string; event: string }>;
+}> {
+  const { channel, close, drop } = createDroppableChannel();
+  const deliveryErrors: Array<{ message: string; event: string }> = [];
+  const handshake = makeHandshakeStub();
+  const gate = new PairingGate({
+    channel,
+    session,
+    secret: 's',
+    role: 'initiator',
+    localFingerprint: 'AA',
+    remoteFingerprint: 'BB',
+    startHandshake: handshake.start,
+    onDeliveryError: (error, event) => deliveryErrors.push({ message: error.message, event }),
+  });
+  handshake.accept();
+  await new Promise((resolve) => setTimeout(resolve, 0)); // the gate accepts on a microtask
+  return { gate, channelClose: close, drop, deliveryErrors };
+}
+
+describe('PairingGate bare-handler branch + the outbound boundary (ARCH-030)', () => {
+  it('a command resolving after the channel dropped reports once and leaks no rejection', async () => {
+    let releaseCommand: (() => void) | undefined;
+    const commandGate = new Promise<void>((resolve) => {
+      releaseCommand = resolve;
+    });
+    const executed: string[] = [];
+    const session: IInteractiveSession = createTestInteractiveSession({
+      executeCommand: (name: string) =>
+        commandGate.then(() => {
+          executed.push(name);
+          return { success: true, message: 'done' };
+        }),
+    } as Partial<IInteractiveSession>);
+    const { gate, channelClose, drop, deliveryErrors } = await acceptedGate(session);
+
+    const rejections = await withUnhandledRejectionCapture(async () => {
+      gate.onInbound(JSON.stringify({ type: 'command', name: 'status' }));
+      drop();
+      releaseCommand?.();
+    });
+
+    expect(rejections).toEqual([]);
+    expect(executed).toEqual(['status']); // the command committed regardless of delivery
+    expect(deliveryErrors).toEqual([
+      { message: 'RTCDataChannel is not open', event: 'command_result' },
+    ]);
+    // Carrier cleanup ran: the gate closed its channel on the delivery failure. Before ARCH-030 the
+    // reply threw from a Promise continuation and none of this happened.
+    expect(channelClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('latches: a burst of replies after the drop reports once', async () => {
+    const session = createTestInteractiveSession();
+    const { gate, drop, deliveryErrors } = await acceptedGate(session);
+    drop();
+
+    gate.onInbound(JSON.stringify({ type: 'get-executing' }));
+    gate.onInbound(JSON.stringify({ type: 'get-messages' }));
+    gate.onInbound(JSON.stringify({ type: 'get-pending' }));
+
+    expect(deliveryErrors).toEqual([{ message: 'RTCDataChannel is not open', event: 'executing' }]);
+  });
+});

--- a/packages/agent-transport-webrtc/src/channel-delivery.ts
+++ b/packages/agent-transport-webrtc/src/channel-delivery.ts
@@ -1,0 +1,34 @@
+/**
+ * The data channel's outbound delivery boundary (ARCH-030).
+ *
+ * Both places that build a bare `createWsHandler` in this package — `PairingGate`'s no-`resumeBridge`
+ * branch and `WebRtcTransport`'s no-secret branch — need exactly the same thing: serialize a
+ * `TServerMessage` onto an `RTCDataChannel` and route a send failure into that carrier's own failure
+ * policy. Written inline at both sites it was two copies of one decision, and it pushed both files past
+ * their size ceilings. One owner, named after what it is.
+ */
+
+import { createOutboundDelivery } from '@robota-sdk/agent-transport-protocol';
+
+import type { TOutboundDeliver } from '@robota-sdk/agent-transport-protocol';
+
+/** The slice of `RTCDataChannel` an outbound boundary needs — `send`, and nothing else. */
+export interface IDataChannelSink {
+  send: (data: string) => void;
+}
+
+/**
+ * Build the connection's outbound boundary over a data channel.
+ *
+ * @param channel - the data channel to serialize onto. `send` may throw once the channel is closing.
+ * @param onDeliveryError - this carrier's failure policy, invoked at most once (the boundary latches).
+ */
+export function createChannelDelivery(
+  channel: IDataChannelSink,
+  onDeliveryError: (error: Error, event: string) => void,
+): TOutboundDeliver {
+  return createOutboundDelivery(
+    (message) => channel.send(JSON.stringify(message)),
+    (error, event) => onDeliveryError(error, event),
+  );
+}

--- a/packages/agent-transport-webrtc/src/pairing-frames.ts
+++ b/packages/agent-transport-webrtc/src/pairing-frames.ts
@@ -1,0 +1,39 @@
+/**
+ * Predicates over the pairing/reconnect frame vocabulary the gate admits pre-accept.
+ *
+ * These answer "what KIND of frame is this", which is a question about the wire vocabulary, not about
+ * the gate's state machine. They lived inside `pairing-gate.ts` where they were the only thing in the
+ * file not about gating.
+ */
+
+import type { TPairingFrame, TReconnectFrame } from '@robota-sdk/agent-remote-pairing';
+
+/** A gate-level identity-exchange frame (first-pair enrollment, post-B3-accept). */
+export interface IEnrollFrame {
+  readonly t: 'enroll-key';
+  readonly spki: string;
+}
+
+/** True when a parsed value is a B3 pairing frame (`{ t: 'pair-nonce' | 'pair-confirm', … }`). */
+export function isPairingFrame(value: unknown): value is TPairingFrame {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = (value as { t?: unknown }).t;
+  return t === 'pair-nonce' || t === 'pair-confirm';
+}
+
+/** True when a parsed value is a reconnect frame the host consumes (`rc-hello` / `rc-device`). */
+export function isReconnectFrame(value: unknown): value is TReconnectFrame {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = (value as { t?: unknown }).t;
+  return t === 'rc-hello' || t === 'rc-device';
+}
+
+/** True when a parsed value is the first-pair enrollment frame carrying a device SPKI. */
+export function isEnrollFrame(value: unknown): value is IEnrollFrame {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { t?: unknown }).t === 'enroll-key' &&
+    typeof (value as { spki?: unknown }).spki === 'string'
+  );
+}

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -16,11 +16,12 @@
  * `pair-nonce`, no enrollment, no reconnect) — preserving existing behavior.
  */
 
-import {
-  createOutboundDelivery,
-  createWsHandler,
-  type SessionResumeBridge,
-} from '@robota-sdk/agent-transport-protocol';
+import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
+
+import { createChannelDelivery } from './channel-delivery.js';
+import { isEnrollFrame, isPairingFrame, isReconnectFrame } from './pairing-frames.js';
+
+import type { IEnrollFrame } from './pairing-frames.js';
 import {
   deriveIdentityId,
   importPublicKey,
@@ -52,12 +53,6 @@ export interface IHostReconnectConfig {
   readonly resolveDevicePublicKey: (deviceId: string) => Promise<CryptoKey | undefined>;
   /** Pin a device's public key on first-pair enrollment (deviceId, base64url SPKI). */
   readonly onEnroll: (deviceId: string, deviceSpki: string) => void;
-}
-
-/** A gate-level identity-exchange frame (first-pair enrollment, post-B3-accept). */
-interface IEnrollFrame {
-  readonly t: 'enroll-key';
-  readonly spki: string;
 }
 
 export interface IPairingGateOptions {
@@ -92,29 +87,6 @@ export interface IPairingGateOptions {
   /** Injection seams (default to the real implementations). */
   readonly startHandshake?: typeof startPairingHandshake;
   readonly createHandler?: typeof createWsHandler;
-}
-
-/** True when a parsed value is a B3 pairing frame (`{ t: 'pair-nonce' | 'pair-confirm', … }`). */
-function isPairingFrame(value: unknown): value is TPairingFrame {
-  if (typeof value !== 'object' || value === null) return false;
-  const t = (value as { t?: unknown }).t;
-  return t === 'pair-nonce' || t === 'pair-confirm';
-}
-
-/** True when a parsed value is a reconnect frame the host consumes (`rc-hello` / `rc-device`). */
-function isReconnectFrame(value: unknown): value is TReconnectFrame {
-  if (typeof value !== 'object' || value === null) return false;
-  const t = (value as { t?: unknown }).t;
-  return t === 'rc-hello' || t === 'rc-device';
-}
-
-function isEnrollFrame(value: unknown): value is IEnrollFrame {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    (value as { t?: unknown }).t === 'enroll-key' &&
-    typeof (value as { spki?: unknown }).spki === 'string'
-  );
 }
 
 type TGateState =
@@ -291,13 +263,11 @@ export class PairingGate {
       this.handlerCleanup = () => bridge.detach();
     } else {
       const create = this.options.createHandler ?? createWsHandler;
-      // ARCH-030: the gate is the carrier on this branch, so it builds the connection's outbound
-      // boundary from its own channel sink and its own failure policy and passes it down.
+      // ARCH-030: the gate is the carrier on this branch — its own channel sink, its own failure policy.
       const { onMessage, cleanup } = create({
         session: this.options.session,
-        deliver: createOutboundDelivery(
-          (serverMessage) => this.options.channel.send(JSON.stringify(serverMessage)),
-          (error, event) => this.handleSessionDeliveryError(error, event),
+        deliver: createChannelDelivery(this.options.channel, (error, event) =>
+          this.handleSessionDeliveryError(error, event),
         ),
       });
       this.onSessionMessage = onMessage;

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -16,7 +16,11 @@
  * `pair-nonce`, no enrollment, no reconnect) — preserving existing behavior.
  */
 
-import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
+import {
+  createOutboundDelivery,
+  createWsHandler,
+  type SessionResumeBridge,
+} from '@robota-sdk/agent-transport-protocol';
 import {
   deriveIdentityId,
   importPublicKey,
@@ -78,8 +82,13 @@ export interface IPairingGateOptions {
    * (never disposes — the bridge is owned by the transport across reconnects).
    */
   readonly resumeBridge?: SessionResumeBridge;
-  /** Post-accept session-frame delivery failure; owning transport performs drop cleanup. */
-  readonly onDeliveryError?: (error: Error, event: TServerMessage['type'] | string) => void;
+  /**
+   * Post-accept session-frame delivery failure; owning transport performs drop cleanup.
+   *
+   * ARCH-030: was `TServerMessage['type'] | string`, which is just `string` — a union that reads as a
+   * narrowing and is not one. Stated as what it is.
+   */
+  readonly onDeliveryError?: (error: Error, event: string) => void;
   /** Injection seams (default to the real implementations). */
   readonly startHandshake?: typeof startPairingHandshake;
   readonly createHandler?: typeof createWsHandler;
@@ -282,10 +291,14 @@ export class PairingGate {
       this.handlerCleanup = () => bridge.detach();
     } else {
       const create = this.options.createHandler ?? createWsHandler;
+      // ARCH-030: the gate is the carrier on this branch, so it builds the connection's outbound
+      // boundary from its own channel sink and its own failure policy and passes it down.
       const { onMessage, cleanup } = create({
         session: this.options.session,
-        send: (serverMessage) => this.options.channel.send(JSON.stringify(serverMessage)),
-        onDeliveryError: (error, event) => this.handleSessionDeliveryError(error, event),
+        deliver: createOutboundDelivery(
+          (serverMessage) => this.options.channel.send(JSON.stringify(serverMessage)),
+          (error, event) => this.handleSessionDeliveryError(error, event),
+        ),
       });
       this.onSessionMessage = onMessage;
       this.handlerCleanup = cleanup;

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -16,25 +16,22 @@
  * `pair-nonce`, no enrollment, no reconnect) — preserving existing behavior.
  */
 
-import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
-
-import { createChannelDelivery } from './channel-delivery.js';
-import { isEnrollFrame, isPairingFrame, isReconnectFrame } from './pairing-frames.js';
-
-import type { IEnrollFrame } from './pairing-frames.js';
 import {
   deriveIdentityId,
   importPublicKey,
   startHostReconnect,
   startPairingHandshake,
   type IPairingResult,
-  type TPairingFrame,
   type TPairingRole,
-  type TReconnectFrame,
 } from '@robota-sdk/agent-remote-pairing';
+import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
 
-import type { IProtocolSession, TServerMessage } from '@robota-sdk/agent-transport-protocol';
+import { createChannelDelivery } from './channel-delivery.js';
 import { pairingChannel } from './pairing-channel-lifecycle.js';
+import { isEnrollFrame, isPairingFrame, isReconnectFrame } from './pairing-frames.js';
+
+import type { IEnrollFrame } from './pairing-frames.js';
+import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
 
 /** The minimal data-channel surface the gate drives (a werift `RTCDataChannel` satisfies it). */
 export interface IPairingChannel {

--- a/packages/agent-transport-webrtc/src/webrtc-transport.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport.ts
@@ -1,4 +1,8 @@
-import { createWsHandler, resolveAdmission } from '@robota-sdk/agent-transport-protocol';
+import {
+  createOutboundDelivery,
+  createWsHandler,
+  resolveAdmission,
+} from '@robota-sdk/agent-transport-protocol';
 import { extractDtlsFingerprint } from '@robota-sdk/agent-remote-pairing';
 import type {
   IConfigurableTransport,
@@ -266,11 +270,14 @@ export class WebRtcTransport implements IConfigurableTransport<IInteractiveSessi
       return;
     }
 
+    // ARCH-030: the transport is the carrier on the no-secret branch — it builds the connection's
+    // outbound boundary from its own data-channel sink and its own delivery lifecycle.
     const { onMessage, cleanup } = createWsHandler({
       session,
-      send: (serverMessage) => channel.send(JSON.stringify(serverMessage)),
-      onDeliveryError: (error, event) =>
-        this.deliveryLifecycle.handleFailure(channel, generation, error, event),
+      deliver: createOutboundDelivery(
+        (serverMessage) => channel.send(JSON.stringify(serverMessage)),
+        (error, event) => this.deliveryLifecycle.handleFailure(channel, generation, error, event),
+      ),
     });
     this.cleanupHandler = cleanup;
     channel.onMessage.subscribe((data) => {

--- a/packages/agent-transport-webrtc/src/webrtc-transport.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport.ts
@@ -1,8 +1,4 @@
-import {
-  createOutboundDelivery,
-  createWsHandler,
-  resolveAdmission,
-} from '@robota-sdk/agent-transport-protocol';
+import { createWsHandler, resolveAdmission } from '@robota-sdk/agent-transport-protocol';
 import { extractDtlsFingerprint } from '@robota-sdk/agent-remote-pairing';
 import type {
   IConfigurableTransport,
@@ -13,6 +9,7 @@ import type { RTCDataChannel, RTCPeerConnection } from 'werift';
 import type { IPairingResult } from '@robota-sdk/agent-remote-pairing';
 import type { IProtocolSession, SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
 
+import { createChannelDelivery } from './channel-delivery.js';
 import { loadWerift } from './werift-loader.js';
 import { PairingGate, type IHostReconnectConfig } from './pairing-gate.js';
 import { createTransportLifecycleError } from './transport-lifecycle-error.js';
@@ -270,13 +267,11 @@ export class WebRtcTransport implements IConfigurableTransport<IInteractiveSessi
       return;
     }
 
-    // ARCH-030: the transport is the carrier on the no-secret branch — it builds the connection's
-    // outbound boundary from its own data-channel sink and its own delivery lifecycle.
+    // ARCH-030: the transport is the carrier on the no-secret branch — its own sink, its own lifecycle.
     const { onMessage, cleanup } = createWsHandler({
       session,
-      deliver: createOutboundDelivery(
-        (serverMessage) => channel.send(JSON.stringify(serverMessage)),
-        (error, event) => this.deliveryLifecycle.handleFailure(channel, generation, error, event),
+      deliver: createChannelDelivery(channel, (error, event) =>
+        this.deliveryLifecycle.handleFailure(channel, generation, error, event),
       ),
     });
     this.cleanupHandler = cleanup;

--- a/packages/agent-transport-ws/docs/SPEC.md
+++ b/packages/agent-transport-ws/docs/SPEC.md
@@ -136,11 +136,14 @@ unroutable channel frame surfaces as a `protocol_error` frame carrying the regis
 misuse of a channel handle (undeclared event, binary on a text-only channel, duplicate name, closed
 channel) throws a plain `Error` at the call site.
 
-Session-event delivery failures are carrier lifecycle failures, not session-operation failures.
-The configurable server treats a non-open socket as a failed send, routes synchronous and asynchronous
-`ws.send` errors through one idempotent connection cleanup/close path, and supplies that path as the
-protocol handler's `onDeliveryError`. `WsTransport` applies the same rule to its single attached socket
-and exposes an optional observer callback after internal cleanup.
+Outbound delivery failures are carrier lifecycle failures, not session-operation failures — and since
+ARCH-030 that covers EVERY outbound frame, replies included, not only the session-event fan-out.
+`WsSessionDelivery` owns the connection's boundary: its raw sink is PRIVATE and `deliver` is the only
+public way onto the socket, so nothing can bypass the guard. It treats a non-open socket as a failed send,
+routes synchronous and asynchronous `ws.send` errors through one idempotent cleanup/close path, and passes
+the boundary DOWN into `createWsHandler`. `WsTransport` applies the same rule to its single attached socket
+and exposes an optional observer callback after internal cleanup. The boundary latches, so a burst of
+frames after the socket closes runs that cleanup once.
 
 ## Test Strategy
 

--- a/packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json
+++ b/packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json
@@ -5,9 +5,7 @@
   "packageName": "@robota-sdk/agent-transport-ws",
   "command": {
     "executable": "pnpm",
-    "args": [
-      "scenario:verify"
-    ],
+    "args": ["scenario:verify"],
     "rendered": "pnpm scenario:verify"
   },
   "cwd": "<cwd>",

--- a/packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json
+++ b/packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "recordType": "scenario-record",
+  "scope": "packages/agent-transport-ws",
+  "packageName": "@robota-sdk/agent-transport-ws",
+  "command": {
+    "executable": "pnpm",
+    "args": [
+      "scenario:verify"
+    ],
+    "rendered": "pnpm scenario:verify"
+  },
+  "cwd": "<cwd>",
+  "status": 0,
+  "stdout": {
+    "raw": "\n> @robota-sdk/agent-transport-ws@3.0.0-beta.79 scenario:verify /home/ubunutu/dev/robota-2/packages/agent-transport-ws\n> pnpm exec tsx --conditions=source examples/verify-outbound-delivery-boundary.ts\n\n{\"scenario\":\"ARCH-030-outbound-delivery-boundary\",\"realCarrier\":{\"carrier\":\"WsTransport(real ws socket)\",\"operationCommitted\":true,\"cleanupRuns\":1,\"unhandledRejections\":0},\"observedCarrier\":{\"carrier\":\"createWsTransport(observable delivery callbacks)\",\"operationCommitted\":true,\"cleanupObserved\":true,\"deliveryErrors\":[{\"message\":\"WebSocket is not open\",\"event\":\"command_result\"}],\"latchThrew\":null,\"unhandledRejections\":0},\"cleanupRemoved\":true}\n",
+    "normalized": "{\"scenario\":\"ARCH-030-outbound-delivery-boundary\",\"realCarrier\":{\"carrier\":\"WsTransport(real ws socket)\",\"operationCommitted\":true,\"cleanupRuns\":1,\"unhandledRejections\":0},\"observedCarrier\":{\"carrier\":\"createWsTransport(observable delivery callbacks)\",\"operationCommitted\":true,\"cleanupObserved\":true,\"deliveryErrors\":[{\"message\":\"WebSocket is not open\",\"event\":\"command_result\"}],\"latchThrew\":null,\"unhandledRejections\":0},\"cleanupRemoved\":true}",
+    "sha256": "26bbc66703bdc9ba2e7b76d28ca893866ff7c8f380d27d2a7eca3a97491f3bed"
+  },
+  "stderr": {
+    "raw": "",
+    "normalized": "",
+    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  }
+}

--- a/packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts
+++ b/packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts
@@ -1,0 +1,231 @@
+/**
+ * ARCH-030 user-execution scenario — a reply that resolves AFTER the carrier disconnected is
+ * reported through the carrier's delivery boundary, not thrown into the void.
+ *
+ * Two phases, both over this package's public barrel exports:
+ *
+ * - **Phase A — real carrier.** A real `WsTransport` binds a loopback port, a real `ws` client
+ *   connects, and a remote `command` is held open by a gate the scenario controls. The client
+ *   disconnects, the command resolves, and the reply is delivered into a socket that is gone.
+ *   Observables: the command still committed (it wrote its marker file), the carrier's protocol
+ *   cleanup ran exactly once (the session's `on`/`off` listener balance), and NO unhandled rejection
+ *   escaped.
+ *
+ * - **Phase B — observable carrier.** `createWsTransport` takes `send`/`onDeliveryError` as public
+ *   options, so the delivery-error count and the latch are directly observable — `WsSessionDelivery`
+ *   is package-internal by design (that IS the fix), so phase A cannot read them.
+ *
+ * Before ARCH-030 this printed `unhandledRejections: 1` for phase A and `deliveryErrors: []` with
+ * `latchThrew: "WebSocket is not open"` for phase B. Run it with:
+ *
+ *     pnpm scenario:verify
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+import { WebSocket } from 'ws';
+
+import { createWsTransport, WsTransport } from '@robota-sdk/agent-transport-ws';
+
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+
+const SCENARIO_PORT = 43117;
+const SCENARIO_MAX_RETRIES = 25;
+
+function assertCondition(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+/** A session whose one command is held open until the scenario releases it. */
+function createGatedSession(markerPath: string): {
+  session: IInteractiveSession;
+  release: () => void;
+  listenerCount: () => number;
+} {
+  const listeners = new Set<string>();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const session = createTestInteractiveSession({
+    on: ((event: string) => {
+      listeners.add(event);
+    }) as IInteractiveSession['on'],
+    off: ((event: string) => {
+      listeners.delete(event);
+    }) as IInteractiveSession['off'],
+    executeCommand: (name: string) =>
+      gate.then(() => {
+        // The committed operation: it happens whether or not its reply can be delivered.
+        writeFileSync(markerPath, `${name} committed\n`, 'utf8');
+        return { success: true, message: 'committed' };
+      }),
+  } as Partial<IInteractiveSession>);
+  return { session, release, listenerCount: () => listeners.size };
+}
+
+/** Phase A — the real `ws` server, the real client socket, the real `WsSessionDelivery`. */
+async function runRealCarrierPhase(markerPath: string): Promise<Record<string, unknown>> {
+  const rejections: unknown[] = [];
+  const collect = (reason: unknown): void => {
+    rejections.push(reason);
+  };
+  process.on('unhandledRejection', collect);
+
+  const gated = createGatedSession(markerPath);
+  const transport = new WsTransport({ port: SCENARIO_PORT, maxRetries: SCENARIO_MAX_RETRIES });
+  transport.attach(gated.session);
+  let client: WebSocket | undefined;
+  try {
+    await transport.start();
+    const port = transport.boundPort;
+    assertCondition(port !== undefined, 'the transport did not report a bound port');
+    const token = transport.resolvedToken;
+    assertCondition(token !== undefined, 'the transport did not auto-mint an admission token');
+
+    client = new WebSocket(`ws://127.0.0.1:${port}/?token=${token}`);
+    await new Promise<void>((resolve, reject) => {
+      client?.once('open', () => resolve());
+      client?.once('error', reject);
+    });
+    const listenersWhileConnected = gated.listenerCount();
+    assertCondition(listenersWhileConnected > 0, 'the handler subscribed to no session events');
+
+    client.send(JSON.stringify({ type: 'command', name: 'status' }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Disconnect, THEN let the command finish: the reply now targets a socket that is gone.
+    await new Promise<void>((resolve) => {
+      client?.once('close', () => resolve());
+      client?.terminate();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    gated.release();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const committed = existsSync(markerPath) && readFileSync(markerPath, 'utf8').includes('status');
+    const cleanupRuns = gated.listenerCount() === 0 ? 1 : 0;
+
+    assertCondition(committed, 'the command did not commit before its reply failed');
+    assertCondition(
+      cleanupRuns === 1,
+      `real carrier cleanup did not run exactly once (listeners still attached: ${gated.listenerCount()})`,
+    );
+    assertCondition(
+      rejections.length === 0,
+      `real carrier produced unhandled rejections: ${JSON.stringify(
+        rejections.map((r) => (r instanceof Error ? r.message : String(r))),
+      )}`,
+    );
+
+    return {
+      carrier: 'WsTransport(real ws socket)',
+      operationCommitted: committed,
+      cleanupRuns,
+      unhandledRejections: rejections.length,
+    };
+  } finally {
+    process.off('unhandledRejection', collect);
+    client?.terminate();
+    await transport.stop();
+  }
+}
+
+/** Phase B — `createWsTransport`, whose delivery callbacks are public options. */
+async function runObservableCarrierPhase(markerPath: string): Promise<Record<string, unknown>> {
+  const rejections: unknown[] = [];
+  const collect = (reason: unknown): void => {
+    rejections.push(reason);
+  };
+  process.on('unhandledRejection', collect);
+
+  const gated = createGatedSession(markerPath);
+  const deliveryErrors: Array<{ message: string; event: string }> = [];
+  const delivered: TServerMessage[] = [];
+  let socketOpen = true;
+  const transport = createWsTransport({
+    send: (message) => {
+      // The real carrier's failure mode, reproduced exactly: a closed socket throws on send.
+      if (!socketOpen) throw new Error('WebSocket is not open');
+      delivered.push(message);
+    },
+    onDeliveryError: (error, event) => deliveryErrors.push({ message: error.message, event }),
+  });
+  transport.attach(gated.session);
+  try {
+    await transport.start();
+    transport.onMessage?.(JSON.stringify({ type: 'command', name: 'status' }));
+
+    socketOpen = false;
+    gated.release();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const committed = existsSync(markerPath) && readFileSync(markerPath, 'utf8').includes('status');
+    const cleanupObserved = transport.onMessage === null;
+
+    // The latch, from outside: a further inbound frame after the failure is dropped — neither a
+    // second delivery error nor a synchronous throw out of the handler.
+    let latchThrew: string | null = null;
+    const retained = transport.onMessage as ((data: string) => void) | null;
+    try {
+      retained?.(JSON.stringify({ type: 'get-messages' }));
+    } catch (error) {
+      latchThrew = error instanceof Error ? error.message : String(error);
+    }
+
+    assertCondition(committed, 'the command did not commit before its reply failed');
+    assertCondition(
+      deliveryErrors.length === 1,
+      `expected exactly one delivery error, got ${JSON.stringify(deliveryErrors)}`,
+    );
+    assertCondition(
+      deliveryErrors[0]?.event === 'command_result',
+      `the delivery error named the wrong frame: ${JSON.stringify(deliveryErrors[0])}`,
+    );
+    assertCondition(cleanupObserved, 'the carrier cleanup did not detach the inbound handler');
+    assertCondition(
+      latchThrew === null,
+      `a post-failure frame escaped the boundary: ${latchThrew}`,
+    );
+    assertCondition(
+      rejections.length === 0,
+      `observable carrier produced unhandled rejections: ${JSON.stringify(
+        rejections.map((r) => (r instanceof Error ? r.message : String(r))),
+      )}`,
+    );
+
+    return {
+      carrier: 'createWsTransport(observable delivery callbacks)',
+      operationCommitted: committed,
+      cleanupObserved,
+      deliveryErrors,
+      latchThrew,
+      unhandledRejections: rejections.length,
+    };
+  } finally {
+    process.off('unhandledRejection', collect);
+    await transport.stop();
+  }
+}
+
+async function main(): Promise<void> {
+  const cwd = mkdtempSync(join(tmpdir(), 'arch-030-outbound-'));
+  let result: Record<string, unknown> | undefined;
+  try {
+    const realCarrier = await runRealCarrierPhase(join(cwd, 'real-carrier.marker'));
+    const observedCarrier = await runObservableCarrierPhase(join(cwd, 'observed-carrier.marker'));
+    result = { scenario: 'ARCH-030-outbound-delivery-boundary', realCarrier, observedCarrier };
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+
+  assertCondition(result !== undefined, 'scenario did not produce a result');
+  assertCondition(!existsSync(cwd), 'scenario cleanup did not remove its temporary directory');
+  process.stdout.write(`${JSON.stringify({ ...result, cleanupRemoved: true })}\n`);
+}
+
+await main();

--- a/packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts
+++ b/packages/agent-transport-ws/examples/verify-outbound-delivery-boundary.ts
@@ -158,7 +158,17 @@ async function runObservableCarrierPhase(markerPath: string): Promise<Record<str
   transport.attach(gated.session);
   try {
     await transport.start();
-    transport.onMessage?.(JSON.stringify({ type: 'command', name: 'status' }));
+    // Captured BEFORE the failure, deliberately. The carrier's cleanup nulls `transport.onMessage`, so
+    // reading it afterwards yields null and pushing a frame through it would exercise nothing — the
+    // observable would report a pass it never measured. Review caught exactly that: `latchThrew` was
+    // unconditionally null because it re-read the property the cleanup had just cleared.
+    const retainedHandler = transport.onMessage;
+    assertCondition(
+      retainedHandler !== null,
+      'the transport exposed no inbound handler after start()',
+    );
+
+    retainedHandler(JSON.stringify({ type: 'command', name: 'status' }));
 
     socketOpen = false;
     gated.release();
@@ -167,12 +177,12 @@ async function runObservableCarrierPhase(markerPath: string): Promise<Record<str
     const committed = existsSync(markerPath) && readFileSync(markerPath, 'utf8').includes('status');
     const cleanupObserved = transport.onMessage === null;
 
-    // The latch, from outside: a further inbound frame after the failure is dropped — neither a
-    // second delivery error nor a synchronous throw out of the handler.
+    // The latch, from outside: a further frame pushed through the RETAINED handler after the failure is
+    // dropped — neither a second delivery error nor a synchronous throw. Pre-ARCH-030 this threw
+    // `WebSocket is not open` straight out of the handler.
     let latchThrew: string | null = null;
-    const retained = transport.onMessage as ((data: string) => void) | null;
     try {
-      retained?.(JSON.stringify({ type: 'get-messages' }));
+      retainedHandler(JSON.stringify({ type: 'get-messages' }));
     } catch (error) {
       latchThrew = error instanceof Error ? error.message : String(error);
     }

--- a/packages/agent-transport-ws/package.json
+++ b/packages/agent-transport-ws/package.json
@@ -42,7 +42,9 @@
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "clean": "rimraf dist",
-    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
+    "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh",
+    "scenario:verify": "pnpm exec tsx --conditions=source examples/verify-outbound-delivery-boundary.ts",
+    "scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-transport-ws --output examples/scenarios/outbound-delivery-boundary.record.json -- pnpm scenario:verify"
   },
   "dependencies": {
     "@robota-sdk/agent-core": "workspace:*",
@@ -54,6 +56,7 @@
     "@types/ws": "^8.18.1",
     "rimraf": "^5.0.10",
     "tsdown": "^0.22.14",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "vitest": "^3.2.6"
   },

--- a/packages/agent-transport-ws/src/__tests__/outbound-delivery-carrier.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/outbound-delivery-carrier.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ARCH-030 at the real WS carrier: a reply that resolves after the socket closed must reach
+ * `WsSessionDelivery`'s cleanup instead of escaping as an unhandled rejection.
+ *
+ * The protocol suite proves the boundary; this one proves the carrier is actually WIRED to it — the
+ * half that was missing before, because the carrier's cleanup was written, idempotent, and never called.
+ */
+
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+import { describe, expect, it, vi } from 'vitest';
+import { WebSocket } from 'ws';
+
+import { WsSessionDelivery } from '../ws-session-delivery.js';
+
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-transport';
+
+/** Collect unhandled rejections while `run` executes, then drain the queue Node reports them on. */
+async function withUnhandledRejectionCapture(run: () => void | Promise<void>): Promise<unknown[]> {
+  const captured: unknown[] = [];
+  const existing = process.listeners('unhandledRejection');
+  for (const listener of existing) process.off('unhandledRejection', listener);
+  const collect = (reason: unknown): void => {
+    captured.push(reason);
+  };
+  process.on('unhandledRejection', collect);
+  try {
+    await run();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  } finally {
+    process.off('unhandledRejection', collect);
+    for (const listener of existing)
+      process.on('unhandledRejection', listener as NodeJS.UnhandledRejectionListener);
+  }
+  return captured;
+}
+
+/** A socket whose `readyState` the test controls, so "disconnected" is deterministic. */
+function createControllableSocket(): { socket: WebSocket; close: () => void } {
+  const state = { readyState: WebSocket.OPEN as number };
+  const socket = {
+    get readyState(): number {
+      return state.readyState;
+    },
+    send: vi.fn(),
+    close: vi.fn(() => {
+      state.readyState = WebSocket.CLOSED;
+    }),
+  } as unknown as WebSocket;
+  return {
+    socket,
+    close: () => {
+      state.readyState = WebSocket.CLOSED;
+    },
+  };
+}
+
+describe('WsSessionDelivery + the outbound boundary (ARCH-030)', () => {
+  it('a command resolving after the socket closed runs cleanup once and leaks no rejection', async () => {
+    const { socket, close } = createControllableSocket();
+    const delivery = new WsSessionDelivery(socket);
+    const detachSink = vi.fn();
+    delivery.bindSinkDetach(detachSink);
+
+    let releaseCommand: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseCommand = resolve;
+    });
+    const executed: string[] = [];
+    const session: IInteractiveSession = createTestInteractiveSession({
+      executeCommand: (name: string) =>
+        gate.then(() => {
+          executed.push(name);
+          return { success: true, message: 'done' };
+        }),
+    } as Partial<IInteractiveSession>);
+
+    const handler = createWsHandler({ session, deliver: delivery.deliver });
+    delivery.bindProtocolCleanup(handler.cleanup);
+
+    const rejections = await withUnhandledRejectionCapture(async () => {
+      handler.onMessage(JSON.stringify({ type: 'command', name: 'status' }));
+      close();
+      releaseCommand?.();
+    });
+
+    expect(rejections).toEqual([]);
+    expect(executed).toEqual(['status']); // the command still committed
+    expect(detachSink).toHaveBeenCalledTimes(1); // the carrier's cleanup finally runs
+    // The socket was already CLOSED when the reply failed, so `close()` has nothing left to close —
+    // what matters is that the cleanup path ran at all, which it never did before ARCH-030.
+    expect(socket.close).not.toHaveBeenCalled();
+
+    // Latched: a second late frame does not run cleanup again.
+    delivery.deliver({ type: 'history_cleared' });
+    expect(detachSink).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the closing socket exactly once for a burst of outbound frames', () => {
+    const { socket, close } = createControllableSocket();
+    const delivery = new WsSessionDelivery(socket);
+    const cleanup = vi.fn();
+    delivery.bindProtocolCleanup(cleanup);
+    close();
+
+    delivery.deliver({ type: 'history_cleared' });
+    delivery.deliver({ type: 'executing', executing: false });
+    delivery.deliver({ type: 'protocol_error', message: 'third' });
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-transport-ws/src/__tests__/outbound-delivery-carrier.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/outbound-delivery-carrier.test.ts
@@ -96,7 +96,11 @@ describe('WsSessionDelivery + the outbound boundary (ARCH-030)', () => {
     expect(detachSink).toHaveBeenCalledTimes(1);
   });
 
-  it('reports the closing socket exactly once for a burst of outbound frames', () => {
+  // NOT a proof of the boundary latch — `WsSessionDelivery.closed` already made this cleanup idempotent
+  // before ARCH-030, so this case would pass either way. It pins that the boundary sitting ABOVE that
+  // latch did not change the carrier's observable behaviour. The latch itself is red-proved in the
+  // protocol suite (`outbound-delivery.test.ts` → 'latches: a connection reports at most one …').
+  it('runs the carrier cleanup once for a burst of outbound frames after the close', () => {
     const { socket, close } = createControllableSocket();
     const delivery = new WsSessionDelivery(socket);
     const cleanup = vi.fn();

--- a/packages/agent-transport-ws/src/__tests__/ws-session-delivery.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-session-delivery.test.ts
@@ -44,7 +44,8 @@ describe('WsSessionDelivery', () => {
     const detachSink = vi.fn();
     delivery.bindSinkDetach(detachSink);
     const harness = createSessionHarness();
-    const handler = createWsHandler({ session: harness.session, deliver: createOutboundDelivery(delivery.send, delivery.close) });
+    // ARCH-030: the carrier's own boundary is what the handler receives — there is no raw sink to pass.
+    const handler = createWsHandler({ session: harness.session, deliver: delivery.deliver });
     delivery.bindProtocolCleanup(handler.cleanup);
 
     expect(harness.fireBranchEvent).not.toThrow();
@@ -70,7 +71,7 @@ describe('WsSessionDelivery', () => {
     delivery.bindProtocolCleanup(cleanup);
     delivery.bindSinkDetach(detachSink);
 
-    delivery.send({ type: 'history_cleared' });
+    delivery.deliver({ type: 'history_cleared' });
     expect(sendCallback).toBeDefined();
     sendCallback?.(new Error('asynchronous send failed'));
     sendCallback?.(new Error('duplicate callback'));

--- a/packages/agent-transport-ws/src/__tests__/ws-session-delivery.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/ws-session-delivery.test.ts
@@ -44,11 +44,7 @@ describe('WsSessionDelivery', () => {
     const detachSink = vi.fn();
     delivery.bindSinkDetach(detachSink);
     const harness = createSessionHarness();
-    const handler = createWsHandler({
-      session: harness.session,
-      send: delivery.send,
-      onDeliveryError: delivery.close,
-    });
+    const handler = createWsHandler({ session: harness.session, deliver: createOutboundDelivery(delivery.send, delivery.close) });
     delivery.bindProtocolCleanup(handler.cleanup);
 
     expect(harness.fireBranchEvent).not.toThrow();

--- a/packages/agent-transport-ws/src/ws-session-delivery.ts
+++ b/packages/agent-transport-ws/src/ws-session-delivery.ts
@@ -1,21 +1,41 @@
+import { createOutboundDelivery } from '@robota-sdk/agent-transport-protocol';
 import { WebSocket } from 'ws';
 
-import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
+import type { TOutboundDeliver, TServerMessage } from '@robota-sdk/agent-transport-protocol';
 
-/** Connection-scoped session delivery lifecycle shared by sync and async WebSocket failures. */
+/**
+ * Connection-scoped session delivery lifecycle shared by sync and async WebSocket failures.
+ *
+ * ARCH-030: {@link deliver} is the ONLY way out of this class. The raw sink — the `readyState` check
+ * plus `socket.send` — is private, so no caller can put a frame on this socket outside the connection's
+ * one outbound boundary. That is not stylistic: the previous shape exposed a public `send` that threw
+ * on a closed socket, and every reply the protocol handler produced went through it unguarded.
+ */
 export class WsSessionDelivery {
   private cleanupProtocol = (): void => undefined;
   private detachSink = (): void => undefined;
   private closed = false;
 
-  constructor(private readonly socket: WebSocket) {}
+  /**
+   * The connection's outbound boundary. Built here, from this class's own sink and its own `close`
+   * policy, and passed DOWN into `createWsHandler` — the carrier owns both halves, so it builds the
+   * boundary rather than handing the protocol layer a raw sink to wrap.
+   */
+  readonly deliver: TOutboundDeliver;
 
-  readonly send = (message: TServerMessage): void => {
+  constructor(private readonly socket: WebSocket) {
+    this.deliver = createOutboundDelivery(
+      (message) => this.rawSend(message),
+      () => this.close(),
+    );
+  }
+
+  private rawSend(message: TServerMessage): void {
     if (this.socket.readyState !== WebSocket.OPEN) throw new Error('WebSocket is not open');
     this.socket.send(JSON.stringify(message), (error) => {
       if (error) this.close();
     });
-  };
+  }
 
   bindProtocolCleanup(cleanup: () => void): void {
     this.cleanupProtocol = cleanup;

--- a/packages/agent-transport-ws/src/ws-transport-configurable.ts
+++ b/packages/agent-transport-ws/src/ws-transport-configurable.ts
@@ -241,11 +241,7 @@ export class WsTransport
           }
 
           const delivery = new WsSessionDelivery(ws);
-          const handler = createWsHandler({
-            session,
-            send: delivery.send,
-            onDeliveryError: delivery.close,
-          });
+          const handler = createWsHandler({ session, deliver: delivery.deliver });
           delivery.bindProtocolCleanup(handler.cleanup);
 
           delivery.bindSinkDetach(
@@ -263,13 +259,13 @@ export class WsTransport
               return;
             }
             const result = channels.receive(toBytes(data));
-            if (!result.ok) delivery.send({ type: 'protocol_error', message: result.error });
+            if (!result.ok) delivery.deliver({ type: 'protocol_error', message: result.error });
           });
           ws.on('close', delivery.close);
           ws.on('error', delivery.close);
 
-          delivery.send({ type: 'messages', messages: session.getMessages() });
-          delivery.send({
+          delivery.deliver({ type: 'messages', messages: session.getMessages() });
+          delivery.deliver({
             type: 'execution_workspace_event',
             snapshot: session.getExecutionWorkspaceSnapshot(),
           });

--- a/packages/agent-transport-ws/src/ws-transport.ts
+++ b/packages/agent-transport-ws/src/ws-transport.ts
@@ -5,7 +5,7 @@
  * After start(), the consumer must wire onMessage to their WebSocket.
  */
 
-import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+import { createOutboundDelivery, createWsHandler } from '@robota-sdk/agent-transport-protocol';
 
 import type {
   IInteractiveSession,
@@ -46,16 +46,15 @@ export function createWsTransport(options: IWsTransportOptions): IWsTransport {
     async start() {
       if (!session) throw lifecycleError('not-attached');
       if (cleanup) throw lifecycleError('already-started');
-      const handler = createWsHandler({
-        session,
-        send: options.send,
-        onDeliveryError: (error, event) => {
-          handler.cleanup();
-          cleanup = null;
-          transport.onMessage = null;
-          options.onDeliveryError?.(error, event);
-        },
+      // ARCH-030: this adapter is the carrier here, so it builds the connection's outbound boundary
+      // from its own injected sink and its own failure policy, then passes it down.
+      const deliver = createOutboundDelivery(options.send, (error, event) => {
+        handler.cleanup();
+        cleanup = null;
+        transport.onMessage = null;
+        options.onDeliveryError?.(error, event);
       });
+      const handler = createWsHandler({ session, deliver });
       cleanup = handler.cleanup;
       this.onMessage = handler.onMessage;
     },

--- a/packages/agent-transport/examples/verify-session-event-delivery.ts
+++ b/packages/agent-transport/examples/verify-session-event-delivery.ts
@@ -42,11 +42,7 @@ async function main(): Promise<void> {
   });
   const transcript: TServerMessage[] = [];
   const deliveryErrors: Array<{ message: string; event: string }> = [];
-  const primary = createWsHandler({
-    session,
-    send: (message) => transcript.push(message),
-    onDeliveryError: (error, event) => deliveryErrors.push({ message: error.message, event }),
-  });
+  const primary = createWsHandler({ session, deliver: createOutboundDelivery((message) => transcript.push(message), (error, event) => deliveryErrors.push({ message: error.message, event })) });
   let failureCleanup: (() => void) | undefined;
   let result: Record<string, unknown> | undefined;
 
@@ -60,13 +56,9 @@ async function main(): Promise<void> {
     assertCondition(first !== undefined && second !== undefined, 'expected two checkpoints');
 
     const forcedFailures: Array<{ message: string; event: string }> = [];
-    const failureCarrier = createWsHandler({
-      session,
-      send: (message) => {
+    const failureCarrier = createWsHandler({ session, deliver: createOutboundDelivery((message) => {
         if (message.type === 'branch_event') throw new Error('forced protocol send failure');
-      },
-      onDeliveryError: (error, event) => forcedFailures.push({ message: error.message, event }),
-    });
+      }, (error, event) => forcedFailures.push({ message: error.message, event })) });
     failureCleanup = failureCarrier.cleanup;
     await session.forkCheckpointBranch(first.id);
     const forkRecord = store.load(session.getSession().getSessionId());

--- a/packages/agent-transport/examples/verify-session-event-delivery.ts
+++ b/packages/agent-transport/examples/verify-session-event-delivery.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
 import { createProjectSessionStore, InteractiveSession } from '@robota-sdk/agent-framework';
-import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+import { createOutboundDelivery, createWsHandler } from '@robota-sdk/agent-transport-protocol';
 
 import type { TServerMessage } from '@robota-sdk/agent-transport-protocol';
 
@@ -42,7 +42,13 @@ async function main(): Promise<void> {
   });
   const transcript: TServerMessage[] = [];
   const deliveryErrors: Array<{ message: string; event: string }> = [];
-  const primary = createWsHandler({ session, deliver: createOutboundDelivery((message) => transcript.push(message), (error, event) => deliveryErrors.push({ message: error.message, event })) });
+  const primary = createWsHandler({
+    session,
+    deliver: createOutboundDelivery(
+      (message) => transcript.push(message),
+      (error, event) => deliveryErrors.push({ message: error.message, event }),
+    ),
+  });
   let failureCleanup: (() => void) | undefined;
   let result: Record<string, unknown> | undefined;
 
@@ -56,9 +62,15 @@ async function main(): Promise<void> {
     assertCondition(first !== undefined && second !== undefined, 'expected two checkpoints');
 
     const forcedFailures: Array<{ message: string; event: string }> = [];
-    const failureCarrier = createWsHandler({ session, deliver: createOutboundDelivery((message) => {
-        if (message.type === 'branch_event') throw new Error('forced protocol send failure');
-      }, (error, event) => forcedFailures.push({ message: error.message, event })) });
+    const failureCarrier = createWsHandler({
+      session,
+      deliver: createOutboundDelivery(
+        (message) => {
+          if (message.type === 'branch_event') throw new Error('forced protocol send failure');
+        },
+        (error, event) => forcedFailures.push({ message: error.message, event }),
+      ),
+    });
     failureCleanup = failureCarrier.cleanup;
     await session.forkCheckpointBranch(first.id);
     const forkRecord = store.load(session.getSession().getSessionId());

--- a/packages/agent-transport/src/__tests__/ws-multi-surface-exit-policy.test.ts
+++ b/packages/agent-transport/src/__tests__/ws-multi-surface-exit-policy.test.ts
@@ -59,12 +59,7 @@ function setupSharedHost(adapters: ICommandHostAdapters): {
   });
   const attach = (driverId: string): ISurface => {
     const sent: TServerMessage[] = [];
-    const { onMessage } = createWsHandler({
-      session,
-      send: (msg) => sent.push(msg),
-      driverId,
-      onDeliveryError: vi.fn(),
-    });
+    const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId });
     return { sent, onMessage };
   };
   return { session, surfaceA: attach('device-A'), surfaceB: attach('device-B') };

--- a/packages/agent-transport/src/__tests__/ws-multi-surface-exit-policy.test.ts
+++ b/packages/agent-transport/src/__tests__/ws-multi-surface-exit-policy.test.ts
@@ -13,7 +13,7 @@
 
 import { createExitCommandModule, createLanguageCommandModule } from '@robota-sdk/agent-command';
 import { InteractiveSession } from '@robota-sdk/agent-framework';
-import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+import { createOutboundDelivery, createWsHandler } from '@robota-sdk/agent-transport-protocol';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ICommandHostAdapters } from '@robota-sdk/agent-framework';
@@ -59,7 +59,11 @@ function setupSharedHost(adapters: ICommandHostAdapters): {
   });
   const attach = (driverId: string): ISurface => {
     const sent: TServerMessage[] = [];
-    const { onMessage } = createWsHandler({ session, deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()), driverId });
+    const { onMessage } = createWsHandler({
+      session,
+      deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()),
+      driverId,
+    });
     return { sent, onMessage };
   };
   return { session, surfaceA: attach('device-A'), surfaceB: attach('device-B') };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
       '@robota-sdk/agent-playground':
         specifier: workspace:*
         version: link:../../packages/agent-playground
-      '@robota-sdk/agent-session':
-        specifier: workspace:*
-        version: link:../../packages/agent-session
       '@robota-sdk/agent-provider-anthropic':
         specifier: workspace:*
         version: link:../../packages/agent-provider-anthropic
@@ -239,6 +236,9 @@ importers:
       '@robota-sdk/agent-provider-openai-compatible':
         specifier: workspace:*
         version: link:../../packages/agent-provider-openai-compatible
+      '@robota-sdk/agent-session':
+        specifier: workspace:*
+        version: link:../../packages/agent-session
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -2394,6 +2394,9 @@ importers:
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.23.1)(typescript@6.0.3)(unrun@0.3.1)
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -54,7 +54,6 @@
   "packages/agent-transport-tui/src/InputArea.tsx": 318,
   "packages/agent-transport-tui/src/TuiInteractionChannel.ts": 616,
   "packages/agent-transport-webrtc-web/src/client/rtc-session-client.ts": 399,
-  "packages/agent-transport-webrtc/src/pairing-gate.ts": 314,
   "packages/dag-builder/src/dag-workflow-converter.ts": 312,
   "packages/dag-cli/src/commands/benchmark.ts": 908,
   "packages/dag-cli/src/commands/build.ts": 531,

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -54,6 +54,12 @@
       "timestamp": "2026-08-15T18:36:04.776Z",
       "ratio": "19/25",
       "reason": "The same citation again, one minute later, explaining to the owner why the finding could not be fixed by a code change. Recorded for the same reason as the entry above."
+    },
+    {
+      "transcript": "e82cfba8-e0c6-4e4b-bf40-c54a5d248ee4.jsonl",
+      "timestamp": "2026-08-15T20:22:23.237Z",
+      "ratio": "8/13",
+      "reason": "A seventh instance, reporting the ARCH backlog survey as 'AGREEMENT-002(8/13 …)' with no percentage — a ratio of how far an initiative has got, written in a summary to the owner, which is the same sentence shape as the six before it. Recorded rather than argued away; the scan found it on the very next run, which is the mechanism working as designed."
     }
   ]
 }


### PR DESCRIPTION
Closes #1734. Completes `ARCH-030` (`priority: critical`, `urgency: now`).

## Accepted recommendation

**One connection-scoped outbound delivery boundary, constructed by the CARRIER, made nominal by a brand.**

`createWsHandler` had two outbound semantics on one connection. The session-event fan-out went through a
guard that reported carrier failures via `onDeliveryError`; every reply to an inbound frame got the raw
carrier `send`. **Eleven reply families were unguarded** — five resolving from a Promise continuation, so
a reply landing after a disconnect escaped as an unhandled rejection with the carrier's cleanup (written,
idempotent, waiting) never notified; and six synchronous ones that threw into the carrier's inbound
listener instead.

`REVIEW VERDICT: ENDORSE` — 2026-08-16, `proposal-reviewer`, after one `REVISE` round whose six required
changes are all folded in. The blocking one changed the design: revision 1 had the protocol layer build
the boundary and hand it back, which leaves the carrier's raw sink reachable and made the
"structurally unbypassable" claim false. **The carrier now builds the boundary** from its own sink and its
own failure policy and passes it down, and `WsSessionDelivery.send` is private with `deliver` as its only
public exit.

`finding-depth` verdict: **FOUNDATIONAL**, with the cause landing inside this item's own scope — the
triager also found that WS-001 (completed 2026-06-27) filed the identical failure mode at the same two
call sites, fixed only the rejects half, and prescribed mirroring the equally-unguarded
`ws-background-messages.ts`, propagating the shape.

## Implementation

- `createOutboundDelivery(send, onDeliveryError) → TOutboundDeliver` is the one boundary per connection.
  The type is **branded** and the factory is its only producer, so a raw `(m: TServerMessage) => void` is
  refused by the compiler wherever a boundary is required. `src/__tests__` is inside the package's
  `tsconfig` `include`, so the `@ts-expect-error` case is a real floor, not decoration.
- **It latches** — at most one delivery failure per connection. All three carriers already treated a
  delivery failure as terminal and each had grown its own latch; it belongs upstream of all three.
- `SessionResumeBridge` builds a fresh boundary per `attach` (which is what un-latches after a reconnect),
  buffers **before** the boundary so a dropped frame still replays, and its string-level guard is deleted.
- `ISubscribeSessionEventsOptions` leaves the barrel: options bag of a package-internal function, already
  absent from the SPEC's public API table.
- Two corrections to the item's own text, both confirmed by review: the WebRTC path it names was already
  guarded through the resume bridge (the unguarded exposure is the bare `createWsHandler` the gate and
  transport build with no bridge), and the six synchronous families were unnamed.

## Tests run

| Suite | Result |
| --- | --- |
| `agent-transport-protocol` | 114 passed |
| `agent-transport-ws` | 47 passed |
| `agent-transport-webrtc` | 43 passed |
| `agent-transport` / `agent-cli` | 81 / 291 passed |
| `pnpm typecheck` | 99 projects, exit 0 |
| `pnpm harness:scan` | 111 passed, 1 skipped, 0 failed |
| `pnpm harness:verify-like-ci` | **PASS — 12/12 stages**, at the final HEAD |
| `check-regression-red-proof.mjs` | `red-proof-ok (assertion-fail)` |

New coverage: one case per reply family (five asserting zero unhandled rejections, six asserting nothing
escapes `onMessage`), the latch, observer isolation, the type floor, both carriers' delayed-reply
lifecycle, and three resume-bridge regressions.

## User execution test scenario gate

**PASSED.** `cd packages/agent-transport-ws && pnpm scenario:verify` → exit `0`, one JSON line:

```json
{"scenario":"ARCH-030-outbound-delivery-boundary",
 "realCarrier":{"carrier":"WsTransport(real ws socket)","operationCommitted":true,"cleanupRuns":1,"unhandledRejections":0},
 "observedCarrier":{"carrier":"createWsTransport(observable delivery callbacks)","operationCommitted":true,"cleanupObserved":true,"deliveryErrors":[{"message":"WebSocket is not open","event":"command_result"}],"latchThrew":null,"unhandledRejections":0},
 "cleanupRemoved":true}
```

Written **before** implementation and matched unchanged: `unhandledRejections` `1 → 0` on the real carrier,
`deliveryErrors` `[] →` exactly one naming `command_result`, `latchThrew` `"WebSocket is not open" → null`.
Canonical record `packages/agent-transport-ws/examples/scenarios/outbound-delivery-boundary.record.json`,
`stdout.sha256 = 26bbc667…f3bed`.

`DONE-GATE-STAGE-1` **PASS** and `DONE-GATE-STAGE-2` **PASS**, each from an independent guard that ran the
scenario itself; Stage 2 re-executed at a later HEAD and reproduced the stdout byte for byte.

## Review findings, and what they caught

Three pre-PR rounds, converging at `ACTIONABLE FINDINGS: 0`. Two round-1 findings were **false signals I
had produced**, worth naming rather than burying:

1. The bridge's `sink` field was write-only — the channel is held by the boundary's closure, so `dispose()`
   released nothing while documenting that it did. `dispose()` now goes through `detach()`.
2. The scenario's `latchThrew` observable **measured nothing**: it read `transport.onMessage` after the
   cleanup had nulled it, so the frame was never pushed and the value was unconditionally `null` — while
   the Task and the gate entry both claimed it pinned the latch. The handler is now captured before the
   failure. Same stdout, same sha256: the observable was wrong, not the behaviour.
3. No commit was typed `fix:`, so the repo's own regression red-proof floor had never evaluated this
   `critical` defect fix. It now runs and returns `red-proof-ok`.
4. Round 2 `MUST`: `unearned-done-claims` went red **on the archival commit** — the rule engages only at
   `status: done`, and I had carried forward a `verify-like-ci` green that predated it. Fixed, and the full
   suite re-run at the final HEAD rather than reused.

The reviewer independently reproduced the RED baseline in a worktree at the merge base
(`exit 1`, `unhandled rejections: ["WebSocket is not open"]`), closing the one gap Stage 2 had listed as
unverified.

## Residual risks

- **Three required checks cannot be mirrored locally** and are unverified until CI runs them:
  `dependency audit` (this diff touches `pnpm-lock.yaml`), `windows-shell` (product code changed), and
  `review-gate` (needs a real PR's CodeQL analysis).
- One archived RED baseline value — `observedCarrier.unhandledRejections: 2` — could not be re-derived by
  the reviewer, who measured `1`. It lives in a historical baseline, not an assertion; every GREEN value is
  independently reproduced. Recorded rather than quietly dropped.
- `packages/agent-transport-webrtc` has no user-execution scenario: its changed symbols are off its barrel,
  so no product surface exposes the observable. WebRTC coverage stays in the engineering test plan.
- The lockfile diff also normalizes a pre-existing out-of-order importer entry pnpm rewrote while adding
  `tsx` — three moved lines, no dependency change.

## Also in this PR

- **`REL-024` filed** — `version-management` says every `@robota-sdk/*` package is in the changesets fixed
  group; the config holds 13 of ~30. Invisible today (all at `3.0.0-beta.79`), but the next major bump
  splits the workspace into two version lines. Not folded in: resolving it changes what the next release
  publishes for ~17 packages, and which rule holds is an owner decision.
- A `progress-report-acknowledgments.json` entry for a real quantified-progress violation of mine.
- `packages/agent-transport-webrtc/src/pairing-gate.ts` falls 314 → 296 lines and leaves the file-size
  baseline entirely; the baseline is re-frozen in the same change so the gain is locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNT541ya929o22PCGQDCcw
