### PR TITLE
fix(harness): wire proposal-reviewer to finding-depth, and guard the wiring

### DIFF
--- a/.claude/agents/proposal-reviewer.md
+++ b/.claude/agents/proposal-reviewer.md
@@ -72,6 +72,29 @@ it FIRST and hardest, even if the proposal itself buries it:
 A proposal that gets the local design right but the placement wrong is still `REVISE`/`REJECT` — placement
 dominates. State the placement verdict explicitly in the review.
 
+## Depth check (mandatory when a finding would EXPAND the proposal's scope)
+
+"Correctness is not maximalism" above tells you not to credit churn. It does not tell you where a
+defect you found along the way BELONGS — and that is a different question, with its own owner.
+
+Whenever a finding of yours would pull work into the proposal that its stated scope does not cover —
+another package, another contract, a defect you discovered while testing a premise — you must say
+which of these it is, and say it explicitly in the review:
+
+- **In scope** — the proposal is wrong without it; fixing it here is fixing this proposal.
+- **A separate root item** — a real defect whose cause sits under or beside this proposal. Name it as
+  a problem another writer can file. Do NOT fold it in silently.
+
+The convention (LOCAL vs FOUNDATIONAL, when containment is permitted, where a root item lives) is
+owned by the repository's finding-depth rule, not by you. Report against it; do not extend it. Where
+that rule and an "absorb defects found along the way" instruction pull in opposite directions, say so
+rather than resolving it silently — the tie-break is the requester's, and a reviewer who defaults to
+absorption grows a proposal one finding at a time with nobody deciding that it should grow.
+
+**Watch the aggregate, not just each finding.** Every expansion can be individually justified and the
+total still be the wrong unit of work. If the scope you are recommending has grown materially across
+your review, say so as its own judgement, separate from the verdict, and recommend the seams.
+
 ## Procedure
 
 1. Read the proposal (problem, alternatives, decision, affected scope).
@@ -81,7 +104,8 @@ dominates. State the placement verdict explicitly in the review.
    proposal did not consider.
 5. Compare the proposal's decision to your derived answer. Judge on correctness; explicitly discount any
    blast-radius / legacy justification.
-6. Run the rule-alignment check.
+6. **Run the depth check on every finding that would expand scope**, and state the aggregate judgement.
+7. Run the rule-alignment check.
 
 ## Output contract
 
@@ -94,6 +118,9 @@ Return a structured review (no edits):
 - **Correctness analysis** — the design principles at stake and which alternative best satisfies them;
   call out and discount any diff-size/legacy reasoning in the proposal.
 - **Rule alignment** — where it fits / conflicts with the repo's rule intent.
+- **Scope** — every finding that would expand the proposal, marked in-scope or separate-root-item, plus
+  the aggregate judgement if the scope has grown materially. Omitting this section is not "no
+  expansion found"; it is the section missing.
 - **Recommendation** — the decision you would approve, concretely, with its reasoning and the migration
   cost stated honestly (not used as a veto).
 

--- a/scripts/harness/__tests__/check-agent-def-convention.test.mjs
+++ b/scripts/harness/__tests__/check-agent-def-convention.test.mjs
@@ -25,6 +25,8 @@ const GOOD_READONLY_AGENT = [
   '',
   'You are read-only: never run tree-mutating git in the working tree.',
   '',
+  'Whether a finding is in scope or a separate root item is owned by the finding-depth rule.',
+  '',
   'End the report with the exact line `ACTIONABLE FINDINGS: <n>`.',
 ].join('\n');
 
@@ -284,5 +286,57 @@ describe('check-agent-def-convention (HARNESS-046) — prettier-wrapped tools ar
     expect(results[0].findings.some((f) => /carries edit tool\(s\): Edit, Write/.test(f))).toBe(
       true,
     );
+  });
+  it('fails a finding-producing agent whose body never references the finding-depth rule', () => {
+    const agent = [
+      '---',
+      'name: scope-creeping-reviewer',
+      'description: Independent, read-only reviewer of a change proposal.',
+      'tools: Read, Grep',
+      'signal: REVIEW VERDICT',
+      '---',
+      '',
+      '# Body',
+      '',
+      'End with the exact line `REVIEW VERDICT: <ENDORSE|REVISE|REJECT>`.',
+    ].join('\n');
+    const findings = analyzeAgent(agent, { referencedInIndex: true });
+    expect(findings.some((f) => /never references the finding-depth rule/.test(f))).toBe(true);
+  });
+
+  it('passes the same agent once it references the finding-depth rule', () => {
+    const agent = [
+      '---',
+      'name: scoped-reviewer',
+      'description: Independent, read-only reviewer of a change proposal.',
+      'tools: Read, Grep',
+      'signal: REVIEW VERDICT',
+      '---',
+      '',
+      '# Body',
+      '',
+      'Whether a finding is in scope or a separate root item is owned by the finding-depth rule.',
+      '',
+      'End with the exact line `REVIEW VERDICT: <ENDORSE|REVISE|REJECT>`.',
+    ].join('\n');
+    const findings = analyzeAgent(agent, { referencedInIndex: true });
+    expect(findings.some((f) => /never references the finding-depth rule/.test(f))).toBe(false);
+  });
+
+  it('does not require the reference of a gate agent, which judges fixed criteria', () => {
+    const agent = [
+      '---',
+      'name: some-gate',
+      'description: Independent gate, read-only.',
+      'tools: Read, Grep',
+      'signal: GATE VERDICT',
+      '---',
+      '',
+      '# Body',
+      '',
+      'End with the exact line `GATE VERDICT: <PASS|FAIL|NON-COMPLIANCE>`.',
+    ].join('\n');
+    const findings = analyzeAgent(agent, { referencedInIndex: true });
+    expect(findings.some((f) => /never references the finding-depth rule/.test(f))).toBe(false);
   });
 });

--- a/scripts/harness/check-agent-def-convention.mjs
+++ b/scripts/harness/check-agent-def-convention.mjs
@@ -17,6 +17,9 @@
  *      tool-absence) declare a token from the CLOSED vocabulary and their body's output-contract
  *      instructs ending with that exact token (the token string appears in the body).
  *   4. The agent is referenced in `.agents/skills/index.md` (registered, not orphaned).
+ *   5. A FINDING-PRODUCING agent (classified by its `signal:` token) references the finding-depth
+ *      rule, so "is this finding in scope, or a separate root item?" has an owner other than the
+ *      agent that wants to absorb it.
  *
  * Exit code 0 = clean, 1 = findings.
  */
@@ -55,6 +58,21 @@ export const CLOSED_SIGNAL_VOCAB = new Set([
 ]);
 
 const EDIT_TOOLS = ['Edit', 'Write'];
+
+/**
+ * The signals whose bearers PRODUCE FINDINGS — open-ended judgements about a body of work, where
+ * "does this finding belong to the thing under review?" is a live question every time.
+ *
+ * Deliberately excluded, and why, so the set is not widened by reflex:
+ * - `GATE VERDICT` — its bearers (the worktree gates, the backlog gate guard) judge a named gate
+ *   against fixed criteria and answer PASS/FAIL/NON-COMPLIANCE. There is no finding whose scope could
+ *   expand, so requiring the reference would be ceremony. Adding them was this guard's own first
+ *   draft, and it was over-reach of exactly the kind the guard exists to catch.
+ * - `DECOMPOSITION`, `PRIOR_ART_RESEARCH`, `SCENARIO DRAFTED` — produce an artifact, judge nothing.
+ * - `MERGE VERIFIED`, `CI TRIAGE` — report a state.
+ * - `DEPTH` — its bearer IS the depth judge; requiring it to cite the rule it implements is circular.
+ */
+const FINDING_PRODUCING_SIGNALS = new Set(['REVIEW VERDICT', 'ACTIONABLE FINDINGS']);
 
 /**
  * Split a markdown file into its frontmatter map + body. Values are a string (scalar) or a
@@ -124,6 +142,21 @@ export function analyzeAgent(text, { referencedInIndex = true } = {}) {
         `declares signal "${token}" but its body's output-contract does not instruct ending with that token`,
       );
     }
+  }
+
+  // An agent that RETURNS A VERDICT on findings decides, implicitly, which findings belong to the
+  // thing under review and which are separate root items. That is the depth question, and it has its
+  // own owner document. `proposal-reviewer` shipped without referencing it and, across a twelve-round
+  // review, defaulted to absorption every time — growing one item's `area` from three packages to
+  // thirteen with nobody deciding that it should grow. Ten of the eleven finding-producing agents
+  // already carried the reference; the guard is what makes that a floor instead of a habit.
+  if (
+    FINDING_PRODUCING_SIGNALS.has(asScalar(frontmatter.signal) ?? '') &&
+    !/finding-depth/.test(body)
+  ) {
+    findings.push(
+      'produces findings but its body never references the finding-depth rule — a finding-producing agent must say which findings are in scope and which are separate root items, and that convention is owned by finding-depth.md, not by the agent',
+    );
   }
 
   if (!referencedInIndex) {


### PR DESCRIPTION
`proposal-reviewer` was the **only finding-producing agent of eleven** that never referenced `finding-depth.md`. That is not cosmetic.

## What the gap did

An agent that returns a verdict on findings decides, implicitly, which findings belong to the thing under review and which are separate root items. That is the depth question, it has its own owner document, and its own agent (`finding-depth-triager`) — which nothing in this path dispatches.

Without the reference the reviewer had two rules pulling opposite ways and nothing arbitrating:

| Rule | Direction |
| --- | --- |
| `code-quality.md:51` | **absorb** defects found along the way |
| `finding-depth.md` | **file the root item separately**; re-plan or labelled containment, never a third option |

Across a twelve-round review of CORE-043 it defaulted to absorption every time, growing that item's `area` from **3 packages to 13**. Every expansion was individually justified and verified against the code — the aggregate was still the wrong unit of work, and no step in the loop was responsible for noticing.

A `finding-depth-triager` pass afterwards found **7 of 10 expansions FOUNDATIONAL**, three of them already filed as existing items (PROV-006, CORE-033). That is the cost this wiring gap has already incurred once.

## The fix

**Agent** — a mandatory depth check: any finding that would pull work beyond the proposal's stated scope is marked *in scope* or *separate root item*; the tie-break between the two rules is named as the requester's rather than resolved silently; and the aggregate is a judgement of its own, separate from the verdict. The output contract gains a **Scope** section, with the note that omitting it is not "no expansion found" — it is the section missing.

**Guard** — prose alone would leave the same gap for the next agent, so `check-agent-def-convention.mjs` gains check 5: a finding-producing agent (classified by its `signal:` token) must reference the rule.

**Red proof performed:** stripping `finding-depth` from `proposal-reviewer.md` makes the guard FAIL with the new message; restoring it PASSes.

## The signal set is deliberately narrow

The first draft included `GATE VERDICT` and caught three worktree/backlog gates — which judge fixed criteria and answer PASS/FAIL, producing no finding whose scope could expand. That was over-reach of exactly the kind this guard exists to catch, so it was narrowed to `REVIEW VERDICT` and `ACTIONABLE FINDINGS`, with the exclusions and their reasons recorded in the constant's comment so the set is not widened by reflex. `DEPTH` is excluded as circular.

## Verification

- 3 new fixture cases: fails without the reference, passes with it, and does not fire on a gate agent.
- The existing "conforming" fixture is updated — it bore a finding-producing signal without the reference, so the guard correctly failed it.
- **599 harness tests pass**, **112 scans pass**, `verify-like-ci` **PASS 12/12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177RGmffprxqf66ZLFKfjwD