### PR TITLE
docs(tasks): file PROC-011 — the merge gate blocks a docs-only PR

### DIFF
--- a/.agents/tasks/PROC-010-re-plan-disposition-blocks-the-filing-that-carries-it.md
+++ b/.agents/tasks/PROC-010-re-plan-disposition-blocks-the-filing-that-carries-it.md
@@ -50,6 +50,13 @@ Note also that `record-local-review` already refuses to record a disposition whe
 (PROC-007's rule), so the author is pushed to open a PR _first_ and then record — which is exactly the
 sequence that produces the mislabelling.
 
+**A second instance landed the same day.**
+[PROC-011](PROC-011-merge-gate-demands-a-review-its-own-classifier-withheld.md): the merge gate
+demands a reviewer verdict on a documentation-only PR that the review automation deliberately skips,
+so that PR also ends in `MERGE_GATE_ACK=1`. Two different mechanisms, one shape — the gate refusing a
+PR because of a state the harness itself produced. Whatever fixes one should be checked against the
+other.
+
 ## Direction
 
 The distinction the label needs to carry is **what the PR contains**, not what the verdict was. A

--- a/.agents/tasks/PROC-011-merge-gate-demands-a-review-its-own-classifier-withheld.md
+++ b/.agents/tasks/PROC-011-merge-gate-demands-a-review-its-own-classifier-withheld.md
@@ -1,0 +1,90 @@
+---
+title: 'PROC-011: the merge gate demands a reviewer verdict on every pull request, but the review automation deliberately skips a documentation-only one — so the two mechanisms disagree about the same PR and the only route through is the override the rules say a gate must never train people to reach for'
+status: todo
+created: 2026-08-16
+priority: medium
+urgency: soon
+area: .claude/hooks, .github/workflows
+depends_on: []
+---
+
+# PROC-011: the merge gate blocks on a review its own classifier withheld
+
+Measured on PR #1756 (2026-08-16), which it blocked.
+
+## Problem
+
+`.claude/hooks/merge-gate.sh` refuses a merge unless the PR carries a comment or review from
+`^github-actions(\[bot\])?$` containing an `ACTIONABLE FINDINGS: <n>` marker. On a documentation-only
+PR no such artifact exists — **by design**: the `classify review applicability` job passes and
+`Claude review` resolves to `skipping`, because the diff carries no code.
+
+That matches the rule the gate is enforcing.
+[git-branch.md](../rules/git-branch.md) § Pre-Merge Code-Review Gate scopes itself explicitly:
+
+> **Scope:** required for any PR that changes code (`.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`). A
+> documentation/spec/backlog-only PR (markdown/JSON config only, no code diff) is exempt — running
+> `/code-review` on it yields no code findings.
+
+So the rule exempts the PR, the CI classifier exempts the PR, and the hook refuses it anyway. Its
+diagnostic compounds the confusion by proposing the wrong cause:
+
+```
+[merge-gate] Blocked: no comment on #1756 is from the reviewer this gate looks for.
+[merge-gate]   looked for: ^github-actions(\[bot\])?$   comments are from: woojubb
+[merge-gate] If the reviewer's login changed, fix REVIEWER_RE — do not route around it.
+```
+
+The login had not changed. The reviewer never ran.
+
+## Why it matters
+
+The only route through is `MERGE_GATE_ACK=1`, which prints that the gate did not verify. Every
+documentation-only PR therefore ends in the override, and the person who learns that lesson carries it
+to a PR where the gate _is_ load-bearing. [git-branch.md](../rules/git-branch.md) names the shape:
+
+> a gate that trains people to route around it has already failed
+
+and, in the same section:
+
+> If a check is wrong, unrunnable, or fires on correct work, **the check is what changes**.
+
+**This is the second instance this session**, which is what makes it a pattern rather than an
+inconvenience. [PROC-010](PROC-010-re-plan-disposition-blocks-the-filing-that-carries-it.md) is the
+first: recording a re-plan disposition labels the PR that _files_ the root item, after which the same
+hook refuses it and instructs the author to close the PR — which would discard the root item. Both
+end in `MERGE_GATE_ACK=1`, and both are the gate blocking on a state its own machinery produced.
+
+## Direction
+
+The hook needs the same applicability answer CI already computes, rather than assuming a verdict
+always exists. Options, not chosen here because this is a judgement about the enforcement design:
+
+- Have the hook read the `classify review applicability` result (or recompute the same
+  code-vs-docs classification from the PR's file list) and require the marker only when the review was
+  applicable.
+- Or have the review workflow post an explicit `ACTIONABLE FINDINGS: 0` with a "not applicable —
+  docs-only" body instead of skipping, so the artifact always exists and the hook stays simple. This
+  is the smaller change and it keeps one code path in the hook, at the cost of a comment on every
+  docs PR.
+
+Whichever is taken, the diagnostic must stop asserting a cause it has not established: "no verdict
+found" and "the reviewer's login changed" are different claims, and printing the second for the first
+is what sent this investigation down the wrong path.
+
+**Consider together with PROC-010.** Both are the merge gate refusing a PR because of something the
+harness itself did; a fix that teaches the hook _why_ an artifact is absent would likely address both.
+
+## Test Plan
+
+- A case pinning that a documentation-only PR does not require a reviewer verdict to merge.
+- A case pinning that a code-carrying PR still does — the property that must not regress.
+- A case pinning that "verdict absent" and "reviewer login mismatch" produce different diagnostics.
+- `depth-verdict-reachable.test.mjs` already enumerates the consumers of the review vocabulary;
+  whatever applicability signal is introduced belongs in that enumeration so it cannot be wired for
+  one consumer only.
+
+## User Execution Test Scenarios
+
+Not applicable — harness and CI machinery with no runnable user-facing behaviour. Verification evidence
+belongs in the engineering test plan above.


### PR DESCRIPTION
Backlog only — no code changes.

## What happened

PR #1756 was a documentation-only change. `merge-gate.sh` refused it:

```
[merge-gate] Blocked: no comment on #1756 is from the reviewer this gate looks for.
[merge-gate]   looked for: ^github-actions(\[bot\])?$   comments are from: woojubb
[merge-gate] If the reviewer's login changed, fix REVIEWER_RE — do not route around it.
```

The login had not changed. **The reviewer never ran** — `classify review applicability` passed and `Claude review` resolved to `skipping`, because the diff carried no code. That is exactly what `git-branch.md`'s own Pre-Merge Code-Review Gate scope says should happen:

> **Scope:** required for any PR that changes code … A documentation/spec/backlog-only PR (markdown/JSON config only, no code diff) is exempt.

So the rule exempts the PR, the CI classifier exempts the PR, and the hook refuses it anyway. The diagnostic then proposes a cause it has not established, which is what sent the investigation down the wrong path first.

## Why this is worth a task rather than a shrug

The only route through is `MERGE_GATE_ACK=1`. Every documentation-only PR therefore ends in the override, and whoever learns that carries it to a PR where the gate **is** load-bearing. `git-branch.md` names the shape:

> a gate that trains people to route around it has already failed

and, in the same section:

> If a check is wrong, unrunnable, or fires on correct work, **the check is what changes**.

**Second instance today**, which is what makes it a pattern rather than an inconvenience. PROC-010 is the first: recording a re-plan disposition publishes a label to the PR that *files* the root item, after which this same hook refuses it and instructs the author to close it — which would discard the root item. Both end in `MERGE_GATE_ACK=1`; both are the gate blocking on a state the harness itself produced. The two items are cross-linked, since a fix that teaches the hook *why* an artifact is absent would likely address both.

## Direction — deliberately not chosen

Two shapes, and picking between them is a judgement about the enforcement design rather than a defect with one right answer: have the hook read the applicability signal CI already computes, or have the review workflow always post a verdict (`ACTIONABLE FINDINGS: 0`, body "not applicable — docs-only") so the artifact always exists and the hook stays simple.

One thing is not optional either way: the diagnostic must stop asserting a cause it has not established. "No verdict found" and "the reviewer's login changed" are different claims.

## Verification

`pnpm harness:verify-like-ci` — 12/12. A local review was run and recorded (0 findings).

**This PR will hit the same gate it describes.** I will merge it with the documented inline override and say so in a comment, rather than routing around it silently — which is the behaviour the item is about.