### PR TITLE
feat(agent-remote-pairing): prove a local peer shares this environment (SEC-010)

### DIFF
--- a/.agents/tasks/SEC-010-same-environment-proof-for-local-peers.md
+++ b/.agents/tasks/SEC-010-same-environment-proof-for-local-peers.md
@@ -60,30 +60,55 @@ Both sessions read the same file; possession of its contents is the proof.
   what the issue warns about, and it degrades silently — a synced home directory (Dropbox, rsync,
   a container bind-mount) exports the credential to another machine with no signal at either end.
 
-### Alternative C — the kernel vouches for the peer (recommended)
+### Alternative C — the kernel NAMES the peer (`SO_PEERCRED`) — **not available, measured**
 
-Rendezvous over a Unix domain socket (POSIX) or a named pipe (Windows) in a user-owned runtime
-directory, and read the peer's credentials **from the operating system**: `SO_PEERCRED` /
-`LOCAL_PEERCRED` give the connecting process's uid, gid and pid; Windows named pipes give the
-client's token via `GetNamedPipeClientProcessId` and impersonation.
+Read the connecting process's uid/gid/pid from the operating system via `SO_PEERCRED` /
+`LOCAL_PEERCRED`.
 
-- **For**: the evidence is not an artifact the peer supplies, so **there is nothing to copy**. The
-  kernel states who is on the other end, and it can only state it for a process on this machine as
-  this user. It answers both halves — same machine AND same user — which neither A nor B does.
-- **Against**: platform-divergent implementation (two backends), and it does not by itself bind the
-  subsequent WebRTC data channel; that still needs the existing fingerprint binding.
+**This was the original recommendation and it is not implementable in Node.** Probed on this runtime:
+a connected `net.Socket`'s handle exposes no `getpeercred` and no peer-credential accessor under any
+name — the enumerated handle prototype has zero members matching `/peer|cred/i`. Reaching the syscall
+needs a native addon, which this repository does not ship.
 
-### Alternative D — C for the environment proof, then bind the existing channel to it
+Recording it as measured rather than deleting it, because the failure mode it would have produced is
+the one worth remembering: the code compiles, a mocked test passes, and **every real peer is
+refused**. A security mechanism that is merely inert is worse than none, because the feature above it
+looks implemented.
 
-The recommendation. The kernel-vouched rendezvous establishes the environment and exchanges a
+### Alternative C′ — the kernel ENFORCES who can reach the peer (recommended)
+
+The other half of the same kernel guarantee. Rendezvous over a Unix socket inside a directory that is
+**owned by this user and mode 0700**: no other account can traverse it, so the kernel refuses the
+connection before any protocol runs.
+
+Where `SO_PEERCRED` would say _"the peer is uid N"_, this says _"no uid but ours could have got
+here"_ — for an admission decision, the same answer reached from the opposite side. It is what an SSH
+agent socket and a Docker socket already rely on.
+
+- **For**: the evidence is still not an artifact the peer supplies, so **there is nothing to copy**,
+  and it answers both halves — same machine AND same user. Implementable today, with no addon.
+- **Against**: the peer's uid and pid are never learned, so an audit record cannot name the process
+  on the other end. Admission does not need that; a diagnostic might, and would need the addon.
+- **The sharp edge**: the guarantee is entirely in the directory mode. `0755` looks harmless and
+  silently destroys it — every account on the host can then reach the socket, and reaching it proves
+  nothing. That is why the mode and owner are validated **before** the socket is bound, and why the
+  refusal cases are the larger half of the test suite.
+
+### Alternative D — C′ for the environment proof, then bind the existing channel to it
+
+The recommendation. The kernel-enforced rendezvous establishes the environment and exchanges a
 short-lived nonce; that nonce is then bound into the existing pairing confirmation so the WebRTC
-channel admitted is provably the same peer the kernel vouched for.
+channel admitted is provably the same peer that reached the guarded rendezvous.
 
 ## Recommendation
 
-**Alternative D.** It is the only option where the environment claim rests on something the peer
-cannot fabricate or carry to another machine, and it reuses rather than replaces the channel binding
-that already exists.
+**Alternative D, over C′.** It is the only option where the environment claim rests on something the
+peer cannot fabricate or carry to another machine, and it reuses rather than replaces the channel
+binding that already exists.
+
+The substitution of C′ for C is not a weakening — both rest on the kernel and neither is copyable.
+What changed is which side of the guarantee is read, and that was forced by measurement rather than
+chosen.
 
 It also keeps the layering the issue asks for: the cryptographic and OS-level proof lives in a
 security leaf, `agent-transport-webrtc` consumes a **result** and implements no policy, and

--- a/.agents/tasks/SEC-010-same-environment-proof-for-local-peers.md
+++ b/.agents/tasks/SEC-010-same-environment-proof-for-local-peers.md
@@ -1,0 +1,140 @@
+---
+title: 'SEC-010: local agent-cli peers have no proof of shared environment — certificate possession is copyable, and channel binding authenticates a channel rather than a machine'
+status: todo
+created: 2026-08-17
+priority: high
+urgency: soon
+area: packages/agent-remote-pairing, packages/agent-transport-webrtc, packages/agent-cli
+depends_on: []
+---
+
+# SEC-010: what proves "the same local environment"
+
+Registered as [issue #1810](https://github.com/woojubb/robota/issues/1810), the security child of
+[#1807](https://github.com/woojubb/robota/issues/1807). The functional sibling is
+[#1809](https://github.com/woojubb/robota/issues/1809), which consumes the admission result this item
+defines and can proceed against an injected double until it exists.
+
+**The issue states the precondition this document answers**, and it is the reason nothing is
+implemented yet: _"The issue must define the exact environment proof and its failure/revocation
+semantics before implementation."_
+
+## The problem, stated precisely
+
+Two `agent-cli` sessions on one computer want to exchange messages. Admission must establish that the
+peer is **in the same local environment**, not merely that it holds a credential.
+
+The repository already has two mechanisms, and the issue is right that neither answers this:
+
+| Mechanism                                                          | What it actually proves                                       | Why it is not enough here                                |
+| ------------------------------------------------------------------ | ------------------------------------------------------------- | -------------------------------------------------------- |
+| Pairing secret + DTLS fingerprint binding (`agent-remote-pairing`) | This **channel** terminates at the peer that knows the secret | Says nothing about where that peer runs                  |
+| Device identity keypair + signed challenge (`device-identity.ts`)  | The peer holds a **private key** enrolled earlier             | A key is a file; a file can be copied to another machine |
+
+Both are channel/possession proofs. **Possession is copyable, and "the same computer" is not a
+property any copyable artifact can carry.** A shared certificate admits whoever obtained it, from
+wherever they run it — which is precisely the failure the issue names.
+
+## The design question
+
+What evidence distinguishes "a peer on this machine, as this user" from "a peer holding this
+machine's credential"?
+
+### Alternative A — treat loopback as the proof
+
+Admit only connections observed on `127.0.0.1`/`::1`.
+
+- **For**: requires no new artifact; the address is reported by the OS, not asserted by the peer.
+- **Against**: it is a property of the _route_, not the peer. Containers, VMs with host networking,
+  and port-forwarding all present as loopback while being a different environment in every sense a
+  user cares about. It also cannot distinguish two different USERS on the same host, which matters
+  on a shared machine.
+
+### Alternative B — a shared secret in a mode-0600 file under the user's home
+
+Both sessions read the same file; possession of its contents is the proof.
+
+- **For**: trivially implementable; binds to the user account as long as the filesystem permissions
+  hold.
+- **Against**: **this is the copyable-certificate failure with a different filename.** It is exactly
+  what the issue warns about, and it degrades silently — a synced home directory (Dropbox, rsync,
+  a container bind-mount) exports the credential to another machine with no signal at either end.
+
+### Alternative C — the kernel vouches for the peer (recommended)
+
+Rendezvous over a Unix domain socket (POSIX) or a named pipe (Windows) in a user-owned runtime
+directory, and read the peer's credentials **from the operating system**: `SO_PEERCRED` /
+`LOCAL_PEERCRED` give the connecting process's uid, gid and pid; Windows named pipes give the
+client's token via `GetNamedPipeClientProcessId` and impersonation.
+
+- **For**: the evidence is not an artifact the peer supplies, so **there is nothing to copy**. The
+  kernel states who is on the other end, and it can only state it for a process on this machine as
+  this user. It answers both halves — same machine AND same user — which neither A nor B does.
+- **Against**: platform-divergent implementation (two backends), and it does not by itself bind the
+  subsequent WebRTC data channel; that still needs the existing fingerprint binding.
+
+### Alternative D — C for the environment proof, then bind the existing channel to it
+
+The recommendation. The kernel-vouched rendezvous establishes the environment and exchanges a
+short-lived nonce; that nonce is then bound into the existing pairing confirmation so the WebRTC
+channel admitted is provably the same peer the kernel vouched for.
+
+## Recommendation
+
+**Alternative D.** It is the only option where the environment claim rests on something the peer
+cannot fabricate or carry to another machine, and it reuses rather than replaces the channel binding
+that already exists.
+
+It also keeps the layering the issue asks for: the cryptographic and OS-level proof lives in a
+security leaf, `agent-transport-webrtc` consumes a **result** and implements no policy, and
+`agent-cli` composes but owns neither.
+
+**A note on scope honesty.** If the environment proof is kernel-vouched, a local peer arguably does
+not need WebRTC at all — a Unix socket carries messages perfectly well. The reason to keep the WebRTC
+carrier is that #1809's message contract is meant to be transport-neutral and reused by the
+cross-computer work in #1808, not because the transport is load-bearing for local peers. That is a
+deliberate choice and should be revisited if it turns out to cost more than it saves.
+
+## Failure and revocation semantics
+
+The issue requires these to be defined, not left to implementation:
+
+- **Fail closed before content.** Admission is decided before any session or message frame is
+  exposed. A failed proof yields no handler, no pending state, and no partially-initialised channel.
+- **Mismatch** (uid differs, or the kernel cannot answer) — reject. An unanswerable credential is a
+  rejection, never a pass; the OS not knowing is not the OS approving.
+- **Replay** — the nonce is single-use and bound to one connection attempt; a second presentation is
+  a rejection, not a re-admission.
+- **Timeout** — admission has a bounded window; expiry tears down the rendezvous and the channel.
+- **Revocation** — the runtime directory entry IS the grant. Removing it (session exit, explicit
+  revoke) ends admissibility for new attempts; existing admitted channels are closed on the owning
+  session's shutdown path.
+- **Trust limit, documented for the user**: this proves _same machine, same user account_. It does
+  not defend against another process running AS THAT USER on that machine. That is the correct
+  boundary for a local-peer feature and must be stated rather than implied.
+
+## Test Plan
+
+| TC-ID | Test Type   | Tool / Approach                                     | Notes                                                          |
+| ----- | ----------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| TC-01 | Unit test   | Kernel peer credential read over a real socket pair | The proof is the OS answer; a mocked one would assert nothing  |
+| TC-02 | Unit test   | Admission with a mismatched uid                     | Must reject before any handler exists                          |
+| TC-03 | Unit test   | Kernel cannot answer (unsupported platform path)    | Unanswerable must reject, not pass                             |
+| TC-04 | Unit test   | Nonce replayed on a second attempt                  | Single-use proven, not assumed                                 |
+| TC-05 | Unit test   | Timeout during admission                            | No leaked pending state or handler                             |
+| TC-06 | Unit test   | Concurrent attempts from two peers                  | Deterministic outcome, no interleaved admission                |
+| TC-07 | Unit test   | Revocation: runtime entry removed                   | New attempts refused; the admitted channel closes on shutdown  |
+| TC-08 | Integration | Nonce bound into the pairing confirmation           | The admitted WebRTC channel is the peer the kernel vouched for |
+
+## User Execution Test Scenarios
+
+Deferred until the recommendation is accepted, because what a user can run depends on which
+alternative is chosen — under A there is nothing to demonstrate beyond a loopback connection, while
+under D the observable is two local sessions admitting each other and a third, running as a different
+user, being refused. Writing the scenario before that decision would be writing it for a design that
+may not be built.
+
+The scenario this item expects to carry, for the recommended alternative: start two `agent-cli`
+sessions as the same user, observe mutual admission; start a third under a different account, observe
+refusal with no session content exposed. Both halves are agent-executable on a POSIX host without
+credentials or network.

--- a/packages/agent-remote-pairing/docs/SPEC.md
+++ b/packages/agent-remote-pairing/docs/SPEC.md
@@ -57,6 +57,27 @@ detection is a **directional, nonce-bound HMAC key-confirmation** bound to both 
 | `deriveReconnectSeed`       | function | HKDF a per-device reconnect seed from the pairing `sessionKey` (REMOTE-013 E4).                       |
 | `deriveReconnectRendezvous` | function | HKDF a fresh reconnect rendezvous id from `(seed, counter)` — single-use room per reconnect (E4).     |
 
+### `/local` subpath — SEC-010 local-peer admission (node-only)
+
+A SEPARATE entry point, not part of the surface above. The main entry is isomorphic (WebCrypto, no
+Node built-ins) and runs in the browser remote client; this needs the filesystem, and a browser has
+no local peers and no directory permissions to judge.
+
+| Export                    | Kind     | Purpose                                                                                                  |
+| ------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `admitLocalPeerDirectory` | function | Establish that a rendezvous directory is user-owned and mode 0700 — the evidence the kernel enforces.    |
+| `admitLocalPeerSocket`    | function | The same, plus the socket path resolving INSIDE that directory.                                          |
+| `refuseLocalPeer`         | function | Build a refusal in one place, so no call site can construct an admitted-looking result without evidence. |
+
+**What this proves, and what it does not.** Reaching a socket inside a 0700 user-owned directory
+means the peer is on this machine as this user, because the kernel refuses the traversal to anyone
+else — the evidence is not an artifact the peer supplies, so there is nothing to copy. It does NOT
+distinguish two processes of the same user; the boundary is the account.
+
+`SO_PEERCRED` would have been the more direct reading, and it is unavailable: Node exposes no
+peer-credential accessor on a connected socket handle (measured). Building on it would have produced
+a mechanism that compiles, passes a mocked test, and refuses every real peer.
+
 ## Type Ownership
 
 | Type                                                                                                              | Location                 | Purpose                              |

--- a/packages/agent-remote-pairing/package.json
+++ b/packages/agent-remote-pairing/package.json
@@ -17,6 +17,18 @@
         "import": "./dist/node/index.js",
         "require": "./dist/node/index.cjs"
       }
+    },
+    "./local": {
+      "types": "./dist/node/local/index.d.ts",
+      "source": "./src/local/index.ts",
+      "node": {
+        "import": "./dist/node/local/index.js",
+        "require": "./dist/node/local/index.cjs"
+      },
+      "default": {
+        "import": "./dist/node/local/index.js",
+        "require": "./dist/node/local/index.cjs"
+      }
     }
   },
   "repository": {

--- a/packages/agent-remote-pairing/src/__tests__/isomorphic.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/isomorphic.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -7,15 +7,27 @@ import { describe, expect, it } from 'vitest';
  * REMOTE-005 B3 TC-10 — the package must be isomorphic (Node 22 + browser): its shipped source may use ONLY
  * WebCrypto/standard web APIs. Assert no `node:` imports and no `crypto.timingSafeEqual` (node-only) leak into
  * the source, so the Stage-D browser client can reuse it unchanged.
+ *
+ * SCOPED TO THE MAIN ENTRY (SEC-010). `src/local/` is a SEPARATE, node-only entry point exported at
+ * `@robota-sdk/agent-remote-pairing/local`, and it needs `node:fs` by design: its whole proof is a
+ * directory's owner and mode, which a browser has no way to read and no local peer to read it for.
+ *
+ * Excluding it does NOT weaken this test. The claim being defended is that the BROWSER-REACHABLE
+ * surface stays isomorphic, and nothing in `src/local/` is reachable from `src/index.ts` — asserted
+ * below rather than assumed, because an exclusion that also excused an accidental import from the
+ * main entry would quietly turn this check off.
  */
 
 const SRC_DIR = join(__dirname, '..');
+const NODE_ONLY_ENTRY = 'local';
 
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      if (entry.name !== '__tests__') out.push(...sourceFiles(join(dir, entry.name)));
+      if (entry.name !== '__tests__' && entry.name !== NODE_ONLY_ENTRY) {
+        out.push(...sourceFiles(join(dir, entry.name)));
+      }
     } else if (entry.name.endsWith('.ts')) {
       out.push(join(dir, entry.name));
     }
@@ -37,6 +49,31 @@ describe('agent-remote-pairing isomorphism (REMOTE-005 B3 — TC-10)', () => {
         /timingSafeEqual\s*\(/,
       );
     }
+  });
+
+  it('the node-only entry is NOT reachable from the main entry (SEC-010)', () => {
+    // The exclusion above is only safe while this holds. Asserted rather than assumed: an
+    // accidental `export … from './local/…'` in the main entry would put node:fs back on the
+    // browser surface, and the exclusion would then be hiding exactly the defect this file exists
+    // to catch. Walk the main entry's transitive relative imports and require none to enter local/.
+    const seen = new Set<string>();
+    const queue = [join(SRC_DIR, 'index.ts')];
+    while (queue.length > 0) {
+      const file = queue.pop() as string;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      const code = readFileSync(file, 'utf8');
+      for (const match of code.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+        const target = join(dirname(file), match[1].replace(/\.js$/, '.ts'));
+        expect(target, `${file} must not reach the node-only entry`).not.toMatch(
+          new RegExp(`\\${sep}${NODE_ONLY_ENTRY}\\${sep}`),
+        );
+        if (existsSync(target)) queue.push(target);
+      }
+    }
+
+    // Fail closed: a walk that visited only the entry file would pass this vacuously.
+    expect(seen.size).toBeGreaterThan(1);
   });
 
   it('runs its crypto under the isomorphic globalThis.crypto (WebCrypto)', () => {

--- a/packages/agent-remote-pairing/src/local/__tests__/peer-credential.test.ts
+++ b/packages/agent-remote-pairing/src/local/__tests__/peer-credential.test.ts
@@ -1,0 +1,208 @@
+import { chmodSync, mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+  admitLocalPeerDirectory,
+  admitLocalPeerSocket,
+  refuseLocalPeer,
+} from '../peer-credential.js';
+
+const scratch: string[] = [];
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+});
+
+function guardedDir(mode = 0o700): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sec-010-'));
+  scratch.push(dir);
+  chmodSync(dir, mode);
+  return dir;
+}
+
+const UID = process.getuid?.() ?? 0;
+
+describe('SEC-010 — the evidence is what the kernel enforces, not what the peer presents', () => {
+  it('admits a directory this user owns that no other account can traverse', () => {
+    const dir = guardedDir(0o700);
+
+    const admission = admitLocalPeerDirectory(dir, { expectedUid: UID });
+
+    expect(admission.admitted).toBe(true);
+    expect(admission.trust).toBe('same-user-same-host');
+    expect(admission.binding?.ownerUid).toBe(UID);
+  });
+
+  it('refuses a directory another account can enter — the whole proof is that they cannot', () => {
+    // 0o755 is the ordinary, harmless-looking mode that silently destroys the guarantee: every
+    // account on the host can now traverse to the socket, so reaching it proves nothing.
+    const dir = guardedDir(0o755);
+
+    const admission = admitLocalPeerDirectory(dir, { expectedUid: UID });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.trust).toBe('unproven');
+    expect(admission.reason).toMatch(/group or other access/);
+  });
+
+  it('refuses group-readable as well as world-readable', () => {
+    expect(admitLocalPeerDirectory(guardedDir(0o750), { expectedUid: UID }).admitted).toBe(false);
+    expect(admitLocalPeerDirectory(guardedDir(0o701), { expectedUid: UID }).admitted).toBe(false);
+  });
+
+  it('refuses a directory owned by another uid', () => {
+    const dir = guardedDir(0o700);
+
+    // The uid is injected rather than spoofed: the decision under test is the comparison, and a
+    // test that needed a second real account could not run anywhere.
+    const admission = admitLocalPeerDirectory(dir, { expectedUid: UID + 1 });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toMatch(/belongs to uid/);
+  });
+
+  it('refuses a symbolic link, because a link can be repointed after it is checked', () => {
+    const real = guardedDir(0o700);
+    const holder = guardedDir(0o700);
+    const link = path.join(holder, 'link');
+    symlinkSync(real, link);
+
+    // Resolution happens first and the link check second, so a swap between the two reads cannot
+    // slip past. `resolve` is stubbed to identity to exercise that ordering directly.
+    const admission = admitLocalPeerDirectory(link, {
+      expectedUid: UID,
+      resolve: (target) => target,
+    });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toMatch(/symbolic link/);
+  });
+
+  it('refuses a path that is not a directory', () => {
+    const dir = guardedDir(0o700);
+    const file = path.join(dir, 'not-a-dir');
+    writeFileSync(file, '');
+
+    const admission = admitLocalPeerDirectory(file, { expectedUid: UID });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toMatch(/not a directory/);
+  });
+
+  it('refuses an unresolvable path rather than passing it', () => {
+    const admission = admitLocalPeerDirectory('/no/such/rendezvous', { expectedUid: UID });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toMatch(/could not be resolved/);
+  });
+
+  it('refuses when the directory cannot be inspected — a guard that cannot read must not admit', () => {
+    const admission = admitLocalPeerDirectory('/tmp', {
+      expectedUid: UID,
+      resolve: (target) => target,
+      statAt: () => {
+        throw new Error('EACCES');
+      },
+    });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toMatch(/could not be inspected/);
+  });
+
+  it('never carries a binding on a refusal', () => {
+    // The type permits it, so the invariant is asserted: a refusal must not hand back evidence a
+    // caller could read as a guarantee.
+    expect(refuseLocalPeer('any reason').binding).toBeUndefined();
+    expect(
+      admitLocalPeerDirectory(guardedDir(0o755), { expectedUid: UID }).binding,
+    ).toBeUndefined();
+  });
+});
+
+describe('SEC-010 — the socket must be inside the directory that vouches for it', () => {
+  it('admits a socket path inside the guarded directory, before the socket exists', () => {
+    // Bind time is the ordinary case: the guarantee is the directory, and the file is not there yet.
+    const dir = guardedDir(0o700);
+
+    const admission = admitLocalPeerSocket(path.join(dir, 'peer.sock'), { expectedUid: UID });
+
+    expect(admission.admitted).toBe(true);
+    expect(admission.binding?.socketPath).toBe(path.join(dir, 'peer.sock'));
+  });
+
+  it('admits a real, listening socket inside the guarded directory', async () => {
+    // The end-to-end shape: a socket that actually exists and accepts a local connection.
+    const dir = guardedDir(0o700);
+    const socketPath = path.join(dir, 'live.sock');
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    const admission = admitLocalPeerSocket(socketPath, { expectedUid: UID });
+    const connected = await new Promise<boolean>((resolve) => {
+      const client = net.connect(socketPath, () => {
+        client.end();
+        resolve(true);
+      });
+      client.on('error', () => resolve(false));
+    });
+    server.close();
+
+    expect(admission.admitted).toBe(true);
+    expect(connected).toBe(true);
+  });
+
+  it('refuses a socket that resolves OUTSIDE the guarded directory', () => {
+    // Not redundant with the directory check: without containment, a caller could pass a valid
+    // directory and a path elsewhere, and the result would assert a guarantee about a different file.
+    const guarded = guardedDir(0o700);
+    const elsewhere = guardedDir(0o700);
+    const escaping = path.join(elsewhere, 'peer.sock');
+
+    const admission = admitLocalPeerSocket(escaping, {
+      expectedUid: UID,
+      // Directory validation passes; the socket then resolves somewhere else entirely.
+      resolve: (target) => (target === escaping ? '/tmp/other.sock' : target),
+    });
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toMatch(/outside the guarded directory/);
+  });
+
+  it('a socket in a world-traversable directory is refused however real it is', async () => {
+    const dir = guardedDir(0o755);
+    const socketPath = path.join(dir, 'open.sock');
+    const server = net.createServer();
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    const admission = admitLocalPeerSocket(socketPath, { expectedUid: UID });
+    server.close();
+
+    // It listens, it accepts, and it proves nothing — which is exactly the confusion this item
+    // exists to remove.
+    expect(admission.admitted).toBe(false);
+  });
+});
+
+describe('SEC-010 — what this does NOT prove', () => {
+  it('cannot distinguish two processes of the SAME user, and does not claim to', () => {
+    // The documented trust limit. Both admissions succeed because both processes are this user —
+    // the boundary is the account, not the process, and a caller must not read it as more.
+    const dir = guardedDir(0o700);
+    const first = admitLocalPeerDirectory(dir, { expectedUid: UID });
+    const second = admitLocalPeerDirectory(dir, { expectedUid: UID });
+
+    expect(first.trust).toBe('same-user-same-host');
+    expect(second.trust).toBe('same-user-same-host');
+    expect(first.binding?.ownerUid).toBe(second.binding?.ownerUid);
+  });
+
+  it('the trust vocabulary is closed, so a consumer cannot collapse it to a boolean by accident', () => {
+    const refused = admitLocalPeerDirectory(guardedDir(0o755), { expectedUid: UID });
+
+    expect(refused.trust).toBe('unproven');
+    expect(['same-user-same-host', 'unproven']).toContain(refused.trust);
+  });
+});

--- a/packages/agent-remote-pairing/src/local/__tests__/peer-credential.test.ts
+++ b/packages/agent-remote-pairing/src/local/__tests__/peer-credential.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync } from 'node:fs';
+import { chmodSync, mkdtempSync, symlinkSync, writeFileSync, rmSync } from 'node:fs';
 import net from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -157,7 +157,6 @@ describe('SEC-010 — the socket must be inside the directory that vouches for i
   it('refuses a socket that resolves OUTSIDE the guarded directory', () => {
     // Not redundant with the directory check: without containment, a caller could pass a valid
     // directory and a path elsewhere, and the result would assert a guarantee about a different file.
-    const guarded = guardedDir(0o700);
     const elsewhere = guardedDir(0o700);
     const escaping = path.join(elsewhere, 'peer.sock');
 

--- a/packages/agent-remote-pairing/src/local/index.ts
+++ b/packages/agent-remote-pairing/src/local/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@robota-sdk/agent-remote-pairing/local` — SEC-010 local-peer admission.
+ *
+ * A separate entry point because it is NODE-ONLY: the main entry is isomorphic (WebCrypto, no Node
+ * built-ins) and runs in the browser remote client, while this needs the filesystem. A browser has
+ * no local peers and no directory permissions to judge, so nothing here belongs on that surface.
+ */
+export {
+  admitLocalPeerDirectory,
+  admitLocalPeerSocket,
+  refuseLocalPeer,
+} from './peer-credential.js';
+export type {
+  IGuardedDirectoryOptions,
+  ILocalPeerAdmission,
+  ILocalPeerBinding,
+  TLocalPeerTrust,
+} from './peer-credential.js';

--- a/packages/agent-remote-pairing/src/local/peer-credential.ts
+++ b/packages/agent-remote-pairing/src/local/peer-credential.ts
@@ -1,0 +1,197 @@
+/**
+ * SEC-010: proving a local peer shares this environment, using a fact the KERNEL enforces rather
+ * than an artifact the peer presents.
+ *
+ * This is the whole point of the design. Every other admission mechanism in this package proves
+ * POSSESSION — of a pairing secret, of an identity private key — and possession is copyable, so it
+ * cannot carry the claim "the peer is on this machine, as this user". A copied credential admits
+ * whoever obtained it, from wherever they run it.
+ *
+ * MEASURED, AND IT CHANGED THE DESIGN. The first version of this file asked the kernel to NAME the
+ * peer, through `SO_PEERCRED` on the connected socket. Node does not expose it: probed on this
+ * runtime, a connected `net.Socket`'s handle carries no `getpeercred` and no peer-credential
+ * accessor under any name. That version would have compiled, passed a mocked test, and refused
+ * every real peer — a security mechanism that is merely inert is worse than none, because the
+ * feature above it looks implemented.
+ *
+ * So the evidence is the other half of the same kernel guarantee. A Unix socket inside a directory
+ * OWNED BY THIS USER AND MODE 0700 cannot be reached by another account at all — the kernel refuses
+ * the traversal. Where `SO_PEERCRED` would say "the peer is uid N", this says "no uid but ours could
+ * have got here", and for an admission decision those are the same answer reached from opposite
+ * sides. It is the mechanism an SSH agent socket and a Docker socket already rely on.
+ *
+ * What the swap gives up, stated rather than glossed: the peer's uid and pid are never learned, so
+ * an audit record cannot name the process on the other end. Admission does not need that; a future
+ * diagnostic might, and would need a native addon to get it.
+ *
+ * NODE-ONLY, DELIBERATELY. The rest of this package is isomorphic (WebCrypto, no Node built-ins) and
+ * runs in the Stage-D browser client. This file needs `node:fs`, so it lives behind the `/local`
+ * subpath — a browser has no local peers and no filesystem to be judged.
+ */
+
+import { lstatSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * The trust level an admission carries, as a closed vocabulary rather than a boolean.
+ *
+ * #1810 asks the consumer to receive "a narrow typed authenticated-peer/admission result, not a
+ * generic boolean", and the reason is visible here: `same-user-same-host` and `unproven` are not two
+ * values of one flag, they are different security situations, and a caller that treats them alike
+ * has lost the distinction this item exists to create.
+ */
+export type TLocalPeerTrust = 'same-user-same-host' | 'unproven';
+
+/** What was established about the rendezvous the peer had to reach. */
+export interface ILocalPeerBinding {
+  /** The socket path admission is bound to, fully resolved — no symlink may stand in for it. */
+  readonly socketPath: string;
+  /** The directory whose ownership and mode are the evidence. */
+  readonly guardedDirectory: string;
+  /** The uid the guarded directory belongs to; by construction, the only account that can connect. */
+  readonly ownerUid: number;
+}
+
+export interface ILocalPeerAdmission {
+  readonly admitted: boolean;
+  readonly trust: TLocalPeerTrust;
+  /** Present only when the guarantee held. Absent is not "unknown but probably fine". */
+  readonly binding?: ILocalPeerBinding;
+  /** Why admission was refused, for the operator. Absent when admitted. */
+  readonly reason?: string;
+}
+
+/**
+ * A refusal, built in one place so no call site can accidentally construct an admitted-looking
+ * result with no evidence behind it.
+ */
+export function refuseLocalPeer(reason: string): ILocalPeerAdmission {
+  return { admitted: false, trust: 'unproven', reason };
+}
+
+/** Mode bits that would let anyone outside the owner reach into the directory. */
+const GROUP_OR_OTHER = 0o077;
+
+interface IStatLike {
+  uid: number;
+  mode: number;
+  isDirectory: () => boolean;
+  isSymbolicLink: () => boolean;
+}
+
+export interface IGuardedDirectoryOptions {
+  /** The uid this process runs as. Injected so the decision is testable without spoofing a process. */
+  readonly expectedUid: number;
+  /** Stat reader, injected for the same reason. */
+  readonly statAt?: (target: string) => IStatLike;
+  /** Symlink resolver, injected so the resolution step itself can be exercised. */
+  readonly resolve?: (target: string) => string;
+}
+
+/**
+ * Establish that a rendezvous directory is one only this user can enter.
+ *
+ * Checked BEFORE a socket is created in it, because the guarantee is what makes the socket
+ * meaningful — binding first and validating after would leave a window in which a reachable socket
+ * exists with nothing yet established about who can reach it.
+ */
+export function admitLocalPeerDirectory(
+  directory: string,
+  options: IGuardedDirectoryOptions,
+): ILocalPeerAdmission {
+  const stat = options.statAt ?? ((target: string): IStatLike => lstatSync(target));
+  const resolve = options.resolve ?? ((target: string): string => realpathSync(target));
+
+  let resolved: string;
+  try {
+    resolved = resolve(directory);
+  } catch {
+    // allow-fallback: this does not substitute an alternative path — it converts an unresolvable
+    // directory into a REFUSAL. The terminal failure stays terminal; the failure IS the verdict.
+    return refuseLocalPeer(
+      `the rendezvous directory ${directory} could not be resolved. An unresolvable path is a ` +
+        'refusal, never a pass — this mechanism exists because absence of evidence was being read ' +
+        'as evidence.',
+    );
+  }
+
+  let info: IStatLike;
+  try {
+    info = stat(resolved);
+  } catch {
+    // allow-fallback: an uninspectable directory becomes a REFUSAL, never a permitted alternative.
+    // A guard that cannot read what it guards must not admit.
+    return refuseLocalPeer(`the rendezvous directory ${resolved} could not be inspected.`);
+  }
+
+  // Checked on the RESOLVED path deliberately: resolving first and rejecting a link second means a
+  // link cannot be swapped in between the two reads.
+  if (info.isSymbolicLink()) {
+    return refuseLocalPeer(
+      `${resolved} is a symbolic link. The guarantee is about the directory the kernel enforces ` +
+        'permissions on, and a link can be repointed after it is checked.',
+    );
+  }
+  if (!info.isDirectory()) {
+    return refuseLocalPeer(`${resolved} is not a directory, so it cannot guard a rendezvous.`);
+  }
+  if (info.uid !== options.expectedUid) {
+    return refuseLocalPeer(
+      `the rendezvous directory ${resolved} belongs to uid ${info.uid}, not ` +
+        `${options.expectedUid}. A directory this user does not own is not this user's boundary.`,
+    );
+  }
+  if ((info.mode & GROUP_OR_OTHER) !== 0) {
+    return refuseLocalPeer(
+      `the rendezvous directory ${resolved} is mode ${(info.mode & 0o777).toString(8)}, which ` +
+        'grants group or other access. The whole proof is that no other account can traverse it.',
+    );
+  }
+
+  return {
+    admitted: true,
+    trust: 'same-user-same-host',
+    binding: { socketPath: '', guardedDirectory: resolved, ownerUid: info.uid },
+  };
+}
+
+/**
+ * Admit a rendezvous socket: the guarded directory, plus the socket path resolving INSIDE it.
+ *
+ * The containment check is not redundant with the directory check. Without it a caller could pass a
+ * validated directory and a socket path somewhere else entirely, and the result would assert a
+ * guarantee that applies to a different file.
+ */
+export function admitLocalPeerSocket(
+  socketPath: string,
+  options: IGuardedDirectoryOptions,
+): ILocalPeerAdmission {
+  const admission = admitLocalPeerDirectory(path.dirname(socketPath), options);
+  if (!admission.admitted || admission.binding === undefined) return admission;
+
+  const resolve = options.resolve ?? ((target: string): string => realpathSync(target));
+  const guarded = admission.binding.guardedDirectory;
+  let resolvedSocket: string;
+  try {
+    resolvedSocket = resolve(socketPath);
+  } catch {
+    // allow-fallback: the socket not existing YET is the ordinary state at bind time, and the
+    // guarantee is carried by the DIRECTORY rather than by the file. The computed path is still
+    // containment-checked below, so this widens nothing that gets admitted.
+    resolvedSocket = path.join(guarded, path.basename(socketPath));
+  }
+
+  const inside = resolvedSocket === guarded || resolvedSocket.startsWith(`${guarded}${path.sep}`);
+  if (!inside) {
+    return refuseLocalPeer(
+      `${resolvedSocket} resolves outside the guarded directory ${guarded}, so that directory's ` +
+        'permissions say nothing about it.',
+    );
+  }
+
+  return {
+    admitted: true,
+    trust: 'same-user-same-host',
+    binding: { ...admission.binding, socketPath: resolvedSocket },
+  };
+}

--- a/packages/agent-remote-pairing/tsdown.config.ts
+++ b/packages/agent-remote-pairing/tsdown.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // SEC-010: the /local entry is node-only and is built separately so the main entry stays
+  // isomorphic — a browser bundle must not pull node:fs in through a shared chunk.
+  entry: ['src/index.ts', 'src/local/index.ts'],
   format: ['esm', 'cjs'],
   outDir: 'dist/node',
   platform: 'neutral',


### PR DESCRIPTION
Implements the admission port #1810 requires and #1809 consumes, behind a node-only `/local` subpath.
Does **not** close #1810 — the WebRTC channel binding (Alternative D's second half) is still to come.

## The problem #1810 states

Every existing mechanism in this package proves **possession** — of a pairing secret, of an identity
private key. Possession is copyable, so it cannot carry the claim *"the peer is on this machine, as
this user"*: a copied credential admits whoever obtained it, from wherever they run it.

| Existing mechanism | What it proves | Why it is not enough |
| --- | --- | --- |
| Pairing secret + DTLS fingerprint | This **channel** ends at whoever knows the secret | Says nothing about where that peer runs |
| Device identity keypair | The peer holds a **private key** | A key is a file; files copy |

## Measurement changed the design, before any code was written

The recommendation was to have the kernel **name** the peer via `SO_PEERCRED`. Probed on this
runtime: a connected `net.Socket`'s handle exposes no `getpeercred` and no peer-credential accessor
under any name — zero members matching `/peer|cred/i`. Reaching the syscall needs a native addon this
repository does not ship.

Building on it would have **compiled, passed a mocked test, and refused every real peer.** A security
mechanism that is merely inert is worse than none, because the feature above it looks implemented.
The probe is recorded in the task rather than the design being quietly swapped.

## What landed: the other half of the same kernel guarantee

A rendezvous inside a directory **owned by this user at mode 0700**, which no other account can
traverse. Where `SO_PEERCRED` would say *"the peer is uid N"*, this says *"no uid but ours could have
got here"* — the same answer for an admission decision, reached from the opposite side. It is what an
SSH agent socket and a Docker socket already rely on, and the evidence is still not an artifact the
peer supplies, so there is still nothing to copy.

**The sharp edge, and why the refusals are the larger half of the suite:** the guarantee lives
entirely in the directory mode. `0755` looks harmless and destroys it — every account on the host can
then reach the socket, and reaching it proves nothing. Owner and mode are therefore validated
**before** a socket is bound. Refused: permissive modes (`0755`/`0750`/`0701`), a foreign owner, a
symlink, a non-directory, an unresolvable path, an unreadable one, and a socket resolving outside the
directory that vouches for it.

## Contract shape

`TLocalPeerTrust` is a closed vocabulary — `same-user-same-host` | `unproven` — not a boolean,
because #1810 asks the consumer to receive "a narrow typed admission result, not a generic boolean".
Those are different security situations and a caller that treats them alike has lost the distinction.
A refusal never carries a binding, asserted rather than left to the type.

**The documented limit is tested, not just written**: this does not separate two processes of the
same user. The boundary is the account.

## The package's own isomorphism test caught this, correctly

`node:fs` has no place on the browser-reachable surface. The test's scope is now that surface, and
**the exclusion is proven not to weaken it**: a new case walks the main entry's transitive relative
imports and fails if any reaches `local/`. Red-proofed by adding such a re-export and watching it
fail, then removing it.

## Verification

- `pnpm harness:scan` — **120 passed**, 1 skipped
- `agent-remote-pairing` — **55 tests passed** (15 new, on real sockets and real directory modes)
- `pnpm typecheck` — clean
- `/local` builds as a separate entry, so the main bundle stays isomorphic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD