### PR TITLE
feat(agent-core): decide the structured-output transport before the first call (CORE-043)

### DIFF
--- a/.agents/tasks/CORE-043-structured-output-capability-has-no-runtime-representation.md
+++ b/.agents/tasks/CORE-043-structured-output-capability-has-no-runtime-representation.md
@@ -1,6 +1,6 @@
 ---
 title: 'CORE-043: structured-output capability has no representation the runtime reads — agent-core emits `responseFormat` unconditionally, each provider silently maps or discards it, the seam cannot tell which, and the fact is a property of the instantiated PACKAGE rather than the endpoint and model actually called, so the documented gateway configuration reports enforcement it does not have'
-status: todo
+status: in-progress
 created: 2026-08-16
 priority: critical
 urgency: now
@@ -165,13 +165,97 @@ in one place rather than three.
 
 ## Test Plan
 
-To be written once the reserved decisions are settled. It must at minimum pin: a structured run
-against a provider without a native surface does not silently report early enforcement; the
-`'json_schema'` catalog flag is either read or removed; and the deepseek catalog no longer declares a
-capability its adapter does not implement.
+Delivered. The three minimum pins the item named, and where each is enforced:
+
+| Pin                                                                                                     | Where                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A structured run against a provider without a native surface does not silently report early enforcement | `packages/agent-core/src/services/__tests__/structured-output-transport.test.ts` — the `sent` / `schemaInPrompt` outcome, and the `structured_output_transport` event asserted end-to-end in Scenario 2 |
+| The `'json_schema'` catalog flag is either read or removed                                              | READ — `mechanismFor()` in `structured-output-transport.ts` is the only consumer, and `applyStructuredOutputTransport` acts on its answer                                                               |
+| The deepseek catalog no longer declares a capability its adapter does not implement                     | `packages/agent-provider-openai-compatible/src/deepseek/capability-table.ts` now declares `json_object`; asserted both ways in `deepseek/__tests__/model-capabilities.test.ts`                          |
+
+Plus, red-proved by reverting each behaviour in place and re-running:
+
+- reading an absent capability table as a denial (which would strip a working `json_schema` from
+  every provider without a verified table) — 1 test red
+- stating the schema only on the retry turn (the original defect) — 2 tests red
+
+Endpoint provenance is covered on the real provider classes:
+`agent-provider-openai/src/openai/__tests__/endpoint-provenance.test.ts` and
+`agent-provider-anthropic/src/anthropic/__tests__/capability-table.test.ts`.
 
 ## User Execution Test Scenarios
 
-To be authored when this item is picked up. Expected `agent-executable` and provider-free for the
-capability-representation half (observe what the SDK builds and what it reports about enforcement);
-the end-to-end half needs an OpenAI-compatible gateway endpoint the executor supplies.
+Both are `agent-executable` and provider-free — no API key, no network. The end-to-end gateway half
+is deliberately NOT claimed here: Scenario 2 proves the provider reports the gateway honestly, which
+is the part this repository owns; what an arbitrary gateway does with the parameter is not ours to
+assert.
+
+### Scenario 1 — a structured run against a provider with no schema parameter
+
+**Command:** `cd scratch && node ../node_modules/tsx/dist/cli.mjs --conditions=source src/core-043-s1.ts`
+
+Runs a real `Robota` agent with a provider declaring DeepSeek's actual capability (`json_object`).
+
+**Evidence:** EXIT:0
+
+```
+validated object: {"name":"Ada","age":36}
+provider calls made: 1
+attempt 1 responseFormat: {"type":"json_object"}
+attempt 1 system instructions: ["Respond with ONLY a JSON object (no prose, no code fences) matching this JSON schema:\n{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"description\":\"The person name\"},\"age\":{\"type\":\"number\",\"description\":\"Age in years\"}},\"required\":[\"name\",\"age\"],\"additionalProperties\":true}"]
+PASS the run resolved to a validated object
+PASS it took exactly ONE provider call — the wasted first attempt is gone
+PASS the wire option was downgraded to what this provider can honour ('json_object'), not the 'json_schema' it would have ignored
+PASS the schema was stated to the model on the FIRST attempt, not only on retry
+SCENARIO 1 PASS
+```
+
+### Scenario 2 — the transport report, and the advertised gateway configuration
+
+**Command:** `cd scratch && node ../node_modules/tsx/dist/cli.mjs --conditions=source src/core-043-s2.ts`
+
+Constructs the REAL `OpenAIProvider` (never called — no request is sent) and runs a real agent turn
+against a provider that declares nothing.
+
+**Evidence:** EXIT:0
+
+```
+openai direct  — endpointIsVendorDefault: true
+openai gateway — endpointIsVendorDefault: false
+openai gateway — declares a capability table: false
+transport report: {"executionId":"exec_1786898563479_cl3a0sfa3","conversationId":"conv_1786898563476_didbfv197","round":1,"provider":"fake-undeclared","model":"some-new-model","mechanism":"response_schema","provenance":"undeclared","sent":"json_schema","schemaInPrompt":false,"reason":"the provider declares no capability table, so the request is sent as asked — silence is not a denial"}
+PASS the vendor endpoint is reported as the vendor endpoint
+PASS a configured baseURL is reported as a gateway
+PASS it answers that WITHOUT declaring a capability table — so the signal never required inventing one
+PASS a structured turn now emits a transport report at all
+PASS the report says what the request DID (which transport carried the schema)
+PASS a provider that declares nothing is still sent the schema — silence is not a denial
+SCENARIO 2 PASS
+```
+
+## What this landing delivers, and what it does not
+
+Answering the four restated decisions:
+
+1. **Whether `agent-provider-openai` reports early enforcement when `baseURL` is set** — ANSWERED.
+   It no longer does. `IAIProvider.endpointIsVendorDefault?()` is a separate member from
+   `capabilityTable?()` precisely so this provider, which declares no table by choice, can still
+   report its endpoint without inventing capability claims. `provenance: 'unverified-endpoint'`
+   carries it to the caller.
+2. **Where capability and transport selection live** — ANSWERED. Capability is declared by the
+   provider package (PROV-006's vocabulary, now actually consumed); transport selection happens at
+   the seam that assembles the request, which is the only point holding both the resolved provider
+   and the outgoing messages. Not in `robotaRunStructured`, which has neither.
+3. **The SPEC's "providers without one ignore it" clause** — REWRITTEN, in both
+   `agent-core/docs/SPEC.md` and `agent-provider-openai-compatible/docs/SPEC.md`.
+4. **Whether a synthetic schema tool may be injected into a user's tool set under
+   `tool_choice: required`** — NOT DELIVERED HERE, and deliberately so. It is a behavioural design
+   question (name collision; the model picking a real tool instead), it was answerable only once (2)
+   existed, and it is now answerable. `TStructuredOutputMechanism` carries no `tool_strict` member
+   yet for the same reason: a union member nothing produces is a branch every consumer must handle
+   and no test can reach. Tracked as **CORE-048**.
+
+Also corrected along the way: `execution-round-provider.ts` used the caller's history array as the
+cache key; it now keys on what was actually sent. And the Anthropic 429→`RateLimitError` mapping
+existed character-for-character on both the streaming and non-streaming paths — extracted to
+`anthropic/errors.ts`, since two copies of a taxonomy decision is how PROV-004's drift starts.

--- a/.agents/tasks/CORE-048-forced-tool-call-as-a-structured-output-transport.md
+++ b/.agents/tasks/CORE-048-forced-tool-call-as-a-structured-output-transport.md
@@ -1,0 +1,55 @@
+---
+title: 'CORE-048: a forced tool call as a structured-output transport — whether a synthetic schema tool may be injected into a user tool set, now that a capability gate exists to decide when'
+status: todo
+created: 2026-08-17
+priority: medium
+urgency: next
+area: packages/agent-core, packages/agent-provider-openai, packages/agent-provider-anthropic
+depends_on: [CORE-043]
+---
+
+# CORE-048: forced-tool-call transport, now that something can decide when to use it
+
+CORE-038 proposed this and was judged `DEPTH: FOUNDATIONAL` — the transport may well be right, but it
+was stated one layer above its cause. [CORE-043](CORE-043-structured-output-capability-has-no-runtime-representation.md)
+built that layer: a `(provider, model)` pair now resolves to a `TStructuredOutputMechanism`, and the
+request is shaped to match at one seam. This is the remaining question, and it is now answerable.
+
+## The question
+
+For a model with **no schema parameter but working strict tool arguments**, a forced call to a
+synthetic tool whose parameters ARE the output schema is a real transport — strict tool arguments are
+enforced where `json_object` is not. CORE-043 left `'tool_strict'` out of the mechanism vocabulary on
+purpose: a union member nothing produces is a branch every consumer must handle and no test can reach.
+
+What has to be decided before it earns a member:
+
+1. **Name collision.** The synthetic tool goes into a tool set the user owns. `respond_with_schema`
+   is not reserved. A collision silently replaces the user's tool or is silently replaced by it.
+2. **The model picks a real tool instead.** Under `toolChoice: 'required'` the model may call one of
+   the user's own tools. CORE-017 already makes forcing directives apply to round 1 only, so this
+   interacts with an existing rule rather than being free to define.
+3. **Whether it beats what CORE-043 already ships.** The prompt statement now goes out on attempt
+   one, so the baseline this is measured against is no longer "guaranteed failure on attempt one".
+   The case has to be made against the improved baseline, not the original defect.
+4. **Which providers actually qualify.** `strictTools` exists on `agent-provider-openai` (PROV-007);
+   nothing else in the workspace has an equivalent. A transport with one implementation may not be
+   worth a vocabulary member.
+
+## Direction
+
+Answer (1)–(4) with a design, per `code-quality.md:50` — lead with the architecturally-correct shape
+and validate it, rather than posing a multiple-choice question before a design exists. If the answer
+is that the improved baseline is good enough, that is a legitimate outcome and this item closes with
+it recorded.
+
+## Test Plan
+
+To be written with the design. It must at minimum pin: a name collision with a user tool is detected
+rather than resolved silently, and a run whose model calls a real tool under the forced directive
+still terminates.
+
+## User Execution Test Scenarios
+
+To be authored when this item is picked up. Expected `agent-executable` and provider-free — the
+tool-set assembly and the collision check are both observable without a network call.

--- a/.changeset/core-043-structured-output-transport.md
+++ b/.changeset/core-043-structured-output-transport.md
@@ -1,0 +1,31 @@
+---
+'@robota-sdk/agent-provider-openai-compatible': patch
+'@robota-sdk/agent-provider-anthropic': patch
+'@robota-sdk/agent-provider-openai': patch
+'@robota-sdk/agent-session': patch
+'@robota-sdk/agent-core': patch
+---
+
+CORE-043: structured output now knows which transport can carry the schema before the first call
+
+`run(input, { output })` asked every provider for `responseFormat: { type: 'json_schema' }`. A
+provider whose surface cannot express that accepted the option and dropped it — and the schema was
+stated in words only by the RETRY feedback turn, which runs on attempt two. So against such a
+provider, attempt one carried nothing describing the required shape and could only succeed by luck:
+the advertised three attempts were really two, and the first was spent discovering something the
+capability table already knew.
+
+A `(provider, model)` pair now resolves to a mechanism (`response_schema` / `json_object` / `none`)
+and a provenance (`catalog` / `vendor-default` / `undeclared` / `unverified-endpoint`), and the
+request is shaped to match at the one seam that holds both the resolved provider and the outgoing
+messages. When the wire cannot carry the shape, the schema is stated in the prompt on the FIRST
+attempt. Each structured request emits a `structured_output_transport` event reporting what the
+request actually did.
+
+- `IAIProvider.endpointIsVendorDefault?()` — a provider configured with a custom `baseURL` reports
+  it, so the runtime stops claiming enforcement a gateway may not provide. Separate from
+  `capabilityTable?()` on purpose: `@robota-sdk/agent-provider-openai` declares no table (nobody has
+  verified one) and must still be able to answer.
+- DeepSeek's capability table declared `json_schema`; DeepSeek guarantees the response PARSES but
+  takes no schema parameter. Corrected to `json_object`.
+- A provider that declares nothing is still sent the request unchanged — silence is not a denial.

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -1015,6 +1015,10 @@ from the final `{ done: true, value }` iterator result).
   provider without a schema parameter no longer spends attempt one discovering the shape was never
   communicated. A provider that declares NO capability table is sent the request unchanged —
   silence is not a denial (PROV-006).
+- **`provider_request` reports the ASSEMBLED request (CORE-043)**: the event is emitted after the
+  capability guards have adjusted the request, not before, so its `messages` are the ones the model
+  actually received — including a schema instruction the transport seam added. Emitting the caller's
+  own conversation array would put a request in the session log that a replay could not reproduce.
 - **Transport report (CORE-043)**: each structured request emits a `structured_output_transport`
   execution event carrying the OUTCOME — `mechanism`, `provenance`, what was `sent`
   (`json_schema` / `json_object` / `omitted`), and whether the schema went into the prompt. It

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -186,6 +186,9 @@ their own price tables. Prices are USD per 1,000,000 tokens.
 | `closeObjectSchemas`                   | function | PROV-007: closes every object node in the universal subset for providers that reject open-world objects, optionally completing `required` for OpenAI strict mode. One recursion, shared |
 | `modelDeclaresCapability`              | function | PROV-006: whether a model declares a capability. `undefined` when the catalog has said nothing, which is NOT `false` — silence is not a denial                                          |
 | `resolveModelCapability`               | function | PROV-006: the same question with the caller's assumption for silence stated at the call site, so an unstated assumption cannot hide there                                               |
+| `IProviderStructuredOutputCapability`  | type     | CORE-043: which transport can carry a schema to a model (`mechanism`) and how sure that answer is (`provenance`) — two axes, because only the first changes the request                 |
+| `TStructuredOutputMechanism`           | type     | CORE-043: `response_schema` \| `json_object` \| `none` — WHICH transport carries the schema                                                                                             |
+| `TStructuredOutputProvenance`          | type     | CORE-043: `catalog` \| `vendor-default` \| `undeclared` \| `unverified-endpoint` — WHERE the mechanism answer came from                                                                 |
 
 <!-- The rows below live under `###` subheadings. `check-spec-public-surface.mjs` stops counting at the
      first non-"Public API" heading, so it reads none of them — which is why this package's undocumented
@@ -1001,11 +1004,30 @@ from the final `{ done: true, value }` iterator result).
   `Robota` class surface) or an explicit `IJsonSchemaOutput` wrapper carrying the universal
   JSON-schema subset (validated structurally by `validateAgainstJsonSchema`). Both normalize to
   `IStructuredOutputSpec` — one internal representation (SSOT).
-- **Provider mapping**: the schema is forwarded as `IChatOptions.responseFormat =
-{ type: 'json_schema', name, schema }`. Providers with a native structured-output surface map it
-  natively (OpenAI `response_format.json_schema`, Anthropic `output_config.format`, Gemini
-  `responseSchema` + JSON mime type); providers without one ignore it — the core-side enforcement
-  loop below is the universal contract either way.
+- **Transport selection (CORE-043)**: before the first model call, the turn asks the resolved
+  provider's capability table which transport can carry the schema for THIS model, and shapes the
+  request to match. `response_schema` → forwarded as `IChatOptions.responseFormat =
+{ type: 'json_schema', name, schema }` and mapped natively by the adapter (OpenAI
+  `response_format.json_schema`, Anthropic `output_config.format`, Gemini `responseSchema` + JSON
+  mime type). `json_object` (DeepSeek: JSON is guaranteed, the SHAPE is not) → downgraded to
+  `{ type: 'json_object' }`. `none` → the option is omitted rather than sent to be ignored.
+  In both non-native cases the schema is stated as a system instruction on the FIRST attempt, so a
+  provider without a schema parameter no longer spends attempt one discovering the shape was never
+  communicated. A provider that declares NO capability table is sent the request unchanged —
+  silence is not a denial (PROV-006).
+- **Transport report (CORE-043)**: each structured request emits a `structured_output_transport`
+  execution event carrying the OUTCOME — `mechanism`, `provenance`, what was `sent`
+  (`json_schema` / `json_object` / `omitted`), and whether the schema went into the prompt. It
+  reports what the request DID, not what a catalog says; `provenance: 'unverified-endpoint'` marks a
+  provider pointed at a custom `baseURL`, where the vendor's guarantees may not be the ones in force.
+- **Endpoint provenance is a separate answer from the capability table.** `IAIProvider` carries
+  `endpointIsVendorDefault?()` alongside `capabilityTable?()` rather than a field inside it, because
+  the two are independent facts: `@robota-sdk/agent-provider-openai` declares no table by choice
+  (nobody has verified one) and must still be able to report that it is behind a gateway. Folding the
+  endpoint into the table would force that provider to invent capability claims in order to answer,
+  and would make a gateway look like a model that lost a capability — a different claim, and a wrong
+  one. It matters most on OpenAI, where setting `baseURL` also switches the API surface to
+  `chat-completions`.
 - **Enforcement loop**: the final response text is parsed (`parseStructuredResponseText`, tolerant
   of one fenced json block) and validated core-side on every run. A violation triggers a retry
   turn whose input contains the validation issues plus the schema, bounded by `outputRetries`

--- a/packages/agent-core/src/interfaces/index.ts
+++ b/packages/agent-core/src/interfaces/index.ts
@@ -95,6 +95,13 @@ export {
 } from './model-capability.js';
 export type { IModelCapabilityDeviation, IProviderCapabilityTable } from './model-capability.js';
 
+// CORE-043: which transport can carry a schema to a given model, and how sure that answer is.
+export type {
+  IProviderStructuredOutputCapability,
+  TStructuredOutputMechanism,
+  TStructuredOutputProvenance,
+} from './structured-output-capability.js';
+
 export type {
   IMediaOutputRef,
   IProviderMediaError,

--- a/packages/agent-core/src/interfaces/provider-definition.ts
+++ b/packages/agent-core/src/interfaces/provider-definition.ts
@@ -64,7 +64,21 @@ export interface IProviderSetupHelpLink {
 export type TProviderModelCatalogStatus = 'live' | 'generated' | 'fallback' | 'unavailable';
 export type TProviderModelLifecycle = 'active' | 'preview' | 'deprecated' | 'unavailable';
 export type TProviderModelCapability =
-  'tools' | 'vision' | 'json_schema' | 'reasoning' | 'native_web' | 'streaming';
+  | 'tools'
+  | 'vision'
+  /** A first-class schema parameter the endpoint enforces. */
+  | 'json_schema'
+  /**
+   * JSON is guaranteed, the SHAPE is not (CORE-043).
+   *
+   * Without this DeepSeek is unrepresentable: the vocabulary offered only `json_schema`, which
+   * DeepSeek does not support, so its catalog entry was wrong and DELETING the entry would have left
+   * it wrong in the other direction — silent about a real capability.
+   */
+  | 'json_object'
+  | 'reasoning'
+  | 'native_web'
+  | 'streaming';
 
 export interface IProviderModelCatalogEntry {
   id: string;

--- a/packages/agent-core/src/interfaces/provider.ts
+++ b/packages/agent-core/src/interfaces/provider.ts
@@ -221,6 +221,21 @@ export interface IAIProvider {
   capabilityTable?(): IProviderCapabilityTable | undefined;
 
   /**
+   * Whether this provider instance is pointed at its vendor's own endpoint. CORE-043.
+   *
+   * A provider configured with a custom `baseURL` still speaks the vendor's protocol, but the
+   * vendor's guarantees are no longer the ones in force — a gateway can accept a structured-output
+   * parameter and forward a request that ignores it, so the runtime would claim enforcement the
+   * endpoint does not provide.
+   *
+   * Separate from `capabilityTable()` deliberately. Endpoint identity and capability declaration are
+   * independent facts, and coupling them would force a provider with no verified table to invent one
+   * in order to report its endpoint. Silence means the provider did not say, which is not a claim
+   * that the endpoint is the vendor's.
+   */
+  endpointIsVendorDefault?(): boolean;
+
+  /**
    * Optional generic hook for enabling provider-native hosted web behavior.
    */
   configureNativeWebTools?(request: IProviderNativeWebToolRequest): IProviderCapabilities;

--- a/packages/agent-core/src/interfaces/structured-output-capability.ts
+++ b/packages/agent-core/src/interfaces/structured-output-capability.ts
@@ -1,0 +1,52 @@
+/**
+ * How a (provider, model) pair can be asked for structured output, and how sure we are. CORE-043.
+ *
+ * The runtime had no way to know whether the attempt it was wrapping carried a schema at all. A
+ * provider whose surface cannot express `json_schema` accepted the request and ignored it, the
+ * retry loop saw prose, and the caller got "failed schema validation after 3 attempts" — three full
+ * model calls to discover something knowable before the first was sent.
+ *
+ * Two axes, not one. An earlier shape proposed a flat `'native' | 'none' | 'unknown'`, which kept the
+ * axis the runtime does not act on and discarded the one that decides what gets sent:
+ *
+ * - **mechanism** — WHICH transport carries the schema. This is what changes the request.
+ * - **provenance** — WHERE the answer came from, and therefore how much to trust it. `'unknown'` was
+ *   never a capability; it is unverified provenance, and separating the two lets a known mechanism
+ *   coexist with an endpoint that may not honour it.
+ *
+ * Both vocabularies list only what something in this repository actually produces. A member no
+ * resolver can emit is a branch consumers must handle and no test can reach.
+ */
+
+/** Which transport can carry a schema to this model. */
+export type TStructuredOutputMechanism =
+  /** A first-class schema parameter the endpoint enforces — Gemini `responseSchema`, OpenAI `json_schema`. */
+  | 'response_schema'
+  /** JSON is guaranteed, the SHAPE is not — DeepSeek. A schema must reach the model as prose. */
+  | 'json_object'
+  /** Nothing on the wire can carry it; the schema travels in the prompt and is validated afterwards. */
+  | 'none';
+
+/** Where the mechanism answer came from, and therefore how far to trust it. */
+export type TStructuredOutputProvenance =
+  /** The provider package declared this model's capabilities explicitly. */
+  | 'catalog'
+  /** The provider's vendor default applied — no model-specific declaration exists. */
+  | 'vendor-default'
+  /** The provider declares no capability table, so nothing is known about this model. */
+  | 'undeclared'
+  /**
+   * A `baseURL` points somewhere this package cannot identify, so the vendor's own guarantees do not
+   * necessarily hold — a gateway may accept the parameter and forward a request that ignores it.
+   *
+   * The mechanism is still reported: the request is still worth sending the declared way. What
+   * changes is that a schema violation downstream is explainable rather than surprising.
+   */
+  | 'unverified-endpoint';
+
+export interface IProviderStructuredOutputCapability {
+  mechanism: TStructuredOutputMechanism;
+  provenance: TStructuredOutputProvenance;
+  /** Why, in one clause, when the answer is not the obvious one. Carried into the outcome report. */
+  reason?: string;
+}

--- a/packages/agent-core/src/services/__tests__/provider-request-event.test.ts
+++ b/packages/agent-core/src/services/__tests__/provider-request-event.test.ts
@@ -1,0 +1,104 @@
+/**
+ * CORE-043: `provider_request` must describe the request that was actually sent.
+ *
+ * The event was emitted BEFORE the provider call, carrying the caller's `conversationMessages`. The
+ * structured-output transport guard adds a system instruction that array does not contain — so for a
+ * provider with no schema parameter, the session log recorded a request the model never received,
+ * and a replay driven from that log could not reproduce the turn.
+ *
+ * This drives a real `Robota` turn rather than calling the round helper directly, because the defect
+ * lives in the ORDER of two calls in `execution-round-streaming.ts`: emit, then assemble. A test that
+ * calls the assembler cannot see that ordering, which is exactly why the emit path had no guard.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { Robota } from '../../core/robota';
+
+import type { IProviderCapabilityTable } from '../../interfaces/model-capability';
+import type { TUniversalMessage } from '../../interfaces/messages';
+import type { IAIProvider, IChatOptions } from '../../interfaces/provider';
+
+/** A populated table that omits every schema capability — a genuine denial, so the prompt is used. */
+const NO_SCHEMA_TABLE: IProviderCapabilityTable = {
+  vendorDefault: ['tools', 'streaming'],
+  verifiedAt: '2026-01-01',
+};
+
+// Structurally typed rather than `implements IAIProvider`: the full contract carries raw-payload
+// members this scenario never reaches, and stubbing them would add noise that asserts nothing. The
+// agent reads the members used below.
+class NoSchemaProvider {
+  readonly name = 'no-schema';
+  readonly version = '1.0.0';
+  received: TUniversalMessage[] = [];
+
+  capabilityTable(): IProviderCapabilityTable {
+    return NO_SCHEMA_TABLE;
+  }
+
+  async chat(messages: TUniversalMessage[], _options: IChatOptions): Promise<TUniversalMessage> {
+    this.received = messages;
+    return {
+      id: 'a1',
+      role: 'assistant',
+      content: JSON.stringify({ ok: true }),
+      timestamp: new Date(),
+      state: 'complete',
+    };
+  }
+
+  async *chatStream(): AsyncGenerator<TUniversalMessage> {
+    throw new Error('unused');
+  }
+
+  supportsTools(): boolean {
+    return true;
+  }
+
+  validateConfig(): boolean {
+    return true;
+  }
+
+  async dispose(): Promise<void> {}
+}
+
+describe('CORE-043 — provider_request describes what was sent', () => {
+  it('carries the schema instruction the transport guard added', async () => {
+    const provider = new NoSchemaProvider();
+    const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+    const agent = new Robota({
+      name: 'provider-request-event',
+      aiProviders: [provider as unknown as IAIProvider],
+      defaultModel: { provider: 'no-schema', model: 'some-model' },
+    });
+
+    try {
+      await agent.run('anything', {
+        // A schema the provider cannot be handed as a parameter, so it must travel in the prompt.
+        output: {
+          name: 'Ok',
+          jsonSchema: {
+            type: 'object',
+            properties: { ok: { type: 'boolean' } },
+            required: ['ok'],
+          },
+        },
+        onExecutionEvent: (event, data) =>
+          events.push({ event, data: data as Record<string, unknown> }),
+      });
+
+      const request = events.find((entry) => entry.event === 'provider_request');
+      expect(request).toBeDefined();
+
+      const logged = request?.data['messages'] as TUniversalMessage[] | undefined;
+      // The assertion that goes red when the emit moves back ahead of the assembly: the logged
+      // messages ARE the ones the provider received, instruction included.
+      expect(logged).toEqual(provider.received);
+      expect(logged?.at(-1)?.role).toBe('system');
+      expect(String(logged?.at(-1)?.content)).toContain('matching this JSON schema');
+    } finally {
+      await agent.destroy();
+    }
+  });
+});

--- a/packages/agent-core/src/services/__tests__/provider-request-event.test.ts
+++ b/packages/agent-core/src/services/__tests__/provider-request-event.test.ts
@@ -48,8 +48,12 @@ class NoSchemaProvider {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async *chatStream(): AsyncGenerator<TUniversalMessage> {
-    throw new Error('unused');
+    // This scenario drives the non-streaming path; a generator that yields nothing is the honest
+    // stub, and reaching it would be a routing bug worth seeing rather than a silent no-op.
+    yield* [];
+    throw new Error('chatStream is not exercised by this scenario');
   }
 
   supportsTools(): boolean {

--- a/packages/agent-core/src/services/__tests__/structured-output-transport.test.ts
+++ b/packages/agent-core/src/services/__tests__/structured-output-transport.test.ts
@@ -195,3 +195,59 @@ describe('applyStructuredOutputTransport', () => {
     expect(plan.messages).toBe(HISTORY);
   });
 });
+
+describe('CORE-043 — the session log records the request that was actually sent', () => {
+  it('reports messages including the added instruction, not the caller history', async () => {
+    // `provider_request` used to be emitted BEFORE the transport guard ran, carrying
+    // `conversationMessages`. When the guard adds a system instruction, that log describes a request
+    // the model never received — and `agent-session/docs/SPEC.md` promises this event carries the
+    // request envelope, so a replay has to be able to reproduce it.
+    const { callProviderWithCache } = await import('../execution-round-provider');
+
+    const seen: Array<{ messages: TUniversalMessage[] }> = [];
+    const sentToProvider: TUniversalMessage[][] = [];
+    const resolved = {
+      provider: {
+        chat: async (messages: TUniversalMessage[]) => {
+          sentToProvider.push(messages);
+          return {
+            id: 'a1',
+            role: 'assistant',
+            content: '{}',
+            timestamp: new Date(),
+            state: 'complete',
+          } as TUniversalMessage;
+        },
+        capabilityTable: () => NO_SCHEMA_TABLE,
+      },
+      currentInfo: { provider: 'test' },
+      aiProviderInfo: {
+        providerName: 'test',
+        model: 'test-model',
+        temperature: undefined,
+        maxTokens: undefined,
+      },
+      toolsInfo: [],
+      availableTools: [],
+    } as unknown as IResolvedProviderInfo;
+
+    await callProviderWithCache(
+      HISTORY,
+      {
+        name: 'test',
+        defaultModel: { provider: 'test', model: 'test-model' },
+        responseFormat: { type: 'json_schema', name: 'Person', schema: { type: 'object' } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      resolved,
+      undefined,
+      undefined,
+      (request) => seen.push({ messages: request.messages }),
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.messages).toEqual(sentToProvider[0]);
+    expect(seen[0]?.messages.at(-1)?.role).toBe('system');
+    expect(seen[0]?.messages.length).toBe(HISTORY.length + 1);
+  });
+});

--- a/packages/agent-core/src/services/__tests__/structured-output-transport.test.ts
+++ b/packages/agent-core/src/services/__tests__/structured-output-transport.test.ts
@@ -1,0 +1,197 @@
+/**
+ * CORE-043: the transport decision, and what it does to an outgoing structured request.
+ *
+ * Each test names the wrong behaviour it would catch. A test that only restates the implementation
+ * cannot go red for the defect the item was filed about.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { applyStructuredOutputTransport } from '../execution-structured-output-guard';
+import { resolveStructuredOutputCapability } from '../structured-output-transport';
+
+import type { IResolvedProviderInfo } from '../execution-types';
+import type { IProviderCapabilityTable } from '../../interfaces/model-capability';
+import type { TUniversalMessage } from '../../interfaces/messages';
+import type { IChatOptions } from '../../interfaces/provider';
+
+const SCHEMA_TABLE: IProviderCapabilityTable = {
+  vendorDefault: ['tools', 'json_schema', 'streaming'],
+  verifiedAt: '2026-01-01',
+};
+
+const JSON_OBJECT_TABLE: IProviderCapabilityTable = {
+  vendorDefault: ['tools', 'json_object', 'streaming'],
+  deviations: {
+    'reasoner-x': { capabilities: ['reasoning', 'json_object'], verifiedAt: '2026-01-01' },
+  },
+  verifiedAt: '2026-01-01',
+};
+
+/** A populated list that omits every schema capability — a genuine denial, not silence. */
+const NO_SCHEMA_TABLE: IProviderCapabilityTable = {
+  vendorDefault: ['tools', 'streaming'],
+  verifiedAt: '2026-01-01',
+};
+
+function resolvedWith(table: IProviderCapabilityTable | undefined): IResolvedProviderInfo {
+  return {
+    provider: {
+      chat: async () => ({}) as TUniversalMessage,
+      capabilityTable: () => table,
+    },
+    currentInfo: { provider: 'test' },
+    aiProviderInfo: {
+      providerName: 'test',
+      model: 'test-model',
+      temperature: undefined,
+      maxTokens: undefined,
+    },
+    toolsInfo: [],
+    availableTools: [],
+  } as unknown as IResolvedProviderInfo;
+}
+
+function structuredOptions(): IChatOptions {
+  return {
+    model: 'test-model',
+    responseFormat: { type: 'json_schema', name: 'Person', schema: { type: 'object' } },
+  };
+}
+
+const HISTORY: TUniversalMessage[] = [
+  { role: 'user', content: 'hi', id: 'u1', timestamp: new Date(), state: 'complete' },
+];
+
+describe('resolveStructuredOutputCapability', () => {
+  it('reports a vendor default separately from a model-specific declaration', () => {
+    // Both resolve to the same mechanism, so a single-axis answer would make them indistinguishable
+    // — and "we checked this model" is a different amount of knowledge from "we checked the vendor".
+    expect(
+      resolveStructuredOutputCapability({ table: JSON_OBJECT_TABLE, model: 'chat-x' }),
+    ).toMatchObject({ mechanism: 'json_object', provenance: 'vendor-default' });
+    expect(
+      resolveStructuredOutputCapability({ table: JSON_OBJECT_TABLE, model: 'reasoner-x' }),
+    ).toMatchObject({ mechanism: 'json_object', provenance: 'catalog' });
+  });
+
+  it('does not read an absent table as a denial', () => {
+    // The regression this guards: resolving "we have no table" to `none` would strip a working
+    // json_schema from every provider that simply has no verified table yet — a gap in OUR records
+    // reported as a limitation of the vendor. PROV-006's miss policy forbids exactly this.
+    expect(resolveStructuredOutputCapability({ table: undefined, model: 'gpt-x' })).toMatchObject({
+      mechanism: 'response_schema',
+      provenance: 'undeclared',
+    });
+  });
+
+  it('does read a populated list that omits every schema capability as a denial', () => {
+    expect(
+      resolveStructuredOutputCapability({ table: NO_SCHEMA_TABLE, model: 'any' }),
+    ).toMatchObject({
+      mechanism: 'none',
+    });
+  });
+
+  it('keeps the mechanism but downgrades provenance behind a custom endpoint', () => {
+    // A gateway still speaks the vendor's protocol, so the request is still worth sending the
+    // declared way; what changes is that a violation downstream is explainable.
+    expect(
+      resolveStructuredOutputCapability({
+        table: SCHEMA_TABLE,
+        model: 'any',
+        endpointIsVendorDefault: false,
+      }),
+    ).toMatchObject({ mechanism: 'response_schema', provenance: 'unverified-endpoint' });
+  });
+
+  it('reports a gateway even when the provider declares no table at all', () => {
+    // The `@robota-sdk/agent-provider-openai` case, and the one decision (1) is about: it declares
+    // no table by choice, and `baseURL` there ALSO switches the API surface to chat-completions. If
+    // the endpoint signal were a field on the table, this provider could only report its endpoint by
+    // inventing capability claims nobody verified.
+    expect(
+      resolveStructuredOutputCapability({
+        table: undefined,
+        model: 'gpt-x',
+        endpointIsVendorDefault: false,
+      }),
+    ).toMatchObject({ mechanism: 'response_schema', provenance: 'unverified-endpoint' });
+  });
+});
+
+describe('applyStructuredOutputTransport', () => {
+  it('leaves a schema-capable request exactly as asked', () => {
+    const options = structuredOptions();
+    const plan = applyStructuredOutputTransport(
+      options,
+      HISTORY,
+      'test-model',
+      resolvedWith(SCHEMA_TABLE),
+    );
+    expect(options.responseFormat).toEqual({
+      type: 'json_schema',
+      name: 'Person',
+      schema: { type: 'object' },
+    });
+    expect(plan.messages).toBe(HISTORY);
+    expect(plan.outcome).toMatchObject({ sent: 'json_schema', schemaInPrompt: false });
+  });
+
+  it('states the schema on the FIRST attempt when the wire cannot carry it', () => {
+    // The defect: the schema was stated in words only by `buildRetryFeedbackInput`, which runs on
+    // attempt TWO. Against a provider with no schema parameter, attempt one carried nothing
+    // describing the shape and was guaranteed to fail — so "3 attempts" were really two.
+    const options = structuredOptions();
+    const plan = applyStructuredOutputTransport(
+      options,
+      HISTORY,
+      'test-model',
+      resolvedWith(JSON_OBJECT_TABLE),
+    );
+    expect(options.responseFormat).toEqual({ type: 'json_object' });
+    expect(plan.outcome).toMatchObject({ sent: 'json_object', schemaInPrompt: true });
+    const added = plan.messages.at(-1);
+    expect(added?.role).toBe('system');
+    expect(added?.content).toContain('matching this JSON schema');
+  });
+
+  it('omits a response-format option no declared transport can honour', () => {
+    const options = structuredOptions();
+    const plan = applyStructuredOutputTransport(
+      options,
+      HISTORY,
+      'test-model',
+      resolvedWith(NO_SCHEMA_TABLE),
+    );
+    expect(options.responseFormat).toBeUndefined();
+    expect(plan.outcome).toMatchObject({ sent: 'omitted', schemaInPrompt: true });
+  });
+
+  it('never appends the instruction to the caller history array', () => {
+    // Appending to `conversationMessages` would persist a per-request transport workaround into the
+    // conversation, repeating it on every following round of the same turn.
+    const before = HISTORY.length;
+    const plan = applyStructuredOutputTransport(
+      structuredOptions(),
+      HISTORY,
+      'test-model',
+      resolvedWith(NO_SCHEMA_TABLE),
+    );
+    expect(HISTORY).toHaveLength(before);
+    expect(plan.messages).not.toBe(HISTORY);
+    expect(plan.messages).toHaveLength(before + 1);
+  });
+
+  it('leaves a non-structured request untouched and reports nothing', () => {
+    const options: IChatOptions = { model: 'test-model' };
+    const plan = applyStructuredOutputTransport(
+      options,
+      HISTORY,
+      'test-model',
+      resolvedWith(NO_SCHEMA_TABLE),
+    );
+    expect(plan.outcome).toBeUndefined();
+    expect(plan.messages).toBe(HISTORY);
+  });
+});

--- a/packages/agent-core/src/services/execution-provider-call.ts
+++ b/packages/agent-core/src/services/execution-provider-call.ts
@@ -1,0 +1,114 @@
+/**
+ * One provider call, honouring the run's cancellation signal and the configured idle timeout.
+ *
+ * Split out of `execution-round-provider.ts`, which had grown two responsibilities: ASSEMBLING a
+ * request (what options, which transport, which tools this model may have) and MAKING one safely
+ * (abort propagation, idle detection, listener cleanup). They change for different reasons.
+ *
+ * Exported so every provider call in the execution turn goes through one implementation — CORE-042:
+ * the forced-summary call was the last one built by hand, and it silently had neither guard.
+ */
+
+import type { TUniversalMessage } from '../interfaces/messages';
+import type { IChatOptions } from '../interfaces/provider';
+
+type TProviderChat = (
+  messages: TUniversalMessage[],
+  options: IChatOptions,
+) => Promise<TUniversalMessage>;
+
+/**
+ * Call a provider honouring the run's cancellation signal and the configured idle timeout.
+ *
+ * Exported so that every provider call in the execution turn goes through one implementation --
+ * CORE-042: the forced-summary call was the last one built by hand, and it silently had neither.
+ */
+export async function callProviderWithIdleTimeout(
+  chat: TProviderChat,
+  messages: TUniversalMessage[],
+  options: IChatOptions,
+  timeoutMs: number | undefined,
+): Promise<TUniversalMessage> {
+  const normalizedTimeoutMs = normalizeTimeoutMs(timeoutMs);
+  const upstreamSignal = options.signal;
+  if (normalizedTimeoutMs === undefined && upstreamSignal === undefined) {
+    return chat(messages, options);
+  }
+  if (upstreamSignal?.aborted) {
+    throw createAbortError();
+  }
+
+  const controller = new AbortController();
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let settled = false;
+  let rejectGuard: ((reason: Error) => void) | undefined;
+
+  const clearIdleTimer = (): void => {
+    if (idleTimer !== undefined) {
+      clearTimeout(idleTimer);
+      idleTimer = undefined;
+    }
+  };
+
+  const failWith = (error: Error): void => {
+    if (settled) return;
+    settled = true;
+    rejectGuard?.(error);
+    controller.abort(error);
+  };
+
+  const resetIdleTimer = (): void => {
+    if (normalizedTimeoutMs === undefined || settled) return;
+    clearIdleTimer();
+    idleTimer = setTimeout(() => {
+      failWith(new Error(`Provider call idle timeout after ${normalizedTimeoutMs}ms`));
+    }, normalizedTimeoutMs);
+  };
+
+  const handleUpstreamAbort = (): void => {
+    failWith(createAbortError());
+  };
+  upstreamSignal?.addEventListener('abort', handleUpstreamAbort, { once: true });
+
+  const originalOnTextDelta = options.onTextDelta;
+  const guardedOptions: IChatOptions = {
+    ...options,
+    signal: controller.signal,
+    ...(originalOnTextDelta !== undefined
+      ? {
+          onTextDelta: (delta: string): void => {
+            resetIdleTimer();
+            originalOnTextDelta(delta);
+          },
+        }
+      : {}),
+  };
+
+  resetIdleTimer();
+
+  try {
+    return await Promise.race([
+      chat(messages, guardedOptions),
+      new Promise<never>((_, reject) => {
+        rejectGuard = reject;
+      }),
+    ]);
+  } finally {
+    settled = true;
+    clearIdleTimer();
+    upstreamSignal?.removeEventListener('abort', handleUpstreamAbort);
+  }
+}
+
+function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return undefined;
+  }
+  return timeoutMs;
+}
+
+function createAbortError(): Error {
+  const error = new Error('aborted');
+  error.name = 'AbortError';
+  return error;
+}

--- a/packages/agent-core/src/services/execution-round-provider.ts
+++ b/packages/agent-core/src/services/execution-round-provider.ts
@@ -5,8 +5,10 @@
 
 import { applyModelToolCapability } from './execution-model-capability-guards.js';
 import { assertToolChoiceValid, buildChatResponseFormat } from './execution-service-helpers';
+import { applyStructuredOutputTransport } from './execution-structured-output-guard.js';
 import { randomId } from '../utils/random-id.js';
 
+import type { IStructuredOutputTransportOutcome } from './execution-structured-output-guard';
 import type { IResolvedProviderInfo, IExecutionRoundState } from './execution-types';
 import type { IAgentConfig, IAssistantMessage } from '../interfaces/agent';
 import type { IToolCall, TUniversalMessage } from '../interfaces/messages';
@@ -34,6 +36,34 @@ export function computeRoundThinkingContext(
   return { thinkingNodeId, previousThinkingNodeId };
 }
 
+/** Assemble the wire options for one round, before any capability guard has adjusted them. */
+function buildRoundChatOptions(
+  model: string,
+  config: IAgentConfig,
+  resolved: IResolvedProviderInfo,
+  overrides: Partial<IChatOptions> | undefined,
+): IChatOptions {
+  const responseFormat = buildChatResponseFormat(config.responseFormat);
+  return {
+    model,
+    // Default the reasoning-effort dial to 'high' at the framework→provider seam so every
+    // model call carries an explicit effort (design §5.1 — neutral default 'high').
+    effort: config.defaultModel?.effort ?? 'high',
+    ...(config.defaultModel?.maxTokens !== undefined && {
+      maxTokens: config.defaultModel.maxTokens,
+    }),
+    ...(config.defaultModel?.temperature !== undefined && {
+      temperature: config.defaultModel.temperature,
+    }),
+    ...(config.defaultModel?.toolChoice !== undefined && {
+      toolChoice: config.defaultModel.toolChoice,
+    }),
+    ...(resolved.availableTools.length > 0 && { tools: resolved.availableTools }),
+    ...(responseFormat ? { responseFormat } : {}),
+    ...overrides,
+  };
+}
+
 /** Call the AI provider with optional cache lookup/store */
 export async function callProviderWithCache(
   conversationMessages: TUniversalMessage[],
@@ -41,6 +71,13 @@ export async function callProviderWithCache(
   resolved: IResolvedProviderInfo,
   cacheService?: ExecutionCacheService,
   overrides?: Partial<IChatOptions>,
+  /**
+   * CORE-043: where the structured-output outcome is reported. A callback rather than a field on
+   * `IResolvedProviderInfo`, because the report is about THIS request, not about the provider — the
+   * caller closes over the run's event emitter so the outcome travels the replay channel like every
+   * other observable step of the turn.
+   */
+  onStructuredOutputTransport?: (outcome: IStructuredOutputTransportOutcome) => void,
 ): Promise<TUniversalMessage> {
   if (!config.defaultModel?.model) {
     throw new Error('Model is required in defaultModel configuration. Please specify a model.');
@@ -49,35 +86,28 @@ export async function callProviderWithCache(
     throw new Error('Model must be a non-empty string in defaultModel configuration.');
   }
 
-  const chatOptions: IChatOptions = {
-    model: config.defaultModel.model,
-    // Default the reasoning-effort dial to 'high' at the framework→provider seam so every
-    // model call carries an explicit effort (design §5.1 — neutral default 'high').
-    effort: config.defaultModel.effort ?? 'high',
-    ...(config.defaultModel.maxTokens !== undefined && {
-      maxTokens: config.defaultModel.maxTokens,
-    }),
-    ...(config.defaultModel.temperature !== undefined && {
-      temperature: config.defaultModel.temperature,
-    }),
-    ...(config.defaultModel.toolChoice !== undefined && {
-      toolChoice: config.defaultModel.toolChoice,
-    }),
-    ...(resolved.availableTools.length > 0 && { tools: resolved.availableTools }),
-    ...(() => {
-      const responseFormat = buildChatResponseFormat(config.responseFormat);
-      return responseFormat ? { responseFormat } : {};
-    })(),
-    ...overrides,
-  };
+  const model = config.defaultModel.model;
+  const chatOptions = buildRoundChatOptions(model, config, resolved, overrides);
   assertToolChoiceValid(chatOptions.toolChoice, chatOptions.tools);
   // PROV-006: what this MODEL can be asked to do, as opposed to what its vendor can.
-  applyModelToolCapability(chatOptions, config.defaultModel.model, resolved);
+  applyModelToolCapability(chatOptions, model, resolved);
+  // CORE-043: which transport can carry the schema — decided before the call rather than discovered
+  // by spending the retry budget. `outgoing` may carry a prompt statement of the schema, so every
+  // use below (cache key included) reads it rather than the caller's history array.
+  const { messages: outgoing, outcome: structuredOutcome } = applyStructuredOutputTransport(
+    chatOptions,
+    conversationMessages,
+    model,
+    resolved,
+  );
+  if (structuredOutcome) {
+    onStructuredOutputTransport?.(structuredOutcome);
+  }
   const providerChat = resolved.provider.chat.bind(resolved.provider) as TProviderChat;
 
   if (cacheService) {
     const cachedResponse = cacheService.lookup(
-      conversationMessages,
+      outgoing,
       config.defaultModel.model,
       config.defaultModel.provider,
       { temperature: config.defaultModel.temperature, maxTokens: config.defaultModel.maxTokens },
@@ -93,13 +123,13 @@ export async function callProviderWithCache(
     }
     const response = await callProviderWithIdleTimeout(
       providerChat,
-      conversationMessages,
+      outgoing,
       chatOptions,
       config.timeout,
     );
     if (typeof response.content === 'string') {
       cacheService.store(
-        conversationMessages,
+        outgoing,
         config.defaultModel.model,
         config.defaultModel.provider,
         response.content,
@@ -109,12 +139,7 @@ export async function callProviderWithCache(
     return response;
   }
 
-  return callProviderWithIdleTimeout(
-    providerChat,
-    conversationMessages,
-    chatOptions,
-    config.timeout,
-  );
+  return callProviderWithIdleTimeout(providerChat, outgoing, chatOptions, config.timeout);
 }
 
 /**

--- a/packages/agent-core/src/services/execution-round-provider.ts
+++ b/packages/agent-core/src/services/execution-round-provider.ts
@@ -4,6 +4,7 @@
  */
 
 import { applyModelToolCapability } from './execution-model-capability-guards.js';
+import { callProviderWithIdleTimeout } from './execution-provider-call.js';
 import { assertToolChoiceValid, buildChatResponseFormat } from './execution-service-helpers';
 import { applyStructuredOutputTransport } from './execution-structured-output-guard.js';
 import { randomId } from '../utils/random-id.js';
@@ -20,6 +21,19 @@ type TProviderChat = (
   messages: TUniversalMessage[],
   options: IChatOptions,
 ) => Promise<TUniversalMessage>;
+
+/**
+ * A provider request as it will actually be sent — after every capability guard has adjusted it.
+ *
+ * `messages` is NOT necessarily the array the caller passed in: the structured-output guard adds a
+ * system instruction when the wire cannot carry the schema. Reporting the caller's array instead
+ * would put a `provider_request` in the session log that no replay could reproduce.
+ */
+export interface IAssembledProviderRequest {
+  messages: TUniversalMessage[];
+  options: IChatOptions;
+  structuredOutput?: IStructuredOutputTransportOutcome;
+}
 
 /** Compute thinking context IDs for event tracking */
 export function computeRoundThinkingContext(
@@ -72,12 +86,15 @@ export async function callProviderWithCache(
   cacheService?: ExecutionCacheService,
   overrides?: Partial<IChatOptions>,
   /**
-   * CORE-043: where the structured-output outcome is reported. A callback rather than a field on
-   * `IResolvedProviderInfo`, because the report is about THIS request, not about the provider — the
-   * caller closes over the run's event emitter so the outcome travels the replay channel like every
-   * other observable step of the turn.
+   * CORE-043: fires once, with the request as it will actually be sent.
+   *
+   * A callback rather than a field on `IResolvedProviderInfo`, because this describes THIS request,
+   * not the provider. The caller closes over the run's event emitter, so the replay channel records
+   * the assembled request rather than the inputs it was assembled from — the transport guard can add
+   * a system instruction the caller's own array does not contain, and a log of the array the caller
+   * passed in would not reconstruct what the model was actually asked.
    */
-  onStructuredOutputTransport?: (outcome: IStructuredOutputTransportOutcome) => void,
+  onRequestAssembled?: (request: IAssembledProviderRequest) => void,
 ): Promise<TUniversalMessage> {
   if (!config.defaultModel?.model) {
     throw new Error('Model is required in defaultModel configuration. Please specify a model.');
@@ -100,9 +117,11 @@ export async function callProviderWithCache(
     model,
     resolved,
   );
-  if (structuredOutcome) {
-    onStructuredOutputTransport?.(structuredOutcome);
-  }
+  onRequestAssembled?.({
+    messages: outgoing,
+    options: chatOptions,
+    ...(structuredOutcome !== undefined && { structuredOutput: structuredOutcome }),
+  });
   const providerChat = resolved.provider.chat.bind(resolved.provider) as TProviderChat;
 
   if (cacheService) {
@@ -140,102 +159,6 @@ export async function callProviderWithCache(
   }
 
   return callProviderWithIdleTimeout(providerChat, outgoing, chatOptions, config.timeout);
-}
-
-/**
- * Call a provider honouring the run's cancellation signal and the configured idle timeout.
- *
- * Exported so that every provider call in the execution turn goes through one implementation --
- * CORE-042: the forced-summary call was the last one built by hand, and it silently had neither.
- */
-export async function callProviderWithIdleTimeout(
-  chat: TProviderChat,
-  messages: TUniversalMessage[],
-  options: IChatOptions,
-  timeoutMs: number | undefined,
-): Promise<TUniversalMessage> {
-  const normalizedTimeoutMs = normalizeTimeoutMs(timeoutMs);
-  const upstreamSignal = options.signal;
-  if (normalizedTimeoutMs === undefined && upstreamSignal === undefined) {
-    return chat(messages, options);
-  }
-  if (upstreamSignal?.aborted) {
-    throw createAbortError();
-  }
-
-  const controller = new AbortController();
-  let idleTimer: ReturnType<typeof setTimeout> | undefined;
-  let settled = false;
-  let rejectGuard: ((reason: Error) => void) | undefined;
-
-  const clearIdleTimer = (): void => {
-    if (idleTimer !== undefined) {
-      clearTimeout(idleTimer);
-      idleTimer = undefined;
-    }
-  };
-
-  const failWith = (error: Error): void => {
-    if (settled) return;
-    settled = true;
-    rejectGuard?.(error);
-    controller.abort(error);
-  };
-
-  const resetIdleTimer = (): void => {
-    if (normalizedTimeoutMs === undefined || settled) return;
-    clearIdleTimer();
-    idleTimer = setTimeout(() => {
-      failWith(new Error(`Provider call idle timeout after ${normalizedTimeoutMs}ms`));
-    }, normalizedTimeoutMs);
-  };
-
-  const handleUpstreamAbort = (): void => {
-    failWith(createAbortError());
-  };
-  upstreamSignal?.addEventListener('abort', handleUpstreamAbort, { once: true });
-
-  const originalOnTextDelta = options.onTextDelta;
-  const guardedOptions: IChatOptions = {
-    ...options,
-    signal: controller.signal,
-    ...(originalOnTextDelta !== undefined
-      ? {
-          onTextDelta: (delta: string): void => {
-            resetIdleTimer();
-            originalOnTextDelta(delta);
-          },
-        }
-      : {}),
-  };
-
-  resetIdleTimer();
-
-  try {
-    return await Promise.race([
-      chat(messages, guardedOptions),
-      new Promise<never>((_, reject) => {
-        rejectGuard = reject;
-      }),
-    ]);
-  } finally {
-    settled = true;
-    clearIdleTimer();
-    upstreamSignal?.removeEventListener('abort', handleUpstreamAbort);
-  }
-}
-
-function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
-  if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return undefined;
-  }
-  return timeoutMs;
-}
-
-function createAbortError(): Error {
-  const error = new Error('aborted');
-  error.name = 'AbortError';
-  return error;
 }
 
 /** Validate and normalize the provider response */
@@ -282,3 +205,7 @@ export function validateAndExtractResponse(
 
   return { assistantResponse, assistantToolCalls };
 }
+
+// Re-exported from its own module (see execution-provider-call.ts) so existing importers of this
+// file keep one import path for "make a provider call safely".
+export { callProviderWithIdleTimeout } from './execution-provider-call.js';

--- a/packages/agent-core/src/services/execution-round-streaming.ts
+++ b/packages/agent-core/src/services/execution-round-streaming.ts
@@ -68,15 +68,6 @@ export async function callRoundProviderWithEvents(
   onProviderFailure?: (error: unknown) => void,
 ): Promise<TUniversalMessage | null> {
   try {
-    fullContext.onExecutionEvent?.('provider_request', {
-      executionId,
-      conversationId: fullContext.conversationId,
-      round: currentRound,
-      provider: resolved.currentInfo.provider,
-      model: config.defaultModel.model,
-      messages: conversationMessages,
-      tools: resolved.availableTools,
-    } as TExecutionEventData);
     const response = await callProviderWithCache(
       conversationMessages,
       config,
@@ -99,25 +90,41 @@ export async function callRoundProviderWithEvents(
           return effectiveToolChoice !== undefined ? { toolChoice: effectiveToolChoice } : {};
         })(),
       },
-      // CORE-043: report which transport actually carried the schema. The OUTCOME, not the
-      // resolution — "the table declares json_schema" describes a catalog, while "the schema was
-      // sent as a parameter, so no prompt statement was needed" explains the result the caller is
-      // holding. Emitted on the replay channel so a session log can answer it after the fact.
-      (structured) => {
-        fullContext.onExecutionEvent?.('structured_output_transport', {
+      // Emitted from here, not before the call, so the replay channel records the request as
+      // ASSEMBLED. The structured-output guard can add a system instruction that
+      // `conversationMessages` does not contain, and a `provider_request` logging the caller's own
+      // array would describe a request that was never sent — `agent-session/docs/SPEC.md` promises
+      // this event carries the request envelope, and a replay has to be able to reproduce it.
+      (request) => {
+        fullContext.onExecutionEvent?.('provider_request', {
           executionId,
           conversationId: fullContext.conversationId,
           round: currentRound,
           provider: resolved.currentInfo.provider,
           model: config.defaultModel.model,
-          mechanism: structured.capability.mechanism,
-          provenance: structured.capability.provenance,
-          sent: structured.sent,
-          schemaInPrompt: structured.schemaInPrompt,
-          ...(structured.capability.reason !== undefined && {
-            reason: structured.capability.reason,
-          }),
+          messages: request.messages,
+          tools: resolved.availableTools,
         } as TExecutionEventData);
+        // CORE-043: which transport actually carried the schema. The OUTCOME, not the resolution —
+        // "the table declares json_schema" describes a catalog, while "the schema was sent as a
+        // parameter, so no prompt statement was needed" explains the result the caller is holding.
+        const structured = request.structuredOutput;
+        if (structured !== undefined) {
+          fullContext.onExecutionEvent?.('structured_output_transport', {
+            executionId,
+            conversationId: fullContext.conversationId,
+            round: currentRound,
+            provider: resolved.currentInfo.provider,
+            model: config.defaultModel.model,
+            mechanism: structured.capability.mechanism,
+            provenance: structured.capability.provenance,
+            sent: structured.sent,
+            schemaInPrompt: structured.schemaInPrompt,
+            ...(structured.capability.reason !== undefined && {
+              reason: structured.capability.reason,
+            }),
+          } as TExecutionEventData);
+        }
       },
     );
     // CORE-042: a provider that returned assembled text without streaming any of it still owes the

--- a/packages/agent-core/src/services/execution-round-streaming.ts
+++ b/packages/agent-core/src/services/execution-round-streaming.ts
@@ -99,6 +99,26 @@ export async function callRoundProviderWithEvents(
           return effectiveToolChoice !== undefined ? { toolChoice: effectiveToolChoice } : {};
         })(),
       },
+      // CORE-043: report which transport actually carried the schema. The OUTCOME, not the
+      // resolution — "the table declares json_schema" describes a catalog, while "the schema was
+      // sent as a parameter, so no prompt statement was needed" explains the result the caller is
+      // holding. Emitted on the replay channel so a session log can answer it after the fact.
+      (structured) => {
+        fullContext.onExecutionEvent?.('structured_output_transport', {
+          executionId,
+          conversationId: fullContext.conversationId,
+          round: currentRound,
+          provider: resolved.currentInfo.provider,
+          model: config.defaultModel.model,
+          mechanism: structured.capability.mechanism,
+          provenance: structured.capability.provenance,
+          sent: structured.sent,
+          schemaInPrompt: structured.schemaInPrompt,
+          ...(structured.capability.reason !== undefined && {
+            reason: structured.capability.reason,
+          }),
+        } as TExecutionEventData);
+      },
     );
     // CORE-042: a provider that returned assembled text without streaming any of it still owes the
     // caller its deltas — `IChatOptions.onTextDelta`'s contract is what such a provider is violating,

--- a/packages/agent-core/src/services/execution-structured-output-guard.ts
+++ b/packages/agent-core/src/services/execution-structured-output-guard.ts
@@ -1,0 +1,116 @@
+/**
+ * Making a structured request survive a provider that cannot carry the schema. CORE-043.
+ *
+ * Two defects, one seam. The turn asked every provider for `responseFormat: 'json_schema'`; a
+ * provider whose surface cannot express that accepted the option and dropped it. And the only place
+ * the schema was ever stated in words is `buildRetryFeedbackInput` — which runs on ATTEMPT TWO. So
+ * for a provider without a schema parameter, attempt one was sent with nothing describing the shape
+ * at all, and was therefore guaranteed to fail. The advertised "3 attempts" were really two, and the
+ * first was spent discovering something the capability table already knew.
+ *
+ * Both are fixed where the request is assembled, because that is the only point that holds the
+ * resolved provider AND the outgoing messages at once. `robotaRunStructured` holds neither: it
+ * composes a turn out of the public API and never learns which model will serve it.
+ */
+
+import { resolveStructuredOutputCapability } from './structured-output-transport.js';
+import { randomId } from '../utils/random-id.js';
+
+import type { IResolvedProviderInfo } from './execution-types';
+import type { ISystemMessage, TUniversalMessage } from '../interfaces/messages';
+import type { IChatOptions } from '../interfaces/provider';
+import type { IProviderStructuredOutputCapability } from '../interfaces/structured-output-capability';
+
+/**
+ * What actually happened to a structured request.
+ *
+ * Reports the OUTCOME, not the resolution. "This provider declares json_schema" is a fact about a
+ * table; "the schema was sent as a parameter and no prompt statement was needed" is a fact about the
+ * request that was made, and only the second one explains a result the caller is holding.
+ */
+export interface IStructuredOutputTransportOutcome {
+  capability: IProviderStructuredOutputCapability;
+  /** What was ultimately put on the wire — `'omitted'` when no response-format option was sent. */
+  sent: 'json_schema' | 'json_object' | 'omitted';
+  /** Whether the schema was stated in the prompt because the wire could not carry it. */
+  schemaInPrompt: boolean;
+}
+
+/** The aligned request: what to send, and the record of why it looks that way. */
+export interface IStructuredOutputTransportPlan {
+  /**
+   * The messages to send. A NEW array when an instruction was added — never the caller's own.
+   * `conversationMessages` is conversation history; appending a per-request instruction to it would
+   * persist a transport workaround into the conversation and repeat it every following round.
+   */
+  messages: TUniversalMessage[];
+  outcome: IStructuredOutputTransportOutcome | undefined;
+}
+
+/**
+ * State the schema in words, for a model that will not receive it as a parameter.
+ *
+ * Deliberately the same instruction the retry path already uses, rather than a second phrasing: a
+ * model that fails and retries should not be told the requirement in two different ways.
+ */
+function schemaInstruction(schema: Record<string, unknown>): string {
+  return [
+    'Respond with ONLY a JSON object (no prose, no code fences) matching this JSON schema:',
+    JSON.stringify(schema),
+  ].join('\n');
+}
+
+/**
+ * Align a structured request with what the provider can actually honour.
+ *
+ * Mutates `chatOptions` and appends to `messages` in place, matching `applyModelToolCapability`
+ * alongside it — the request is assembled once per turn, and a second assembly path is how the
+ * capability answers drifted apart before.
+ *
+ * Returns the outcome, or `undefined` when the request was not structured at all.
+ */
+export function applyStructuredOutputTransport(
+  chatOptions: IChatOptions,
+  messages: TUniversalMessage[],
+  model: string,
+  resolved: IResolvedProviderInfo,
+): IStructuredOutputTransportPlan {
+  const requested = chatOptions.responseFormat;
+  if (requested?.type !== 'json_schema') return { messages, outcome: undefined };
+
+  const capability = resolveStructuredOutputCapability({
+    table: resolved.provider.capabilityTable?.(),
+    model,
+    endpointIsVendorDefault: resolved.provider.endpointIsVendorDefault?.(),
+  });
+
+  if (capability.mechanism === 'response_schema') {
+    return { messages, outcome: { capability, sent: 'json_schema', schemaInPrompt: false } };
+  }
+
+  // The shape cannot ride on the wire, so it rides in the prompt — on the FIRST attempt, which is
+  // the attempt that previously had no statement of the requirement at all.
+  const instruction: ISystemMessage = {
+    role: 'system',
+    content: schemaInstruction(requested.schema),
+    id: randomId(),
+    timestamp: new Date(),
+    state: 'complete',
+  };
+  const outgoing = [...messages, instruction];
+
+  if (capability.mechanism === 'json_object') {
+    // Still worth sending: it does not enforce the shape, but it does remove the prose and the code
+    // fences that are the most common reason the parse step fails before validation is even reached.
+    chatOptions.responseFormat = { type: 'json_object' };
+    return {
+      messages: outgoing,
+      outcome: { capability, sent: 'json_object', schemaInPrompt: true },
+    };
+  }
+
+  // `'none'` and any undeclared provider: sending an option the endpoint ignores tells the caller
+  // nothing and risks a hard rejection from a strict gateway. Omit it and rely on the prompt.
+  delete chatOptions.responseFormat;
+  return { messages: outgoing, outcome: { capability, sent: 'omitted', schemaInPrompt: true } };
+}

--- a/packages/agent-core/src/services/execution-types.ts
+++ b/packages/agent-core/src/services/execution-types.ts
@@ -51,6 +51,12 @@ export interface IResolvedProviderInfo {
      * uses rather than depending on the whole provider interface.
      */
     capabilityTable?: () => IProviderCapabilityTable | undefined;
+    /**
+     * CORE-043: whether this provider is pointed at its vendor's own endpoint. Separate from the
+     * table on purpose — a provider with no verified capability table must still be able to say it
+     * is behind a gateway.
+     */
+    endpointIsVendorDefault?: () => boolean;
   };
   currentInfo: { provider: string };
   aiProviderInfo: {

--- a/packages/agent-core/src/services/structured-output-transport.ts
+++ b/packages/agent-core/src/services/structured-output-transport.ts
@@ -1,0 +1,118 @@
+/**
+ * Deciding — before the first model call — which transport can carry a schema. CORE-043.
+ *
+ * `robotaRunStructured` wrapped an ordinary run in a validate-and-retry loop and asked the provider
+ * for `responseFormat: 'json_schema'` unconditionally. A provider whose surface cannot express that
+ * accepted the option and ignored it, so the schema never reached the model; the loop then spent its
+ * full retry budget rediscovering that, and reported "failed schema validation after 3 attempts" —
+ * a description of the symptom, on a fact that was knowable before anything was sent.
+ *
+ * The decision lives HERE, at the seam that builds the wire option, rather than in
+ * `robotaRunStructured`. That function has no provider — it composes a run out of the public API and
+ * never sees which model will serve it, so a decision made there would have to guess at exactly the
+ * thing being decided. `buildChatResponseFormat` is the one place every structured request passes
+ * through with the resolved provider in hand.
+ */
+
+import { modelDeclaresCapability } from '../interfaces/model-capability.js';
+
+import type { IProviderCapabilityTable } from '../interfaces/model-capability.js';
+import type {
+  IProviderStructuredOutputCapability,
+  TStructuredOutputMechanism,
+} from '../interfaces/structured-output-capability.js';
+
+export interface IStructuredOutputResolutionInput {
+  /** The provider's own declaration, or `undefined` when it declares nothing. */
+  table: IProviderCapabilityTable | undefined;
+  /**
+   * Which model will serve the request. Required, not optional.
+   *
+   * Capability is a property of a (provider, model) pair — `deepseek-chat` and `deepseek-reasoner`
+   * differ — so an optional model argument would let a caller ask a question that has no answer and
+   * receive a confident one.
+   */
+  model: string;
+  /**
+   * Whether the provider is pointed at its vendor's own endpoint (CORE-043).
+   *
+   * Deliberately NOT a field on the capability table. Endpoint identity and capability declaration
+   * are independent facts: a provider that declines to declare a table — because it has no verified
+   * source for one — must still be able to say it is pointed at a gateway. Coupling them would force
+   * that provider to invent a table in order to report an endpoint, which is exactly the fabricated
+   * claim PROV-006 refused to make. `undefined` means the provider did not say.
+   */
+  endpointIsVendorDefault?: boolean | undefined;
+}
+
+/** Which transport the declared capabilities imply, most capable first. */
+function mechanismFor(
+  table: IProviderCapabilityTable | undefined,
+  model: string,
+): TStructuredOutputMechanism {
+  if (modelDeclaresCapability(table, model, 'json_schema') === true) {
+    return 'response_schema';
+  }
+  if (modelDeclaresCapability(table, model, 'json_object') === true) {
+    return 'json_object';
+  }
+  return 'none';
+}
+
+/**
+ * What this model can be asked for, and how confident that answer is.
+ *
+ * A model absent from a table's deviations resolves to the vendor default — that is the table's own
+ * miss policy (PROV-006), not a guess made here. What this function adds is the record of WHICH of
+ * those routes produced the answer, because a caller told "no schema transport" deserves to know
+ * whether that was declared for this model or inherited from a baseline.
+ */
+export function resolveStructuredOutputCapability(
+  input: IStructuredOutputResolutionInput,
+): IProviderStructuredOutputCapability {
+  const { table, model, endpointIsVendorDefault } = input;
+
+  if (!table) {
+    // Silence is not denial (PROV-006). A provider that declares nothing has said nothing, and
+    // resolving that to `'none'` would strip a working `json_schema` from every provider that simply
+    // has no verified table yet — reading a gap in our own records as a limitation of the vendor.
+    // The request goes out as asked; `provenance` is what carries the uncertainty.
+    if (endpointIsVendorDefault === false) {
+      return {
+        mechanism: 'response_schema',
+        provenance: 'unverified-endpoint',
+        reason:
+          'a custom baseURL is configured and the provider declares no capability table, so nothing here can claim the endpoint enforces the schema',
+      };
+    }
+    return {
+      mechanism: 'response_schema',
+      provenance: 'undeclared',
+      reason:
+        'the provider declares no capability table, so the request is sent as asked — silence is not a denial',
+    };
+  }
+
+  const mechanism = mechanismFor(table, model);
+  const declaredForThisModel = table.deviations?.[model] !== undefined;
+
+  if (endpointIsVendorDefault === false) {
+    return {
+      mechanism,
+      provenance: 'unverified-endpoint',
+      reason:
+        'a custom baseURL is configured, so the vendor capability table describes the protocol but not necessarily the endpoint serving it',
+    };
+  }
+
+  return {
+    mechanism,
+    provenance: declaredForThisModel ? 'catalog' : 'vendor-default',
+    ...(mechanism === 'none' && {
+      reason: `${model} declares no schema transport, so the schema travels in the prompt and is enforced by validation`,
+    }),
+    ...(mechanism === 'json_object' && {
+      reason: `${model} guarantees JSON but not its shape, so the schema travels in the prompt and is enforced by validation`,
+    }),
+  };
+}

--- a/packages/agent-provider-anthropic/src/anthropic/__tests__/capability-table.test.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/__tests__/capability-table.test.ts
@@ -1,0 +1,37 @@
+/**
+ * CORE-043: Anthropic's capability declaration and where it is actually pointed are separate answers.
+ *
+ * The table describes the vendor's models. `baseURL` describes the endpoint serving them. A gateway
+ * still speaks Anthropic's protocol, so the table remains the right description of the request — what
+ * changes is that nothing here can claim the far end enforces the schema it is handed.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ANTHROPIC_CAPABILITY_TABLE } from '../capability-table';
+import { AnthropicProvider } from '../provider';
+
+describe('CORE-043 — Anthropic endpoint provenance', () => {
+  it('reports the vendor endpoint when no baseURL is configured', () => {
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    expect(provider.endpointIsVendorDefault()).toBe(true);
+  });
+
+  it('reports a gateway when baseURL is configured', () => {
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://gateway.test/v1',
+    });
+    expect(provider.endpointIsVendorDefault()).toBe(false);
+  });
+
+  it('does not change the capability table itself behind a gateway', () => {
+    // The regression this guards: folding the endpoint into the table would make a gateway look like
+    // a model that lost a capability, which is a different claim and a wrong one.
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://gateway.test/v1',
+    });
+    expect(provider.capabilityTable()).toBe(ANTHROPIC_CAPABILITY_TABLE);
+  });
+});

--- a/packages/agent-provider-anthropic/src/anthropic/errors.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Mapping Anthropic's HTTP errors onto the shared error taxonomy.
+ *
+ * The 429 mapping existed twice — once on the non-streaming path and once on the streaming one —
+ * character for character. Two copies of a taxonomy decision is how the two paths end up classifying
+ * the same failure differently the first time one of them is edited; PROV-004 already records error
+ * taxonomy drifting across provider surfaces as a defect.
+ */
+
+import { RateLimitError } from '@robota-sdk/agent-core';
+
+const HTTP_TOO_MANY_REQUESTS = 429;
+
+/** The shape of an Anthropic SDK HTTP error, narrowed from `unknown`. */
+interface IAnthropicHttpError {
+  status?: number;
+  error?: { type?: string };
+  message?: string;
+}
+
+/**
+ * Re-throw an Anthropic SDK error, as a `RateLimitError` when that is what it is.
+ *
+ * Always throws — the return type says so, so a caller cannot fall through it by accident.
+ */
+export function rethrowAnthropicError(error: unknown): never {
+  // allow-fallback: re-throws the original after mapping 429 to RateLimitError
+  // allow-any: narrowing an unknown HTTP error shape from the Anthropic SDK
+  const anthropicError = error as IAnthropicHttpError;
+  if (
+    anthropicError.status === HTTP_TOO_MANY_REQUESTS ||
+    anthropicError.error?.type === 'rate_limit_error'
+  ) {
+    throw new RateLimitError(
+      anthropicError.message ?? 'Anthropic rate limit exceeded.',
+      undefined,
+      'anthropic',
+    );
+  }
+  throw error;
+}

--- a/packages/agent-provider-anthropic/src/anthropic/provider-capabilities.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/provider-capabilities.ts
@@ -7,7 +7,9 @@
  * boolean stand in for a per-model fact everywhere else.
  */
 
-import type { IProviderCapabilities } from '@robota-sdk/agent-core';
+import { ANTHROPIC_CAPABILITY_TABLE } from './capability-table';
+
+import type { IProviderCapabilities, IProviderCapabilityTable } from '@robota-sdk/agent-core';
 
 const CONFIGURE_HINT = 'Call configureNativeWebTools({ webSearch: true }) or set enableWebTools.';
 

--- a/packages/agent-provider-anthropic/src/anthropic/provider-capabilities.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/provider-capabilities.ts
@@ -7,9 +7,7 @@
  * boolean stand in for a per-model fact everywhere else.
  */
 
-import { ANTHROPIC_CAPABILITY_TABLE } from './capability-table';
-
-import type { IProviderCapabilities, IProviderCapabilityTable } from '@robota-sdk/agent-core';
+import type { IProviderCapabilities } from '@robota-sdk/agent-core';
 
 const CONFIGURE_HINT = 'Call configureNativeWebTools({ webSearch: true }) or set enableWebTools.';
 

--- a/packages/agent-provider-anthropic/src/anthropic/provider.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/provider.ts
@@ -1,15 +1,11 @@
 import { randomUUID } from 'node:crypto';
 
 import Anthropic from '@anthropic-ai/sdk';
-import {
-  AbstractAIProvider,
-  RateLimitError,
-  ConfigurationError,
-  ValidationError,
-} from '@robota-sdk/agent-core';
+import { AbstractAIProvider, ConfigurationError, ValidationError } from '@robota-sdk/agent-core';
 
 import { ANTHROPIC_CAPABILITY_TABLE } from './capability-table';
 import { resolveAnthropicMaxTokens } from './claude-models.js';
+import { rethrowAnthropicError } from './errors';
 import {
   convertToAnthropicFormat,
   convertToolsToAnthropicFormat,
@@ -17,7 +13,7 @@ import {
 } from './message-converter';
 import { buildOutputConfig } from './output-schema.js';
 import { anthropicProviderCapabilities } from './provider-capabilities';
-import { streamAndAssemble } from './streaming-handler';
+import { streamAndAssemble, toUniversalStreamChunks } from './streaming-handler';
 
 import type { IAnthropicProviderOptions } from './types';
 import type {
@@ -159,20 +155,7 @@ export class AnthropicProvider extends AbstractAIProvider {
         options?.onProviderNativeRawPayload,
       );
     } catch (error) {
-      // allow-fallback: re-throws original after mapping 429 to RateLimitError
-      const anthropicError = error as {
-        status?: number;
-        error?: { type?: string };
-        message?: string;
-      };
-      if (anthropicError.status === 429 || anthropicError.error?.type === 'rate_limit_error') {
-        throw new RateLimitError(
-          anthropicError.message ?? 'Anthropic rate limit exceeded.',
-          undefined,
-          'anthropic',
-        );
-      }
-      throw error;
+      rethrowAnthropicError(error);
     }
   }
 
@@ -242,20 +225,7 @@ export class AnthropicProvider extends AbstractAIProvider {
     try {
       stream = await this.client.messages.create(requestParams);
     } catch (streamError) {
-      // allow-fallback: re-throws original after mapping 429 to RateLimitError
-      const anthropicError = streamError as {
-        status?: number;
-        error?: { type?: string };
-        message?: string;
-      }; // allow-any: narrowing unknown HTTP error shape from Anthropic SDK
-      if (anthropicError.status === 429 || anthropicError.error?.type === 'rate_limit_error') {
-        throw new RateLimitError(
-          anthropicError.message ?? 'Anthropic rate limit exceeded.',
-          undefined,
-          'anthropic',
-        );
-      }
-      throw streamError;
+      rethrowAnthropicError(streamError);
     }
 
     let sequence = 0;
@@ -268,21 +238,18 @@ export class AnthropicProvider extends AbstractAIProvider {
         payload: chunk,
       });
       sequence++;
-      if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
-        yield {
-          id: randomUUID(),
-          role: 'assistant',
-          content: chunk.delta.text,
-          state: 'complete' as const,
-          timestamp: new Date(),
-        };
-      }
+      yield* toUniversalStreamChunks(chunk);
     }
   }
 
   /** What THIS vendor's models can do, per model (PROV-008). */
   capabilityTable(): IProviderCapabilityTable {
     return ANTHROPIC_CAPABILITY_TABLE;
+  }
+
+  /** CORE-043: a configured `baseURL` is a gateway, whose guarantees are not the vendor's. */
+  endpointIsVendorDefault(): boolean {
+    return this.options.baseURL === undefined;
   }
 
   override supportsTools(): boolean {

--- a/packages/agent-provider-anthropic/src/anthropic/streaming-handler.ts
+++ b/packages/agent-provider-anthropic/src/anthropic/streaming-handler.ts
@@ -204,3 +204,24 @@ async function* streamWithAbort(
     yield event;
   }
 }
+
+/**
+ * Turn one raw Anthropic stream event into the universal chunks it carries, forwarding the raw
+ * payload on the way past.
+ *
+ * Lives here rather than inline in the provider: shaping a vendor delta into a universal message is
+ * this module's job, and the provider class is orchestration.
+ */
+export function* toUniversalStreamChunks(
+  chunk: Anthropic.MessageStreamEvent,
+): Generator<TUniversalMessage> {
+  if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+    yield {
+      id: randomUUID(),
+      role: 'assistant',
+      content: chunk.delta.text,
+      state: 'complete' as const,
+      timestamp: new Date(),
+    };
+  }
+}

--- a/packages/agent-provider-openai-compatible/docs/SPEC.md
+++ b/packages/agent-provider-openai-compatible/docs/SPEC.md
@@ -77,27 +77,27 @@ dist/
     └── shared ...             # sub-path entry
 ```
 
-## Structured Output — not mapped here (CORE-043)
+## Structured Output — carried by the core transport seam (CORE-043)
 
-**`IChatOptions.responseFormat` is not read by any adapter in this package.** `deepseek`, `qwen` and
-`gemma` build their requests without it, so a `run(input, { output })` call against them carries
-**no schema signal on the first attempt at all** — not a native `response_format`, and not a prose
-instruction either. `spec.jsonSchema` reaches the model only through the retry-feedback turn that
-agent-core's enforcement loop sends _after_ a first attempt has already failed validation.
+**No adapter in this package reads `IChatOptions.responseFormat`.** `deepseek`, `qwen` and `gemma`
+build their requests without it. That used to mean a `run(input, { output })` call against them
+carried **no schema signal on the first attempt at all** — not a native `response_format`, and not a
+prose instruction either, because `spec.jsonSchema` reached the model only through the retry-feedback
+turn agent-core sends _after_ a first attempt has already failed. A structured run against this
+family cost at least one extra turn by construction, and `outputRetries: 0` could only succeed by
+luck.
 
-The consequence is worth stating plainly rather than leaving to be measured: a structured run against
-this family costs at least one extra turn by construction, and `outputRetries: 0` can only succeed by
-luck. agent-core's bounded validate-and-retry loop still guarantees the returned object matches the
-schema or throws — the guarantee holds; the cost is real.
+CORE-043 closed that at the seam that assembles the request, not per adapter. agent-core now asks
+this package's capability table which transport applies and, when no schema parameter exists, states
+the schema as a system instruction on the FIRST attempt. So the extra turn is gone without any
+adapter here gaining a `responseFormat` branch — the mapping belongs where the capability is known,
+and duplicating it into three request builders is how the two answers would drift apart.
 
-**This is a stated gap, not a design.** It is recorded here because a user currently has no way to
-learn it except by measuring: the SPEC's § Structured Output Contract says providers without a native
-surface "ignore it — the core-side enforcement loop is the universal contract either way", which is
-true of the guarantee and silent about the cost. The per-model catalog makes it worse:
-`src/deepseek/model-catalog.ts` declares `'json_schema'` on all three entries, a capability this
-package does not implement, and nothing reads that flag anyway (PROV-006).
+**The capability claims were also wrong, and are corrected.** `DEEPSEEK_CAPABILITY_TABLE` declared
+`'json_schema'`; DeepSeek's JSON Output guarantees the response PARSES but takes no schema parameter
+and enforces no shape. It now declares `'json_object'`, which agent-core maps to
+`responseFormat: { type: 'json_object' }` plus the prompt statement of the schema. `qwen` declares
+neither, so its structured requests omit the option entirely rather than sending one to be ignored.
 
-Fixing it — threading `responseFormat` through the shared request builder, and deciding where
-capability is represented so the runtime can tell a mapped provider from a discarding one — is
-**CORE-043** (issue #1750), whose load-bearing decisions are reserved for the project owner. PROV-004
-carries the same row. Until then, treat structured output on this family as retry-driven.
+agent-core's bounded validate-and-retry loop remains the guarantee: the returned object matches the
+schema or it throws.

--- a/packages/agent-provider-openai-compatible/src/deepseek/__tests__/model-capabilities.test.ts
+++ b/packages/agent-provider-openai-compatible/src/deepseek/__tests__/model-capabilities.test.ts
@@ -51,7 +51,11 @@ describe('PROV-006 — deepseek stops contradicting its own catalog', () => {
     // and silence is not denial — so the entry has to be populated for the omission to mean anything.
     const table = provider.capabilityTable();
     expect(modelDeclaresCapability(table, 'deepseek-reasoner', 'reasoning')).toBe(true);
-    expect(modelDeclaresCapability(table, 'deepseek-reasoner', 'json_schema')).toBe(true);
+    // CORE-043: `json_object`, not `json_schema`. DeepSeek guarantees the response PARSES; it takes
+    // no schema parameter and enforces no shape, and the old claim is why a structured turn sent an
+    // option the endpoint ignored.
+    expect(modelDeclaresCapability(table, 'deepseek-reasoner', 'json_object')).toBe(true);
+    expect(modelDeclaresCapability(table, 'deepseek-reasoner', 'json_schema')).toBe(false);
     expect(modelDeclaresCapability(table, 'deepseek-reasoner', 'streaming')).toBe(true);
   });
 });

--- a/packages/agent-provider-openai-compatible/src/deepseek/capability-table.ts
+++ b/packages/agent-provider-openai-compatible/src/deepseek/capability-table.ts
@@ -19,14 +19,20 @@ import {
 import type { IProviderCapabilityTable } from '@robota-sdk/agent-core';
 
 export const DEEPSEEK_CAPABILITY_TABLE: IProviderCapabilityTable = {
-  vendorDefault: ['tools', 'json_schema', 'streaming'],
+  /**
+   * `json_object`, not `json_schema` (CORE-043). DeepSeek's JSON Output guarantees the response
+   * PARSES; it takes no schema parameter and enforces no shape. The catalog this table was lifted
+   * from claimed `json_schema`, which is why a structured turn against DeepSeek sent a parameter the
+   * endpoint ignored and then spent its whole retry budget discovering the shape was never enforced.
+   */
+  vendorDefault: ['tools', 'json_object', 'streaming'],
   deviations: {
     /**
      * The reasoning model has no function calling. This single line is what
      * `supportsTools() === true` used to contradict, and what nothing could read.
      */
     'deepseek-reasoner': {
-      capabilities: ['reasoning', 'json_schema', 'streaming'],
+      capabilities: ['reasoning', 'json_object', 'streaming'],
       verifiedAt: DEEPSEEK_MODEL_LAST_VERIFIED_AT,
       sourceUrl: DEEPSEEK_MODEL_CATALOG_SOURCE_URL,
     },

--- a/packages/agent-provider-openai-compatible/src/deepseek/provider.ts
+++ b/packages/agent-provider-openai-compatible/src/deepseek/provider.ts
@@ -196,6 +196,16 @@ export class DeepSeekProvider extends AbstractAIProvider {
     return DEEPSEEK_CAPABILITY_TABLE;
   }
 
+  /**
+   * CORE-043: compared against the vendor default rather than merely checked for presence — passing
+   * DeepSeek's own URL explicitly is not a gateway, and reporting it as one would make the signal
+   * noise.
+   */
+  endpointIsVendorDefault(): boolean {
+    const configured = this.options.baseURL;
+    return configured === undefined || configured === DEFAULT_DEEPSEEK_PROVIDER_BASE_URL;
+  }
+
   override getCapabilities(): IProviderCapabilities {
     return DEEPSEEK_PROVIDER_CAPABILITIES;
   }

--- a/packages/agent-provider-openai/docs/SPEC.md
+++ b/packages/agent-provider-openai/docs/SPEC.md
@@ -99,3 +99,22 @@ provided". A handler that distinguishes an absent key from a null value will see
 Because the transformation is lossy it runs **only** when `strict` is actually being sent. With
 `strictTools` off or unset, `tool.parameters` is forwarded verbatim — OpenAI accepts the honest
 schema there, and rewriting it would change a contract for no reason.
+
+## Endpoint Provenance (CORE-043)
+
+This package declares **no** `capabilityTable()`. Nobody has verified a per-model capability table
+for OpenAI, and inventing one would be a fabricated claim — agent-core's miss policy already handles
+the silence correctly (a provider that declares nothing is sent a structured request unchanged;
+silence is not a denial).
+
+It does declare `endpointIsVendorDefault()`, which returns `false` whenever `baseURL` is configured.
+That is a separate member rather than a field on the capability table precisely so a provider with no
+table can still answer it.
+
+It matters more here than anywhere else in the workspace: setting `baseURL` also switches the API
+surface to `chat-completions` (`resolveApiSurface`), so the advertised gateway configuration is the
+one where whatever is on the far end is least likely to honour a structured-output parameter. Before
+CORE-043 the runtime reported early enforcement on it regardless. Now a structured request through a
+gateway is reported with `provenance: 'unverified-endpoint'` on the `structured_output_transport`
+execution event — the request is still sent the declared way, but nothing claims the endpoint
+enforced it.

--- a/packages/agent-provider-openai/src/openai/__tests__/endpoint-provenance.test.ts
+++ b/packages/agent-provider-openai/src/openai/__tests__/endpoint-provenance.test.ts
@@ -1,0 +1,44 @@
+/**
+ * CORE-043 decision (1): the advertised gateway configuration must not report enforcement it has not
+ * got.
+ *
+ * `llms.txt` and `types.ts` advertise `baseURL` for OpenAI-compatible gateways. Setting it also
+ * switches the API surface to `chat-completions` (`resolveApiSurface`), so it is precisely the
+ * configuration where whatever is on the far end is least likely to honour a structured-output
+ * parameter — and the runtime claimed early enforcement on it anyway.
+ *
+ * This provider declares no capability table by choice; nobody has verified one, and inventing one
+ * would be a fabricated claim. It can still answer this question, which is why the endpoint signal is
+ * a separate member rather than a field on the table.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { OpenAIProvider } from '../provider';
+
+import type { IAIProvider } from '@robota-sdk/agent-core';
+
+describe('CORE-043 — OpenAI endpoint provenance', () => {
+  it('reports the vendor endpoint when no baseURL is configured', () => {
+    const provider = new OpenAIProvider({ apiKey: 'test-key' });
+    expect(provider.endpointIsVendorDefault()).toBe(true);
+  });
+
+  it('reports a gateway when baseURL is configured', () => {
+    const provider = new OpenAIProvider({ apiKey: 'test-key', baseURL: 'https://gateway.test/v1' });
+    expect(provider.endpointIsVendorDefault()).toBe(false);
+  });
+
+  it('still declares no capability table, so the signal cannot depend on one', () => {
+    // If the endpoint signal had been a field on the table, this provider could only report its
+    // endpoint by first inventing capability claims nobody verified. Read through `IAIProvider`
+    // rather than the class: `capabilityTable` is optional on the contract, and the point is that
+    // this provider leaves it unimplemented while still answering the endpoint question.
+    const provider: IAIProvider = new OpenAIProvider({
+      apiKey: 'test-key',
+      baseURL: 'https://gateway.test/v1',
+    });
+    expect(provider.capabilityTable).toBeUndefined();
+    expect(provider.endpointIsVendorDefault?.()).toBe(false);
+  });
+});

--- a/packages/agent-provider-openai/src/openai/provider.ts
+++ b/packages/agent-provider-openai/src/openai/provider.ts
@@ -155,6 +155,19 @@ export class OpenAIProvider extends AbstractAIProvider {
     });
   }
 
+  /**
+   * CORE-043: this provider declares no capability table — nobody has verified one for OpenAI, and
+   * inventing one would be a fabricated claim. It can still answer THIS question honestly, which is
+   * why the endpoint signal is not a field on the table.
+   *
+   * It matters most here of all the providers: setting `baseURL` also switches the API surface to
+   * `chat-completions` (see `resolveApiSurface`), so the advertised gateway configuration is exactly
+   * the one where a structured request is least likely to be enforced by whatever is on the far end.
+   */
+  endpointIsVendorDefault(): boolean {
+    return this.options.baseURL === undefined;
+  }
+
   override supportsTools(): boolean {
     return true;
   }

--- a/packages/agent-session/src/session-log-events.ts
+++ b/packages/agent-session/src/session-log-events.ts
@@ -33,6 +33,13 @@ export const SESSION_LOG_EVENT = {
   providerStreamRawDelta: 'provider_stream_raw_delta',
   providerResponseRaw: 'provider_response_raw',
   providerResponseNormalized: 'provider_response_normalized',
+  /**
+   * CORE-043: which transport actually carried a structured-output schema on this request, and
+   * whether the schema had to be stated in the prompt instead. Diagnostic, not replay substrate — a
+   * replay answers a `provider_request` from its recorded response, and this line explains why that
+   * request looked the way it did.
+   */
+  structuredOutputTransport: 'structured_output_transport',
   assistantMessageCommitted: 'assistant_message_committed',
 
   // Tool replay substrate (keyed by executionId + toolCallId).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6002,6 +6002,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-darwin-x64@0.34.5:
@@ -6023,6 +6024,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-freebsd-wasm32@0.35.2:
@@ -6032,6 +6034,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@img/sharp-wasm32': 0.35.2
+    dev: true
     optional: true
 
   /@img/sharp-libvips-darwin-arm64@1.2.4:
@@ -6047,6 +6050,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-darwin-x64@1.2.4:
@@ -6062,6 +6066,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-arm64@1.2.4:
@@ -6077,6 +6082,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-arm@1.2.4:
@@ -6092,6 +6098,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-ppc64@1.2.4:
@@ -6107,6 +6114,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-riscv64@1.2.4:
@@ -6122,6 +6130,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-s390x@1.2.4:
@@ -6137,6 +6146,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-x64@1.2.4:
@@ -6152,6 +6162,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linuxmusl-arm64@1.2.4:
@@ -6167,6 +6178,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-libvips-linuxmusl-x64@1.2.4:
@@ -6182,6 +6194,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-linux-arm64@0.34.5:
@@ -6203,6 +6216,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linux-arm@0.34.5:
@@ -6224,6 +6238,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linux-ppc64@0.34.5:
@@ -6245,6 +6260,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-ppc64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linux-riscv64@0.34.5:
@@ -6266,6 +6282,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linux-s390x@0.34.5:
@@ -6287,6 +6304,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linux-x64@0.34.5:
@@ -6308,6 +6326,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linuxmusl-arm64@0.34.5:
@@ -6329,6 +6348,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-linuxmusl-x64@0.34.5:
@@ -6350,6 +6370,7 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+    dev: true
     optional: true
 
   /@img/sharp-wasm32@0.34.5:
@@ -6368,6 +6389,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@emnapi/runtime': 1.11.2
+    dev: true
     optional: true
 
   /@img/sharp-webcontainers-wasm32@0.35.2:
@@ -6377,6 +6399,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@img/sharp-wasm32': 0.35.2
+    dev: true
     optional: true
 
   /@img/sharp-win32-arm64@0.34.5:
@@ -6394,6 +6417,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-win32-ia32@0.34.5:
@@ -6411,6 +6435,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@img/sharp-win32-x64@0.34.5:
@@ -6428,6 +6453,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@inquirer/ansi@2.0.7:
@@ -12003,7 +12029,7 @@ packages:
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      sharp: 0.35.2
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -21264,6 +21290,7 @@ packages:
       '@img/sharp-win32-arm64': 0.35.2
       '@img/sharp-win32-ia32': 0.35.2
       '@img/sharp-win32-x64': 0.35.2
+    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3633,6 +3633,9 @@ importers:
       '@robota-sdk/agent-provider-defaults':
         specifier: workspace:*
         version: link:../packages/agent-provider-defaults
+      '@robota-sdk/agent-provider-openai':
+        specifier: workspace:*
+        version: link:../packages/agent-provider-openai
       '@robota-sdk/agent-remote-client':
         specifier: workspace:*
         version: link:../packages/agent-remote-client
@@ -5999,7 +6002,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-darwin-x64@0.34.5:
@@ -6021,7 +6023,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-freebsd-wasm32@0.35.2:
@@ -6031,7 +6032,6 @@ packages:
     requiresBuild: true
     dependencies:
       '@img/sharp-wasm32': 0.35.2
-    dev: true
     optional: true
 
   /@img/sharp-libvips-darwin-arm64@1.2.4:
@@ -6047,7 +6047,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-darwin-x64@1.2.4:
@@ -6063,7 +6062,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-arm64@1.2.4:
@@ -6079,7 +6077,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-arm@1.2.4:
@@ -6095,7 +6092,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-ppc64@1.2.4:
@@ -6111,7 +6107,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-riscv64@1.2.4:
@@ -6127,7 +6122,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-s390x@1.2.4:
@@ -6143,7 +6137,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linux-x64@1.2.4:
@@ -6159,7 +6152,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linuxmusl-arm64@1.2.4:
@@ -6175,7 +6167,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-libvips-linuxmusl-x64@1.2.4:
@@ -6191,7 +6182,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-linux-arm64@0.34.5:
@@ -6213,7 +6203,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linux-arm@0.34.5:
@@ -6235,7 +6224,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linux-ppc64@0.34.5:
@@ -6257,7 +6245,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-ppc64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linux-riscv64@0.34.5:
@@ -6279,7 +6266,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linux-s390x@0.34.5:
@@ -6301,7 +6287,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linux-x64@0.34.5:
@@ -6323,7 +6308,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linuxmusl-arm64@0.34.5:
@@ -6345,7 +6329,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-linuxmusl-x64@0.34.5:
@@ -6367,7 +6350,6 @@ packages:
     requiresBuild: true
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.1
-    dev: true
     optional: true
 
   /@img/sharp-wasm32@0.34.5:
@@ -6386,7 +6368,6 @@ packages:
     requiresBuild: true
     dependencies:
       '@emnapi/runtime': 1.11.2
-    dev: true
     optional: true
 
   /@img/sharp-webcontainers-wasm32@0.35.2:
@@ -6396,7 +6377,6 @@ packages:
     requiresBuild: true
     dependencies:
       '@img/sharp-wasm32': 0.35.2
-    dev: true
     optional: true
 
   /@img/sharp-win32-arm64@0.34.5:
@@ -6414,7 +6394,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-win32-ia32@0.34.5:
@@ -6432,7 +6411,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@img/sharp-win32-x64@0.34.5:
@@ -6450,7 +6428,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@inquirer/ansi@2.0.7:
@@ -12026,7 +12003,7 @@ packages:
       yargs-parser: 22.0.0
       zod: 4.4.3
     optionalDependencies:
-      sharp: 0.34.5
+      sharp: 0.35.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -21287,7 +21264,6 @@ packages:
       '@img/sharp-win32-arm64': 0.35.2
       '@img/sharp-win32-ia32': 0.35.2
       '@img/sharp-win32-x64': 0.35.2
-    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}

--- a/scratch/package.json
+++ b/scratch/package.json
@@ -11,6 +11,7 @@
     "@robota-sdk/agent-core": "workspace:*",
     "@robota-sdk/agent-framework": "workspace:*",
     "@robota-sdk/agent-provider-defaults": "workspace:*",
+    "@robota-sdk/agent-provider-openai": "workspace:*",
     "@robota-sdk/agent-remote-client": "workspace:*",
     "@robota-sdk/agent-session": "workspace:*",
     "@robota-sdk/agent-testing": "workspace:*",

--- a/scripts/harness/__tests__/staged-auto-fix.test.mjs
+++ b/scripts/harness/__tests__/staged-auto-fix.test.mjs
@@ -144,7 +144,12 @@ describe('INFRA-089 staged and full auto-fix contract', () => {
           '--config',
           path.join(WORKSPACE_ROOT, '.lintstagedrc.json'),
         ],
-        { cwd: fixtureRoot, encoding: 'utf8', stdio: 'pipe' },
+        // Spawn from the WORKSPACE, not the fixture. `pnpm` is version-pinned by the workspace's
+        // `packageManager` field, and corepack resolves that from the process CWD — so launching it
+        // from a bare temp directory picked up whatever pnpm happens to be installed globally and
+        // aborted on the version mismatch, failing this test for a reason that has nothing to do
+        // with what it asserts. The fixture is addressed by `--cwd`, which is what lint-staged reads.
+        { cwd: WORKSPACE_ROOT, encoding: 'utf8', stdio: 'pipe' },
       );
 
       expect(`${result.stdout}${result.stderr}`).not.toContain('FAILED');

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -41,7 +41,6 @@
   "packages/agent-plugin/src/execution-analytics/execution-analytics-plugin.ts": 329,
   "packages/agent-plugin/src/usage/usage-plugin.ts": 301,
   "packages/agent-plugin/src/webhook/webhook-plugin.ts": 302,
-  "packages/agent-provider-anthropic/src/anthropic/provider.ts": 302,
   "packages/agent-provider-openai-compatible/src/qwen/responses-parser.ts": 302,
   "packages/agent-session/src/session-run.ts": 323,
   "packages/agent-session/src/session.ts": 316,

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -41,7 +41,7 @@
   "packages/agent-plugin/src/execution-analytics/execution-analytics-plugin.ts": 329,
   "packages/agent-plugin/src/usage/usage-plugin.ts": 301,
   "packages/agent-plugin/src/webhook/webhook-plugin.ts": 302,
-  "packages/agent-provider-anthropic/src/anthropic/provider.ts": 331,
+  "packages/agent-provider-anthropic/src/anthropic/provider.ts": 302,
   "packages/agent-provider-openai-compatible/src/qwen/responses-parser.ts": 302,
   "packages/agent-session/src/session-run.ts": 323,
   "packages/agent-session/src/session.ts": 316,


### PR DESCRIPTION
Closes #1750.

## The defect

`run(input, { output })` asked every provider for `responseFormat: { type: 'json_schema' }`. A provider whose surface cannot express that accepted the option and dropped it — and the schema was stated in words only by the RETRY feedback turn, which runs on **attempt two**.

So against such a provider, attempt one carried nothing describing the required shape and could only succeed by luck. The advertised three attempts were really two, and the first was spent discovering something the capability table already knew. The caller got `response failed schema validation after 3 attempts` — a description of the symptom.

## The change

A `(provider, model)` pair now resolves to two independent axes:

- **mechanism** — `response_schema` | `json_object` | `none`. WHICH transport carries the schema. This is what changes the request.
- **provenance** — `catalog` | `vendor-default` | `undeclared` | `unverified-endpoint`. WHERE the answer came from, and therefore how far to trust it.

CORE-038 proposed a flat `native | none | unknown`, which keeps the axis the runtime does not act on and discards the one that decides what gets sent. `unknown` was never a capability; it is unverified provenance.

The decision happens at `callProviderWithCache` — the one seam holding both the resolved provider and the outgoing messages. Not `robotaRunStructured`, which has neither: it composes a turn out of the public API and never learns which model will serve it.

When the wire cannot carry the shape, the schema is stated as a system instruction on the **first** attempt, using the same wording the retry path already uses. Each structured request emits a `structured_output_transport` event reporting the **outcome** — what was sent, whether the schema went into the prompt — not the resolution.

## Answering the item's four reserved decisions

1. **Does `agent-provider-openai` report early enforcement when `baseURL` is set?** No longer. `IAIProvider.endpointIsVendorDefault?()` is a **separate member** from `capabilityTable?()`, because this provider declares no table by choice — nobody has verified one — and must still be able to report that it is behind a gateway. Folding the endpoint into the table would force it to invent capability claims in order to answer. It matters most here: setting `baseURL` also switches the API surface to `chat-completions`.
2. **Where capability and transport selection live.** Capability is declared by the provider package (PROV-006's vocabulary, now actually consumed); transport selection happens at the request-assembly seam.
3. **The SPEC's "providers without one ignore it" clause.** Rewritten in `agent-core` and `agent-provider-openai-compatible`.
4. **A synthetic schema tool under `tool_choice: required`.** **Not delivered here, deliberately.** It is a behavioural design question that was only answerable once (2) existed. `TStructuredOutputMechanism` carries no `tool_strict` member for the same reason: a union member nothing produces is a branch every consumer must handle and no test can reach. Filed as **CORE-048**.

## Corrections found along the way

- DeepSeek's capability table declared `json_schema`. DeepSeek guarantees the response PARSES but takes no schema parameter and enforces no shape — corrected to `json_object`.
- A provider that declares **nothing** is still sent the request unchanged. An early draft resolved that to `none`, which would have stripped a working `json_schema` from every provider without a verified table — reading a gap in our own records as a limitation of the vendor. Red-proved.
- The round cache keyed on the caller's history array rather than on what was actually sent.
- The Anthropic 429→`RateLimitError` mapping existed character-for-character on both the streaming and non-streaming paths. Extracted to `anthropic/errors.ts` — two copies of a taxonomy decision is how PROV-004's drift starts.
- `staged-auto-fix.test.mjs` spawned the workspace-pinned `pnpm` from a bare temp directory, so corepack resolved whatever pnpm is installed globally and aborted on the version mismatch. Pre-existing red on `develop` on any machine whose global pnpm differs from the pin.

## Verification

- 116 harness scans pass. Full build and typecheck clean.
- New tests red-proved by reverting each behaviour in place: the miss-policy inversion (1 red), the schema-only-on-retry defect (2 red).
- Both user-execution scenarios executed, evidence recorded in the task file. Provider-free — no API key, no network.
- Still red and unrelated: `dag-adapters-sqlite` (22) and `dag-worker` (1) fail on a missing `better-sqlite3` native binding — pre-existing, environmental, issue #1768, outside this change's file set.

## Lockfile note

`pnpm install` for the new scratch dependency also dropped `dev: true` from every `@img/sharp-*` entry and bumped sharp 0.34.5→0.35.2. The win32 binaries carry LGPL-3.0-or-later, outside the allowlist. The lockfile here is `develop`'s plus only the three lines the new dependency needs; `--frozen-lockfile` accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181TvbjHWtLp45qXk7Ma612