### PR TITLE
chore(backlog): complete CORE-043 and scope its transport report to the core turn path

### DIFF
--- a/.agents/spec-docs/done/CORE-043-structured-output-capability-has-no-runtime-representation.md
+++ b/.agents/spec-docs/done/CORE-043-structured-output-capability-has-no-runtime-representation.md
@@ -1,12 +1,12 @@
 ---
-status: draft
+status: done
 type: DATA
 tags: [typescript, json-schema]
 ---
 
 # CORE-043: structured-output capability is not represented at runtime
 
-Design for Task [`.agents/tasks/CORE-043-structured-output-capability-has-no-runtime-representation.md`](../../tasks/CORE-043-structured-output-capability-has-no-runtime-representation.md)
+Design for Task [`.agents/tasks/completed/CORE-043-structured-output-capability-has-no-runtime-representation.md`](../../tasks/completed/CORE-043-structured-output-capability-has-no-runtime-representation.md)
 (issue [#1750](https://github.com/woojubb/robota/issues/1750)), the root item for CORE-038 / issue
 [#1738](https://github.com/woojubb/robota/issues/1738).
 
@@ -1229,6 +1229,23 @@ actually changes, not whether the number went up or down.
 - **TC-08** PROV-006 is closed: all six `TProviderModelCapability` flags resolve through the step-1
   seam, and the deepseek `supportsTools()`-vs-catalog contradiction is gone as a consequence rather
   than as a separate fix.
+
+## User Execution Test Scenarios
+
+Both scenarios are `agent-executable` and provider-free — no API key, no network, no live credential.
+They were authored before implementation and executed against the landed change; the full observed
+output is recorded as the gate evidence in
+[the Task](../../tasks/completed/CORE-043-structured-output-capability-has-no-runtime-representation.md#user-execution-test-scenarios),
+which is the SSOT for the evidence and is not duplicated here.
+
+| #   | Command                                                                                      | Expected observable result                                                                                                                                                                                                                           | Outcome |
+| --- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| 1   | `cd scratch && node ../node_modules/tsx/dist/cli.mjs --conditions=source src/core-043-s1.ts` | A structured `run` against a provider whose capability is `json_object` resolves in ONE provider call, the wire option is downgraded from `json_schema`, and the schema is stated to the model on attempt one.                                       | PASS    |
+| 2   | `cd scratch && node ../node_modules/tsx/dist/cli.mjs --conditions=source src/core-043-s2.ts` | The real `OpenAIProvider` reports `endpointIsVendorDefault()` as `false` behind a configured `baseURL` while declaring no capability table, and a structured turn emits a `structured_output_transport` event naming what the request actually sent. | PASS    |
+
+The end-to-end gateway half is deliberately not claimed: scenario 2 proves the provider reports the
+gateway honestly, which is the part this repository owns. What an arbitrary gateway does with the
+parameter is not ours to assert.
 
 ## Evidence Log
 

--- a/.agents/tasks/CORE-048-forced-tool-call-as-a-structured-output-transport.md
+++ b/.agents/tasks/CORE-048-forced-tool-call-as-a-structured-output-transport.md
@@ -11,7 +11,7 @@ depends_on: [CORE-043]
 # CORE-048: forced-tool-call transport, now that something can decide when to use it
 
 CORE-038 proposed this and was judged `DEPTH: FOUNDATIONAL` — the transport may well be right, but it
-was stated one layer above its cause. [CORE-043](CORE-043-structured-output-capability-has-no-runtime-representation.md)
+was stated one layer above its cause. [CORE-043](completed/CORE-043-structured-output-capability-has-no-runtime-representation.md)
 built that layer: a `(provider, model)` pair now resolves to a `TStructuredOutputMechanism`, and the
 request is shaped to match at one seam. This is the remaining question, and it is now answerable.
 

--- a/.agents/tasks/completed/CORE-043-structured-output-capability-has-no-runtime-representation.md
+++ b/.agents/tasks/completed/CORE-043-structured-output-capability-has-no-runtime-representation.md
@@ -1,7 +1,8 @@
 ---
 title: 'CORE-043: structured-output capability has no representation the runtime reads — agent-core emits `responseFormat` unconditionally, each provider silently maps or discards it, the seam cannot tell which, and the fact is a property of the instantiated PACKAGE rather than the endpoint and model actually called, so the documented gateway configuration reports enforcement it does not have'
-status: in-progress
+status: done
 created: 2026-08-16
+completed: 2026-08-17
 priority: critical
 urgency: now
 area: packages/agent-core, packages/agent-provider-openai, packages/agent-provider-anthropic, packages/agent-provider-openai-compatible, packages/agent-provider-gemini, packages/agent-provider-replay, packages/agent-session
@@ -10,8 +11,8 @@ depends_on: [PROV-007, PROV-006, PROV-008]
 
 # CORE-043: structured-output capability is not represented at runtime
 
-Root item filed under [finding-depth.md](../rules/finding-depth.md) for the `DEPTH: FOUNDATIONAL`
-verdict on [CORE-038](completed/CORE-038-forced-tool-call-as-structured-output-fallback-transport.md)
+Root item filed under [finding-depth.md](../../rules/finding-depth.md) for the `DEPTH: FOUNDATIONAL`
+verdict on [CORE-038](CORE-038-forced-tool-call-as-structured-output-fallback-transport.md)
 (2026-08-16). Registered as [issue #1750](https://github.com/woojubb/robota/issues/1750); the
 proposal it was raised from is [issue #1738](https://github.com/woojubb/robota/issues/1738).
 CORE-038 proposed a transport (forced tool call instead of a prose re-prompt); the
@@ -119,7 +120,7 @@ published-contract change, semver/changeset gate."
 > `3.0.0-beta.79`. There has never been a stable release, so no consumer holds a compatibility claim
 > against any of these surfaces.
 >
-> [code-quality.md](../rules/code-quality.md) already says so twice as an owner directive: cost,
+> [code-quality.md](../../rules/code-quality.md) already says so twice as an owner directive: cost,
 > scale and churn "are NOT reasons to prefer a lesser design ... **(unreleased — no backward-compat
 > constraint)**" (`:50`), and "**Legacy is disposable in service of the correct structure** ...
 > Pre-release, existing files, rules, packages, or names are not preserved for their own sake"
@@ -259,3 +260,24 @@ Also corrected along the way: `execution-round-provider.ts` used the caller's hi
 cache key; it now keys on what was actually sent. And the Anthropic 429→`RateLimitError` mapping
 existed character-for-character on both the streaming and non-streaming paths — extracted to
 `anthropic/errors.ts`, since two copies of a taxonomy decision is how PROV-004's drift starts.
+
+## Scope of the transport report (PROV-009)
+
+[PROV-009](../PROV-009-provider-packages-shape-requests-outside-any-core-seam.md) requires this item to
+scope its report claim to the core turn path until that boundary rule lands, and it is right to. The
+`structured_output_transport` event describes **what core supplied**, not everything the request
+carried. `@robota-sdk/agent-provider-openai` publishes `responseFormat` / `jsonSchema` as
+construction-time options and merges them with the per-call ones in
+`packages/agent-provider-openai/src/openai/openai-request-format.ts` — the per-call value wins, so a
+request core shaped is reported correctly. The gap is the turn core does not shape at all: a run
+without `output` resolves no transport and emits no event, yet a provider constructed with
+`responseFormat: 'json_schema'` still puts `response_format` on the wire. (Note the case this is NOT:
+`mechanism: 'none'` cannot arise for that provider, which declares no capability table at all, so
+every structured turn against it resolves `response_schema` / `undeclared`.) Recorded in
+`packages/agent-core/docs/SPEC.md` under the Structured Output Contract; widening the report to cover
+that channel is PROV-009's to decide, not this item's to assume.
+
+Also correcting an assertion this item's design made: it claimed the constructor caller set for those
+options was "verified empty". It is not — the sweep that produced it excluded `*.test.*`, and
+`packages/agent-provider-openai/src/openai/provider.test.ts` constructs the provider with
+`responseFormat: 'json_schema'` and asserts the mapping. PROV-009 caught it.

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -1020,6 +1020,15 @@ from the final `{ done: true, value }` iterator result).
   (`json_schema` / `json_object` / `omitted`), and whether the schema went into the prompt. It
   reports what the request DID, not what a catalog says; `provenance: 'unverified-endpoint'` marks a
   provider pointed at a custom `baseURL`, where the vendor's guarantees may not be the ones in force.
+  **The report is scoped to what CORE supplied.** `@robota-sdk/agent-provider-openai` publishes
+  `responseFormat` / `jsonSchema` as CONSTRUCTION-time options and merges them with the per-call ones
+  (`mergeChatResponseFormat`). A per-call value wins, so a request core shaped is reported correctly.
+  The gap is the turn core does not shape at all: a run WITHOUT `output` resolves no transport and
+  emits no `structured_output_transport` event, yet a provider constructed with
+  `responseFormat: 'json_schema'` still puts `response_format` on the wire — shaped by a channel no
+  core seam observes and no core event reports. Read this event as "what the core turn path put on
+  the request", not "everything the request carried". Closing the gap needs the boundary rule
+  PROV-009 owns.
 - **Endpoint provenance is a separate answer from the capability table.** `IAIProvider` carries
   `endpointIsVendorDefault?()` alongside `capabilityTable?()` rather than a field inside it, because
   the two are independent facts: `@robota-sdk/agent-provider-openai` declares no table by choice


### PR DESCRIPTION
## Summary

CORE-043's implementation landed in #1802. This records the completion and answers the one thing that
was still open before it could close.

**PROV-009 required a scoping note, and it was right to.** `structured_output_transport` describes
what CORE supplied — not everything the request carried. `@robota-sdk/agent-provider-openai`
publishes `responseFormat` / `jsonSchema` as CONSTRUCTION-time options and merges them with the
per-call ones (`packages/agent-provider-openai/src/openai/openai-request-format.ts`). A per-call
value wins, so a request core shaped is reported correctly. The gap is the turn core does not shape
at all: a `run()` **without** `output` resolves no transport and emits no event, yet a provider
constructed with `responseFormat: 'json_schema'` still puts `response_format` on the wire — through a
channel no core seam observes. `packages/agent-core/docs/SPEC.md` now says so instead of implying a
coverage the seam does not have. Closing the gap is PROV-009's decision, not this item's to assume.

**A claim of this item's own design is retracted.** It asserted the constructor caller set for those
options was "verified empty". It is not — the sweep excluded `*.test.*`, and
`packages/agent-provider-openai/src/openai/provider.test.ts` constructs the provider with
`responseFormat: 'json_schema'`. PROV-009 caught it; the Task file records the retraction.

**The spec document reaches `done/` carrying the section it was missing.** It had no
`## User Execution Test Scenarios`. The two scenarios and their observed evidence stay in the Task
file as the single owner; the spec doc names the commands, the expected observable results, and the
outcomes.

## Changes

- `.agents/tasks/CORE-043-…md` → `completed/`, `status: done`, `completed: 2026-08-17`
- `.agents/spec-docs/draft/CORE-043-…md` → `done/`, `status: done`, `## User Execution Test Scenarios` added
- `packages/agent-core/docs/SPEC.md` — the scoping paragraph under Structured Output Contract
- `.agents/tasks/CORE-048-…md` — repointed its CORE-043 link across the move

## Verification

Docs and backlog only — **no source changes** (`git diff --stat` is four `.md` files).
`pnpm harness:scan` → 118 passed, 1 skipped.

While reviewing my own diff I found one overstatement and fixed it before pushing: the SPEC note
first illustrated the gap with `mechanism: 'none'`, which that provider can never resolve — it
declares no capability table, so every structured turn against it resolves `response_schema` /
`undeclared`. Restated with the case that actually occurs.

Refs #1750