### PR TITLE
docs(tasks): file CORE-044 and drop CORE-042's invalid reservation

### DIFF
--- a/.agents/tasks/CORE-042-the-execution-turn-is-implemented-twice.md
+++ b/.agents/tasks/CORE-042-the-execution-turn-is-implemented-twice.md
@@ -125,10 +125,21 @@ construction, so it is planned with them rather than beside them; doing this one
 CORE-032 would re-derive the same seam twice. Whether the three are executed as one work unit or as an
 ordered initiative is the first decision the spec-doc must make.
 
-**A prerequisite, not an afterthought:** give the shared test double a `chatStream`, so a streaming
-turn can be exercised from the sanctioned surface rather than from a double re-written per test file
-— the state that let this happen. This is **this item's** work, not a contained fix's: it widens a
-published `./testing` export, which `backlog-execution.md` § Agent Decision Authority reserves.
+**A prerequisite, not an afterthought:** the shared test double must be able to exercise a streaming
+turn, rather than each test file re-writing its own — the state that let this happen.
+
+> **Correction (2026-08-16).** This paragraph previously said the work was reserved because "it widens
+> a published `./testing` export, which `backlog-execution.md` § Agent Decision Authority reserves."
+> **That ground does not exist here and is withdrawn.** No stable version has been released, the beta
+> is not distributed, and the rules forbid keeping legacy or compatibility code (`code-quality.md:50`
+> — _"unreleased — no backward-compat constraint"_). That clause reserves a change for the coordination
+> cost with a party who cannot be updated; inside this repository there is none. The test to apply is
+> **"is there a party who cannot be updated?"**, not "is this exported?".
+>
+> It is also not a widening: `createScriptedProvider.chat()` currently ignores `options.onTextDelta`,
+> which is a clause of the `IAIProvider` contract it claims to implement. Bringing it into conformance
+> needs no permission. Recording the `IChatOptions` it was called with IS additive, and is ordinary
+> agent-authority work.
 
 ## Test Plan
 

--- a/.agents/tasks/CORE-044-remote-executor-drops-every-per-call-option.md
+++ b/.agents/tasks/CORE-044-remote-executor-drops-every-per-call-option.md
@@ -1,0 +1,143 @@
+---
+title: 'CORE-044: the remote provider seam implements none of the IChatOptions contract at either end — the client sends no options, the server drops the `tools` the client does send so a remote agent silently has NO TOOLS, and the streaming client posts to a route the server does not serve, spelled two different ways'
+status: todo
+created: 2026-08-16
+priority: critical
+urgency: soon
+area: packages/agent-remote-client, apps/agent-server
+depends_on: [CORE-042]
+---
+
+# CORE-044: the remote seam implements none of the contract it declares
+
+Found while planning [CORE-042](CORE-042-the-execution-turn-is-implemented-twice.md), which made the
+gap load-bearing: once the streaming entry becomes an adapter over the round path, a remote provider
+that ignores `signal` is a turn that cannot be cancelled.
+
+## Problem
+
+`IChatOptions` carries `signal`, `onTextDelta`, `toolChoice`, `maxTokens`, `temperature` and `effort`.
+The remote provider seam implements **none** of it, at **both** ends — and the damage is worse than
+options.
+
+### The server silently discards the agent's tools
+
+`apps/agent-server/src/app.ts:121` destructures `{ provider, messages, model }` and `:138` calls
+`provider.chat(messages, { model })`. The client **does** send `tools`
+(`chat-http-methods.ts:99-104`) — the server never reads them. So **a remote-executor agent has no
+tools at all**, and nothing anywhere says so: the model simply never calls one. The BYOK handler
+(`:147-193`) has the identical shape.
+
+That is the same silent-drop failure class CORE-042 exists to end, at a different seam, and it is
+user-facing: an agent configured with tools appears to work and quietly cannot act.
+
+### There is no streaming route in this repository
+
+The server's entire route table is `remote/health`, `remote/chat`, `byok/chat`, `/`,
+`remote/ws/status`, `/health`, and the playground router. There is **no** stream route. Meanwhile:
+
+- `chat-http-methods.ts:174` posts to `${baseUrl}/stream`,
+- `request-handler-simple.ts:47-48` names a third spelling, `/chat/stream`,
+- `app.ts:111` and `apps/agent-server/docs/SPEC.md:31` both claim "Provider chat/stream routes are
+  inlined" — only the chat route actually was.
+
+So the streaming client points at an endpoint that does not exist, under two spellings, while the
+documentation asserts it does.
+
+### And every per-call option is dropped, in both directions
+
+- **Client.** `SimpleRemoteExecutor.executeChat`
+  (`packages/agent-remote-client/src/client/remote-executor-simple.ts:110-124`) calls
+  `httpClient.chat(messages, provider, model, request.tools)`, and `HttpClient.chat`
+  (`client/http-client.ts:71-86`) has **no options parameter at all**. The body is
+  `{ messages, provider, model, tools }`; `fetch` is called with no `signal` (`:108-118`).
+- **Server.** As above — even if the client sent them, the handler would drop them.
+
+`LocalExecutor` forwards `request.options` correctly
+(`agent-core/src/executors/local-executor.ts:104-108`), so this is the remote path specifically, not
+the executor contract.
+
+## What each dropped thing costs
+
+- **`tools`** — the agent cannot act. Silent, and the most serious of these.
+- **`signal`** — the remote path is **uncancellable**: the same class as CORE-018 (fixed for the
+  streaming path) and RUNTIME-004, on a seam neither covered.
+- **`toolChoice`** — CORE-017's forcing directive is silently ignored; `'required'` and a named tool
+  degrade to `'auto'` with no signal to the caller.
+- **`maxTokens` / `temperature` / `effort`** — CORE-016's run-scoped options are silently ignored, the
+  same defect CORE-016 fixed on the streaming path.
+- **`onTextDelta`** — a function cannot cross a wire; restoring live deltas needs a streaming route
+  that does not currently exist.
+
+**Nothing tests any of this.** That is the mechanism, not an aside: the seam declares a contract, no
+test asserts the contract at the boundary, and each dropped member was found only by reading.
+
+## Why this is not part of CORE-042
+
+Both halves were considered for that unit and split out on the reviewer's ruling, for reasons of
+correctness and size rather than authority:
+
+1. **The streaming route does not exist**, so routing `executeChat` to it would turn a working remote
+   `run()` into a 404. That alone settles it.
+2. **The delta predicate is not narrow either.** `execution-round-streaming.ts:80-88` passes
+   `onTextDelta` **unconditionally on every round-path provider call**, not gated on the caller
+   supplying one. So "route to the streaming surface when a delta callback is present" would move
+   **100% of remote traffic, including every plain `run()`**, onto it — a transport migration, not a
+   narrow restoration.
+3. **It needs an assembler CORE-042 deletes.** `remote-executor-simple.ts:166` says so itself —
+   _"yield every chunk as-is (ExecutionService merges them)"_ — and the merger is the tool-call
+   fragment accumulator CORE-042 removes with `execution-stream.ts`. Porting that into the remote
+   client, against a fragmentation behaviour that cannot be observed in-repo, risks silently corrupting
+   tool calls: the same silent-failure class CORE-042 exists to end.
+4. CORE-042 already exceeds the soft PR ceiling, and this work must additionally design the wire
+   representation of the options, decide whether a streaming route is implemented at all, and pick a
+   transport for it (SSE or chunked) — a unit of its own, not a loose end of another.
+
+CORE-042 does land the one piece that is genuinely client-local and that its own cancellation claim
+depends on: `signal` threaded into `fetch`.
+
+**Accepted in the meantime, stated rather than discovered:** on the remote seam `runStream()` yields
+one terminal chunk rather than live deltas — which is exactly what `run()` does there today, so it is
+not a regression.
+
+## Not an owner decision
+
+An earlier framing reserved the wire-schema half for the owner as "an externally visible contract".
+**That is withdrawn.** It is agent-authority work like any other. Both ends are in this repository, no stable version has been released, the
+current beta is not distributed, and the rules forbid keeping legacy or compatibility code
+(`code-quality.md:50` — _"unreleased — no backward-compat constraint"_). The reservation in
+`backlog-execution.md` § Agent Decision Authority exists for coordination cost with parties who cannot
+be updated; here there are none.
+
+## Direction
+
+Make the remote seam implement the contract it declares, and prove it at the boundary. Carry
+`IChatOptions` end to end. The client sends the serializable options in the POST body and threads
+`signal` into `fetch`; the server handler forwards them into `provider.chat`. `onTextDelta` is handled
+by routing to the streaming surface and assembling client-side — which is only safe once the fragment
+assembly it depends on has an owner, so sequence it after CORE-042 lands.
+
+The `/chat` and `/chat/stream` bodies should carry the options as one object rather than as parallel
+top-level fields, so a future option does not require touching both ends again — the parallel-collection
+failure mode `code-quality.md` names.
+
+## Test Plan
+
+- **The tools regression first, red:** a remote-executor agent with a registered tool reaches the
+  provider with that tool. It does not today.
+- Either implement the streaming route or delete the client that posts to it — a client calling an
+  endpoint nobody serves, under two spellings, with the SPEC claiming otherwise, is worse than either.
+- Client: the POST body carries `toolChoice`/`maxTokens`/`temperature`/`effort` when the caller sets
+  them, and `fetch` receives the run's `signal` (the existing `vi.mock('../http-client')` seam in
+  `remote-executor-simple.test.ts` covers the first half).
+- Server: the handler forwards the received options into `provider.chat`, asserted with a recording
+  provider.
+- An aborted remote run rejects rather than running to completion.
+- A remote run with `toolChoice: 'required'` reaches the provider with that directive.
+- `pnpm harness:verify-like-ci` green.
+
+## User Execution Test Scenarios
+
+To be authored when this item is picked up. The client half is `agent-executable` and provider-free
+(observe the request the client builds); the end-to-end half needs `apps/agent-server` running locally,
+which the work can start as part of the scenario.


### PR DESCRIPTION
Documentation and backlog only — no code changes.

## What this corrects

I reserved four decisions on **CORE-043** for the owner because each "changes a published or externally visible contract". **That ground does not exist in this repository, and I was misapplying the rule.** No stable version has been released, the current beta is not distributed, and the rules forbid keeping legacy or compatibility code — `code-quality.md:50` says it in the paragraph I had been quoting: *"(unreleased — no backward-compat constraint)"*.

`backlog-execution.md` § Agent Decision Authority reserves a contract change because of the **coordination cost with a party who cannot be updated**. Where every counterparty is in this repository, that cost is zero. The test that replaces "is this exported?" is **"is there a party who cannot be updated?"** — and inside this repo the answer is always no, so the question collapses to size, coherence, and whether the change is the correct design. Those are judgements to defend, not decisions to reserve.

**Four instances this session**, now all withdrawn or already corrected by other routes:

| Where | The invalid framing |
| --- | --- |
| CORE-043 | four decisions "reserved for the owner" as published-contract changes |
| CORE-042 Direction | the test-double work reserved because it "widens a published `./testing` export" |
| CORE-042 plan | "preserve `IStreamChunk` — the shape is public" (already fell to a false premise) |
| CORE-042 plan | "keep the throw — preserves today's error exactly" (already fell to evidence) |

The test-double case was not even a widening: `createScriptedProvider.chat()` ignores `options.onTextDelta`, which is a clause of the `IAIProvider` contract it claims to implement. Bringing a non-conformant double into conformance needs no permission.

## Two facts I had wrong, and what checking them found

I wrote that `/chat` was "served by an external `config.serverUrl`" with no in-repo counterparty. **False** — `apps/agent-server/src/app.ts:120` serves `/api/v1/remote/chat`, BYOK at `:147`. Checking it surfaced two defects worse than the one being filed:

### The server silently discards the agent's tools

`app.ts:121` destructures `{ provider, messages, model }`; `:138` calls `provider.chat(messages, { model })`. The client **does** send `tools` (`chat-http-methods.ts:99-104`) — the server never reads them.

**So a remote-executor agent has no tools at all, and nothing says so.** The model simply never calls one. An agent configured with tools appears to work and quietly cannot act. Same silent-drop failure class as CORE-042, different seam, and user-facing.

### There is no streaming route in this repository

The server's whole route table is `remote/health`, `remote/chat`, `byok/chat`, `/`, `remote/ws/status`, `/health`, and the playground router. Meanwhile the client posts to `${baseUrl}/stream` (`chat-http-methods.ts:174`), a second site names `/chat/stream` (`request-handler-simple.ts:47-48`), and both `app.ts:111` and `apps/agent-server/docs/SPEC.md:31` claim the chat/stream routes were inlined — only the chat route was.

A client calling an endpoint nobody serves, under two spellings, with the documentation asserting otherwise.

## Filed as CORE-044 (`critical`)

The remote provider seam implements **none** of the `IChatOptions` contract at either end: the client's `HttpClient.chat` has no options parameter at all, and the server drops what does arrive. Costs: tools gone (silent), the path uncancellable (`signal` — the class CORE-018 and RUNTIME-004 fixed elsewhere), `toolChoice` silently degraded to `'auto'` (CORE-017's directive), and `maxTokens`/`temperature`/`effort` ignored (CORE-016's options). Nothing tests any of it at the boundary — which is the mechanism, not an aside.

**Not owner-reserved either.** It is sequenced after CORE-042 for correctness and size: routing `executeChat` to the streaming surface would point it at a route that does not exist, would move *all* remote traffic there (the round path passes `onTextDelta` unconditionally), and needs the tool-call fragment assembler CORE-042 deletes.

That last finding also **strengthens** CORE-042's scope decision, which previously rested on "I cannot verify the far end": the far end demonstrably is not there.

## Verification

`pnpm harness:verify-like-ci` — **12/12 stages pass**.