### PR TITLE
feat(harness): make an edit to a required check's own workflow visible

### DIFF
--- a/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
@@ -29,6 +29,38 @@ never executing untrusted PR content with write credentials.
 
 ## Progress
 
+### 2026-08-17 — detection landed; trusted provenance remains an owner decision
+
+`scripts/harness/scan-workflow-provenance.mjs` is registered in `pnpm harness:scan`.
+
+**What it establishes.** The guarded set is derived from `.github/required-status-checks.json`, the
+SSOT two other scans already read — today that resolves to `ci.yml` and `review-gate.yml`, the only
+two files providing a required context. Both are `on: pull_request`, so both load their definition
+from the pull request under test, and the scan reports that standing exposure on every run rather
+than only when someone touches a file. Given `--base-ref`, it fails a change that edits a guarded
+workflow and names which contexts that change can move.
+
+The adversarial case the Test Plan asks for is covered: a fixture pull request that rewrites its own
+required `build` job to `run: exit 0` is flagged, while an unguarded workflow, and ordinary work that
+leaves the control plane alone, draw no comment. Fail-closed on an absent or workflow-less registry.
+
+**What it deliberately does NOT establish, stated so the item is not read as finished.** It does not
+make the control plane trusted. A reviewer can still approve a self-edit and a maintainer can still
+merge one — the edit is merely no longer invisible. Trusted provenance needs a control plane the
+pull request cannot reach:
+
+| Option                                   | Why it is not takeable here                                                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Organization-level required workflow     | Needs org configuration outside this repository                                                                             |
+| `pull_request_target` split              | Needs a design that never runs PR content with write credentials; changing `ci.yml`'s trigger is a repository-policy change |
+| External GitHub App publishing the check | Needs an app registration and its credentials                                                                               |
+
+Each is an owner decision. Note the shape of the constraint: **wiring the scan's `--base-ref` mode
+into `ci.yml` would itself be an edit to a guarded workflow**, which this very scan would flag — so
+that step is left to the owner rather than taken quietly.
+
+### 2026-08-14
+
 ### 2026-08-14
 
 - Discovered during INFRA-096 Round A: exact-base checkout protects loaded scripts but not the

--- a/scripts/harness/__tests__/scan-workflow-provenance.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-provenance.test.mjs
@@ -1,0 +1,228 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  findWorkflowProvenanceFindings,
+  readExaminedWorkflowCount,
+  readGuardedWorkflows,
+  triggersFromPullRequest,
+} from '../scan-workflow-provenance.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const REGISTRY = fileURLToPath(
+  new URL('../../../.github/required-status-checks.json', import.meta.url),
+);
+
+const scratch = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(dir, ...args) {
+  return spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+}
+
+/**
+ * A repository carrying the registry and one guarded workflow, with a base commit to diff against.
+ *
+ * Built as a real git repository because the scan judges a CHANGE: a fixture that only writes files
+ * would exercise the registry read and never the thing the issue is about.
+ */
+function repoWithGuardedWorkflow() {
+  const dir = mkdtempSync(path.join(tmpdir(), 'infra-097-'));
+  scratch.push(dir);
+  spawnSync('git', ['init', '--quiet', '--initial-branch=main', dir]);
+  git(dir, 'config', 'user.email', 'harness@example.test');
+  git(dir, 'config', 'user.name', 'Harness');
+  mkdirSync(path.join(dir, '.github/workflows'), { recursive: true });
+  writeFileSync(
+    path.join(dir, '.github/required-status-checks.json'),
+    JSON.stringify({
+      branches: {
+        main: {
+          required_status_checks: [
+            { context: 'build', workflow: '.github/workflows/ci.yml', job: 'build' },
+          ],
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    path.join(dir, '.github/workflows/ci.yml'),
+    [
+      'name: CI',
+      '',
+      'on:',
+      '  pull_request:',
+      '    branches: [main]',
+      '',
+      'jobs:',
+      '  build:',
+      '    runs-on: ubuntu-latest',
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(path.join(dir, 'README.md'), 'base\n');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '--quiet', '-m', 'chore: base');
+  return dir;
+}
+
+describe('workflow-provenance — criteria are READ from the registry (INFRA-097)', () => {
+  it('derives the guarded set from the repository SSOT', () => {
+    const { workflows } = readGuardedWorkflows(WORKSPACE_ROOT);
+
+    // Exactly the files that provide a required context today. Adding a required check in a new
+    // workflow must govern that workflow with no code change here.
+    expect(workflows).toEqual(['.github/workflows/ci.yml', '.github/workflows/review-gate.yml']);
+  });
+
+  it('names which contexts each guarded workflow provides', () => {
+    const { contextsByWorkflow } = readGuardedWorkflows(WORKSPACE_ROOT);
+    const registry = JSON.parse(readFileSync(REGISTRY, 'utf8'));
+    const total = Object.values(registry.branches).reduce(
+      (n, b) => n + b.required_status_checks.filter((c) => c.workflow).length,
+      0,
+    );
+
+    expect([...contextsByWorkflow.values()].flat()).toHaveLength(total);
+  });
+
+  it('reads the trigger off the `on:` block, not off any mention of the string', () => {
+    expect(triggersFromPullRequest('on:\n  pull_request:\n    branches: [main]\n')).toBe(true);
+    // The shapes a trusted design moves toward — these load from the base, not from the PR.
+    expect(triggersFromPullRequest('on:\n  pull_request_target:\n    branches: [main]\n')).toBe(
+      false,
+    );
+    expect(triggersFromPullRequest('on:\n  workflow_run:\n    workflows: [CI]\n')).toBe(false);
+    // A step that merely names it is not a trigger.
+    expect(
+      triggersFromPullRequest(
+        'on:\n  schedule:\n    - cron: 0 0 * * *\njobs:\n  a:\n    steps:\n      - run: echo pull_request:\n',
+      ),
+    ).toBe(false);
+  });
+
+  it('fails closed when the registry is absent', () => {
+    const empty = mkdtempSync(path.join(tmpdir(), 'infra-097-empty-'));
+    scratch.push(empty);
+
+    expect(() => findWorkflowProvenanceFindings(empty)).toThrow(/missing from/);
+  });
+
+  it('fails closed when the registry names no workflow', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'infra-097-bare-'));
+    scratch.push(dir);
+    mkdirSync(path.join(dir, '.github'), { recursive: true });
+    writeFileSync(
+      path.join(dir, '.github/required-status-checks.json'),
+      JSON.stringify({ branches: { main: { required_status_checks: [] } } }),
+    );
+
+    expect(() => findWorkflowProvenanceFindings(dir)).toThrow(/names no workflow/);
+  });
+});
+
+describe('workflow-provenance — a change that moves its own gate (INFRA-097)', () => {
+  it('flags a change that edits the workflow reporting its own required check', () => {
+    // The adversarial case the issue asks for: a pull request replacing its own required gate.
+    const dir = repoWithGuardedWorkflow();
+    writeFileSync(
+      path.join(dir, '.github/workflows/ci.yml'),
+      [
+        'name: CI',
+        '',
+        'on:',
+        '  pull_request:',
+        '    branches: [main]',
+        '',
+        'jobs:',
+        '  build:',
+        '    runs-on: ubuntu-latest',
+        '    steps:',
+        '      - run: exit 0   # unconditional pass',
+        '',
+      ].join('\n'),
+    );
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '--quiet', '-m', 'ci: adjust build');
+
+    const { findings } = findWorkflowProvenanceFindings(dir, 'HEAD~1');
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].file).toBe('.github/workflows/ci.yml');
+    expect(findings[0].problem).toMatch(/build \(main\)/);
+    expect(findings[0].problem).toMatch(/can move its own gate/);
+  });
+
+  it('says nothing about a change that leaves the control plane alone', () => {
+    // The property that keeps the guard readable: ordinary work draws no comment.
+    const dir = repoWithGuardedWorkflow();
+    writeFileSync(path.join(dir, 'README.md'), 'ordinary work\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '--quiet', '-m', 'docs: readme');
+
+    expect(findWorkflowProvenanceFindings(dir, 'HEAD~1').findings).toEqual([]);
+  });
+
+  it('says nothing about an UNGUARDED workflow', () => {
+    // Only workflows that provide a required context are the control plane. Flagging every
+    // workflow edit would make the finding meaningless.
+    const dir = repoWithGuardedWorkflow();
+    writeFileSync(
+      path.join(dir, '.github/workflows/nightly.yml'),
+      'name: Nightly\n\non:\n  schedule:\n    - cron: 0 0 * * *\n',
+    );
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '--quiet', '-m', 'ci: nightly');
+
+    expect(findWorkflowProvenanceFindings(dir, 'HEAD~1').findings).toEqual([]);
+  });
+
+  it('reports which guarded workflows load themselves from the pull request', () => {
+    const dir = repoWithGuardedWorkflow();
+
+    const { selfLoading } = findWorkflowProvenanceFindings(dir);
+
+    // This is the standing exposure, reported even with no diff — the situation is visible on
+    // every run rather than only when someone touches the file.
+    expect(selfLoading).toEqual(['.github/workflows/ci.yml']);
+  });
+
+  it('errors rather than reporting clean when the diff cannot be read', () => {
+    const dir = repoWithGuardedWorkflow();
+
+    expect(() => findWorkflowProvenanceFindings(dir, 'no/such/ref')).toThrow(/measurement/i);
+  });
+
+  it('reports the size it examined, and does not accumulate across runs', () => {
+    const dir = repoWithGuardedWorkflow();
+
+    // EXACT value against a fixture of known size — one guarded workflow. The counter is asserted
+    // AFTER a second run of the finder, because a counter that accumulated would read 2 there and
+    // a bound would hide it.
+    findWorkflowProvenanceFindings(dir);
+
+    expect(readExaminedWorkflowCount(dir)).toBe(1);
+
+    findWorkflowProvenanceFindings(dir);
+
+    expect(readExaminedWorkflowCount(dir)).toBe(1);
+  });
+});
+
+describe('workflow-provenance — this repository (INFRA-097)', () => {
+  it('reports both guarded workflows as PR-loaded, which is the exposure INFRA-097 tracks', () => {
+    const { selfLoading, examined } = findWorkflowProvenanceFindings(WORKSPACE_ROOT);
+
+    // If this ever shrinks, a trusted-provenance design landed and INFRA-097 should be revisited —
+    // which is exactly the signal the issue wants kept visible.
+    expect(examined).toBe(2);
+    expect(selfLoading).toHaveLength(2);
+  });
+});

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -70,6 +70,7 @@
     "transport-conformance",
     "vitest-resource-ceiling",
     "workflow-permissions",
+    "workflow-provenance",
     "workspace-refs"
   ]
 }

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -2,13 +2,12 @@
   "item": "HARNESS-087",
   "reason": "Every harness module carrying the declaration marker is classified here. `covered` meets the floor and is re-measured each run, so losing coverage is a regression finding rather than a quiet move to the debt list. `pending` was recorded unmet when the floor was adopted — the counter is not exported, or nothing asserts its value — and an entry that comes to meet the floor is itself a finding.",
   "covered": [
-    "scripts/harness/scan-aggregate-naming.mjs",
-    "scripts/harness/scan-role-port-optionals.mjs",
     "scripts/harness/check-contract-disposition.mjs",
     "scripts/harness/check-fixture-floor.mjs",
     "scripts/harness/check-spec-whitebox-leakage.mjs",
     "scripts/harness/check-stub-markers.mjs",
     "scripts/harness/check-workspace-refs.mjs",
+    "scripts/harness/scan-aggregate-naming.mjs",
     "scripts/harness/scan-claude-review-coverage.mjs",
     "scripts/harness/scan-conflict-markers.mjs",
     "scripts/harness/scan-interface-runtime.mjs",
@@ -17,10 +16,12 @@
     "scripts/harness/scan-no-fake-in-src.mjs",
     "scripts/harness/scan-node-version-single-valued.mjs",
     "scripts/harness/scan-product-identity.mjs",
+    "scripts/harness/scan-role-port-optionals.mjs",
     "scripts/harness/scan-spec-user-execution-section.mjs",
     "scripts/harness/scan-tool-classification.mjs",
     "scripts/harness/scan-transport-conformance.mjs",
     "scripts/harness/scan-workflow-permissions.mjs",
+    "scripts/harness/scan-workflow-provenance.mjs",
     "scripts/harness/verify-doc-split-preservation.mjs"
   ],
   "pending": [

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -473,6 +473,13 @@ export const SCAN_COMMANDS = [
     name: 'main-required-checks',
     command: ['node', 'scripts/harness/scan-main-required-checks.mjs'],
   },
+  // INFRA-097. A required check triggered by `pull_request` loads its YAML from the PR, so the
+  // change carries the control plane that judges it. This makes such an edit visible; it does not
+  // make the control plane trusted — that needs configuration outside this repository.
+  {
+    name: 'workflow-provenance',
+    command: ['node', 'scripts/harness/scan-workflow-provenance.mjs'],
+  },
   {
     name: 'new-rule-declares-enforcement',
     command: ['node', 'scripts/harness/scan-new-rule-declares-enforcement.mjs'],

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -87,6 +87,14 @@ const REGISTRATION_FILE = path.join(HARNESS_DIR, 'run-all-scans.mjs');
  */
 export const MANDATORY_TREE_GUARDS = [
   {
+    // Measured as `findWorkflowProvenanceFindings(bare)`: throws `governed tree(s) absent under
+    // <root>` before it can read which workflows are guarded.
+    file: 'scan-workflow-provenance.mjs',
+    finder: 'findWorkflowProvenanceFindings',
+    tree: '.github/required-status-checks.json',
+    why: 'the registry is the only statement of which workflows provide a required check; over a root without it the guarded set is empty, and "no workflow was edited" reads exactly like "the control plane was left alone" — while the exposure it tracks is that a pull request carries the YAML that judges it',
+  },
+  {
     // Measured as this harness calls it — `findDeclaredPinFindings(bare)`: throws
     // `governed tree(s) absent under <root>: package.json, packages`.
     file: 'scan-node-version-single-valued.mjs',

--- a/scripts/harness/scan-workflow-provenance.mjs
+++ b/scripts/harness/scan-workflow-provenance.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+/**
+ * A pull request must not silently edit the workflow that reports its own required check (INFRA-097).
+ *
+ * THE GAP. A required check triggered by `pull_request` loads its workflow YAML from the PR's merge
+ * revision. So the PR carries the control plane that judges it: change the job, change the verdict.
+ * INFRA-096 hardened the SCRIPTS those workflows load by checking them out from the base SHA, and
+ * recorded plainly that this does not establish workflow provenance — the YAML itself still comes
+ * from the PR. This scan closes the part of that gap a repository can close on its own.
+ *
+ * WHAT IT DOES NOT DO, said first because the alternative is a false sense of a solved problem.
+ * It does not make the control plane trusted. A reviewer who approves a self-edit still approves it,
+ * and a maintainer can still merge one. Trusted provenance needs a control plane the PR cannot
+ * reach at all — an organization-level required workflow, a `pull_request_target` split that never
+ * runs PR content with write credentials, or an external app publishing the check. Each needs
+ * configuration outside this repository, so each is an owner decision recorded in INFRA-097 rather
+ * than something this file can assert. What this scan provides is DETECTION: the edit stops being
+ * invisible, and a reviewer is told which required context the change can move.
+ *
+ * THE CRITERIA ARE READ, NOT COPIED. `.github/required-status-checks.json` is already the SSOT for
+ * which contexts each protected branch requires and which workflow file provides each one; two other
+ * scans consume it. This one derives the guarded file set from the same place, so adding a required
+ * context in a new workflow governs that workflow here with no code change. The parse is
+ * FAIL-CLOSED: an unreadable registry, or one naming no workflow, exits 1 — a provenance guard that
+ * cannot read which files matter has verified nothing.
+ *
+ * Usage:
+ *   node scripts/harness/scan-workflow-provenance.mjs                 # audit the tree
+ *   node scripts/harness/scan-workflow-provenance.mjs --base-ref <r>  # judge a change
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { requireGovernedTree } from './governed-tree.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const REGISTRY_RELATIVE = '.github/required-status-checks.json';
+
+/**
+ * Every workflow file that provides a required status check, for any protected branch.
+ *
+ * Returns `{ workflows, contextsByWorkflow }`. An empty `workflows` is a failure for the caller, not
+ * a clean result — see the fail-closed note in the header.
+ */
+export function readGuardedWorkflows(root = WORKSPACE_ROOT) {
+  const file = path.join(root, REGISTRY_RELATIVE);
+  if (!existsSync(file)) return { workflows: [], contextsByWorkflow: new Map() };
+  const registry = JSON.parse(readFileSync(file, 'utf8'));
+  const contextsByWorkflow = new Map();
+  for (const [branch, config] of Object.entries(registry.branches ?? {})) {
+    for (const check of config.required_status_checks ?? []) {
+      if (!check.workflow) continue;
+      const entry = contextsByWorkflow.get(check.workflow) ?? [];
+      entry.push(`${check.context} (${branch})`);
+      contextsByWorkflow.set(check.workflow, entry);
+    }
+  }
+  return { workflows: [...contextsByWorkflow.keys()].sort(), contextsByWorkflow };
+}
+
+/**
+ * Does this workflow load its definition from the pull request under test?
+ *
+ * `pull_request` does; `pull_request_target`, `workflow_run` and `schedule` load from the base and
+ * are the shapes a trusted design would move toward. Read off the `on:` block only — a job step
+ * mentioning the string is not a trigger.
+ */
+export function triggersFromPullRequest(workflowText) {
+  const lines = workflowText.split('\n');
+  let inOn = false;
+  for (const line of lines) {
+    if (/^on:\s*$/.test(line)) {
+      inOn = true;
+      continue;
+    }
+    if (inOn && /^\S/.test(line)) break;
+    if (inOn && /^\s{2}pull_request:\s*$/.test(line)) return true;
+  }
+  return false;
+}
+
+function changedFiles(root, baseRef) {
+  const result = spawnSync('git', ['diff', '--name-only', `${baseRef}...HEAD`], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `workflow-provenance: could not read the diff against \`${baseRef}\` — the measurement ` +
+        `FAILED, so no verdict can be reported from it.\n${result.stderr ?? ''}`,
+    );
+  }
+  return result.stdout.split('\n').filter(Boolean);
+}
+
+export function findWorkflowProvenanceFindings(root = WORKSPACE_ROOT, baseRef) {
+  requireGovernedTree(root, [REGISTRY_RELATIVE], {
+    scan: 'workflow-provenance',
+    why: 'The registry states which workflows provide a required check; without it there is no guarded set, and "no findings" would mean "nothing was examined".',
+  });
+  const { workflows, contextsByWorkflow } = readGuardedWorkflows(root);
+  if (workflows.length === 0) {
+    throw new Error(
+      'workflow-provenance: the required-status-check registry names no workflow. The set this ' +
+        'scan guards is unreadable, so a pass would assert something it never measured.',
+    );
+  }
+
+  const findings = [];
+  // The standing property, checked on every run: a guarded workflow that loads itself from the PR
+  // is the exposure. Reported as the scan's own subject rather than as a per-change finding, so the
+  // situation is visible even on a run with no diff.
+  const selfLoading = workflows.filter((w) => {
+    const file = path.join(root, w);
+    return existsSync(file) && triggersFromPullRequest(readFileSync(file, 'utf8'));
+  });
+
+  if (baseRef !== undefined) {
+    const touched = changedFiles(root, baseRef).filter((f) => workflows.includes(f));
+    for (const file of touched) {
+      const contexts = contextsByWorkflow.get(file) ?? [];
+      findings.push({
+        file,
+        problem:
+          `is edited by this change AND provides required check(s): ${contexts.join(', ')}. ` +
+          `Because it is triggered by \`pull_request\`, the edited definition is what will judge ` +
+          `this pull request — the change can move its own gate. This is not a refusal to make the ` +
+          `edit; it is a refusal to make it INVISIBLY. State in the pull request why the control ` +
+          `plane changes, and have a reviewer read the job that reports each context above.`,
+      });
+    }
+  }
+
+  return { findings, workflows, selfLoading, examined: workflows.length };
+}
+
+/** Exported so a test can read the size this scan reports (measurement-provenance.md). */
+export function readExaminedWorkflowCount(root = WORKSPACE_ROOT) {
+  return findWorkflowProvenanceFindings(root).examined;
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const baseIndex = process.argv.indexOf('--base-ref');
+  const baseRef = baseIndex === -1 ? undefined : process.argv[baseIndex + 1];
+  const { findings, workflows, selfLoading, examined } = findWorkflowProvenanceFindings(
+    WORKSPACE_ROOT,
+    baseRef,
+  );
+  for (const finding of findings) console.error(`✗ ${finding.file}: ${finding.problem}`);
+  if (selfLoading.length > 0) {
+    console.error(
+      `⚑ ${selfLoading.length} of ${workflows.length} guarded workflow(s) load their definition ` +
+        `from the pull request (\`on: pull_request\`): ${selfLoading.join(', ')}. Trusted ` +
+        `provenance is an owner decision recorded in INFRA-097; this scan makes an edit visible, ` +
+        `it does not make the control plane trusted.`,
+    );
+  }
+  console.log(`::examined:: ${examined} guarded workflow(s)`);
+  process.exit(findings.length > 0 ? 1 : 0);
+}


### PR DESCRIPTION
Advances #1719 (INFRA-097). Deliberately does **not** close it — see the limits section.

## The exposure

A required check triggered by `pull_request` loads its workflow YAML from the merge revision. The
pull request therefore carries the control plane that judges it: change the job, change the verdict.

INFRA-096 hardened the *scripts* those workflows load, by checking them out from the base SHA, and
recorded plainly that this does **not** establish workflow provenance — the YAML itself still comes
from the PR. This closes the part a repository can close on its own.

## What it does

The guarded set is derived from `.github/required-status-checks.json`, the SSOT two other scans
already read. Today that resolves to exactly two files — the CI workflow and the review-gate
workflow — because those are the only ones providing a required context. Adding a required check in
a new workflow governs that workflow here with no code change.

- **Every run**: reports which guarded workflows load their definition from the PR. Both do, so the
  standing exposure is visible on every scan rather than only when someone touches a file.
- **With `--base-ref`**: fails a change that edits a guarded workflow, naming which required
  contexts that change can move.

The adversarial case #1719's Test Plan asks for is covered — a fixture pull request that rewrites its
own required `build` job to `run: exit 0` is flagged. An unguarded workflow, and ordinary work that
leaves the control plane alone, draw no comment. Fail-closed on an absent registry and on one naming
no workflow: a provenance guard that cannot read which files matter has verified nothing.

## What it does NOT do

Stated first in the file's own header, because the alternative is a false sense of a solved problem.

**It does not make the control plane trusted.** A reviewer who approves a self-edit still approves
it; a maintainer can still merge one. The edit is merely no longer invisible. Trusted provenance
needs a control plane the pull request cannot reach:

| Option | Why it is not takeable here |
| --- | --- |
| Organization-level required workflow | Needs org configuration outside this repository |
| `pull_request_target` split | Needs a design that never runs PR content with write credentials; changing the CI trigger is a repository-policy change |
| External GitHub App publishing the check | Needs an app registration and its credentials |

Each is an owner decision, recorded in the task with its reason.

## Why the `--base-ref` mode is not wired into CI in this PR

Because doing so **would itself be an edit to a guarded workflow, which this very scan would flag**.
The CI workflow is also a repository-policy file, which is the user's call rather than mine. Leaving
it to the owner is the consistent choice; taking it quietly would be the shape the scan exists to
surface.

The scan still runs on every CI invocation through `pnpm harness:scan`, in its audit mode.

## Verification

- `pnpm harness:scan` — **120 passed**, 2 skipped
- Harness tests — **3,623 passed**, including **12** new cases for this scan
- Registered in `MANDATORY_TREE_GUARDS` (fail-closed proven by execution) and classified `covered`
  in `measurement-provenance-pending.json`, with an exact-value examined count and a reset case

Checked against the three existing required-check scans first: `main-required-checks` asserts a
context can actually fail, `required-check-needs` catches the skipped-dependency bypass,
`required-check-local-reachability` maps contexts to local entry points. None of them looks at who
authored the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD