### PR TITLE
docs(harness): define issue and task boundaries

### DIFF
--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -15,6 +15,34 @@ gate passes_ by the [`backlog-gate-guard`](../../.claude/agents/backlog-gate-gua
 [`user-execution-scenario-author`](../../.claude/agents/user-execution-scenario-author.md) agent. This
 document states only what must hold, wherever those run.
 
+## GitHub Issue ↔ Task Boundary
+
+GitHub issues and Task files are complementary records, not duplicate work queues.
+
+- A **GitHub issue** captures externally trackable intent or a problem: user value, constraints, scope,
+  non-goals, discussion, and links. A parent issue may represent an initiative; a child issue represents
+  an independently discussable cause or outcome.
+- A **Task** records one executable unit of work: one problem cause, one recommendation gate, one
+  verification plan, and one completion decision. A Task may span several packages or files when they are
+  one coherent cause and one independently verifiable outcome.
+- A **spec-doc** is the plan paired with a Task. It records alternatives, the accepted design, completion
+  criteria, affected files, and the test plan. It is neither a GitHub issue nor a substitute for a Task.
+
+Convert issue contents by **cause and independent verification**, not by the number of deliverables,
+packages, files, or test suites named. Keep one issue and make several Tasks when the decomposition is
+only internal implementation sequencing. Create separate child issues when the causes need separate
+external discussion, priority, ownership, security review, or independently tracked disposition.
+
+When one parent issue produces several related Tasks, create a parent `AGREEMENT` Task and its paired
+spec-doc to own the shared boundary and child relationship. Do not create an `AGREEMENT` merely because
+the work touches several packages. When a feature and its authentication/security policy have different
+trust assumptions, failure policy, or verification, keep them as separate causes even if they use the
+same transport.
+
+Every Task converted from an issue must cite its source issue. Conversion does not authorize
+implementation; the issue remains open until the tracked work lands or receives an explicit terminal
+disposition. The `issue-to-backlog` skill owns the conversion procedure; this rule owns the boundary.
+
 ## Agent Decision Authority
 
 When a decision must be made during backlog work, the agent must first determine whether it falls

--- a/.agents/skills/backlog-writer/SKILL.md
+++ b/.agents/skills/backlog-writer/SKILL.md
@@ -6,11 +6,14 @@ invocable: true
 
 # Backlog Writer
 
-Content authoring guide for spec documents. This skill produces a correctly structured spec document file ready for GATE-WRITE. It does not run gates, judge gate outcomes, or make implementation decisions.
+Content authoring guide for spec documents. This skill produces a correctly structured spec document file
+paired with one Task and ready for GATE-WRITE. A spec-doc is the plan, not a GitHub issue or a replacement
+for the Task problem statement. It does not run gates, judge gate outcomes, or make implementation decisions.
 
 ## Rule Anchor
 
 - `.agents/rules/spec-workflow.md` > HARD GATE: No Immediate Implementation
+- `.agents/tasks/README.md` — Task/spec pairing and Task ownership
 - `backlog-pipeline` skill > State Machine
 
 ## When to Use

--- a/.agents/skills/issue-to-backlog/SKILL.md
+++ b/.agents/skills/issue-to-backlog/SKILL.md
@@ -3,15 +3,17 @@ name: issue-to-backlog
 description: Convert a filed GitHub issue into the backlog Task document(s) it actually is — deciding how many items its contents are, not assuming one. Use when a session picks up an issue to work on, before any code changes. The counterpart to find-to-issue, which files at a different time for a different reason.
 ---
 
-# Issue → Backlog
+# Issue → Task
 
-An issue is a capture. A Task is a unit of work. **They are not the same shape, and one issue is not
-automatically one Task.**
+A GitHub issue is an externally tracked capture of intent or a problem. A Task is an executable unit of
+work. **They are not the same shape, and one issue is not automatically one Task.**
 
 ## Rule Anchor
 
 - [`.agents/tasks/README.md`](../../tasks/README.md) — required frontmatter, Test Plan, scenarios,
   and the done gate.
+- [`backlog-execution.md`](../../rules/backlog-execution.md) — the policy SSOT for the Issue ↔ Task
+  boundary and one-Task/one-PR execution shape.
 - [finding-depth.md](../../rules/finding-depth.md) — owns "is this one item or several".
 - [user-request-gate](../user-request-gate/SKILL.md) — the conversion IS the gate step for the issue.
 
@@ -29,6 +31,26 @@ wrong unit of work, and nothing in the loop was responsible for noticing.
 **Read the issue for the groupings it already makes.** An author who wrote "both of these are the same
 root error" or "two skills, because they run at different times" has done part of this work for you.
 
+## Boundary decision
+
+Use this order:
+
+1. Keep the GitHub issue as the parent initiative when it states a broad outcome or coordinates several
+   causes. Do not implement directly from a broad parent issue.
+2. Create a child issue when a cause needs separate external discussion, priority, ownership, security
+   review, or terminal disposition.
+3. Create a Task when the cause can have one recommendation gate, one verification plan, and one
+   independent completion decision. A Task may cross package boundaries.
+4. Keep package adapters, protocol frames, tests, and CLI wiring in the same Task when they are only
+   implementation steps for that cause. Do not create one Task per package or deliverable.
+5. Split a Task only when the design reveals distinct causes or independently verifiable outcomes. If
+   several related Tasks share a cross-package boundary, add a parent `AGREEMENT` Task and paired
+   spec-doc; do not add another GitHub issue solely for internal sequencing.
+
+Security/authentication and feature behavior are separate Tasks when their trust assumptions, failure
+policy, or verification differ, even if they use the same transport. This is a cause split, not a package
+split.
+
 ## Procedure
 
 1. **Read the issue in full**, including its constraints — those become the Task's, not prose to
@@ -36,11 +58,14 @@ root error" or "two skills, because they run at different times" has done part o
 2. **Survey what already exists** before writing. A skill, rule or scan the issue asks for may be
    present under another name, or its subject may already be filed. Record what you find in the Task;
    the next session should not re-derive it.
-3. **Group by cause.** Say how many items the issue's contents are, and why. Dispatch
+3. **Classify the issue.** Decide whether it is a parent initiative, one child cause, or several causes.
+   Say how many Tasks the contents become and why. Dispatch
    `finding-depth-triager` if the grouping is not obvious.
-4. **Write the Task(s)** per the README schema. For several children, add a parent `AGREEMENT` Task
+4. **Write the Task(s)** per the README schema. Cite the source issue in every Task. For several
+   related children, add a parent `AGREEMENT` Task
    **and its paired spec-doc** — `task-archival` fails an AGREEMENT with no spec.
-5. **Cite the issue** in each Task, and record any finding the conversion itself produced.
+5. Record any finding the conversion itself produced; do not turn internal implementation steps into
+   new issues unless they meet the child-issue test above.
 6. **Verify**: `task-lifecycle.mjs classify` returns `open` for each, and `pnpm harness:scan` is green.
 
 ## Do not

--- a/.agents/skills/multi-backlog-initiative/SKILL.md
+++ b/.agents/skills/multi-backlog-initiative/SKILL.md
@@ -6,9 +6,11 @@ invocable: true
 
 # Multi-Backlog Initiative — pipeline only
 
-When one unit of intent needs several backlog items, they land on an **integration base branch** rather
-than one at a time on the shared integration branch. This skill owns that outer loop: establish the base,
-run each item through the per-item pipeline against it, and hand the assembled result to the user.
+When one unit of intent needs several Task items, they land on an **integration base branch** rather than
+one at a time on the shared integration branch. This skill operates on already-classified Tasks, not raw
+GitHub issues; use [issue-to-backlog](../issue-to-backlog/SKILL.md) first when the work starts from an
+issue. It owns that outer loop: establish the base, run each item through the per-item pipeline against
+it, and hand the assembled result to the user.
 
 It holds no branch policy and no gate definitions. Which branches may target which, when a merge needs
 approval, and what a work item must satisfy before it merges are owned by the rules below.

--- a/.agents/skills/task-tracking/SKILL.md
+++ b/.agents/skills/task-tracking/SKILL.md
@@ -9,12 +9,14 @@ description: Track work using task files in .agents/tasks/. Use when starting, p
 
 - [backlog-execution.md](../../rules/backlog-execution.md) — Completion Steps and Status Invariants
 - [`.agents/tasks/README.md`](../../tasks/README.md) — Task schema and lifecycle vocabulary
+- [issue-to-backlog](../issue-to-backlog/SKILL.md) — GitHub Issue → Task conversion and cause grouping
 
 ## Use This Skill When
 
 - Starting a new task or feature that involves multiple steps.
 - Resuming work from a previous session.
 - Completing a task and archiving the record.
+- Converting a GitHub issue into executable Task document(s).
 
 ## Directory Structure
 
@@ -27,76 +29,39 @@ description: Track work using task files in .agents/tasks/. Use when starting, p
 
 ## Task File Format
 
-```markdown
----
-title: '<ID>: <Task title>'
-status: todo | in-progress | blocked | done | wontfix | skipped | superseded
-created: YYYY-MM-DD
-completed: YYYY-MM-DD # terminal statuses only
-priority: high
-urgency: now
-area: <scope>
-depends_on: []
----
+Use the canonical schema in [`.agents/tasks/README.md`](../../tasks/README.md). Do not reproduce a
+second frontmatter or body template here. A Task converted from a GitHub issue must cite the issue URL.
 
-## Objective
-
-What this task aims to achieve (1-3 sentences).
-
-## Plan
-
-- [ ] Step 1
-- [ ] Step 2
-- [ ] Step 3
-
-## Progress
-
-### YYYY-MM-DD
-
-- Completed step 1
-- Started step 2
-
-## Decisions
-
-- Chose approach A over B because ...
-
-## Blockers
-
-- (none, or describe current blockers)
-
-## Result
-
-(Filled when completed — summary of what was done and any follow-up items.)
-```
+Before creating a Task, classify the source request by cause and independent verification. A single
+feature may remain one Task across several packages. If one issue contains several related causes, create
+a parent `AGREEMENT` Task and its paired spec-doc, then connect the child Tasks to it.
 
 ## Execution Steps
 
 ### Starting a Task
 
-1. Create `.agents/tasks/<task-name>.md` using the format above.
+1. If the work originated as a GitHub issue, run [issue-to-backlog](../issue-to-backlog/SKILL.md)
+   before creating Task files. Do not close the issue or start implementation during conversion.
+2. Create `.agents/tasks/<task-name>.md` using the canonical schema in `tasks/README.md`.
    - Use a descriptive kebab-case name: `agents-test-coverage`, `runtime-refactor`, `harness-cleanup`.
-   - Set status to `in-progress`.
-   - Write the objective and initial plan.
+   - Set the status required by the schema and cite the source issue when applicable.
+   - Write one cause, its independent completion outcome, and the initial plan.
 
-2. If the task requires a branch, follow the `branch-guard` skill.
+3. If the task requires a branch, follow the `branch-guard` skill.
 
 ### During a Task
 
-3. Update the Progress section with dated entries as milestones are reached.
-4. Update the Plan checklist — check off completed items, add new items as discovered.
-5. Record key decisions in the Decisions section.
-6. Note any blockers in the Blockers section.
+4. Update the Task's progress and decisions according to the canonical schema and execution rules.
 
 ### Completing a Task
 
-7. Set frontmatter status to the correct terminal value and add `completed: YYYY-MM-DD`.
-8. Fill the Result section with a summary and any follow-up items.
-9. Move the file to `completed/` with `git mv`:
+5. Set frontmatter status to the correct terminal value and add `completed: YYYY-MM-DD`.
+6. Move the file to `completed/` with `git mv`:
    ```bash
    git mv .agents/tasks/<task-name>.md .agents/tasks/completed/<task-name>.md
    ```
-10. Update every declaring AGREEMENT Task `## Children` row and paired spec `## Tasks` row.
-11. Commit the status, move, and parent projections **in the same commit as the work it tracks**.
+7. Update every declaring AGREEMENT Task `## Children` row and paired spec `## Tasks` row.
+8. Commit the status, move, and parent projections **in the same commit as the work it tracks**.
 
 ### Archival Timing (when exactly to move) — enforced
 
@@ -114,9 +79,9 @@ hook must consume it rather than implementing their own status regex.
 
 ### Resuming a Task
 
-12. Check `.agents/tasks/` for active task files.
-13. Read the task file to restore context.
-14. Continue from the last progress entry.
+9. Check `.agents/tasks/` for active Task files.
+10. Read the Task file to restore context.
+11. Continue from the last progress entry.
 
 ## Naming Convention
 
@@ -127,7 +92,9 @@ hook must consume it rather than implementing their own status regex.
 ## Stop Conditions
 
 - Do not create task files for trivial, single-step changes (e.g., fixing a typo).
-- Do not create multiple task files for the same work.
+- Do not create one Task per package, file, adapter, or test suite when they serve one cause.
+- Do not create a Task directly from a broad parent issue without first classifying its causes.
+- Do not create a new GitHub issue solely for internal implementation sequencing.
 - Do not leave completed tasks in the active directory.
 
 ## Checklist

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -25,6 +25,22 @@ with no direction chosen yet. And `backlog` was simultaneously a _lifecycle fold
   were moved OUT rather than merged. They are a retired artefact kind, not old Tasks, and keeping
   them inside this tree made two scans start judging them the moment the move happened.
 
+## GitHub Issue Relationship
+
+A GitHub issue is the externally tracked capture of intent or a problem. A Task is the executable unit
+that can pass its own recommendation, verification, and completion gates. One issue may produce one or
+several Tasks; one Task may span several packages when those changes solve one cause and have one
+independent completion outcome.
+
+Split by cause and independent verification, not by package, file, deliverable, or test count. Keep
+implementation-only decomposition inside the Task. Use separate child issues only when the causes need
+separate external discussion, priority, ownership, security review, or terminal disposition.
+
+When a Task is converted from a GitHub issue, cite the issue URL in its frontmatter or body. When one
+parent issue produces several related Tasks, the parent `AGREEMENT` Task and paired spec-doc own the
+shared boundary and child relationship; the `AGREEMENT` is complete only after every declared child is
+complete.
+
 ## Process
 
 1. Create a new `.md` file in this directory with the required frontmatter (see File Format below).


### PR DESCRIPTION
## Summary

- Define the boundary between GitHub Issues, Task files, and paired spec-docs.
- Require cause-based decomposition and independent verification rather than package/file-based splitting.
- Clarify parent/child issue handling, AGREEMENT Tasks, issue provenance, and internal implementation sequencing.
- Align task-tracking, backlog-writer, and multi-backlog-initiative with the canonical boundary.

## Validation

- `pnpm exec prettier --check` — passed
- `pnpm harness:verify-like-ci` — passed
  - 115 harness scans passed
  - full typecheck passed
  - affected verification passed
- User execution scenario: not applicable; this is a rule/skill/documentation-only change.

## Notes

- The PR targets `develop` per the repository's protected-branch flow.
- After this lands, promote `develop` to `main` through the required release-grade PR path.