### PR TITLE
docs(tasks): file CORE-043 and close CORE-038 as superseded

### DIFF
--- a/.agents/tasks/CORE-043-structured-output-capability-has-no-runtime-representation.md
+++ b/.agents/tasks/CORE-043-structured-output-capability-has-no-runtime-representation.md
@@ -1,0 +1,141 @@
+---
+title: 'CORE-043: structured-output capability has no representation the runtime reads — agent-core emits `responseFormat` unconditionally, each provider silently maps or discards it, the seam cannot tell which, and the fact is a property of the instantiated PACKAGE rather than the endpoint and model actually called, so the documented gateway configuration reports enforcement it does not have'
+status: todo
+created: 2026-08-16
+priority: critical
+urgency: now
+area: packages/agent-core, packages/agent-provider-openai, packages/agent-provider-openai-compatible
+depends_on: []
+---
+
+# CORE-043: structured-output capability is not represented at runtime
+
+Root item filed under [finding-depth.md](../rules/finding-depth.md) for the `DEPTH: FOUNDATIONAL`
+verdict on [CORE-038](completed/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md)
+(2026-08-16). Registered as [issue #1750](https://github.com/woojubb/robota/issues/1750); the
+proposal it was raised from is [issue #1738](https://github.com/woojubb/robota/issues/1738).
+CORE-038 proposed a transport (forced tool call instead of a prose re-prompt); the
+transport may well be the right one, but it is stated one layer above its cause.
+
+**This item is not a proposal to implement. Several of its load-bearing decisions are reserved for
+the owner** — see § Decisions reserved for the owner. What can proceed without them is listed there
+too.
+
+## Problem
+
+`agent-core` emits `IChatOptions.responseFormat` on every structured run. Each provider package
+either maps it onto a native surface or silently discards it. **The seam has no way to know which
+happened, and no way to react.**
+
+The one place the fact could live is per-model capability: `TProviderModelCapability`
+(`packages/agent-core/src/interfaces/provider-definition.ts:66-67`) already contains `'json_schema'`.
+It is read by nothing (PROV-006), and it is declared **falsely** — all three entries in
+`packages/agent-provider-openai-compatible/src/deepseek/model-catalog.ts` claim `'json_schema'`
+against an adapter that implements none of it.
+
+Because capability is a property of the **package the caller instantiated** rather than of the
+**endpoint and model actually being called**, the configuration the project documents as its gateway
+story reports enforcement it does not have:
+
+- `packages/agent-provider-openai/src/openai/provider.ts:66` passes `baseURL` to the SDK, and `:216`
+  returns `options.baseURL ? 'chat-completions' : 'responses'` — setting a gateway URL switches to
+  the one surface that maps `response_format`.
+- `llms.txt:22` advertises exactly that: "OpenAI-compatible gateway via `baseURL` — any gateway
+  (Vercel AI Gateway, LiteLLM, OpenRouter), Azure, vLLM, Ollama, LM Studio", and
+  `agent-provider-openai/src/openai/types.ts:98` gives a gateway URL as the documented example.
+
+So the advertised configuration sends `response_format: json_schema` to a model that may ignore it,
+the endpoint accepts the parameter, and the core-side enforcement loop believes it enforced early.
+
+**And the SPEC has already recorded the cause as intent.** `packages/agent-core/docs/SPEC.md`
+§ Structured Output Contract: _"providers without one ignore it — the core-side enforcement loop
+below is the universal contract either way."_ That sentence is the design decision that produces
+every symptom below.
+
+## Two corrections to what CORE-038 reported
+
+Both verified against `origin/develop` after CORE-039 landed:
+
+1. **There is no first-attempt prose fallback. There is no first-attempt transport at all.**
+   `spec.jsonSchema` has exactly two consumers in the run path —
+   `packages/agent-core/src/core/robota-execution.ts:173` (config override) and `:186` (the retry
+   feedback prose). Nothing injects the schema into attempt 1. On the compat family the adapter
+   never reads `options.responseFormat`, so **attempt 1 carries no schema signal whatsoever**. The
+   reporter's measured 0/4 is not a property of their gateway; in robota it is structurally
+   guaranteed on that family, and `outputRetries: 0` there can only succeed by luck.
+2. **`agent-provider-bytedance` is not a text provider.** `src/bytedance/provider.ts:25` is
+   `class BytedanceProvider implements IVideoGenerationProvider` — no `chat()`, no `IAIProvider`.
+   Structured output never routes through it; CORE-038's grep found nothing because there is nothing
+   to find. Its `area:` frontmatter named the package wrongly.
+
+Relatedly, CORE-038's "openai-compatible is the path for DeepSeek, Groq, Together, OpenRouter,
+vLLM/Ollama and any gateway" is wrong in the same direction: that package exports only
+deepseek/qwen/gemma, and `llms.txt:22` routes gateways through `agent-provider-openai` instead.
+
+## Evidence: the same defect, filed three times in three days
+
+| Filed      | Item     | Input channel        | What it says                                                                                                                                                                                                                                                                                                                                        |
+| ---------- | -------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-13 | PROV-004 | internal critic      | "**responseFormat dropped by the compat family (VIOLATION)** … ZERO references in `agent-provider-openai-compatible/src` … a `json_schema` run's fidelity depends silently on vendor choice", with the direction "thread `responseFormat` through the compat `buildRequestParams` (via `./shared`), or document the intentional per-provider no-op" |
+| 2026-08-13 | PROV-006 | internal critic      | the missing mechanism itself: per-model capability flags declared and read by nothing                                                                                                                                                                                                                                                               |
+| 2026-08-16 | CORE-038 | external issue #1738 | the same symptom again, as a transport proposal, naming PROV-006 only in a parenthetical                                                                                                                                                                                                                                                            |
+
+Three filings, three channels, no reconciliation between them. That is the cost this item exists to
+stop: the fact has no owner, so each observer files it as whatever it looked like from where they
+stood.
+
+## Interaction with PROV-007
+
+CORE-038's proposed forced-tool-call transport is **not** dead on arrival —
+`convertToOpenAIResponsesTools` sends `strict: strictTools ?? false`, so the default path accepts an
+injected schema tool, and the compat family emits no `strict` at all while already mapping
+`tool_choice: 'required'`. But a `strictTools: true` user is already wholly broken per PROV-007 (after
+CORE-039, Zod's default `strip` emits `additionalProperties: true`, which strict mode refuses). Today
+that costs tool users only. If structured output moves onto the tool seam, **PROV-007 becomes a hard
+prerequisite on the OpenAI path** rather than an adjacent limitation.
+
+## Direction
+
+Give structured-output capability a representation the runtime reads, keyed to what is actually being
+called rather than to which package was imported. Everything else in CORE-038 — including whether a
+forced tool call is the right transport — becomes answerable once that exists, and is not answerable
+before it: a transport chosen without a capability gate replaces one blind emission with another, and
+CORE-038's own open question ("does the schema tool collide with the agent's own tools under
+`tool_choice: required`?") exists only because nothing decides _when_ to inject.
+
+This subsumes PROV-004's structured-output row and requires PROV-006's own open decision to be
+settled first (consume the per-model vocabulary or delete it) — PROV-006 marks that decision "a
+published-contract change, semver/changeset gate."
+
+## Decisions reserved for the owner
+
+Named explicitly rather than folded into a plan, because `backlog-execution.md` § Agent Decision
+Authority reserves each of them:
+
+1. **Whether `agent-provider-openai` changes behaviour when `baseURL` is set.** A provider default on
+   a documented, published surface (`llms.txt:22`, `types.ts:86-103`). CORE-038's own first open
+   question.
+2. **Where capability and transport selection live** — provider capability declaration, agent config,
+   or `IRunOptions`. Multiple architecturally valid approaches with long-term structural impact, and
+   unanswerable before PROV-006's decision.
+3. **Whether the SPEC's "providers without one ignore it" clause is rewritten.** Published contract.
+4. **Whether a synthetic schema tool may be injected into a user's tool set** under
+   `tool_choice: required`. Observable behaviour change for every tool-using agent.
+
+**What can proceed without them:** PROV-004's already-scoped row — thread `responseFormat` through
+the compat `./shared` request builder, or document the no-op the way the per-call effort dial is
+documented. That is a correctness/documentation fix inside one package with no contract change, and
+it is the honest floor under whatever the owner decides above.
+
+## Test Plan
+
+To be written once the reserved decisions are settled. It must at minimum pin: a structured run
+against a provider without a native surface does not silently report early enforcement; the
+`'json_schema'` catalog flag is either read or removed; and the deepseek catalog no longer declares a
+capability its adapter does not implement.
+
+## User Execution Test Scenarios
+
+To be authored when this item is picked up. Expected `agent-executable` and provider-free for the
+capability-representation half (observe what the SDK builds and what it reports about enforcement);
+the end-to-end half needs an OpenAI-compatible gateway endpoint the executor supplies.

--- a/.agents/tasks/PROC-010-re-plan-disposition-blocks-the-filing-that-carries-it.md
+++ b/.agents/tasks/PROC-010-re-plan-disposition-blocks-the-filing-that-carries-it.md
@@ -1,0 +1,81 @@
+---
+title: 'PROC-010: recording a re-plan disposition labels the CURRENT pull request, but a re-plan found before any change exists has only the filing PR to label — so the mechanism blocks the very artifact that makes the root item exist, and instructs the author to close it'
+status: todo
+created: 2026-08-16
+priority: medium
+urgency: soon
+area: scripts/harness, .claude/hooks
+depends_on: []
+---
+
+# PROC-010: the re-plan label blocks its own filing
+
+Found while executing CORE-038 (2026-08-16), which it blocked.
+
+## Problem
+
+`finding-depth.md` says a `FOUNDATIONAL` finding takes **re-plan** or **containment**, and re-plan
+"HALTS the loop and is reported with its root item". The mechanism for that report is
+`scripts/harness/record-local-review.mjs --disposition re-plan`, which publishes the
+`disposition-re-plan` label to the current pull request; `.claude/hooks/merge-gate.sh:156-160` then
+refuses to merge that PR — _"A foundational finding withdrew this change rather than patching it …
+close it and work the root item instead."_
+
+That is correct when the re-plan withdraws **a change the PR carries**. It is wrong when the re-plan
+is reached **before any change exists**.
+
+In that case the only pull request in existence is the one that FILES the root item and closes the
+symptom item. Labelling it means:
+
+- the merge gate refuses the PR whose entire content is the root item's problem statement and the
+  symptom's closure;
+- its instruction — "close it and work the root item instead" — would **discard the root item**,
+  because the root item exists only inside the PR being closed;
+- the author's only route is to remove the label, which the gate defines as _"what un-withdraws it"_
+  — i.e. to assert the opposite of what happened.
+
+Measured: on PR #1751 (CORE-038 → CORE-043) the label was published, the PR became unmergeable, and
+the label had to be removed by hand. The disposition is still recorded, correctly, in three places
+that are not a label: the symptom item's `## Outcome`, the root item's header, and the PR body.
+
+## Why it matters beyond the inconvenience
+
+The gate's refusal is fail-closed and its override is `MERGE_GATE_ACK=1`. A rule whose correct
+application produces a false refusal is the shape `git-branch.md` names explicitly: _"a gate that
+trains people to route around it has already failed."_ The first author who hits this and reaches for
+the override has been taught that the disposition flag is something to avoid, which is the opposite of
+what `finding-depth.md` wants — it wants the disposition recorded.
+
+Note also that `record-local-review` already refuses to record a disposition when no PR resolves
+(PROC-007's rule), so the author is pushed to open a PR _first_ and then record — which is exactly the
+sequence that produces the mislabelling.
+
+## Direction
+
+The distinction the label needs to carry is **what the PR contains**, not what the verdict was. A
+re-plan whose finding was raised against a change withdraws that change; a re-plan reached before any
+change exists withdraws nothing and its PR must land.
+
+Options, none chosen here because this is a judgement about the enforcement design rather than a
+defect with one right answer:
+
+- Have `record-local-review` distinguish the two — e.g. a re-plan recorded on a PR whose diff contains
+  no source change is a _filing_, not a withdrawal, and publishes the disposition without the blocking
+  label.
+- Or keep the label unconditional and teach `merge-gate.sh` the same distinction.
+- Or give the filing case its own disposition value, so the vocabulary says which happened.
+
+Whichever is taken, `finding-depth.md`'s prose should say plainly that a re-plan can be reached before
+a change exists, since today it reads as though a foundational finding is always raised against a diff.
+
+## Test Plan
+
+- A case pinning that a re-plan recorded on a source-free PR does not produce a merge-blocking state.
+- A case pinning that a re-plan recorded on a PR carrying source changes still does.
+- `depth-verdict-reachable.test.mjs` already enumerates the consumers of the depth vocabulary; whatever
+  distinction is introduced belongs in that enumeration so it cannot be added for one consumer only.
+
+## User Execution Test Scenarios
+
+Not applicable — this is harness/process machinery with no runnable user-facing behaviour. Verification
+evidence belongs in the engineering test plan above.

--- a/.agents/tasks/completed/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md
+++ b/.agents/tasks/completed/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md
@@ -1,11 +1,12 @@
 ---
-title: "CORE-038: the structured-output fallback transport re-asks for JSON in prose, which is the path every provider without a native responseFormat surface takes — and, because a native surface is detected per PROVIDER PACKAGE rather than per endpoint, an OpenAI-compatible gateway serving a non-OpenAI model is silently on the prompt path while the enforcement loop believes it enforced early"
-status: todo
+title: 'CORE-038: the structured-output fallback transport re-asks for JSON in prose, which is the path every provider without a native responseFormat surface takes — and, because a native surface is detected per PROVIDER PACKAGE rather than per endpoint, an OpenAI-compatible gateway serving a non-OpenAI model is silently on the prompt path while the enforcement loop believes it enforced early'
+status: superseded
 created: 2026-08-16
+completed: 2026-08-16
 priority: medium
 urgency: soon
-area: packages/agent-core, packages/agent-provider-openai-compatible, packages/agent-provider-bytedance
-depends_on: [CORE-037]
+area: packages/agent-core, packages/agent-provider-openai, packages/agent-provider-openai-compatible
+depends_on: []
 ---
 
 # CORE-038: forced tool call as the structured-output fallback transport
@@ -13,6 +14,48 @@ depends_on: [CORE-037]
 Proposed by an external user in [issue #1738](https://github.com/woojubb/robota/issues/1738), as a
 follow-up to CORE-015 (first-class structured output). The reporter offered to open a PR for either
 piece if the direction is agreed.
+
+## Outcome
+
+**Superseded by [CORE-043](../CORE-043-structured-output-capability-has-no-runtime-representation.md)
+([#1750](https://github.com/woojubb/robota/issues/1750)).** `finding-depth-triager` returned
+`DEPTH: FOUNDATIONAL` (2026-08-16): the proposal states the problem one layer above its cause.
+
+The transport this item proposes may well be the right one — that is not what was rejected. What the
+verdict found is that a transport chosen without a capability gate replaces one blind emission with
+another, and that this item's own open question ("does the schema tool collide with the agent's own
+tools under `tool_choice: required`?") exists only because nothing in the runtime decides _when_ to
+inject. The cause is that structured-output capability has no representation the runtime reads, and
+is a property of the instantiated package rather than of the endpoint and model actually called.
+
+**The same defect had already been filed twice**, three days earlier, from two internal channels:
+PROV-004 carries this exact symptom with this exact evidence and a direction, and PROV-006 carries
+the missing mechanism. This item is the third filing, from a third channel, reconciled with neither.
+
+**Two factual corrections to the report below**, both verified against `develop` after CORE-039
+landed. They are recorded rather than edited into the text, so the original report stays readable:
+
+1. **There is no first-attempt prose fallback — there is no first-attempt transport at all.**
+   `spec.jsonSchema` has exactly two consumers in the run path (`robota-execution.ts:173` config
+   override, `:186` retry prose). Nothing injects the schema into attempt 1, and the compat adapters
+   never read `responseFormat`, so attempt 1 carries **no schema signal whatsoever**. The reporter's
+   measured 0/4 is therefore not a property of their gateway — in robota it is structurally
+   guaranteed on that family, and `outputRetries: 0` can only succeed there by luck. The Problem
+   section below mis-describes the mechanism; this item's Scenario 1 states it correctly.
+2. **`agent-provider-bytedance` is not a text provider.** `src/bytedance/provider.ts:25` is
+   `class BytedanceProvider implements IVideoGenerationProvider` — no `chat()`, no `IAIProvider`.
+   Structured output never routes through it, so the table row below is wrong and the grep found
+   nothing because there was nothing to find. The frontmatter `area:` has been corrected. Relatedly,
+   "openai-compatible is the path for … any gateway" is wrong in the same direction: that package
+   exports only deepseek/qwen/gemma, and `llms.txt:22` routes gateways through
+   `agent-provider-openai`.
+
+The "Blocked in effect by CORE-037" note below is also cleared: CORE-037 is superseded and CORE-039
+has landed.
+
+**Status is `superseded`, not `done`:** the reported concern is real and is carried forward in full by
+CORE-043, but nothing this item proposed was implemented, and several of the decisions it leaves open
+are reserved for the owner rather than for an agent.
 
 ## Problem
 
@@ -38,11 +81,11 @@ Two things make this worth changing rather than accepting:
    `responseFormat` mapping exists in three provider packages and in neither of the other two
    text-generation packages:
 
-   | provider package                   | native structured-output surface | evidence |
-   | ---------------------------------- | -------------------------------- | -------- |
-   | `agent-provider-anthropic`         | yes — `output_config.format`     | `src/anthropic/provider.ts:349-356` |
+   | provider package                   | native structured-output surface | evidence                                  |
+   | ---------------------------------- | -------------------------------- | ----------------------------------------- |
+   | `agent-provider-anthropic`         | yes — `output_config.format`     | `src/anthropic/provider.ts:349-356`       |
    | `agent-provider-gemini`            | yes — `responseSchema`           | `src/gemini/execution-helpers.ts:142-145` |
-   | `agent-provider-openai`            | yes — `response_format`          | `src/openai/chat-completions-chat.ts` |
+   | `agent-provider-openai`            | yes — `response_format`          | `src/openai/chat-completions-chat.ts`     |
    | `agent-provider-openai-compatible` | **no** — prompt fallback         | `grep -rn responseFormat …/src` → no hits |
    | `agent-provider-bytedance`         | **no** — prompt fallback         | `grep -rn responseFormat …/src` → no hits |
 
@@ -110,7 +153,7 @@ The issue also asks that `llms.txt` mention structured output. On `develop` it a
   returns a validated typed object with provider-native mapping + bounded retry".
 
 So the gap the reporter hit is closed. What is worth checking as part of this Task is whether that
-line conveys the *guarantee* strongly enough for an agent reading `llms.txt` to choose robota's path
+line conveys the _guarantee_ strongly enough for an agent reading `llms.txt` to choose robota's path
 over its own SDK's helper, and whether it should state that non-native providers go through the
 bounded loop rather than degrading silently. Reply to the issue with the correction either way.
 

--- a/packages/agent-provider-openai-compatible/docs/SPEC.md
+++ b/packages/agent-provider-openai-compatible/docs/SPEC.md
@@ -78,3 +78,28 @@ dist/
     └── index.js / index.cjs / index.d.ts   # root export
     └── shared ...             # sub-path entry
 ```
+
+## Structured Output — not mapped here (CORE-043)
+
+**`IChatOptions.responseFormat` is not read by any adapter in this package.** `deepseek`, `qwen` and
+`gemma` build their requests without it, so a `run(input, { output })` call against them carries
+**no schema signal on the first attempt at all** — not a native `response_format`, and not a prose
+instruction either. `spec.jsonSchema` reaches the model only through the retry-feedback turn that
+agent-core's enforcement loop sends _after_ a first attempt has already failed validation.
+
+The consequence is worth stating plainly rather than leaving to be measured: a structured run against
+this family costs at least one extra turn by construction, and `outputRetries: 0` can only succeed by
+luck. agent-core's bounded validate-and-retry loop still guarantees the returned object matches the
+schema or throws — the guarantee holds; the cost is real.
+
+**This is a stated gap, not a design.** It is recorded here because a user currently has no way to
+learn it except by measuring: the SPEC's § Structured Output Contract says providers without a native
+surface "ignore it — the core-side enforcement loop is the universal contract either way", which is
+true of the guarantee and silent about the cost. The per-model catalog makes it worse:
+`src/deepseek/model-catalog.ts` declares `'json_schema'` on all three entries, a capability this
+package does not implement, and nothing reads that flag anyway (PROV-006).
+
+Fixing it — threading `responseFormat` through the shared request builder, and deciding where
+capability is represented so the runtime can tell a mapped provider from a discarding one — is
+**CORE-043** (issue #1750), whose load-bearing decisions are reserved for the project owner. PROV-004
+carries the same row. Until then, treat structured output on this family as retry-driven.


### PR DESCRIPTION
Closes **CORE-038** as `superseded` (issue #1738). Files **CORE-043** (issue #1750) as its cause.

**Documentation and backlog only — no code changes.** Nothing CORE-038 proposed was implemented, and that is the point of this PR.

## What was proposed, and what the depth verdict found

An external user proposed that when a provider has no native structured-output surface, the fallback transport should be a forced tool call rather than a prose re-prompt, with a measurement outside robota: same schema, same prompt, one OpenAI-compatible gateway — JSON-schema response format gave DeepSeek **0/4**, forced tool call gave **4/4**.

`finding-depth-triager` returned **`DEPTH: FOUNDATIONAL`**. The transport may well be the right one; that is not what was rejected. The finding is that the item states the problem one layer above its cause — **a transport chosen without a capability gate replaces one blind emission with another**, and the item's own open question ("does the schema tool collide with the agent's own tools under `tool_choice: required`?") exists only because nothing in the runtime decides *when* to inject.

## Two factual errors in the report, one of which changes the conclusion

Both verified against `develop` after CORE-039 landed. **Recorded rather than edited away**, so the original report stays readable.

1. **There is no first-attempt prose fallback — there is no first-attempt transport at all.** `spec.jsonSchema` has exactly two consumers in the run path: a config override and the retry-feedback prose. Nothing injects the schema into attempt 1, and the compat adapters never read `responseFormat`. So the reporter's 0/4 is **not** a property of their gateway — in robota it is structurally guaranteed on that family, and `outputRetries: 0` can only succeed there by luck. The proposal was reasoning about a transport that does not exist.
2. **`agent-provider-bytedance` is not a text provider.** It implements `IVideoGenerationProvider` and has no `chat()`. Structured output never routes through it; the item's grep found nothing because there was nothing to find, and its `area:` frontmatter named the package wrongly.

## The same defect, filed three times in three days

| Filed | Item | Channel |
| --- | --- | --- |
| 2026-08-13 | PROV-004 | internal critic — carries this exact symptom, this exact evidence, **and a direction** |
| 2026-08-13 | PROV-006 | internal critic — carries the missing mechanism: per-model capability flags read by nothing |
| 2026-08-16 | **CORE-038** | external issue #1738 — the same symptom again, as a transport proposal, reconciled with neither |

The fact has no owner, so each observer filed it as whatever it looked like from where they stood. That is what CORE-043 exists to stop.

## The cause

Structured-output capability has no representation the runtime reads. `agent-core` emits `responseFormat` on every structured run; each provider maps it or silently discards it; the seam cannot tell which. The one place the fact could live — per-model `TProviderModelCapability`, which already contains `'json_schema'` — is read by nothing and is declared **falsely** for deepseek (all three catalog entries claim it against an adapter implementing none).

Because capability belongs to the **instantiated package** rather than to the **endpoint and model actually called**, the configuration `llms.txt` advertises as the gateway story reports enforcement it does not have: `agent-provider-openai` + `baseURL` switches to the one surface that maps `response_format`, sends it to a model that may ignore it, and the enforcement loop believes it enforced early.

The SPEC already records the cause as intent — § Structured Output Contract: *"providers without one ignore it — the core-side enforcement loop below is the universal contract either way."*

## Decisions reserved for you, not for me

`backlog-execution.md` § Agent Decision Authority reserves each of these, so CORE-043 states them rather than planning around them:

1. **Whether `agent-provider-openai` changes behaviour when `baseURL` is set** — a provider default on a documented, published surface.
2. **Where capability and transport selection live** (provider declaration / agent config / `IRunOptions`) — unanswerable before PROV-006's own reserved decision.
3. **Whether the SPEC's "providers without one ignore it" clause is rewritten** — published contract.
4. **Whether a synthetic schema tool may be injected into a user's tool set** under `tool_choice: required` — observable behaviour change for every tool-using agent.

## What proceeded without them

The one piece the triage identified as non-reserved: **stating the compat family's structured-output no-op in its own SPEC.** A user currently has no way to learn it except by measuring — which is exactly how it reached an external report. The guarantee still holds (the bounded loop returns a conforming object or throws); what was undocumented is the **cost**: at least one extra turn by construction, and `outputRetries: 0` succeeding only by luck. It also names the contradiction next door — the deepseek catalog declaring a capability its adapter does not implement.

## Verification

`pnpm harness:verify-like-ci` — **12/12 stages pass**.

## Why `superseded` and not `done`

The reported concern is real and is carried forward in full by CORE-043. But nothing this item proposed was implemented, and four of the decisions it leaves open are yours. Marking it `done` would claim work that did not happen.