### PR TITLE
fix(harness): judge blind assertions by AST, and reconcile ARCH-012's two figures

### DIFF
--- a/packages/agent-framework/src/testing/agent-job-host-double.ts
+++ b/packages/agent-framework/src/testing/agent-job-host-double.ts
@@ -1,6 +1,10 @@
 /**
  * ARCH-029: the conformant `IAgentJobHostContext` double.
  *
+ * It exists so a test never needs an `as unknown as IAgentJobHostContext` partial. Building the real
+ * shape once, here, is what lets every consumer drop that assertion — the double IS the removal of
+ * the cast, not a place to hide one.
+ *
  * Split out of `command-host-double.ts` when that file passed the anti-monolith limit. The seam is
  * the same one the role ports draw: one file per contract axis.
  */

--- a/packages/agent-interface-transport/docs/SPEC.md
+++ b/packages/agent-interface-transport/docs/SPEC.md
@@ -227,9 +227,23 @@ reserved members. The flattened host has a null prototype and a final non-overri
 
 **`createTestInteractiveSession` lives here, with the contract.** A double existed before, published
 from `@robota-sdk/agent-framework` and documented in its SPEC — with zero consumers, because every
-transport package sits BELOW `agent-framework` and could not import it. The 41 hand-rolled
+transport package sits BELOW `agent-framework` and could not import it. The hand-rolled
 `as unknown as IInteractiveSession` partials were not an oversight; they were the only thing those
-packages could reach. The sole published owner is
+packages could reach.
+
+**Two figures are on record for those partials, and they measure different things** — quote whichever
+you mean, never one as the other:
+
+| Figure             | What it measures                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------- |
+| **37**             | The AST ratchet baseline ARCH-012's TC-04 actually drove to zero. This is the number that was MIGRATED. |
+| 41 across 29 files | The corrected pre-work audit count, taken by hand before the ratchet existed.                           |
+
+This SPEC previously carried the 41 alone. A package SPEC is a package-level SSOT, so a reader
+comparing a later migration against ARCH-012 would have taken 41 as the number that was migrated; it
+was not.
+
+The sole published owner is
 `@robota-sdk/agent-interface-transport/testing`; `agent-framework` intentionally does not re-export it,
 because pass-through re-exports would create two apparent owners for one contract.
 

--- a/scripts/harness/__tests__/cleanup-drift.test.mjs
+++ b/scripts/harness/__tests__/cleanup-drift.test.mjs
@@ -14,6 +14,8 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+
 /**
  * HARNESS-069 — a script that could only succeed.
  *
@@ -467,5 +469,73 @@ describe('fail-closed over a root it cannot judge (HARNESS-069)', () => {
     // The SHARED `requireGovernedTree` message (HARNESS-052), not a private copy of the rule — a
     // same-named local twin would have broken the property that helper exists for.
     expect(result.stderr).toMatch(/cleanup-drift: packages missing from/);
+  });
+});
+
+describe('a docblock explaining the rule is not a violation of it (#1803)', () => {
+  // `blind-assertion-*` counted the literal text, so prose EXPLAINING the rule was reported as
+  // breaking it. Measured while ARCH-029 landed: the two conformant, cast-free doubles built to
+  // REMOVE those assertions were both flagged for the docblock saying why they exist, and splitting
+  // one file into two raised the frozen count by one. It was worked around by rewording the prose,
+  // which puts the pressure on documentation instead of code and leaves the next accurate docblock
+  // to trip it again.
+  //
+  // The same defect was fixed once before here: scan-subagent-runner-composition moved from a regex
+  // to lib/ts-ast.mjs, and its suite carries "does NOT flag prose that merely names the symbols".
+
+  const source = (body) => body;
+
+  it('does NOT flag prose that merely names the assertion', async () => {
+    const { hasBlindAssertion } = await import('../cleanup-drift.mjs');
+
+    const prose = source(
+      [
+        '/**',
+        ' * Exists so a test never needs an `as unknown as IThing` partial.',
+        ' */',
+        'export const a = 1;',
+      ].join('\n'),
+    );
+
+    expect(hasBlindAssertion(prose, 'double.ts', 'unknown')).toBe(false);
+  });
+
+  it('does NOT flag `as any` inside a comment or a string', async () => {
+    const { hasBlindAssertion } = await import('../cleanup-drift.mjs');
+
+    expect(hasBlindAssertion('// never write `as any` here\nconst a = 1;', 'f.ts', 'any')).toBe(
+      false,
+    );
+    expect(hasBlindAssertion('const msg = "as any is banned";', 'f.ts', 'any')).toBe(false);
+  });
+
+  it('DOES flag a real assertion, so the narrowing did not disarm the check', async () => {
+    const { hasBlindAssertion } = await import('../cleanup-drift.mjs');
+
+    // Red proof for the fix itself: if the AST walk were wrong in the permissive direction, every
+    // assertion in the repository would stop being reported and the floor would silently vanish.
+    expect(hasBlindAssertion('const a = x as unknown as Foo;', 'f.ts', 'unknown')).toBe(true);
+    expect(hasBlindAssertion('const b = y as any;', 'f.ts', 'any')).toBe(true);
+  });
+
+  it('reads `as unknown as T` as the outer node, not as a bare `unknown` cast', async () => {
+    const { hasBlindAssertion } = await import('../cleanup-drift.mjs');
+
+    // `as unknown as T` parses as AsExpression(AsExpression(expr, unknown), T). A lone `as unknown`
+    // is not the banned double assertion and must not be counted as one.
+    expect(hasBlindAssertion('const a = x as unknown;', 'f.ts', 'unknown')).toBe(false);
+  });
+
+  it('holds on the real doubles the issue named', async () => {
+    const { hasBlindAssertion } = await import('../cleanup-drift.mjs');
+    const file = path.join(
+      WORKSPACE_ROOT,
+      'packages/agent-framework/src/testing/agent-job-host-double.ts',
+    );
+    const text = readFileSync(file, 'utf8');
+
+    // The docblock states the rule accurately — the text check counts that as a violation.
+    expect(text).toMatch(/as unknown as/);
+    expect(hasBlindAssertion(text, file, 'unknown')).toBe(false);
   });
 });

--- a/scripts/harness/cleanup-drift-baseline.json
+++ b/scripts/harness/cleanup-drift-baseline.json
@@ -1,5 +1,5 @@
 {
-  "blind-assertion-unknown": 28,
+  "blind-assertion-unknown": 26,
   "dynamic-import": 8,
   "spec-missing-sections": 46
 }

--- a/scripts/harness/cleanup-drift.mjs
+++ b/scripts/harness/cleanup-drift.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 import { requireGovernedTree } from './governed-tree.mjs';
+import * as ts from './lib/ts-ast.mjs';
 import { listWorkspaceScopes, pathExists, readText } from './shared.mjs';
 import { normalizeSpecHeading, readSpecSectionContract } from './spec-sections.mjs';
 
@@ -201,6 +202,47 @@ function grepLines(args, what) {
   return result.status === 1 || output === '' ? [] : output.split(/\r?\n/);
 }
 
+/**
+ * Does this file contain a REAL blind assertion, as an AST node rather than as text?
+ *
+ * The text form counted a docblock EXPLAINING the rule as a violation of it. Measured: while
+ * ARCH-029 landed, `command-host-double.ts` and `agent-job-host-double.ts` — the conformant,
+ * cast-free doubles built to REMOVE those assertions — were both flagged, because each explains in
+ * prose why it exists. Splitting one file into two raised the frozen count by one. It was worked
+ * around by rewording the prose, which puts the pressure on the documentation instead of the code
+ * and leaves the next accurate docblock to trip it again.
+ *
+ * The same defect was fixed once already in this repository: `scan-subagent-runner-composition.mjs`
+ * moved from a regex to `lib/ts-ast.mjs` for exactly this reason, and its test file carries a case
+ * named "does NOT flag prose that merely names the symbols". This follows that precedent.
+ *
+ * `as unknown as T` parses as `AsExpression(AsExpression(expr, unknown), T)`, so the OUTER node is
+ * found by asking whether its own expression is an `unknown` assertion — which is why the two kinds
+ * are not one predicate with a different string.
+ */
+export function hasBlindAssertion(sourceText, fileName, kind) {
+  let found = false;
+  const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const typeTextOf = (node) => (node.type ? node.type.getText().trim() : '');
+  const visit = (node) => {
+    if (found) return;
+    if (ts.isAsExpression(node)) {
+      if (kind === 'any' && typeTextOf(node) === 'any') found = true;
+      else if (
+        kind === 'unknown' &&
+        node.expression &&
+        ts.isAsExpression(node.expression) &&
+        typeTextOf(node.expression) === 'unknown'
+      ) {
+        found = true;
+      }
+    }
+    if (!found) ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return found;
+}
+
 async function checkBoundaryValidation(findings) {
   // Scan for blind type assertions in production code (not tests).
   //
@@ -216,18 +258,22 @@ async function checkBoundaryValidation(findings) {
   // boundary, so it stays open.
   const patterns = [
     {
+      // develop tightened the prefilter to word boundaries; this change adds the AST `kind`.
+      // Both are kept: the regex is the cheap prefilter, `kind` selects the judge that runs on it.
       regex: '\\bas any\\b',
+      kind: 'any',
       type: 'blind-assertion-any',
       detail: 'Blind `as any` assertion in production code.',
     },
     {
       regex: '\\bas unknown as\\b',
+      kind: 'unknown',
       type: 'blind-assertion-unknown',
       detail: 'Blind `as unknown as T` assertion in production code.',
     },
   ];
 
-  for (const { regex, type, detail } of patterns) {
+  for (const { regex, type, detail, kind } of patterns) {
     const files = grepLines(
       [
         '-rn',
@@ -250,6 +296,10 @@ async function checkBoundaryValidation(findings) {
       ) {
         continue;
       }
+
+      // `grep` is the cheap prefilter; the AST is the judge. A file whose only match is in a
+      // comment or a string literal has no assertion to report.
+      if (!hasBlindAssertion(await readText(file), file, kind)) continue;
 
       findings.push({
         file,


### PR DESCRIPTION
Closes #1803 and #1800 — two issues that meet on one line of source.

## #1803 — a docblock explaining the rule counted as a violation of it

`cleanup-drift`'s `blind-assertion-*` matched the literal text, with no code/comment distinction. The
two conformant, **cast-free** doubles built to REMOVE those assertions were both flagged for the
docblock saying why they exist, and splitting one file into two raised the frozen count by one.

It had been worked around by rewording the prose. That is the wrong fix, and is why the issue was
filed: it puts the pressure on the documentation rather than the code, and leaves the next person who
documents the rule accurately to trip it again.

**`grep` is now the cheap prefilter; the AST is the judge.** This follows the precedent this
repository already set — `scan-subagent-runner-composition` moved from a regex to `lib/ts-ast.mjs`
for exactly this reason, and its suite carries a case named *"does NOT flag prose that merely names
the symbols"*.

`as unknown as T` parses as `AsExpression(AsExpression(expr, unknown), T)`, so the outer node is
found by asking whether its own expression is an `unknown` assertion — which is why the two kinds are
not one predicate with a different string. A lone `as unknown` is not the banned double assertion and
is not counted as one.

### Measured on the tree

| type | before | after |
| --- | --- | --- |
| `blind-assertion-any` | 1 | **0** |
| `blind-assertion-unknown` | 28 | **26** |

Three false positives — and the `as any` count was **entirely** false: the single production
"violation" in the whole repository was a comment. The baseline is re-frozen in this same change,
which is what the ratchet demands of a fall.

### The workaround is reverted, which is the actual point

ARCH-029 landed while this was being written, so the two files the issue observed now exist.
`agent-job-host-double.ts` again states plainly that it exists so a test never needs an
`as unknown as IAgentJobHostContext` partial. Text check: **1 match**. AST: **none**. That is the
issue's scenario reproduced and then fixed, not argued.

Red-proofed in the permissive direction too: a real `x as unknown as Foo` and a real `y as any` are
still reported. Had the walk been wrong that way, every assertion in the repository would have
stopped being counted and the floor would have silently vanished.

## #1800 — a superseded figure carried with no reconciling note

`agent-interface-transport`'s SPEC carried ARCH-012's **41** with nothing saying what it measures.
Both figures are verified at their cited lines and now stated with what each means:

- **37** — the AST ratchet baseline TC-04 actually drove to zero. **This is the number that was migrated.**
- 41 across 29 files — the corrected pre-work hand audit, taken before the ratchet existed.

A package SPEC is a package-level SSOT, so a reader comparing a later migration against ARCH-012
would have taken 41 as the migrated figure. It was not.

The two issues intersect: one of the false positives #1803 removes is a docblock quoting this very
figure.

## Verification

- `pnpm harness:scan` — **119 passed**, 2 skipped
- `cleanup-drift` suite — **17/17**, including five new cases for the prose/code split
- `agent-framework` — **1367/1367**

A note on that last number: it read 30 failures until I rebuilt. That was stale `dist/`, not a
defect — checked before reporting it, because I got this exact call wrong earlier in the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD