### PR TITLE
feat(harness): close the four self-judgement gaps (AGREEMENT-003, issue #1763)

### DIFF
--- a/.agents/spec-docs/draft/AGREEMENT-003-close-the-self-judgement-failure-class.md
+++ b/.agents/spec-docs/draft/AGREEMENT-003-close-the-self-judgement-failure-class.md
@@ -1,0 +1,114 @@
+---
+status: draft
+type: AGREEMENT
+tags: [typescript]
+---
+
+# AGREEMENT-003: close the self-judgement failure class
+
+Paired with `.agents/tasks/AGREEMENT-003-close-the-self-judgement-failure-class.md`. Converted from
+[issue #1763](https://github.com/woojubb/robota/issues/1763).
+
+## Problem
+
+Six times in one session, a role judged its own output. Every one was caught by an independent
+reviewer; none by the producer.
+
+The rule already exists. [enforcement-architecture.md](../../rules/enforcement-architecture.md) `:21`:
+_"A skill/agent that both produces and judges, or that judges and also routes, violates this rule.
+Split it."_ The failure is not a missing policy — it is four places the policy does not reach:
+
+1. **A contract's state is read from a proxy signal** — `grep` finds no consumer, so "dead"; the
+   surface is "published", so "unmodifiable" — and the agent that reads the proxy then acts on it.
+2. **A verification's verdict is not a function of the condition it names** — it cannot go red on the
+   violation, or cannot go green on correct input.
+3. **Wiring is performed and declared done by the same role**, with nothing asking whether the
+   registration check would have gone red had the wiring been absent.
+4. **A defect found mid-task has no filing path** that neither interrupts the work nor loses the
+   finding.
+
+## Prior Art Research
+
+Waived: in-repo governance change with no external product analog — this initiative applies an
+existing in-repo rule to four in-repo gaps, and the relevant prior art is the repository's own
+worker/guardian/orchestrator implementations, enumerated under Architecture Review below rather than
+sought externally.
+
+The waiver is recorded rather than the section left empty, per
+[research.md](../../rules/research.md). It applies to **this decomposition document only** — each
+child brings its own design, and a child that proposes a mechanism with an external analog (a
+published-version check, a scan-coverage convention) should run its own pass rather than inherit this
+one.
+
+## Architecture Review
+
+**The split is already implemented several times here and should be matched, not re-derived:**
+
+| Existing                                        | Shape                                                                               |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `architecture-refresh`, `documentation-refresh` | Orchestrators holding no policy, routing on a guardian's verdict                    |
+| `backlog-gate-guard`, the worktree gates        | Guardians judging one thing, emitting `GATE VERDICT`                                |
+| `backlog-writer`, `prior-art-researcher`        | Workers that produce and do not inspect their own output                            |
+| `check-agent-def-convention.mjs`                | Mechanizes role shape: read-only tool scope, closed signal vocabulary, registration |
+
+**Reachability.** Every child's mechanism targets `.agents/` or `scripts/harness/`, both already
+scanned by `pnpm harness:scan`. No new dependency edge, no new package.
+
+**Capability preservation.** Nothing existing is replaced. The four children add roles and checks;
+the `contract-audit` **name** is the one collision, recorded in the Task and reserved to HARNESS-097's
+design.
+
+**Adversarial pass — not yet run.** Required before GATE-APPROVAL for anything crossing a contract
+boundary. At draft stage this document proposes a decomposition, not a design; each child brings its
+own design and its own pass. Stated so the gap is visible rather than assumed closed.
+
+**The initiative's own strongest failure mode:** HARNESS-098 is about checks that cannot fail. Any
+mechanism this initiative ships without its red proof would be the initiative committing the defect it
+exists to close. That is why step 9 is a constraint here and not a formality.
+
+## Solution
+
+Four children, one cause each — see the Task's table for the mapping from the issue's eight skills.
+Splitting by cause rather than by artifact count is the decision, and it is made against a measured
+alternative: an adjacent item's `area` grew from 3 packages to 13 across twelve review rounds because
+each verified finding was absorbed rather than routed to its owner.
+[finding-depth.md](../../rules/finding-depth.md) owns that distinction.
+
+## Completion Criteria
+
+- **TC-01** Each child reaches a **named terminal state** for its mechanism — mechanized, or
+  infeasible-now with a written concrete obstacle **and** a tracked item. Silence fails.
+- **TC-02** Each mechanized check is proven against its pre-fix state: **FAILS** before, **PASSES**
+  after, recorded in the child.
+- **TC-03** No partial wiring — every artifact each child ships is registered and connected, or none
+  of it is.
+- **TC-04** HARNESS-099's guardian demonstrates the falsifiability half: an unwired fixture makes the
+  registration check go red.
+- **TC-05** HARNESS-097 does not reuse the `contract-audit` name, and its artifact is distinguishable
+  from the existing skill by description alone.
+- **TC-06** `pnpm harness:scan` green; every new Task passes `task-lifecycle.mjs classify`.
+
+## Test Plan
+
+Per-child. At the initiative level, the check is TC-01 and TC-02 across all four: a child whose
+mechanism has no named terminal state, or no recorded before/after, is not complete regardless of what
+prose it carries (`lesson-to-harness` step 11).
+
+## Tasks
+
+- [ ] HARNESS-097 — todo — `.agents/tasks/HARNESS-097-contract-state-judged-by-proxy-signal.md`
+- [ ] HARNESS-098 — todo — `.agents/tasks/HARNESS-098-verifications-that-cannot-fail-or-cannot-pass.md`
+- [ ] HARNESS-099 — todo — `.agents/tasks/HARNESS-099-wiring-is-performed-and-judged-by-the-same-role.md`
+- [ ] HARNESS-100 — todo — `.agents/tasks/HARNESS-100-mid-task-discovery-has-no-filing-path-that-does-not-disturb-the-work.md`
+
+## Evidence Log
+
+| Claim                                                         | Verified at                                                                |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| The produce-vs-judge rule already exists                      | `.agents/rules/enforcement-architecture.md:21`                             |
+| Removal of an unconsumed surface is a product decision        | `.agents/project-structure.md:225`                                         |
+| Wire fully / mechanism / prove-it-fails are existing steps    | `.agents/skills/lesson-to-harness/SKILL.md` steps 6, 8, 9, 11              |
+| A `contract-audit` skill already exists, about something else | `.agents/skills/contract-audit/SKILL.md` — SPEC.md Class Contract Registry |
+| Registration is already mechanized                            | `scripts/harness/check-agent-def-convention.mjs` (check 4)                 |
+| The unfalsifiable mirror is filed separately                  | <https://github.com/woojubb/robota/issues/1765>                            |
+| The source directives                                         | <https://github.com/woojubb/robota/issues/1763>                            |

--- a/.agents/tasks/AGREEMENT-003-close-the-self-judgement-failure-class.md
+++ b/.agents/tasks/AGREEMENT-003-close-the-self-judgement-failure-class.md
@@ -1,0 +1,105 @@
+---
+title: 'AGREEMENT-003: close the self-judgement failure class — six times in one session a role judged its own output, every one caught by an independent reviewer and never by the producer, in areas where enforcement-architecture.md already forbids it'
+status: todo
+created: 2026-08-16
+priority: high
+urgency: now
+area: cross-cutting harness governance initiative
+depends_on: []
+children: [HARNESS-097, HARNESS-098, HARNESS-099, HARNESS-100]
+---
+
+# AGREEMENT-003: the self-judgement failure class
+
+Converted from [issue #1763](https://github.com/woojubb/robota/issues/1763) — owner directives from
+the 2026-08-16 session, filed as an issue so the work then in flight was not disturbed. This document
+is that issue's conversion, and the conversion is itself one of the capabilities the issue asks for
+(HARNESS-100).
+
+## Objective
+
+The issue's own diagnosis is the objective:
+
+> Six times in one session the same failure recurred: I judged my own output. Every one was caught by
+> an independent reviewer, never by me. The repo's `enforcement-architecture.md` already forbids a
+> role that both produces and judges — the skills below apply that to areas where it currently is not
+> applied.
+
+So this is not a request for new policy. `enforcement-architecture.md:21` already says _"A skill/agent
+that both produces and judges, or that judges and also routes, violates this rule. Split it."_ The
+initiative is to apply an existing rule to four places it does not reach.
+
+## Why four children, not one item or eight
+
+The issue lists eight skills. They are not eight causes — grouping them by cause gives four, and the
+issue itself makes two of the groupings:
+
+| Child           | Cause                                                                     | Issue items                                                         |
+| --------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| **HARNESS-097** | A contract's state judged from a proxy signal instead of its actual state | 1, 2 — _"Both this and #1 are the same root error"_ (issue's words) |
+| **HARNESS-098** | A verification whose verdict is not a function of the condition it names  | 3                                                                   |
+| **HARNESS-099** | Wiring performed and judged by the same role                              | 4, 5, 6 — one trio                                                  |
+| **HARNESS-100** | Mid-task discovery has no filing path that leaves the work undisturbed    | 7, 8 — _"Two skills, because they run at different times"_          |
+
+Splitting by cause rather than by skill count is deliberate, and this session paid to learn it: an
+adjacent item's `area` grew from 3 packages to 13 across twelve review rounds because each verified
+finding was absorbed rather than routed to its owner. `finding-depth.md` owns that distinction. Four
+children with one cause each are independently verifiable; one item with eight skills is not.
+
+## Children
+
+- [ ] HARNESS-097 — todo — `.agents/tasks/HARNESS-097-contract-state-judged-by-proxy-signal.md`
+- [ ] HARNESS-098 — todo — `.agents/tasks/HARNESS-098-verifications-that-cannot-fail-or-cannot-pass.md`
+- [ ] HARNESS-099 — todo — `.agents/tasks/HARNESS-099-wiring-is-performed-and-judged-by-the-same-role.md`
+- [ ] HARNESS-100 — todo — `.agents/tasks/HARNESS-100-mid-task-discovery-has-no-filing-path-that-does-not-disturb-the-work.md`
+
+## Plan
+
+No hard ordering between the children — none blocks another. Two couplings to respect:
+
+1. **HARNESS-099 depends on HARNESS-098's standard being right**, not on its delivery. The wiring
+   guardian's second half ("would the registration check have gone red had it not been wired?") is
+   itself a falsifiability requirement; if HARNESS-098 settles what that means first, HARNESS-099
+   inherits it instead of inventing a second answer.
+2. **HARNESS-100 is the meta-item** — the path by which the other three were filed. Its worked
+   example is this conversion, so it can be written from evidence that already exists.
+
+Cheapest first if a sequence is wanted: HARNESS-100 (documents what just happened), HARNESS-098
+(sets the falsifiability bar), HARNESS-099 (consumes it), HARNESS-097 (needs the most design, since
+its mechanism must read npm state).
+
+## Constraints (from the issue, non-negotiable)
+
+- **Wire fully or not at all** — no partial wiring (`lesson-to-harness` step 6).
+- **Each child needs a mechanical prevention**, or a written concrete obstacle plus a tracked item
+  (step 8). "Hard to check" / "low value" / silence are not acceptable.
+- **Prove each mechanism catches its incident** — run it against the pre-fix state and confirm it
+  FAILS (step 9). For this initiative that step is load-bearing rather than ceremonial: HARNESS-098
+  is _about_ checks that cannot fail, so a mechanism shipped without its red proof would be the
+  initiative committing the defect it exists to close.
+
+## Findings from the conversion
+
+Recorded here because a later session would otherwise re-derive them:
+
+- **A skill named `contract-audit` already exists** (`.agents/skills/contract-audit/`) and is about a
+  package's SPEC.md Class Contract Registry — interface implementations, inheritance chains,
+  cross-package port consumers. It is **not** what the issue means by "contract audit". Whatever
+  HARNESS-097 builds must not reuse that name, and the two must be distinguishable from their
+  descriptions alone.
+- **The mirror of the unfalsifiable check is already filed separately** as
+  [issue #1765](https://github.com/woojubb/robota/issues/1765) (the spec public-surface parser that
+  cannot PASS on correct input). HARNESS-098 covers both directions; #1765 is the concrete instance.
+
+## Test Plan
+
+Per-child, in each child document. At the initiative level: every child reaches a **named terminal
+state** for its mechanism (mechanized, or infeasible-now with obstacle + tracked item), and the
+prove-it-fails result is recorded for each. `lesson-to-harness` step 11: no named terminal state means
+the lesson is not closed.
+
+## User Execution Test Scenarios
+
+Not applicable — this initiative is harness governance with no runnable user-facing behaviour. Per the
+Task README, governance-only changes record `Not applicable` with the reason and keep verification in
+the Test Plan. Each child states the same, with its mechanism's before/after result as the evidence.

--- a/.agents/tasks/HARNESS-097-contract-state-judged-by-proxy-signal.md
+++ b/.agents/tasks/HARNESS-097-contract-state-judged-by-proxy-signal.md
@@ -1,0 +1,85 @@
+---
+title: 'HARNESS-097: a contract''s state is judged from a proxy signal instead of its actual state — "no consumer found" is read as dead, and "published" is read as unmodifiable, and both readings are made by the same agent that then acts on them'
+status: todo
+created: 2026-08-16
+priority: high
+urgency: now
+area: .agents/rules, .agents/skills, scripts/harness
+depends_on: []
+---
+
+# HARNESS-097: dead-by-grep and unmodifiable-by-assumption
+
+Converted from [issue #1763](https://github.com/woojubb/robota/issues/1763) (owner directives,
+2026-08-16 session), items **1 (contract audit)** and **2 (exposure gate)**. They are one item because
+the issue states they share a root: _"Both this and #1 are the same root error — judging a contract by
+a proxy signal instead of its actual state."_
+
+## Problem
+
+Two mirror-image errors, both made in one session, both from the same substitution:
+
+| Proxy signal read          | Conclusion drawn            | What was actually true                                                    |
+| -------------------------- | --------------------------- | ------------------------------------------------------------------------- |
+| `grep` finds no consumer   | "dead contract — remove it" | forward-provisioned, or the owner is wrong and it should be **relocated** |
+| the surface is "published" | "we cannot change this"     | the project is pre-release beta; **nothing is externally exposed**        |
+
+Both readings were then acted on by the agent that made them, with no independent check.
+
+**The first rule already existed and was violated anyway.** `project-structure.md:225`: _"Removal of an
+unconsumed public surface is a PRODUCT decision — never a grep-based cleanup. Propose it as a user
+decision item with options; do not file it as 'dead code'."_ Prose alone did not hold, which is why
+this needs a procedure **and** a mechanism rather than more prose.
+
+**Measured instances (from the issue):**
+
+- `branchName` deleted on a grep result; relocated after the owner corrected it.
+- `providerProfile` labelled a "dead contract field" in a **shipped changeset**, when it is
+  carried-but-not-honored — ARCH-021 is the item that honors it.
+- The mirror: three of CORE-043's four "decisions reserved for the owner" were reserved because the
+  surfaces were read as published contracts. They are not — 71 npm versions, zero non-prerelease.
+
+## Direction
+
+**The exposure gate is a mandatory step, not advice (owner directive).** Before any "we cannot change
+this" judgement, verify the **actual current exposure state** and decide from that. Concretely
+checkable here: npm dist-tags and whether any non-prerelease version exists.
+
+**The disposition vocabulary is closed.** An unconsumed public contract has exactly three correct
+dispositions, and "delete because grep found nothing" is not among them:
+
+1. **Keep + document** as intentional forward provision;
+2. **Relocate** if the owner is wrong;
+3. **Remove** only by an explicit product decision.
+
+**Naming collision to resolve first.** A skill named `contract-audit` **already exists**
+(`.agents/skills/contract-audit/`) and is about something else entirely — a package's SPEC.md Class
+Contract Registry, interface implementations and inheritance chains. Whatever this item builds must
+not reuse that name, and the two must be distinguishable from their descriptions alone.
+
+## Mechanism (required — see `lesson-to-harness` step 8)
+
+Candidates, to be decided during design:
+
+- A scan that fails a changeset or commit body asserting a contract is "dead"/"unused"/"removed as
+  unused" without a recorded disposition from the closed vocabulary above.
+- A scan that fails a document asserting a backward-compatibility constraint while the package's
+  published versions are all prereleases — the exposure fact is mechanically derivable.
+
+**Infeasible-now is a permitted terminal state only with a written concrete obstacle plus a tracked
+item.** "Hard to check" is not a reason.
+
+## Test Plan
+
+- Prove-it-fails (step 9): run the mechanism against the two recorded instances' pre-fix state — the
+  `providerProfile` changeset text and CORE-043's original "published contract" reservations — and
+  confirm it FAILS, then against the corrected state and confirm it PASSES.
+- Sweep (step 5): enumerate every current instance of both readings in the repo, not just the three
+  recorded ones.
+- `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+Not applicable — harness/process change with no runnable user-facing behaviour. The mechanism's
+before/after result under Test Plan is the evidence, per the Task README's rule for
+governance-only changes.

--- a/.agents/tasks/HARNESS-098-verifications-that-cannot-fail-or-cannot-pass.md
+++ b/.agents/tasks/HARNESS-098-verifications-that-cannot-fail-or-cannot-pass.md
@@ -1,0 +1,77 @@
+---
+title: 'HARNESS-098: a verification that cannot fail on the condition it names converts unverified into verified — the state nobody re-examines — and its mirror, a check that cannot pass on correct input, is equally live in this repo'
+status: todo
+created: 2026-08-16
+priority: high
+urgency: now
+area: .agents/rules, .agents/skills, scripts/harness
+depends_on: []
+---
+
+# HARNESS-098: unfalsifiable checks, in both directions
+
+Converted from [issue #1763](https://github.com/woojubb/robota/issues/1763) (owner directives,
+2026-08-16 session), item **3**.
+
+## Problem
+
+A check that cannot go red on the condition it claims to test is worse than no check: it moves a fact
+from **unverified** — a state someone might re-examine — to **verified**, which nobody re-examines.
+The green is the damage.
+
+**Three measured instances, one session:**
+
+1. The ARCH-030 `latchThrew` observable that measured nothing.
+2. A typecheck "proof" that could not catch the second structural re-declaration.
+3. An "`rg` finds zero repo-wide" claim that was one off.
+
+**The mirror exists too, and was found in the same session:** the spec public-surface parser stops
+counting at the first subheading, so a correctly-structured grouped Public API table reads as
+entirely undocumented — a check that cannot PASS on correct input. Filed separately as
+[issue #1765](https://github.com/woojubb/robota/issues/1765). Both directions are the same defect:
+the check's verdict is not a function of the condition it names.
+
+**This item's own risk is the sharpest argument for it.** Any check built to catch unfalsifiable
+checks can itself be unfalsifiable. The prove-it-fails step is not ceremony here; it is the only
+thing separating this item from the defect it is about.
+
+## Direction
+
+**Before proposing any check, state what would make it FAIL.** That sentence is the artifact — if it
+cannot be written, the check is not ready.
+
+Two properties to design for, since the instances split evenly between them:
+
+- **Can go red** on the named condition (instances 1–3).
+- **Can go green** on correctly-formed input (the parser mirror).
+
+`lesson-to-harness` step 9 already requires running a new check against the pre-fix state and
+confirming it FAILS. That step exists and these three instances still shipped — so the gap is not the
+rule's absence but that nothing verifies the step was performed. Whatever this item builds should make
+the step's _result_ recorded and checkable, not merely instructed.
+
+## Mechanism (required — see `lesson-to-harness` step 8)
+
+Candidates, to be decided during design:
+
+- Require every new `scripts/harness/check-*.mjs` / `scan-*.mjs` to ship a fixture test asserting
+  **both** directions (red on the violation, green on the conforming case) — the existing
+  `__tests__/` fixtures already do this for several scans, so the floor is a coverage assertion over
+  scans rather than a new convention.
+- A scan over the harness's own test files that fails when a check has only a green-path fixture.
+
+**Infeasible-now is permitted only with a written concrete obstacle plus a tracked item.**
+
+## Test Plan
+
+- Prove-it-fails (step 9): run the mechanism against the three recorded instances' pre-fix state and
+  confirm each FAILS; confirm the corrected state PASSES.
+- Include the mirror direction: a fixture where correct input must PASS, asserted to fail if the
+  check regresses to the parser's shape.
+- Sweep (step 5): enumerate every harness check lacking a red-direction fixture.
+- `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+Not applicable — harness/process change with no runnable user-facing behaviour. The before/after
+mechanism result under Test Plan is the evidence.

--- a/.agents/tasks/HARNESS-099-wiring-is-performed-and-judged-by-the-same-role.md
+++ b/.agents/tasks/HARNESS-099-wiring-is-performed-and-judged-by-the-same-role.md
@@ -1,0 +1,74 @@
+---
+title: 'HARNESS-099: a skill that is not wired is not invoked, and wiring that is not verified is not wiring — today the same role performs the wiring and declares it done, and nothing asks whether the registration check would have gone red had it not been wired'
+status: todo
+created: 2026-08-16
+priority: high
+urgency: now
+area: .agents/skills, .claude/agents, scripts/harness
+depends_on: []
+---
+
+# HARNESS-099: split wiring into worker, guardian, orchestrator
+
+Converted from [issue #1763](https://github.com/woojubb/robota/issues/1763) (owner directives,
+2026-08-16 session), items **4 / 5 / 6**.
+
+## Problem
+
+`enforcement-architecture.md:21` is unambiguous: _"A skill/agent that both produces and judges, or
+that judges and also routes, violates this rule. Split it."_ Wiring is currently exempt from it in
+practice — the same role registers a skill in the index, adds the AGENTS.md routing row, connects it
+to its dispatching pipeline, and then declares it wired.
+
+`lesson-to-harness` step 6 already says "no partial wiring", and step 8 requires a mechanism. Neither
+asks the question that actually matters.
+
+## Direction — three roles, per the owner directive
+
+| Role                    | Does                                                                                                           | Does not    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- | ----------- |
+| **wiring worker**       | Performs the wiring: index registration, AGENTS.md routing, connection to the dispatching pipeline             | Judge       |
+| **wiring guardian**     | Judges whether it is wired **and whether the registration check would actually have gone red had it not been** | Fix         |
+| **wiring orchestrator** | Thin: sequences worker → guardian, routes on the verdict                                                       | Hold policy |
+
+**The guardian's second half is the whole point, and the directive says why:** _"Without that second
+half we would be installing an unfalsifiable check in the wiring-verification slot, which is defect
+#3 one layer up."_ A guardian that only confirms "the name appears in the index" is exactly the shape
+HARNESS-098 exists to eliminate. This item and HARNESS-098 constrain each other and should be
+designed with that in mind, though neither blocks the other.
+
+## Prior art in the repo — build from it, do not re-derive
+
+The worker/guardian/orchestrator split is already implemented several times, and the shapes are worth
+matching rather than reinventing:
+
+- `architecture-refresh`, `documentation-refresh` — orchestrators that hold no policy and route on a
+  guardian's verdict.
+- `backlog-gate-guard`, the worktree gates — guardians that judge one thing and emit `GATE VERDICT`.
+- `check-agent-def-convention.mjs` already asserts registration (`.agents/skills/index.md`
+  reference) mechanically, so the guardian has a mechanism to lean on for half its job — the half it
+  does **not** have is the falsifiability check.
+
+## Mechanism (required — see `lesson-to-harness` step 8)
+
+The registration half exists. What must be added is evidence that the check is falsifiable: a fixture
+in which an unwired artifact makes the registration check go **red**, asserted in the harness's own
+tests, so the guardian's verdict rests on something checkable rather than on its own reading.
+
+**Infeasible-now is permitted only with a written concrete obstacle plus a tracked item.**
+
+## Test Plan
+
+- Prove-it-fails (step 9): construct an unwired fixture artifact and confirm the registration check
+  FAILS on it; wire it and confirm it PASSES. That pair IS the guardian's second half, mechanized.
+- Assert the three roles' tool scopes match their responsibilities — the guardian read-only, the
+  worker without judgement authority, the orchestrator holding no policy — via
+  `check-agent-def-convention.mjs`, which already enforces read-only tool scope.
+- Sweep (step 5): enumerate skills/agents currently registered but not connected to any dispatching
+  pipeline, which is the failure "wired" was supposed to exclude.
+- `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+Not applicable — harness/process change with no runnable user-facing behaviour. The prove-it-fails
+pair under Test Plan is the evidence.

--- a/.agents/tasks/HARNESS-100-mid-task-discovery-has-no-filing-path-that-does-not-disturb-the-work.md
+++ b/.agents/tasks/HARNESS-100-mid-task-discovery-has-no-filing-path-that-does-not-disturb-the-work.md
@@ -1,0 +1,79 @@
+---
+title: 'HARNESS-100: a defect found mid-task has no filing path that leaves the work in flight undisturbed — writing a backlog file inline interrupts it, and dropping the finding loses it, so the repo has no owned answer for the most common moment a defect is discovered'
+status: todo
+created: 2026-08-16
+priority: medium
+urgency: soon
+area: .agents/skills, .agents/rules
+depends_on: []
+---
+
+# HARNESS-100: find→issue and issue→backlog
+
+Converted from [issue #1763](https://github.com/woojubb/robota/issues/1763) (owner directives,
+2026-08-16 session), items **7 / 8**.
+
+## Problem
+
+A defect or follow-up is most often discovered **in the middle of other work**. The repo's filing
+machinery assumes the opposite: `.agents/tasks/` files are written deliberately, and
+`user-request-gate` gates code behind a backlog draft. Applied mid-task, that means stopping to author
+a Task document — which disturbs the work in flight — and the practical alternative is dropping the
+finding.
+
+The owner directive states the split:
+
+> When a defect or follow-up is discovered mid-task, file a GitHub **issue** and keep going —
+> creating a backlog file inline disturbs the work in flight. When a later session picks the issue up,
+> convert issue → backlog then. **Two skills, because they run at different times for different
+> reasons.**
+
+Issue #1763 is itself an instance: it was filed as an issue precisely so the session that produced it
+could continue, and it says so in its first line.
+
+## Direction
+
+**find→issue** — the mid-task path. Cheap, non-interrupting, and it must capture enough that the later
+session does not have to re-derive the finding: what was observed, where, and why it was not fixed
+inline. Its own risk is becoming a drop-box for anything inconvenient, so it needs a stated bar for
+what is issue-worthy versus fix-now.
+
+**issue→backlog** — the pickup path. Converts a filed issue into a Task document with the frontmatter,
+Test Plan and scenario sections the Task README requires. **This item's own creation is the worked
+example**: issue #1763 → this Task and its three siblings, including the judgement of how many items
+the issue's contents actually are.
+
+Two interactions to design against rather than discover later:
+
+- **`user-request-gate`** gates code behind a backlog draft. find→issue must not become a way around
+  that gate — filing an issue is not authorization to change code.
+- **`finding-depth.md`** owns whether a finding belongs to the current item or is its own root item.
+  find→issue should route that question there rather than answering it, or it becomes a second place
+  the same judgement is made — the defect this session already paid for once.
+
+## Mechanism (required — see `lesson-to-harness` step 8)
+
+Weaker mechanical leverage than the sibling items, and that should be stated plainly rather than
+papered over: "did the agent file an issue instead of dropping the finding?" is not observable from
+the tree. What _is_ checkable:
+
+- An issue converted to a Task carries the issue reference, and the Task's frontmatter validates
+  (`task-lifecycle.mjs classify`).
+- The `task-tracking` hook already surfaces open issues at session start — the pickup path can be
+  anchored there rather than relying on memory.
+
+**Infeasible-now for the find half is a likely and permitted terminal state — but only with the
+written concrete obstacle plus a tracked item**, per `lesson-to-harness` step 8. Silence is not.
+
+## Test Plan
+
+- The conversion path is exercised end to end on a real issue and the resulting Task passes
+  `task-lifecycle.mjs classify` and `backlog-placement`.
+- Prove-it-fails (step 9) for whichever half is mechanized; for the half that is not, record the
+  obstacle and the tracked item.
+- `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+Not applicable — process change with no runnable user-facing behaviour. The conversion exercised
+under Test Plan is the evidence.


### PR DESCRIPTION
Converts issue #1763 into AGREEMENT-003 and **implements all four children**.

## The eight skills are four causes

The issue lists eight. Grouped by cause they are four, and **the issue makes two of the groupings itself** ("both this and #1 are the same root error"; "two skills, because they run at different times"). Splitting by cause rather than artifact count is measured, not stylistic: an item in this same session grew from 3 packages to 13 across twelve review rounds because each verified finding was absorbed rather than routed to its owner.

## What landed, with its terminal state and red proof

| Item | Mechanism | Red proof |
| --- | --- | --- |
| **HARNESS-097** contract state from a proxy signal | **MECHANIZED** — `check-contract-disposition.mjs` | The `providerProfile` changeset **in the shape it shipped** FAILS; the same text with `carried-but-not-honored` named PASSES |
| **HARNESS-098** verifications that cannot fail | **MECHANIZED (stage 1)** — `check-fixture-floor.mjs`, 116 modules | **It went red on itself** the first time it ran, demanding its own fixture |
| **HARNESS-099** wiring judged by its own author | **MECHANIZED** — registration + falsifiability | The orchestration-map scan went red on both new agents until each had a row |
| **HARNESS-100** mid-task discovery | **INFEASIBLE-NOW**, obstacle written | A dropped finding leaves no artifact, so there is nothing for a check to read |

`lesson-to-harness` step 11: a lesson with no named terminal state is not closed. All four have one.

## Three things I got wrong, caught by the repo's own guards

1. **Both new checks guarded execution with an `import.meta.url` string compare** — which fails toward silence: `main()` does not run, the script exits 0, and that reads as a pass. That is **HARNESS-098's own subject**, committed in the change that closes it. Fixed to the `path.resolve` form the guard names.
2. **`check-contract-disposition`'s first draft included `dead code`** and fired on a real changeset describing an unreachable `--import tsx` branch — the exact over-matching the file's own comment warned against *one line above*. A subject noun is now required, and the real text is pinned as a green case.
3. **`measurement-provenance` and `orchestration-map`** required the examined counter to be asserted against an exact value and across a reset, and refused a mention in prose or a diagram as a listing.

## What is deliberately NOT delivered

**HARNESS-098's second stage.** Fixture *existence* is not fixture *quality* — a green-path-only test satisfies this floor and still leaves a check unfalsifiable. Detecting the red direction textually was considered and **rejected**: a heuristic over assertion shapes would itself be a check that cannot reliably fail, which is this item's defect committed by the file closing it. The obstacle is written in the file and the Task, not summarized as "hard to check".

**The `contract-audit` name was not reused.** A skill by that name already exists, about SPEC.md Class Contract Registries. The new one is `contract-disposition`.

## Wiring (step 6 — fully or not at all)

Both agents in `.agents/skills/index.md` **and** the orchestration map's agent table; a `Wiring` pipeline row with its escalation semantics (`NON-COMPLIANCE` routes to escalation, never back to the worker); four skills in the index; both scans in `run-all-scans.mjs`; the examined-size adoption baseline re-frozen.

## Verification

`verify-like-ci` **PASS 12/12** · **114 scans pass** · **3959 harness tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177RGmffprxqf66ZLFKfjwD