### PR TITLE
fix(harness): an open PR's diff is frozen except to resolve a finding

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -446,6 +446,31 @@ comment (or the PR description):
 No CONFIRMED/PLAUSIBLE finding may be left silently unaddressed. **Only after all findings are resolved**
 may the PR be merged.
 
+### An open PR's diff is frozen except to resolve a finding
+
+**Open a PR only when the unit of work is complete.** An open PR is a merge invitation: it may be
+merged the moment its review reports clean. A PR opened on a half-finished unit invites a merge of
+half the work.
+
+**Once it is open, the only permitted reason to push a new commit is to RESOLVE A REPORTED FINDING**
+(the "fixed" branch above). Not the next part of the same task, and not an improvement the reviewer
+did not ask for. A reviewer who reported clean reviewed a diff that no longer exists, and the merge
+decision was made on the PR as it read.
+
+The merge gate refuses a merge whose review names a stale head — but that ordering is not guaranteed.
+A merge that lands before the push sees nothing to refuse, and the unpushed work is simply absent
+from it.
+
+If more work belongs to the same task, **finish it before opening the PR**, or open a second PR after
+the first lands. If a finding's fix requires work beyond the finding, say so on the thread and let the
+reviewer re-scope; do not widen the diff and leave them to discover it.
+
+Enforced by: `.claude/hooks/pre-push-check.sh`. Its open-PR exemption rests on the premise that a
+push into an open PR resolves what the review reported; when the PR's latest review reports
+`ACTIONABLE FINDINGS: 0` there is nothing to resolve, so the push is new work and the hook refuses.
+An unreadable count is not zero — the exemption stands, because a refusal on a failed measurement
+blocks correct work on no evidence. Deliberate exception: `PRE_PUSH_ALLOW_UNREVIEWED=1` inline.
+
 **Enforced** by `.claude/hooks/merge-gate.sh`, which refuses `gh pr merge` unless the PR is `CLEAN`
 and carries a review naming the exact current `baseRefOid` and `headRefOid`, and refuses outright
 when the reviewer's own `ACTIONABLE FINDINGS: <n>` says findings remain. Timestamp recency is not

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -834,6 +834,12 @@ if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
     # the owner of "what the reviewer said", and a second reading here would be a second answer.
     # Unknown is NOT zero: if the count cannot be read, the original exemption stands, because a
     # refusal on a failed measurement blocks correct work on no evidence.
+    # The MARKER pattern is merge-gate.sh's, unanchored, and that is not a style choice: jq's regex
+    # does not make `^`/`$` match at line boundaries, so an anchored pattern finds nothing in a review
+    # body whose marker is not the whole text — and the `2>/dev/null` below turns that into an empty
+    # count, which reads as unknown and lets the push through. Fail-OPEN on the exact case this gate
+    # exists to block. The precise line extraction is `sed`'s job below, where `^`/`$` do mean lines.
+    #
     # The AUTHOR FILTER is not optional, and it is the same one merge-gate.sh applies
     # (merge-gate.sh:208). Without it this reads the latest comment from ANYONE carrying the marker,
     # so the branch's own author could post `ACTIONABLE FINDINGS: 3` to unfreeze a clean pull request,
@@ -843,7 +849,7 @@ if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
     REVIEWER_RE='^github-actions(\\[bot\\])?$'
     LATEST_COUNT=$( (cd "$PROJECT_DIR" &&
       bounded_gh pr view "$OPEN_PR" --json comments,reviews \
-        --jq "([.comments[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"$REVIEWER_RE\"))) | map(select(.body | test(\"^ACTIONABLE FINDINGS: [0-9]+$\"; \"m\"))) | sort_by(.at) | last // {} | .body // \"\"" 2>/dev/null) |
+        --jq "([.comments[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"$REVIEWER_RE\"))) | map(select(.body | test(\"ACTIONABLE FINDINGS:[[:space:]]*[0-9]+\"; \"i\"))) | sort_by(.at) | last // {} | .body // \"\"" 2>/dev/null) |
       sed -nE 's/^ACTIONABLE FINDINGS: ([0-9]+)$/\1/p' | tail -1 || echo "")
 
     if [[ "$LATEST_COUNT" == "0" ]]; then

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -834,9 +834,16 @@ if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
     # the owner of "what the reviewer said", and a second reading here would be a second answer.
     # Unknown is NOT zero: if the count cannot be read, the original exemption stands, because a
     # refusal on a failed measurement blocks correct work on no evidence.
+    # The AUTHOR FILTER is not optional, and it is the same one merge-gate.sh applies
+    # (merge-gate.sh:208). Without it this reads the latest comment from ANYONE carrying the marker,
+    # so the branch's own author could post `ACTIONABLE FINDINGS: 3` to unfreeze a clean pull request,
+    # or `ACTIONABLE FINDINGS: 0` to block someone else's legitimate push. A gate whose input its own
+    # subject can write is not a gate. Kept as its own literal because merge-gate.sh does not export
+    # it — the two must be changed together, said here rather than left to be noticed.
+    REVIEWER_RE='^github-actions(\\[bot\\])?$'
     LATEST_COUNT=$( (cd "$PROJECT_DIR" &&
       bounded_gh pr view "$OPEN_PR" --json comments,reviews \
-        --jq '([.comments[]? | {body: (.body // ""), at: (.createdAt // "")}] + [.reviews[]? | {body: (.body // ""), at: (.submittedAt // "")}]) | map(select(.body | test("^ACTIONABLE FINDINGS: [0-9]+$"; "m"))) | sort_by(.at) | last // {} | .body // ""' 2>/dev/null) |
+        --jq "([.comments[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"$REVIEWER_RE\"))) | map(select(.body | test(\"^ACTIONABLE FINDINGS: [0-9]+$\"; \"m\"))) | sort_by(.at) | last // {} | .body // \"\"" 2>/dev/null) |
       sed -nE 's/^ACTIONABLE FINDINGS: ([0-9]+)$/\1/p' | tail -1 || echo "")
 
     if [[ "$LATEST_COUNT" == "0" ]]; then

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -807,8 +807,48 @@ if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
   # `gh pr list --head` and not `gh pr view "$CUR_BRANCH"`: `pr view` takes a number, a URL or a
   # branch and decides which by shape, so a branch named `42` would be answered with pull request
   # #42's state — a waiver granted on some other change's evidence. `--head` only ever means a branch.
-  if [[ "$(cd "$PROJECT_DIR" &&
-    bounded_gh pr list --head "$CUR_BRANCH" --state open --json number --jq 'length')" =~ ^[1-9] ]]; then
+  # `|| echo ""` is load-bearing: under `set -e` a bare assignment whose command substitution fails
+  # aborts the script with THAT status, so an unavailable `gh` turned this gate into exit 1 — a
+  # refusal nobody asked for, in place of the exit 2 the gate is supposed to give. The previous
+  # `if [[ $(...) ]]` form tolerated it because a condition does not trip `set -e`; hoisting it to an
+  # assignment removed that tolerance. Caught by hook-boundary-parity, which asserts the gate engages.
+  OPEN_PR=$(cd "$PROJECT_DIR" &&
+    bounded_gh pr list --head "$CUR_BRANCH" --state open --json number --jq '.[0].number // empty' || echo "")
+  # `^[1-9]` and not `^[0-9]`: a pull-request number is never 0, but a COUNT is — and this lookup
+  # previously asked for a count. Anything still answering the old question prints `0` for "none
+  # open", which `^[0-9]+$` would accept as pull request #0 and hand the exemption to a branch with
+  # no pull request at all. Caught by review-before-push, whose stub answers the old shape.
+  if [[ "$OPEN_PR" =~ ^[1-9][0-9]*$ ]]; then
+    # The exemption above rests on a premise: that a push into an open PR is RESOLVING what its
+    # review reported. That premise is checkable, and when it is false the exemption is a hole.
+    #
+    # Measured (2026-08-16, #1789): a PR was opened on a half-finished unit, its review reported
+    # clean, the owner merged it five minutes later, and a follow-up commit was authored twenty-five
+    # minutes AFTER the merge. This hook waved that push through. `merge-gate.sh` refuses a merge
+    # whose review names a stale head — but only when the merge comes after the push. Here it came
+    # first, so nothing refused anything and half the work was left behind, costing a fresh branch, a
+    # cherry-pick and a second PR.
+    #
+    # So: a review reporting ZERO actionable findings leaves nothing to resolve, which makes any push
+    # into it new work by definition. Read the count the same way `merge-gate.sh` does — its parse is
+    # the owner of "what the reviewer said", and a second reading here would be a second answer.
+    # Unknown is NOT zero: if the count cannot be read, the original exemption stands, because a
+    # refusal on a failed measurement blocks correct work on no evidence.
+    LATEST_COUNT=$( (cd "$PROJECT_DIR" &&
+      bounded_gh pr view "$OPEN_PR" --json comments,reviews \
+        --jq '([.comments[]? | {body: (.body // ""), at: (.createdAt // "")}] + [.reviews[]? | {body: (.body // ""), at: (.submittedAt // "")}]) | map(select(.body | test("^ACTIONABLE FINDINGS: [0-9]+$"; "m"))) | sort_by(.at) | last // {} | .body // ""' 2>/dev/null) |
+      sed -nE 's/^ACTIONABLE FINDINGS: ([0-9]+)$/\1/p' | tail -1 || echo "")
+
+    if [[ "$LATEST_COUNT" == "0" ]]; then
+      echo "[pre-push-check] Blocked: PR #$OPEN_PR's latest review reports ACTIONABLE FINDINGS: 0," >&2
+      echo "[pre-push-check] so there is nothing for this push to resolve — it is new work on a PR" >&2
+      echo "[pre-push-check] that is already merge-ready, and a reviewer who passed it never saw it." >&2
+      echo "[pre-push-check] git-branch.md: an open PR's diff is frozen except to resolve a finding." >&2
+      echo "[pre-push-check] Let #$OPEN_PR land, then open a second PR for this work." >&2
+      echo "[pre-push-check] Deliberate exception: PRE_PUSH_ALLOW_UNREVIEWED=1 inline." >&2
+      exit 2
+    fi
+
     echo "[pre-push-check] Open pull request on '$CUR_BRANCH': its review automation owns the review" >&2
     echo "[pre-push-check] of this push. Resolve what that review reports; do not review it again." >&2
     exit 0

--- a/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
+++ b/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
@@ -1,0 +1,127 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+/**
+ * An open PR's diff is frozen except to resolve a finding (git-branch.md).
+ *
+ * The hook's open-PR exemption rests on a premise: that a push into an open pull request RESOLVES
+ * what its review reported. A review reporting zero findings leaves nothing to resolve, which makes
+ * the push new work landing on a pull request that is already merge-ready — reviewed by someone who
+ * never saw it. `merge-gate.sh` refuses a merge whose review names a stale head, but a merge that
+ * lands BEFORE the push has nothing to refuse.
+ *
+ * Each case runs the REAL hook against a SCRATCH repository with a stubbed `gh`, never the
+ * workspace: pointing it at the live tree made the verdict depend on whether that branch happened to
+ * have a review recorded, which is the environment answering instead of the case.
+ */
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/pre-push-check.sh');
+const BRANCH = 'feat/probe';
+const scratch = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A repository with one commit, a lockfile, and no recorded local review. */
+function scratchRepo() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'openpr-freeze-'));
+  scratch.push(dir);
+  const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('init', '--quiet', `--initial-branch=${BRANCH}`);
+  git('config', 'user.email', 'harness@example.test');
+  git('config', 'user.name', 'Harness');
+  writeFileSync(path.join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', 'chore: root');
+  return dir;
+}
+
+/**
+ * A `gh` answering the two questions this branch of the hook asks, in the shape real `gh` prints
+ * AFTER applying the `--jq` the hook passes: a bare pull-request number, and the body of the latest
+ * comment carrying the verdict marker. A stub answering its own preferred shape would keep passing
+ * while the hook stopped working.
+ */
+function stubGh({ prNumber, findings }) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'openpr-gh-'));
+  scratch.push(dir);
+  const body = findings === null ? '' : `ACTIONABLE FINDINGS: ${findings}`;
+  writeFileSync(
+    path.join(dir, 'gh'),
+    [
+      '#!/bin/bash',
+      'if [[ "$*" == *"comments,reviews"* ]]; then',
+      `  printf '%s\\n' ${JSON.stringify(body)}`,
+      '  exit 0',
+      'fi',
+      'for arg in "$@"; do',
+      `  if [ "$arg" = "--head" ]; then printf '%s\\n' '${prNumber}'; exit 0; fi`,
+      'done',
+      'printf "OPEN\\n"',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+  return dir;
+}
+
+function push({ findings, prNumber = 4242 }) {
+  const dir = scratchRepo();
+  const result = spawnSync('bash', [HOOK], {
+    input: JSON.stringify({
+      tool_name: 'Bash',
+      cwd: dir,
+      tool_input: { command: `git push -u origin ${BRANCH}` },
+    }),
+    encoding: 'utf8',
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: dir,
+      PATH: `${stubGh({ prNumber, findings })}${path.delimiter}${process.env.PATH}`,
+    },
+  });
+  return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
+
+describe('pre-push open-PR freeze — RED direction', () => {
+  it('refuses a push when the open PR’s latest review reports zero findings', () => {
+    const res = push({ findings: 0 });
+    expect(res.status).toBe(2);
+    expect(res.output).toMatch(/ACTIONABLE FINDINGS: 0/);
+    expect(res.output).toMatch(/nothing for this push to resolve/);
+  });
+
+  it('names the recovery, not only the refusal', () => {
+    const res = push({ findings: 0 });
+    expect(res.output).toMatch(/open a second PR/i);
+    expect(res.output).toMatch(/PRE_PUSH_ALLOW_UNREVIEWED=1/);
+  });
+});
+
+describe('pre-push open-PR freeze — GREEN direction', () => {
+  it('allows the push when findings remain, since that push is the resolution', () => {
+    const res = push({ findings: 2 });
+    expect(res.status).toBe(0);
+    expect(res.output).toMatch(/its review automation owns the review/);
+  });
+
+  it('allows the push when the count cannot be read — unknown is not zero', () => {
+    const res = push({ findings: null });
+    expect(res.status).toBe(0);
+    expect(res.output).toMatch(/its review automation owns the review/);
+  });
+
+  it('does not read a stale COUNT answer as a pull-request number', () => {
+    // The lookup once asked for a count; anything still answering that prints `0` for "none open",
+    // which read as a number would be pull request #0 — handing the exemption to a branch with none.
+    const res = push({ findings: 0, prNumber: 0 });
+    expect(res.status).toBe(2);
+    expect(res.output).not.toMatch(/nothing for this push to resolve/);
+  });
+});

--- a/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
+++ b/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
@@ -51,19 +51,49 @@ function scratchRepo() {
 function stubGh({ prNumber, findings, author = 'github-actions[bot]' }) {
   const dir = mkdtempSync(path.join(tmpdir(), 'openpr-gh-'));
   scratch.push(dir);
-  // The author filter is applied by `gh` server-side, from the comment's `author.login` — which lives
-  // in the DATA, not in the query string. So the stub decides it here, exactly as gh would: a marker
-  // from anyone other than the reviewer the hook trusts is simply not returned. A stub that echoed
-  // the body regardless of author would keep passing after the filter was removed from the hook.
-  const trusted = /^github-actions(\[bot\])?$/.test(author);
-  const body = findings === null || !trusted ? '' : `ACTIONABLE FINDINGS: ${findings}`;
+
+  // The payload real `gh` would have fetched, in the shape the hook's `--json comments,reviews` asks
+  // for. The stub does NOT pre-compute an answer from it: it runs the hook's OWN `--jq` expression
+  // over this with real jq, so the filter, the marker pattern and the `sort_by(.at)` ordering are all
+  // exercised as written in the hook.
+  //
+  // The earlier stub echoed a body it had decided in JS, which left the jq string untested — and a
+  // malformed jq is swallowed by the hook's `2>/dev/null`, yielding an empty count that reads as
+  // unknown and lets the push through. That is fail-open on exactly the scenario this gate exists to
+  // block, and the tests would have stayed green through it.
+  const payload = {
+    comments:
+      findings === null
+        ? []
+        : [
+            {
+              author: { login: 'someone-else' },
+              body: 'unrelated chatter',
+              createdAt: '2020-01-01T00:00:00Z',
+            },
+            {
+              author: { login: author },
+              body: `REVIEWED HEAD: ${'0'.repeat(40)}\nACTIONABLE FINDINGS: ${findings}`,
+              createdAt: '2020-01-02T00:00:00Z',
+            },
+          ],
+    reviews: [],
+  };
+  writeFileSync(path.join(dir, 'payload.json'), JSON.stringify(payload));
+
   writeFileSync(
     path.join(dir, 'gh'),
     [
       '#!/bin/bash',
+      "# Run the caller's own --jq over the fixture payload, the way gh does.",
       'if [[ "$*" == *"comments,reviews"* ]]; then',
-      `  printf '%s\\n' ${JSON.stringify(body)}`,
-      '  exit 0',
+      '  jqexpr=""',
+      '  while [ $# -gt 0 ]; do',
+      '    if [ "$1" = "--jq" ]; then jqexpr="$2"; fi',
+      '    shift',
+      '  done',
+      `  jq -r "$jqexpr" ${JSON.stringify(path.join(dir, 'payload.json'))}`,
+      '  exit $?',
       'fi',
       'for arg in "$@"; do',
       `  if [ "$arg" = "--head" ]; then printf '%s\\n' '${prNumber}'; exit 0; fi`,

--- a/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
+++ b/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
@@ -48,10 +48,15 @@ function scratchRepo() {
  * comment carrying the verdict marker. A stub answering its own preferred shape would keep passing
  * while the hook stopped working.
  */
-function stubGh({ prNumber, findings }) {
+function stubGh({ prNumber, findings, author = 'github-actions[bot]' }) {
   const dir = mkdtempSync(path.join(tmpdir(), 'openpr-gh-'));
   scratch.push(dir);
-  const body = findings === null ? '' : `ACTIONABLE FINDINGS: ${findings}`;
+  // The author filter is applied by `gh` server-side, from the comment's `author.login` — which lives
+  // in the DATA, not in the query string. So the stub decides it here, exactly as gh would: a marker
+  // from anyone other than the reviewer the hook trusts is simply not returned. A stub that echoed
+  // the body regardless of author would keep passing after the filter was removed from the hook.
+  const trusted = /^github-actions(\[bot\])?$/.test(author);
+  const body = findings === null || !trusted ? '' : `ACTIONABLE FINDINGS: ${findings}`;
   writeFileSync(
     path.join(dir, 'gh'),
     [
@@ -70,7 +75,7 @@ function stubGh({ prNumber, findings }) {
   return dir;
 }
 
-function push({ findings, prNumber = 4242 }) {
+function push({ findings, prNumber = 4242, author }) {
   const dir = scratchRepo();
   const result = spawnSync('bash', [HOOK], {
     input: JSON.stringify({
@@ -83,7 +88,7 @@ function push({ findings, prNumber = 4242 }) {
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: dir,
-      PATH: `${stubGh({ prNumber, findings })}${path.delimiter}${process.env.PATH}`,
+      PATH: `${stubGh({ prNumber, findings, author })}${path.delimiter}${process.env.PATH}`,
     },
   });
   return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
@@ -123,5 +128,16 @@ describe('pre-push open-PR freeze — GREEN direction', () => {
     const res = push({ findings: 0, prNumber: 0 });
     expect(res.status).toBe(2);
     expect(res.output).not.toMatch(/nothing for this push to resolve/);
+  });
+
+  it('does not let a non-reviewer spoof a blocking count', () => {
+    // The pair that proves the author filter. The SAME `0` blocks when the reviewer says it (the RED
+    // case above) and does not when anyone else does — because a non-reviewer's marker is filtered
+    // out, the count becomes unknown, and unknown is not zero. Without the filter this push would be
+    // refused on a stranger's say-so, and the mirror spoof (a fake non-zero count) would unfreeze a
+    // clean pull request. A gate whose input its own subject can write is not a gate.
+    const res = push({ findings: 0, author: 'some-contributor' });
+    expect(res.status).toBe(0);
+    expect(res.output).toMatch(/its review automation owns the review/);
   });
 });

--- a/scripts/harness/__tests__/review-before-push.test.mjs
+++ b/scripts/harness/__tests__/review-before-push.test.mjs
@@ -78,8 +78,10 @@ function push(dir, command = 'git push -u origin feat/probe', { openPrs = 0 } = 
 /**
  * A `gh` on PATH that answers the one question the hook asks it.
  *
- * `openPrs` is what `gh pr list --head <branch> --state open --json number --jq length` prints: how
- * many open pull requests that branch heads. `''` makes it exit non-zero instead — the
+ * `openPrs` is the number of open pull requests the branch heads. The hook asks
+ * `gh pr list --head <branch> --state open --json number --jq '.[0].number // empty'`, so the stub
+ * prints a pull-request NUMBER when there is one and nothing when there is none — the shape real
+ * `gh` prints after applying that jq. `''` makes it exit non-zero instead — the
  * unauthenticated / offline / no-such-repository case, which reaches the same refusal as `gh` being
  * absent altogether, because `command -v gh` and the lookup sit in one condition and either half
  * failing leaves the demand in place.
@@ -97,7 +99,9 @@ function stubGh(openPrs) {
       ? '#!/bin/bash\nexit 1\n'
       : `#!/bin/bash
 for arg in "$@"; do
-  if [ "$arg" = "--head" ]; then printf '%s\\n' ${JSON.stringify(String(openPrs))}; exit 0; fi
+  if [ "$arg" = "--head" ]; then ${
+    Number(openPrs) > 0 ? `printf '%s\\n' '4242'` : 'printf ""'
+  }; exit 0; fi
 done
 printf 'OPEN\\n'
 `;


### PR DESCRIPTION
Root cause of a process failure this session: a PR was opened on a half-finished unit, its review reported clean, it was merged five minutes later on that basis, and a follow-up commit was authored twenty-five minutes **after** the merge. Half the work was left behind and recovery cost a fresh branch, a cherry-pick and a second PR.

## Why nothing stopped it

**The rule had a gap.** The pre-merge review gate enumerates when a follow-up commit is *required* — to fix a reported finding — but never made that the **only** permitted reason to push into an open PR.

**The mechanism had a matching one.** `pre-push-check.sh`'s open-PR branch exited 0 **unconditionally**, on the premise that any push into an open PR resolves what its review reported:

> "Open pull request on '$CUR_BRANCH': its review automation owns the review of this push. Resolve what that review reports."

That premise is checkable, and it is false when the review reports **zero** findings — there is nothing to resolve, so the push is new work by definition. `merge-gate.sh` refuses a merge whose review names a stale head, but that ordering is not guaranteed: a merge landing first has nothing to refuse.

## The fix

**Rule** — `git-branch.md` gains the invariant: open a PR only when the unit is complete; once open, push only to resolve a reported finding.

**Mechanism** — the hook reads the latest review's `ACTIONABLE FINDINGS` count *the same way `merge-gate.sh` does* (one owner, not a second answer) and refuses when it is zero. **An unreadable count is not zero** — the exemption stands, because a refusal on a failed measurement blocks correct work on no evidence.

## Three defects in my own drafts, each caught by a test that already existed

1. **`set -e` tolerance lost.** Hoisting the lookup out of an `if [[ $(...) ]]` condition into a bare assignment meant an unavailable `gh` aborted the hook with **exit 1** — a refusal nobody asked for, in place of the exit 2 the gate owes. Caught by `hook-boundary-parity`.
2. **A changed question left a stale stub.** The lookup asked for a **count** and now asks for a **number** — and `0`, the count for "none open", matched `^[0-9]+$` and was read as **pull request #0**, handing the exemption to a branch with no PR at all. The hook now requires `^[1-9]`; the stub is updated; a fixture case pins it. Caught by `review-before-push`.
3. **My own fixture read the live repo**, so its verdict changed when this branch gained a review record — the environment answering instead of the case, which is precisely what the neighbouring test file warns against. Rewritten against a scratch repo.

## On the rule's wording

A first draft carried the incident that produced it — a date, a PR number, an elapsed time. `rule-case-narrative` refused it, and it is right: *a rule justified by an incident invites the reader to judge whether their situation resembles it, which is the discretion a rule exists to remove.* The incident lives in the hook comments and this PR instead.

## Verification

`verify-like-ci` **PASS 12/12** · 5 fixture cases (2 red, 3 green including the unknown-is-not-zero and stale-count cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177RGmffprxqf66ZLFKfjwD