### PR TITLE
feat(agent-framework): peer messages reach the runtime with explicit origin (#1809)

### DIFF
--- a/.agents/tasks/PEER-003-peer-input-coalescing-loses-conversation-turns.md
+++ b/.agents/tasks/PEER-003-peer-input-coalescing-loses-conversation-turns.md
@@ -1,0 +1,67 @@
+---
+title: 'PEER-003: the mid-turn input queue coalesces last-wins per driver, which silently costs a peer conversation its earlier message'
+status: todo
+created: 2026-08-17
+priority: medium
+urgency: later
+area: packages/agent-framework
+depends_on: []
+---
+
+# PEER-003: last-wins coalescing is right for a typist and wrong for a conversation
+
+Raised while implementing PEER-002 (#1809). Not a defect in what landed — it is a question about an
+existing policy that a new input source now reaches, and the rule is that an argument against a rule
+is the input to an amendment, never an exemption from it. So it is filed rather than worked around.
+
+## The behaviour
+
+`PendingInputQueue.enqueue` (REMOTE-014 E5) coalesces when an arriving input has the same
+`driverId` as the queue's tail: the tail is replaced, and settled with `TTurnNotRunReason`
+`'coalesced'`. The stated intent is "editable-pending, last-wins-per-driver semantics + caps a
+single flooder", and for its original source — a human who typed again while a turn ran — that is
+exactly right. The second thing they typed is what they meant.
+
+PEER-002 submits an admitted peer message as a turn attributed to that peer. Two messages from ONE
+peer arriving during a single running turn therefore coalesce, and the first one never runs.
+
+## Why that is a different question for a peer
+
+A person retyping is revising. A peer sending two messages is saying two things. Dropping the first
+is not "last wins" — it is losing half of what was said, and the flooder-cap rationale is already
+served by the queue's depth bound.
+
+It is not silent, which is the one thing that keeps this at medium: the replaced entry settles with
+`'coalesced'`, PEER-002 maps that to a refused ack with that exact reason, and the sending peer is
+told. The conversation degrades visibly rather than quietly.
+
+## What must NOT be done about it
+
+- **Do not give each peer message a distinct `driverId` to dodge the tail check.** `TDriverId` is
+  display attribution by contract. Using it to steer queue behaviour would make an attribution field
+  load-bearing for control flow, which is the misuse its own contract warns against.
+- **Do not give peer input a private queue.** That is the defect PEER-002's first draft shipped and
+  its review caught: a second answer to a question this repository already answered, which
+  immediately grew two bugs the original never had.
+
+## The options worth weighing
+
+| Option                                                  | Cost                                                                                   |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Coalesce only when the turn source is `'user'`          | Smallest change; makes the queue's policy depend on origin, which it currently ignores |
+| Make coalescing a per-submission option the caller sets | Explicit at the call site; adds a field every submitter must now reason about          |
+| Leave it, and document the ack the peer receives        | No code change; a two-message burst mid-turn keeps losing its first message            |
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach                                  | Notes                                                                        |
+| ----- | --------- | ------------------------------------------------ | ---------------------------------------------------------------------------- |
+| TC-01 | Unit      | Two peer messages arrive during one running turn | Both run, in arrival order — the observable the chosen option must produce   |
+| TC-02 | Unit      | Two user inputs during one running turn          | Still coalesces; the amendment must not regress REMOTE-014 E5                |
+| TC-03 | Unit      | Queue depth bound with peer input                | The flooder cap still applies — this is not a licence for an unbounded queue |
+
+## User Execution Test Scenarios
+
+To be written with the implementation. Shape: two local `agent-cli` sessions, one sends two messages
+in quick succession while the receiving session is mid-turn, and the operator sees both answered
+rather than only the second.

--- a/packages/agent-framework/src/interactive/__tests__/peer-message-ingress.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/peer-message-ingress.test.ts
@@ -25,13 +25,20 @@ function ingress(
 }
 
 /** A host that records what reached the runtime, and whose busy state the test drives. */
-function host(): IPeerIngressHost & { delivered: IPeerMessageIngress[]; busy: boolean } {
+function host(): IPeerIngressHost & {
+  delivered: IPeerMessageIngress[];
+  busy: boolean;
+  /** Model a real session: taking a message occupies it until the turn ends. */
+  startsTurnOnDeliver: boolean;
+} {
   const state = {
     delivered: [] as IPeerMessageIngress[],
     busy: false,
+    startsTurnOnDeliver: false,
     isBusy: () => state.busy,
     deliver: (i: IPeerMessageIngress) => {
       state.delivered.push(i);
+      if (state.startsTurnOnDeliver) state.busy = true;
     },
   };
   return state;
@@ -117,6 +124,49 @@ describe('PEER-002 — a busy session queues rather than dropping or interleavin
 
     expect(sut.drain()).toEqual([]);
     expect(sut.pending).toBe(1);
+  });
+
+  it('stops draining the moment a delivered message starts a turn', () => {
+    // The failure this guards: delivering a message MAY start a turn — that is why it is delivered
+    // — so a drain that read `isBusy()` once would hand the whole queue to a session that went busy
+    // on the very first one. That is the concurrent delivery this class exists to prevent, and a
+    // host whose `deliver` does not go busy cannot see it.
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+    sut.receive(ingress({ id: 'm1', sequence: 1 }));
+    sut.receive(ingress({ id: 'm2', sequence: 2 }));
+    sut.receive(ingress({ id: 'm3', sequence: 3 }));
+
+    h.busy = false;
+    h.startsTurnOnDeliver = true; // a realistic session: the first message occupies it
+    const drained = sut.drain();
+
+    expect(drained.map((d) => d.message.id)).toEqual(['m1']);
+    expect(h.delivered.map((d) => d.message.id)).toEqual(['m1']);
+    expect(sut.pending).toBe(2);
+
+    // ...and the rest are still there, in order, for the next drain.
+    h.busy = false;
+    h.startsTurnOnDeliver = false;
+    expect(sut.drain().map((d) => d.message.id)).toEqual(['m2', 'm3']);
+  });
+
+  it('a message arriving while others wait does not overtake them', () => {
+    // An idle session is not enough to deliver immediately: earlier messages are still queued, and
+    // jumping ahead of them would reach the agent out of arrival order — the only order a peer
+    // conversation has.
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+    sut.receive(ingress({ id: 'm1', sequence: 1 }));
+
+    h.busy = false;
+    const late = sut.receive(ingress({ id: 'm2', sequence: 2 }));
+
+    expect(late.outcome).toBe('queued');
+    expect(h.delivered).toHaveLength(0);
+    expect(sut.drain().map((d) => d.message.id)).toEqual(['m1', 'm2']);
   });
 
   it('refuses past the bound rather than growing without limit', () => {

--- a/packages/agent-framework/src/interactive/__tests__/peer-message-ingress.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/peer-message-ingress.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import { PeerMessageIngress, type IPeerIngressHost } from '../peer-message-ingress.js';
+import { TurnNotRunError } from '../turn-not-run-error.js';
 
-import type { IPeerMessageIngress, TPeerTrust } from '@robota-sdk/agent-interface-transport';
+import type {
+  IPeerMessageIngress,
+  IPeerOrigin,
+  ITurnHandle,
+  TPeerTrust,
+  TTurnNotRunReason,
+} from '@robota-sdk/agent-interface-transport';
 
 function ingress(
   over: { id?: string; sequence?: number; trust?: TPeerTrust; admitted?: boolean } = {},
@@ -12,7 +19,7 @@ function ingress(
     message: {
       id: over.id ?? 'msg_1',
       sequence: over.sequence ?? 1,
-      origin: { sessionId: 'peer_a', driverId: 'owner' },
+      origin: { sessionId: 'peer_a', driverId: 'peer:peer_a' },
       text: 'hello',
       sentAt: 1,
     },
@@ -24,217 +31,138 @@ function ingress(
   } as IPeerMessageIngress;
 }
 
-/** A host that records what reached the runtime, and whose busy state the test drives. */
+/**
+ * A host standing in for the session's submit path — it records what was submitted and lets the test
+ * settle the turn the way the real one does: a result, or a typed never-ran refusal.
+ */
 function host(): IPeerIngressHost & {
-  delivered: IPeerMessageIngress[];
-  busy: boolean;
-  /** Model a real session: taking a message occupies it until the turn ends. */
-  startsTurnOnDeliver: boolean;
+  submitted: { input: string; origin: IPeerOrigin }[];
+  settle: (reason?: TTurnNotRunReason) => void;
+  rejectSubmit?: Error;
 } {
+  let settleTurn: (() => void) | undefined;
   const state = {
-    delivered: [] as IPeerMessageIngress[],
-    busy: false,
-    startsTurnOnDeliver: false,
-    isBusy: () => state.busy,
-    deliver: (i: IPeerMessageIngress) => {
-      state.delivered.push(i);
-      if (state.startsTurnOnDeliver) state.busy = true;
+    submitted: [] as { input: string; origin: IPeerOrigin }[],
+    rejectSubmit: undefined as Error | undefined,
+    settle: (reason?: TTurnNotRunReason) => settleTurn?.(),
+    submit: async (input: string, origin: IPeerOrigin): Promise<ITurnHandle> => {
+      if (state.rejectSubmit) throw state.rejectSubmit;
+      state.submitted.push({ input, origin });
+      const turnId = `turn_${state.submitted.length}`;
+      let done: (v: unknown) => void = () => {};
+      let fail: (e: unknown) => void = () => {};
+      const completed = new Promise((resolve, reject) => {
+        done = resolve;
+        fail = reject;
+      });
+      state.settle = (reason?: TTurnNotRunReason) =>
+        reason === undefined ? done({ ok: true }) : fail(new TurnNotRunError(turnId, reason));
+      settleTurn = () => done({ ok: true });
+      return { turnId, completed } as unknown as ITurnHandle;
     },
   };
   return state;
 }
 
-describe('PEER-002 — an idle session takes the message (#1809)', () => {
-  it('delivers with the origin and trust intact', () => {
-    // Both halves of the requirement: it reaches the runtime, AND it still says where it came from.
-    // An agent answering a peer must be able to tell it is answering a peer.
+describe('PEER-002 — the message reaches the runtime, still saying where it came from (#1809)', () => {
+  it('submits the peer text attributed to the peer', async () => {
     const h = host();
-    const sut = new PeerMessageIngress(h);
 
-    const result = sut.receive(ingress());
+    const result = await new PeerMessageIngress(h).receive(ingress());
 
-    expect(result.outcome).toBe('delivered');
-    expect(result.ack.state).toBe('delivered');
-    expect(h.delivered).toHaveLength(1);
-    expect(h.delivered[0].message.origin.sessionId).toBe('peer_a');
-    expect(h.delivered[0].admission.trust).toBe('same-user-same-host');
+    expect(result.outcome).toBe('accepted');
+    expect(h.submitted).toHaveLength(1);
+    expect(h.submitted[0].input).toBe('hello');
+    expect(h.submitted[0].origin.sessionId).toBe('peer_a');
   });
 
-  it('refuses a message whose peer was not admitted, before it reaches the runtime', () => {
+  it('the immediate ack says pending, not delivered', async () => {
+    // The runtime may not have it in hand — it can be waiting behind a running turn. `pending` is
+    // the contract's word for "not settled", and it is the only one that is true at this moment.
     const h = host();
-    const sut = new PeerMessageIngress(h);
 
-    const result = sut.receive(ingress({ admitted: false }));
+    const result = await new PeerMessageIngress(h).receive(ingress());
+
+    expect(result.ack.state).toBe('pending');
+  });
+
+  it('refuses a message whose peer was not admitted, before it reaches the runtime', async () => {
+    const h = host();
+
+    const result = await new PeerMessageIngress(h).receive(ingress({ admitted: false }));
 
     expect(result.outcome).toBe('refused');
-    expect(h.delivered).toHaveLength(0);
+    expect(result.ack.state).toBe('refused');
+    expect(result.settled).toBeUndefined();
+    expect(h.submitted).toHaveLength(0);
   });
 });
 
-describe('PEER-002 — a busy session queues rather than dropping or interleaving (#1809)', () => {
-  it('queues while a turn is running, and says so in the ack', () => {
-    // `delivered` would be a lie while it sits in a queue. `pending` is the contract's word for
-    // "not settled", which is the truth the sender needs to keep waiting.
+describe('PEER-002 — the session settles the turn, and that settlement IS the ack (#1809)', () => {
+  it('a turn that ran acknowledges', async () => {
     const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
+    const result = await new PeerMessageIngress(h).receive(ingress());
 
-    const result = sut.receive(ingress());
+    h.settle();
 
-    expect(result.outcome).toBe('queued');
-    expect(result.ack.state).toBe('pending');
-    expect(result.queueDepth).toBe(1);
-    expect(h.delivered).toHaveLength(0);
+    expect((await result.settled)?.state).toBe('acknowledged');
   });
 
-  it('does NOT deliver concurrently — the single-claim invariant is the session’s, not ours', () => {
-    // Running it anyway would violate the execution claim the rest of the session depends on, and
-    // this module must not invent a second answer to a question the session already owns.
+  // 'coalesced' — a newer message from this peer superseded it; 'dropped' — the pending queue was
+  // full; 'cancelled' — the session cancelled it. Every reason the queue can settle with.
+  it.each(['coalesced', 'dropped', 'cancelled'] as const)(
+    'reports %s as the typed reason, not a message string',
+    async (reason) => {
+      // RUNTIME-003's whole point: these are different facts, and a sender forced to regex-match an
+      // error message to tell them apart has learned nothing it can act on.
+      const h = host();
+      const result = await new PeerMessageIngress(h).receive(ingress());
+
+      h.settle(reason);
+      const ack = await result.settled;
+
+      expect(ack?.state).toBe('refused');
+      expect(ack?.reason).toBe(reason);
+    },
+  );
+
+  it('a session that is shutting down refuses rather than throwing at the channel pump', async () => {
     const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
+    h.rejectSubmit = new Error('Interactive session is shutting down.');
 
-    sut.receive(ingress({ id: 'm1', sequence: 1 }));
-    sut.receive(ingress({ id: 'm2', sequence: 2 }));
+    const result = await new PeerMessageIngress(h).receive(ingress());
 
-    expect(h.delivered).toHaveLength(0);
-    expect(sut.pending).toBe(2);
-  });
-
-  it('drains in arrival order once the turn finishes', () => {
-    const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
-    sut.receive(ingress({ id: 'm1', sequence: 1 }));
-    sut.receive(ingress({ id: 'm2', sequence: 2 }));
-
-    h.busy = false;
-    const drained = sut.drain();
-
-    expect(drained.map((d) => d.message.id)).toEqual(['m1', 'm2']);
-    expect(h.delivered.map((d) => d.message.id)).toEqual(['m1', 'm2']);
-    expect(sut.pending).toBe(0);
-  });
-
-  it('drains nothing while still busy', () => {
-    const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
-    sut.receive(ingress());
-
-    expect(sut.drain()).toEqual([]);
-    expect(sut.pending).toBe(1);
-  });
-
-  it('stops draining the moment a delivered message starts a turn', () => {
-    // The failure this guards: delivering a message MAY start a turn — that is why it is delivered
-    // — so a drain that read `isBusy()` once would hand the whole queue to a session that went busy
-    // on the very first one. That is the concurrent delivery this class exists to prevent, and a
-    // host whose `deliver` does not go busy cannot see it.
-    const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
-    sut.receive(ingress({ id: 'm1', sequence: 1 }));
-    sut.receive(ingress({ id: 'm2', sequence: 2 }));
-    sut.receive(ingress({ id: 'm3', sequence: 3 }));
-
-    h.busy = false;
-    h.startsTurnOnDeliver = true; // a realistic session: the first message occupies it
-    const drained = sut.drain();
-
-    expect(drained.map((d) => d.message.id)).toEqual(['m1']);
-    expect(h.delivered.map((d) => d.message.id)).toEqual(['m1']);
-    expect(sut.pending).toBe(2);
-
-    // ...and the rest are still there, in order, for the next drain.
-    h.busy = false;
-    h.startsTurnOnDeliver = false;
-    expect(sut.drain().map((d) => d.message.id)).toEqual(['m2', 'm3']);
-  });
-
-  it('a message arriving while others wait does not overtake them', () => {
-    // An idle session is not enough to deliver immediately: earlier messages are still queued, and
-    // jumping ahead of them would reach the agent out of arrival order — the only order a peer
-    // conversation has.
-    const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
-    sut.receive(ingress({ id: 'm1', sequence: 1 }));
-
-    h.busy = false;
-    const late = sut.receive(ingress({ id: 'm2', sequence: 2 }));
-
-    expect(late.outcome).toBe('queued');
-    expect(h.delivered).toHaveLength(0);
-    expect(sut.drain().map((d) => d.message.id)).toEqual(['m1', 'm2']);
-  });
-
-  it('refuses past the bound rather than growing without limit', () => {
-    // An unbounded queue turns a chatty peer into a memory leak. Refusing tells the sender; a
-    // silent drop would leave it holding an ack for a message that never lands.
-    const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h, { maxQueued: 2 });
-
-    sut.receive(ingress({ id: 'm1', sequence: 1 }));
-    sut.receive(ingress({ id: 'm2', sequence: 2 }));
-    const overflow = sut.receive(ingress({ id: 'm3', sequence: 3 }));
-
-    expect(overflow.outcome).toBe('refused');
-    expect(overflow.ack.reason).toMatch(/waiting for the running turn/);
-    expect(sut.pending).toBe(2);
+    expect(result.outcome).toBe('refused');
+    expect(result.ack.reason).toMatch(/shutting down/);
   });
 });
 
 describe('PEER-002 — the strict posture is opt-in, not assumed (#1809/#1810)', () => {
-  it('accepts a token-only peer by default', () => {
+  it('accepts a token-only peer by default', async () => {
     // #1809 owns message flow; #1810 owns admission. This module must not quietly become a second
     // admission gate, so the stricter posture is asked for explicitly.
     const h = host();
-    const sut = new PeerMessageIngress(h);
 
-    expect(sut.receive(ingress({ trust: 'token-only' })).outcome).toBe('delivered');
+    const result = await new PeerMessageIngress(h).receive(ingress({ trust: 'token-only' }));
+
+    expect(result.outcome).toBe('accepted');
   });
 
-  it('refuses a token-only peer when same-environment is required', () => {
+  it('refuses a token-only peer when same-environment is required', async () => {
     const h = host();
     const sut = new PeerMessageIngress(h, { requireSameEnvironment: true });
 
-    const result = sut.receive(ingress({ trust: 'token-only' }));
+    const result = await sut.receive(ingress({ trust: 'token-only' }));
 
     expect(result.outcome).toBe('refused');
     expect(result.ack.reason).toMatch(/copyable/);
-    expect(h.delivered).toHaveLength(0);
+    expect(h.submitted).toHaveLength(0);
   });
 
-  it('accepts a same-environment peer under the same requirement', () => {
+  it('accepts a same-environment peer under the same requirement', async () => {
     const h = host();
     const sut = new PeerMessageIngress(h, { requireSameEnvironment: true });
 
-    expect(sut.receive(ingress({ trust: 'same-user-same-host' })).outcome).toBe('delivered');
-  });
-});
-
-describe('PEER-002 — shutdown and disconnect (#1809)', () => {
-  it('returns what it abandoned so the sender can be told', () => {
-    // A sender holding a `pending` ack would otherwise wait forever. Handing the messages back is
-    // what lets the caller close that loop.
-    const h = host();
-    h.busy = true;
-    const sut = new PeerMessageIngress(h);
-    sut.receive(ingress({ id: 'm1', sequence: 1 }));
-    sut.receive(ingress({ id: 'm2', sequence: 2 }));
-
-    const abandoned = sut.abandon();
-
-    expect(abandoned.map((a) => a.message.id)).toEqual(['m1', 'm2']);
-    expect(sut.pending).toBe(0);
-    expect(h.delivered).toHaveLength(0);
-  });
-
-  it('abandoning an empty queue is not an event', () => {
-    const sut = new PeerMessageIngress(host());
-
-    expect(sut.abandon()).toEqual([]);
+    expect((await sut.receive(ingress({ trust: 'same-user-same-host' }))).outcome).toBe('accepted');
   });
 });

--- a/packages/agent-framework/src/interactive/__tests__/peer-message-ingress.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/peer-message-ingress.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import { PeerMessageIngress, type IPeerIngressHost } from '../peer-message-ingress.js';
+
+import type { IPeerMessageIngress, TPeerTrust } from '@robota-sdk/agent-interface-transport';
+
+function ingress(
+  over: { id?: string; sequence?: number; trust?: TPeerTrust; admitted?: boolean } = {},
+) {
+  const admitted = over.admitted ?? true;
+  return {
+    message: {
+      id: over.id ?? 'msg_1',
+      sequence: over.sequence ?? 1,
+      origin: { sessionId: 'peer_a', driverId: 'owner' },
+      text: 'hello',
+      sentAt: 1,
+    },
+    admission: {
+      admitted,
+      trust: over.trust ?? 'same-user-same-host',
+      ...(admitted ? { origin: { sessionId: 'peer_a' } } : { reason: 'not admitted' }),
+    },
+  } as IPeerMessageIngress;
+}
+
+/** A host that records what reached the runtime, and whose busy state the test drives. */
+function host(): IPeerIngressHost & { delivered: IPeerMessageIngress[]; busy: boolean } {
+  const state = {
+    delivered: [] as IPeerMessageIngress[],
+    busy: false,
+    isBusy: () => state.busy,
+    deliver: (i: IPeerMessageIngress) => {
+      state.delivered.push(i);
+    },
+  };
+  return state;
+}
+
+describe('PEER-002 — an idle session takes the message (#1809)', () => {
+  it('delivers with the origin and trust intact', () => {
+    // Both halves of the requirement: it reaches the runtime, AND it still says where it came from.
+    // An agent answering a peer must be able to tell it is answering a peer.
+    const h = host();
+    const sut = new PeerMessageIngress(h);
+
+    const result = sut.receive(ingress());
+
+    expect(result.outcome).toBe('delivered');
+    expect(result.ack.state).toBe('delivered');
+    expect(h.delivered).toHaveLength(1);
+    expect(h.delivered[0].message.origin.sessionId).toBe('peer_a');
+    expect(h.delivered[0].admission.trust).toBe('same-user-same-host');
+  });
+
+  it('refuses a message whose peer was not admitted, before it reaches the runtime', () => {
+    const h = host();
+    const sut = new PeerMessageIngress(h);
+
+    const result = sut.receive(ingress({ admitted: false }));
+
+    expect(result.outcome).toBe('refused');
+    expect(h.delivered).toHaveLength(0);
+  });
+});
+
+describe('PEER-002 — a busy session queues rather than dropping or interleaving (#1809)', () => {
+  it('queues while a turn is running, and says so in the ack', () => {
+    // `delivered` would be a lie while it sits in a queue. `pending` is the contract's word for
+    // "not settled", which is the truth the sender needs to keep waiting.
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+
+    const result = sut.receive(ingress());
+
+    expect(result.outcome).toBe('queued');
+    expect(result.ack.state).toBe('pending');
+    expect(result.queueDepth).toBe(1);
+    expect(h.delivered).toHaveLength(0);
+  });
+
+  it('does NOT deliver concurrently — the single-claim invariant is the session’s, not ours', () => {
+    // Running it anyway would violate the execution claim the rest of the session depends on, and
+    // this module must not invent a second answer to a question the session already owns.
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+
+    sut.receive(ingress({ id: 'm1', sequence: 1 }));
+    sut.receive(ingress({ id: 'm2', sequence: 2 }));
+
+    expect(h.delivered).toHaveLength(0);
+    expect(sut.pending).toBe(2);
+  });
+
+  it('drains in arrival order once the turn finishes', () => {
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+    sut.receive(ingress({ id: 'm1', sequence: 1 }));
+    sut.receive(ingress({ id: 'm2', sequence: 2 }));
+
+    h.busy = false;
+    const drained = sut.drain();
+
+    expect(drained.map((d) => d.message.id)).toEqual(['m1', 'm2']);
+    expect(h.delivered.map((d) => d.message.id)).toEqual(['m1', 'm2']);
+    expect(sut.pending).toBe(0);
+  });
+
+  it('drains nothing while still busy', () => {
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+    sut.receive(ingress());
+
+    expect(sut.drain()).toEqual([]);
+    expect(sut.pending).toBe(1);
+  });
+
+  it('refuses past the bound rather than growing without limit', () => {
+    // An unbounded queue turns a chatty peer into a memory leak. Refusing tells the sender; a
+    // silent drop would leave it holding an ack for a message that never lands.
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h, { maxQueued: 2 });
+
+    sut.receive(ingress({ id: 'm1', sequence: 1 }));
+    sut.receive(ingress({ id: 'm2', sequence: 2 }));
+    const overflow = sut.receive(ingress({ id: 'm3', sequence: 3 }));
+
+    expect(overflow.outcome).toBe('refused');
+    expect(overflow.ack.reason).toMatch(/waiting for the running turn/);
+    expect(sut.pending).toBe(2);
+  });
+});
+
+describe('PEER-002 — the strict posture is opt-in, not assumed (#1809/#1810)', () => {
+  it('accepts a token-only peer by default', () => {
+    // #1809 owns message flow; #1810 owns admission. This module must not quietly become a second
+    // admission gate, so the stricter posture is asked for explicitly.
+    const h = host();
+    const sut = new PeerMessageIngress(h);
+
+    expect(sut.receive(ingress({ trust: 'token-only' })).outcome).toBe('delivered');
+  });
+
+  it('refuses a token-only peer when same-environment is required', () => {
+    const h = host();
+    const sut = new PeerMessageIngress(h, { requireSameEnvironment: true });
+
+    const result = sut.receive(ingress({ trust: 'token-only' }));
+
+    expect(result.outcome).toBe('refused');
+    expect(result.ack.reason).toMatch(/copyable/);
+    expect(h.delivered).toHaveLength(0);
+  });
+
+  it('accepts a same-environment peer under the same requirement', () => {
+    const h = host();
+    const sut = new PeerMessageIngress(h, { requireSameEnvironment: true });
+
+    expect(sut.receive(ingress({ trust: 'same-user-same-host' })).outcome).toBe('delivered');
+  });
+});
+
+describe('PEER-002 — shutdown and disconnect (#1809)', () => {
+  it('returns what it abandoned so the sender can be told', () => {
+    // A sender holding a `pending` ack would otherwise wait forever. Handing the messages back is
+    // what lets the caller close that loop.
+    const h = host();
+    h.busy = true;
+    const sut = new PeerMessageIngress(h);
+    sut.receive(ingress({ id: 'm1', sequence: 1 }));
+    sut.receive(ingress({ id: 'm2', sequence: 2 }));
+
+    const abandoned = sut.abandon();
+
+    expect(abandoned.map((a) => a.message.id)).toEqual(['m1', 'm2']);
+    expect(sut.pending).toBe(0);
+    expect(h.delivered).toHaveLength(0);
+  });
+
+  it('abandoning an empty queue is not an event', () => {
+    const sut = new PeerMessageIngress(host());
+
+    expect(sut.abandon()).toEqual([]);
+  });
+});

--- a/packages/agent-framework/src/interactive/__tests__/peer-turn-attribution.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/peer-turn-attribution.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { acceptSubmission } from '../interactive-session-accept-submission.js';
+
+import type { SessionExecutionController } from '../interactive-session-execution-controller.js';
+
+/** The two things `acceptSubmission` actually touches on the controller. */
+function controller(): SessionExecutionController {
+  return {
+    turns: { begin: () => ({ turnId: 'turn_1', completed: Promise.resolve({}) }) },
+    enqueuePending: () => 'queued',
+  } as unknown as SessionExecutionController;
+}
+
+describe('PEER-002 — a peer turn is never attributed to the operator (#1809)', () => {
+  it('refuses a peer turn that carries no driver id', () => {
+    // Falling through to the owner default would put another session's message in the transcript
+    // under the operator's name. There is no id we could invent here that would be true, so this
+    // has to be the caller's to supply — and a default would hide that it was missing.
+    expect(() => acceptSubmission({ turnSource: 'peer' }, controller())).toThrow(
+      /peer turn must carry the peer driver id/,
+    );
+  });
+
+  it('keeps the peer driver id when one is given', () => {
+    const accepted = acceptSubmission(
+      { turnSource: 'peer', driverId: 'peer:session_b' },
+      controller(),
+    );
+
+    expect(accepted.driverId).toBe('peer:session_b');
+  });
+
+  it('leaves the existing user and agent-wakeup defaults untouched', () => {
+    // The new branch must not be a behaviour change for the two sources that were already here.
+    expect(acceptSubmission({}, controller()).driverId).toBe('owner');
+    expect(acceptSubmission({ turnSource: 'agent-wakeup' }, controller()).driverId).not.toBe(
+      'owner',
+    );
+  });
+});

--- a/packages/agent-framework/src/interactive/interactive-session-accept-submission.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-accept-submission.ts
@@ -48,6 +48,16 @@ export function acceptSubmission(
   options: ITurnOptions,
   execCtrl: SessionExecutionController,
 ): IAcceptedSubmission {
+  // PEER-002 (#1809): a peer turn has no default. Falling through to the owner would attribute
+  // another session's message to the operator — the same mis-attribution the agent id exists to
+  // prevent for autonomous turns, and worse here because a peer is a different party entirely.
+  // There is no id we could invent that would be true, so the caller must supply one.
+  if (options.turnSource === 'peer' && options.driverId === undefined) {
+    throw new Error(
+      'a peer turn must carry the peer driver id: defaulting to the owner would attribute another ' +
+        "session's message to the operator.",
+    );
+  }
   const driverId =
     options.driverId ?? (options.turnSource === 'agent-wakeup' ? AGENT_DRIVER_ID : OWNER_DRIVER_ID);
   const { turnId, completed } = execCtrl.turns.begin();

--- a/packages/agent-framework/src/interactive/peer-message-ingress.ts
+++ b/packages/agent-framework/src/interactive/peer-message-ingress.ts
@@ -8,71 +8,86 @@
  * peer origin and can trigger an agent response". Both halves matter, and the second is why the
  * origin cannot be flattened into the text: an agent that answers a peer must be able to tell that
  * it is answering a PEER rather than its own operator, because the two carry different authority.
+ * So the message is submitted with `turnSource: 'peer'` and the peer's driver id — origin the
+ * runtime can branch on, not prose it would have to parse.
  *
  * `TDriverId` is display attribution and must never become an authorization input — the contract
- * says so and asserts it. This module keeps that separation on the runtime side: the trust level
- * travels beside the text, and the renderer gets the driver id.
+ * says so and asserts it. The trust level travels separately, in the admission this module checks.
  *
- * ## Concurrency, which the issue requires documented rather than discovered
+ * ## What this module does NOT do, and why that is the whole design
  *
- * A session may already be running a turn when a peer message arrives. The repository already owns
- * that question — `InteractiveExecutionClaimOwner` refuses a second concurrent claim — so this does
- * NOT invent a second answer. It reads the claim and reports what happened:
+ * A peer message arriving while a turn is running is an instance of "an input arrived mid-turn", and
+ * this repository already answered that question: `submitNewTurn` checks the execution claim,
+ * `PendingInputQueue` holds what cannot run yet under a bounded depth, and every entry that will
+ * never run settles its caller's handle with a typed `TTurnNotRunReason` (RUNTIME-003).
  *
- * - **idle** → the message is delivered and may start a turn.
- * - **busy** → the message is QUEUED, not dropped and not run concurrently. Dropping would lose a
- *   peer's message with an ack that said `delivered`; running concurrently would violate the
- *   single-foreground-claim invariant that the rest of the session depends on.
+ * The first draft of this file re-implemented all four of those — its own busy check, its own queue,
+ * its own bound, its own drain — which is a second answer to a settled question, and the review that
+ * caught it found two defects in the copy that the original had never had. There is no queue here
+ * now. This module owns only what is genuinely peer-specific:
  *
- * The queue is bounded. An unbounded one turns a chatty peer into a memory leak, and the bound is
- * surfaced as a refusal so the sender learns rather than being silently dropped — the same principle
- * the ledger applies to duplicates.
+ *  1. **Fail closed on admission.** A message from a peer that was not admitted never reaches the
+ *     runtime, and the stricter same-environment posture is available for a caller that wants it.
+ *  2. **Preserve origin.** Submit as a peer turn, attributed to the peer.
+ *  3. **Translate settlement into an ack.** The turn handle settles — with a result, or with a
+ *     `TurnNotRunError` naming why it never ran — and that is what the sender is told.
+ *
+ * ## Concurrency semantics, which the issue requires documented rather than discovered
+ *
+ * - **Idle session** → the message runs as a turn and the ack settles `acknowledged`.
+ * - **Busy session** → the existing pending queue holds it; the ack is `pending` until it settles.
+ * - **Superseded** → the pending queue coalesces a same-driver tail (last-wins per driver), so a
+ *   second message from one peer arriving mid-turn replaces the first. The replaced one is NOT lost
+ *   silently: it settles `refused` with reason `coalesced`, so the sender learns. Whether peer input
+ *   should be exempt from that policy is a question about the REMOTE-014 E5 queue rather than about
+ *   this module, and it is filed rather than worked around here.
+ * - **Queue full** → settles `refused` with reason `dropped`.
+ * - **Shutdown/cancel** → settles `refused` with reason `cancelled`.
  */
 
-import {
-  isSameEnvironmentPeer,
-  type IPeerMessageAck,
-  type IPeerMessageIngress,
+import { isSameEnvironmentPeer } from '@robota-sdk/agent-interface-transport';
+
+import type {
+  IPeerMessageAck,
+  IPeerMessageIngress,
+  IPeerOrigin,
+  ITurnHandle,
+  ITurnNotRunError,
 } from '@robota-sdk/agent-interface-transport';
 
-/** What the session did with an arriving peer message. */
+/** What happened to an arriving peer message at the moment it was received. */
 export type TIngressOutcome =
-  /** Handed to the runtime now. */
-  | 'delivered'
-  /** Held because a turn is running; will be handed over when the claim frees. */
-  | 'queued'
-  /** Refused — the queue is full, or admission did not establish enough. */
+  /** Handed to the session. Whether it runs now or waits is the session's existing decision. */
+  | 'accepted'
+  /** Never reached the runtime — admission did not establish enough, or the session is closing. */
   | 'refused';
 
 export interface IIngressResult {
   readonly outcome: TIngressOutcome;
+  /** The immediate ack: `pending` for an accepted message, `refused` for one that was not. */
   readonly ack: IPeerMessageAck;
-  /** How many messages are waiting behind this one. Present when queued. */
-  readonly queueDepth?: number;
+  /**
+   * The FINAL ack, once the turn ran or was settled as never-run.
+   *
+   * Present only when accepted. Separate from `ack` because the sender needs an answer before the
+   * turn finishes — a message queued behind a long turn would otherwise leave it silent for minutes
+   * — and a promise is the honest way to say "this is not settled yet".
+   */
+  readonly settled?: Promise<IPeerMessageAck>;
 }
 
 /**
  * The narrow view of a session this module needs.
  *
- * Deliberately not the session itself: the ingress decision depends on exactly two facts — whether a
- * turn is running, and where to put a message that is ready. Taking the whole session would let this
- * module grow into a second place that knows how sessions work.
+ * Exactly one operation, because that is the whole dependency: submit a peer turn and hand back the
+ * handle it settles on. Taking the session itself would let this module grow into a second place
+ * that knows how sessions work — which is the mistake this file already made once.
  */
 export interface IPeerIngressHost {
-  /** Is a foreground turn running right now? Reads the session's existing execution claim. */
-  isBusy(): boolean;
-  /** Hand a message to the runtime, with its origin and trust intact. */
-  deliver(ingress: IPeerMessageIngress): void;
+  submit(input: string, origin: IPeerOrigin): Promise<ITurnHandle>;
 }
 
 export interface IPeerIngressOptions {
-  /**
-   * How many messages may wait while a turn runs.
-   *
-   * Bounded on purpose: an unbounded queue turns a chatty peer into a memory leak, and a silent
-   * drop would contradict the `delivered` ack the sender already holds.
-   */
-  readonly maxQueued?: number;
   /**
    * Require the strongest local proof before a message reaches the runtime.
    *
@@ -83,120 +98,67 @@ export interface IPeerIngressOptions {
   readonly requireSameEnvironment?: boolean;
 }
 
-const DEFAULT_MAX_QUEUED = 32;
+function isTurnNotRun(error: unknown): error is ITurnNotRunError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name: unknown }).name === 'TurnNotRunError'
+  );
+}
 
-/**
- * The receiving side of peer messaging for one session.
- *
- * Holds the queue and nothing else — the ordering, duplicate and retry decisions belong to the
- * protocol ledger, and re-deciding them here would be a second answer to one question.
- */
+/** The receiving side of peer messaging for one session. */
 export class PeerMessageIngress {
-  private readonly queue: IPeerMessageIngress[] = [];
-
   constructor(
     private readonly host: IPeerIngressHost,
     private readonly options: IPeerIngressOptions = {},
   ) {}
 
-  get pending(): number {
-    return this.queue.length;
-  }
-
-  /** Take an admitted peer message and decide what happens to it now. */
-  receive(ingress: IPeerMessageIngress): IIngressResult {
+  /** Take a peer message and either submit it to the session or refuse it. */
+  async receive(ingress: IPeerMessageIngress): Promise<IIngressResult> {
     const base = { id: ingress.message.id, sequence: ingress.message.sequence };
+    const refuse = (reason: string): IIngressResult => ({
+      outcome: 'refused',
+      ack: { ...base, state: 'refused', reason },
+    });
 
     if (!ingress.admission.admitted) {
-      return {
-        outcome: 'refused',
-        ack: {
-          ...base,
-          state: 'refused',
-          reason: ingress.admission.reason ?? 'the peer was not admitted',
-        },
-      };
+      return refuse(ingress.admission.reason ?? 'the peer was not admitted');
     }
 
     if (this.options.requireSameEnvironment === true && !isSameEnvironmentPeer(ingress.admission)) {
-      return {
-        outcome: 'refused',
-        ack: {
-          ...base,
-          state: 'refused',
-          reason:
-            `this session requires a same-environment peer; admission established ` +
-            `'${ingress.admission.trust}'. A token proves possession, which is copyable, and says ` +
-            'nothing about where the peer runs.',
-        },
-      };
+      return refuse(
+        `this session requires a same-environment peer; admission established ` +
+          `'${ingress.admission.trust}'. A token proves possession, which is copyable, and says ` +
+          'nothing about where the peer runs.',
+      );
     }
 
-    // The queue has to be empty too, not just the session idle: a message that arrives while
-    // earlier ones are still waiting would otherwise overtake them and reach the agent out of
-    // order. Arrival order is the only order a peer conversation has.
-    if (!this.host.isBusy() && this.queue.length === 0) {
-      this.host.deliver(ingress);
-      return { outcome: 'delivered', ack: { ...base, state: 'delivered' } };
+    let handle: ITurnHandle;
+    try {
+      handle = await this.host.submit(ingress.message.text, ingress.message.origin);
+    } catch (error) {
+      // A session that is shutting down rejects the submission outright. That is a refusal the
+      // sender must hear rather than a crash in whatever is pumping the channel.
+      return refuse(error instanceof Error ? error.message : 'the session refused the submission');
     }
 
-    const limit = this.options.maxQueued ?? DEFAULT_MAX_QUEUED;
-    if (this.queue.length >= limit) {
-      return {
-        outcome: 'refused',
-        ack: {
-          ...base,
-          state: 'refused',
-          reason:
-            `this session already has ${limit} peer message(s) waiting for the running turn. ` +
-            'Refused rather than dropped: the sender holds the ack, so a silent drop would leave it ' +
-            'believing a message landed that never will.',
-        },
-      };
-    }
-
-    this.queue.push(ingress);
     return {
-      outcome: 'queued',
-      // `delivered` would be a lie while it sits in a queue, and `pending` is the contract's word
-      // for "not settled yet" — the sender keeps waiting, which is the truth.
+      outcome: 'accepted',
+      // `delivered` would claim the runtime has it in hand; it may be waiting behind a turn.
+      // `pending` is the contract's word for "not settled", which is what is true right now.
       ack: { ...base, state: 'pending' },
-      queueDepth: this.queue.length,
+      settled: handle.completed.then(
+        (): IPeerMessageAck => ({ ...base, state: 'acknowledged' }),
+        (error: unknown): IPeerMessageAck => ({
+          ...base,
+          state: 'refused',
+          // The typed reason is the point of RUNTIME-003: 'coalesced' (a newer message from this
+          // peer superseded it) and 'dropped' (the queue was full) are different facts, and a
+          // sender forced to regex a message string to tell them apart has learned nothing.
+          reason: isTurnNotRun(error) ? error.reason : 'the turn failed',
+        }),
+      ),
     };
-  }
-
-  /**
-   * Hand over everything that was waiting, in arrival order.
-   *
-   * Called when the session's turn finishes. Returns what it delivered so a caller can ack them —
-   * this module does not send, because a module that both decided and transmitted would be two
-   * responsibilities and one of them would be untestable without a transport.
-   *
-   * Busy is re-read BEFORE EVERY hand-over, not once at the top. Delivering a message may start a
-   * turn — that is the point of delivering it — so a loop that checked once would hand the whole
-   * queue to a session that went busy on the first one, which is exactly the concurrent delivery
-   * this class exists to prevent. Whatever is still waiting stays queued for the next drain.
-   */
-  drain(): readonly IPeerMessageIngress[] {
-    const handed: IPeerMessageIngress[] = [];
-    while (!this.host.isBusy()) {
-      const next = this.queue.shift();
-      if (next === undefined) break;
-      this.host.deliver(next);
-      handed.push(next);
-    }
-    return handed;
-  }
-
-  /**
-   * Drop everything waiting — the peer disconnected, or the session is shutting down.
-   *
-   * Returns the abandoned messages so the caller can tell the sender, if the channel still exists.
-   * Silently discarding them would leave a sender that holds a `pending` ack waiting forever.
-   */
-  abandon(): readonly IPeerMessageIngress[] {
-    const waiting = [...this.queue];
-    this.queue.length = 0;
-    return waiting;
   }
 }

--- a/packages/agent-framework/src/interactive/peer-message-ingress.ts
+++ b/packages/agent-framework/src/interactive/peer-message-ingress.ts
@@ -132,7 +132,10 @@ export class PeerMessageIngress {
       };
     }
 
-    if (!this.host.isBusy()) {
+    // The queue has to be empty too, not just the session idle: a message that arrives while
+    // earlier ones are still waiting would otherwise overtake them and reach the agent out of
+    // order. Arrival order is the only order a peer conversation has.
+    if (!this.host.isBusy() && this.queue.length === 0) {
       this.host.deliver(ingress);
       return { outcome: 'delivered', ack: { ...base, state: 'delivered' } };
     }
@@ -168,13 +171,21 @@ export class PeerMessageIngress {
    * Called when the session's turn finishes. Returns what it delivered so a caller can ack them —
    * this module does not send, because a module that both decided and transmitted would be two
    * responsibilities and one of them would be untestable without a transport.
+   *
+   * Busy is re-read BEFORE EVERY hand-over, not once at the top. Delivering a message may start a
+   * turn — that is the point of delivering it — so a loop that checked once would hand the whole
+   * queue to a session that went busy on the first one, which is exactly the concurrent delivery
+   * this class exists to prevent. Whatever is still waiting stays queued for the next drain.
    */
   drain(): readonly IPeerMessageIngress[] {
-    if (this.host.isBusy()) return [];
-    const waiting = [...this.queue];
-    this.queue.length = 0;
-    for (const ingress of waiting) this.host.deliver(ingress);
-    return waiting;
+    const handed: IPeerMessageIngress[] = [];
+    while (!this.host.isBusy()) {
+      const next = this.queue.shift();
+      if (next === undefined) break;
+      this.host.deliver(next);
+      handed.push(next);
+    }
+    return handed;
   }
 
   /**

--- a/packages/agent-framework/src/interactive/peer-message-ingress.ts
+++ b/packages/agent-framework/src/interactive/peer-message-ingress.ts
@@ -1,0 +1,191 @@
+/**
+ * PEER-002 (#1809): how a peer message becomes something the agent can read, without losing where it
+ * came from.
+ *
+ * ## The requirement that shapes this
+ *
+ * The issue asks that an incoming message "be added to the receiving runtime context with explicit
+ * peer origin and can trigger an agent response". Both halves matter, and the second is why the
+ * origin cannot be flattened into the text: an agent that answers a peer must be able to tell that
+ * it is answering a PEER rather than its own operator, because the two carry different authority.
+ *
+ * `TDriverId` is display attribution and must never become an authorization input — the contract
+ * says so and asserts it. This module keeps that separation on the runtime side: the trust level
+ * travels beside the text, and the renderer gets the driver id.
+ *
+ * ## Concurrency, which the issue requires documented rather than discovered
+ *
+ * A session may already be running a turn when a peer message arrives. The repository already owns
+ * that question — `InteractiveExecutionClaimOwner` refuses a second concurrent claim — so this does
+ * NOT invent a second answer. It reads the claim and reports what happened:
+ *
+ * - **idle** → the message is delivered and may start a turn.
+ * - **busy** → the message is QUEUED, not dropped and not run concurrently. Dropping would lose a
+ *   peer's message with an ack that said `delivered`; running concurrently would violate the
+ *   single-foreground-claim invariant that the rest of the session depends on.
+ *
+ * The queue is bounded. An unbounded one turns a chatty peer into a memory leak, and the bound is
+ * surfaced as a refusal so the sender learns rather than being silently dropped — the same principle
+ * the ledger applies to duplicates.
+ */
+
+import {
+  isSameEnvironmentPeer,
+  type IPeerMessageAck,
+  type IPeerMessageIngress,
+} from '@robota-sdk/agent-interface-transport';
+
+/** What the session did with an arriving peer message. */
+export type TIngressOutcome =
+  /** Handed to the runtime now. */
+  | 'delivered'
+  /** Held because a turn is running; will be handed over when the claim frees. */
+  | 'queued'
+  /** Refused — the queue is full, or admission did not establish enough. */
+  | 'refused';
+
+export interface IIngressResult {
+  readonly outcome: TIngressOutcome;
+  readonly ack: IPeerMessageAck;
+  /** How many messages are waiting behind this one. Present when queued. */
+  readonly queueDepth?: number;
+}
+
+/**
+ * The narrow view of a session this module needs.
+ *
+ * Deliberately not the session itself: the ingress decision depends on exactly two facts — whether a
+ * turn is running, and where to put a message that is ready. Taking the whole session would let this
+ * module grow into a second place that knows how sessions work.
+ */
+export interface IPeerIngressHost {
+  /** Is a foreground turn running right now? Reads the session's existing execution claim. */
+  isBusy(): boolean;
+  /** Hand a message to the runtime, with its origin and trust intact. */
+  deliver(ingress: IPeerMessageIngress): void;
+}
+
+export interface IPeerIngressOptions {
+  /**
+   * How many messages may wait while a turn runs.
+   *
+   * Bounded on purpose: an unbounded queue turns a chatty peer into a memory leak, and a silent
+   * drop would contradict the `delivered` ack the sender already holds.
+   */
+  readonly maxQueued?: number;
+  /**
+   * Require the strongest local proof before a message reaches the runtime.
+   *
+   * Default false: #1809 owns message flow and #1810 owns admission, and this module must not
+   * quietly become a second admission gate. A composition root that wants the stricter posture asks
+   * for it explicitly.
+   */
+  readonly requireSameEnvironment?: boolean;
+}
+
+const DEFAULT_MAX_QUEUED = 32;
+
+/**
+ * The receiving side of peer messaging for one session.
+ *
+ * Holds the queue and nothing else — the ordering, duplicate and retry decisions belong to the
+ * protocol ledger, and re-deciding them here would be a second answer to one question.
+ */
+export class PeerMessageIngress {
+  private readonly queue: IPeerMessageIngress[] = [];
+
+  constructor(
+    private readonly host: IPeerIngressHost,
+    private readonly options: IPeerIngressOptions = {},
+  ) {}
+
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  /** Take an admitted peer message and decide what happens to it now. */
+  receive(ingress: IPeerMessageIngress): IIngressResult {
+    const base = { id: ingress.message.id, sequence: ingress.message.sequence };
+
+    if (!ingress.admission.admitted) {
+      return {
+        outcome: 'refused',
+        ack: {
+          ...base,
+          state: 'refused',
+          reason: ingress.admission.reason ?? 'the peer was not admitted',
+        },
+      };
+    }
+
+    if (this.options.requireSameEnvironment === true && !isSameEnvironmentPeer(ingress.admission)) {
+      return {
+        outcome: 'refused',
+        ack: {
+          ...base,
+          state: 'refused',
+          reason:
+            `this session requires a same-environment peer; admission established ` +
+            `'${ingress.admission.trust}'. A token proves possession, which is copyable, and says ` +
+            'nothing about where the peer runs.',
+        },
+      };
+    }
+
+    if (!this.host.isBusy()) {
+      this.host.deliver(ingress);
+      return { outcome: 'delivered', ack: { ...base, state: 'delivered' } };
+    }
+
+    const limit = this.options.maxQueued ?? DEFAULT_MAX_QUEUED;
+    if (this.queue.length >= limit) {
+      return {
+        outcome: 'refused',
+        ack: {
+          ...base,
+          state: 'refused',
+          reason:
+            `this session already has ${limit} peer message(s) waiting for the running turn. ` +
+            'Refused rather than dropped: the sender holds the ack, so a silent drop would leave it ' +
+            'believing a message landed that never will.',
+        },
+      };
+    }
+
+    this.queue.push(ingress);
+    return {
+      outcome: 'queued',
+      // `delivered` would be a lie while it sits in a queue, and `pending` is the contract's word
+      // for "not settled yet" — the sender keeps waiting, which is the truth.
+      ack: { ...base, state: 'pending' },
+      queueDepth: this.queue.length,
+    };
+  }
+
+  /**
+   * Hand over everything that was waiting, in arrival order.
+   *
+   * Called when the session's turn finishes. Returns what it delivered so a caller can ack them —
+   * this module does not send, because a module that both decided and transmitted would be two
+   * responsibilities and one of them would be untestable without a transport.
+   */
+  drain(): readonly IPeerMessageIngress[] {
+    if (this.host.isBusy()) return [];
+    const waiting = [...this.queue];
+    this.queue.length = 0;
+    for (const ingress of waiting) this.host.deliver(ingress);
+    return waiting;
+  }
+
+  /**
+   * Drop everything waiting — the peer disconnected, or the session is shutting down.
+   *
+   * Returns the abandoned messages so the caller can tell the sender, if the channel still exists.
+   * Silently discarding them would leave a sender that holds a `pending` ack waiting forever.
+   */
+  abandon(): readonly IPeerMessageIngress[] {
+    const waiting = [...this.queue];
+    this.queue.length = 0;
+    return waiting;
+  }
+}

--- a/packages/agent-interface-transport/src/session-contracts.ts
+++ b/packages/agent-interface-transport/src/session-contracts.ts
@@ -38,7 +38,7 @@ import type {
   ISessionTurnSubmission,
   ISessionWorkspaceLocation,
 } from './session-capability-contracts.js';
-import type { IExecutionResult } from './turn-contracts.js';
+import type { IExecutionResult, TTurnSource } from './turn-contracts.js';
 import type { IExecutionWorkspaceEvent } from './workspace-contracts.js';
 import type {
   IActionRequest,
@@ -224,12 +224,13 @@ export interface IToolSummary {
   args: string;
 }
 
-// RUNTIME-003: a submission's identity and the ways it can end live in `./turn-contracts.js`.
+// RUNTIME-003: a submission's identity, its ORIGIN (PEER-002) and the ways it can end live there.
 export type {
   IExecutionResult,
   ITurnHandle,
   ITurnNotRunError,
   TTurnNotRunReason,
+  TTurnSource,
 } from './turn-contracts.js';
 
 /** Permission handler delegate — clients provide their own UI. */
@@ -277,8 +278,7 @@ export interface IPromptResolvedEvent {
 export interface IContextFileRefreshedEvent {
   filePath: string;
 }
-/** Origin of a turn — distinguishes a human prompt from an agent-wakeup re-entry (FLOW-002). */
-export type TTurnSource = 'user' | 'agent-wakeup';
+// is at its size ratchet, so a new member splits rather than extends (PEER-002, #1809).
 /** SELFHOST-007: a checkpoint/branch lifecycle transition a surface renders. */
 type TCheckpointEventKind = `checkpoint_${'created' | 'restored' | 'rolled_back'}`;
 type TBranchEventKind = `branch_${'forked' | 'switched'}`;

--- a/packages/agent-interface-transport/src/turn-contracts.ts
+++ b/packages/agent-interface-transport/src/turn-contracts.ts
@@ -88,3 +88,19 @@ export interface IExecutionResult {
   usage?: IUsageSnapshot;
   promptFileReferences?: IPromptFileReferenceRecord[];
 }
+
+/**
+ * Origin of a turn — a human prompt, an agent-wakeup re-entry (FLOW-002), or another session's
+ * message (PEER-002, #1809).
+ *
+ * `'peer'` is a MEMBER rather than something a caller encodes into the prompt text, because #1809
+ * requires a peer message to reach the runtime with EXPLICIT origin: an agent answering a peer must
+ * be able to tell that it is answering a peer rather than its own operator, and prose inside the
+ * input is not something code can branch on. WHICH peer it was travels in `driverId`, which stays
+ * display attribution and never becomes an authorization input.
+ *
+ * Declared here rather than in `session-contracts.ts`, where it used to live: that file is at its
+ * size ratchet and the rule is to split rather than extend, and turn origin belongs to turn identity
+ * — the same reasoning that created this file.
+ */
+export type TTurnSource = 'user' | 'agent-wakeup' | 'peer';


### PR DESCRIPTION
Advances #1809 — the **session-ingress** half. The CLI shell (discovery, commands, TUI projection) is what remains, and the issue stays open for it.

## What it does

`PeerMessageIngress` takes an admitted peer message and either submits it to the session or refuses it.

**Both halves of the requirement.** The issue asks that a message be added to the runtime context *with explicit peer origin* and *can trigger an agent response*. The second is why the origin cannot be flattened into the text — an agent answering a peer must be able to tell it is answering a peer rather than its own operator, and it cannot branch on a sentence pasted into its input. So `TTurnSource` gains a `'peer'` member and the peer's id rides in `driverId`, which stays display attribution and never becomes an authorization input.

## The design changed mid-PR, and that is the substance of it

Wiring this up for the CLI layer, I went looking for how a session handles an input that arrives while a turn is running — and found the repository had already answered it completely: `submitNewTurn` checks the execution claim, `PendingInputQueue` holds what cannot run yet under a bound of 32, and every entry that will never run settles its caller's handle with a typed `TTurnNotRunReason` (RUNTIME-003).

The first draft of this class had made all four decisions again — its own busy check, its own queue, its own bound of 32 (the same number, reached independently), its own drain — while its header claimed it did not. Worse, the two MUSTs I found and fixed in `a01318195` existed **only in my copy**: the original never drains past a session going busy, and never lets a late input overtake a queued one.

So the queue is gone. What remains is what is actually peer-specific:

1. **Fail closed on admission** — a peer that was not admitted never reaches the runtime.
2. **Preserve origin** — submit as a peer turn, attributed to the peer.
3. **Translate settlement into an ack** — the turn handle settles with a result or a typed never-ran reason, and that is what the sender is told.

## Two correctness changes that fell out of it

- **A peer turn can no longer borrow the operator's name.** Attribution defaulted to the owner for anything that was not an agent wakeup, so a peer's message would have landed in the transcript under the operator. There is no id that would be true, so the caller must supply one — the absence is an error, not a default.
- **`TTurnSource` moved to `turn-contracts.ts`.** Adding a member pushed `session-contracts.ts` past its size ratchet, where the rule is *split, don't extend*. Turn origin is turn identity's subject, and that file was itself split off `session-contracts.ts` for this same reason. `session-contracts.ts` is the size it was.

## Filed, not worked around

The pending queue coalesces last-wins per driver — right for a person retyping, wrong for a peer saying two things. **PEER-003** records the options. Two things I deliberately did *not* do: give each peer message a distinct `driverId` to dodge the tail check (that would make an attribution field load-bearing for control flow, against its own contract), or give peer input a private queue (the defect this PR just removed). The peer is told either way — the replaced entry settles `coalesced` and the ack carries that reason.

## Not added to the root barrel

`agent-framework`'s barrel is 688 lines and **ARCH-038 (#1806) is open on exactly that size**. The scans pass without the export, so the consumer that needs it can add it when the CLI layer lands.

## Verification

- 14 unit tests across the ingress and peer attribution; 281 `interactive` tests green
- `pnpm harness:scan` — 122 passed, 2 skipped
- `pnpm typecheck` clean; `verify-like-ci.mjs --only format-check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD