### PR TITLE
feat(agent-remote-pairing): bind the rendezvous proof to the channel with single-use grants (#1810)

### DIFF
--- a/packages/agent-remote-pairing/docs/SPEC.md
+++ b/packages/agent-remote-pairing/docs/SPEC.md
@@ -103,11 +103,38 @@ no local peers and no directory permissions to judge.
 | `admitLocalPeerDirectory` | function | Establish that a rendezvous directory is user-owned and mode 0700 — the evidence the kernel enforces.    |
 | `admitLocalPeerSocket`    | function | The same, plus the socket path resolving INSIDE that directory.                                          |
 | `refuseLocalPeer`         | function | Build a refusal in one place, so no call site can construct an admitted-looking result without evidence. |
+| `RendezvousGrantLedger`   | class    | The single-use, time-bounded, revocable grants that carry the rendezvous proof onto the channel.         |
+| `DEFAULT_GRANT_TTL_MS`    | const    | How long a grant stays admissible (30s — a channel handshake, not a session).                            |
 
 **What this proves, and what it does not.** Reaching a socket inside a 0700 user-owned directory
 means the peer is on this machine as this user, because the kernel refuses the traversal to anyone
 else — the evidence is not an artifact the peer supplies, so there is nothing to copy. It does NOT
 distinguish two processes of the same user; the boundary is the account.
+
+**Why the grant ledger is part of the proof rather than a convenience.** The directory check
+establishes the environment at the RENDEZVOUS, but the session's messages travel over a different
+carrier. Without a binding, a peer could pass the kernel's check at the socket and then hand the
+channel to somebody else, and the admission would still read `same-user-same-host` — the environment
+proof would be true and useless. The ledger issues a nonce at the rendezvous that the channel's
+pairing confirmation must present back.
+
+Its lifetime rules are the security properties, not bookkeeping:
+
+- **Single use.** A nonce honoured twice has become a copyable credential — the exact failure SEC-010
+  exists to prevent. A presentation spends the value even when the presentation is then refused,
+  so probing does not preserve it for a later real attempt.
+- **Bounded window.** Admission expires, so a value left in a log or a crashed process is not a
+  standing invitation.
+- **Revocation is the entry.** `revokeRendezvous` ends admissibility for everything a departing
+  session handed out.
+- **Deterministic under concurrency.** Two peers presenting one nonce cannot both win; the loser is
+  refused rather than queued, because a race resolved by timing is a decision nobody made.
+
+A replay is reported as `replayed` rather than folded into `unknown`. The usual argument for merging
+them — not telling a prober which values once existed — does not apply at this boundary: the only
+party who can reach this rendezvous already passed the kernel's check as this user, and could read
+the process's memory outright. An operator who cannot distinguish a replay from a slow peer cannot
+act on either.
 
 `SO_PEERCRED` would have been the more direct reading, and it is unavailable: Node exposes no
 peer-credential accessor on a connected socket handle (measured). Building on it would have produced

--- a/packages/agent-remote-pairing/src/local/__tests__/rendezvous-nonce.test.ts
+++ b/packages/agent-remote-pairing/src/local/__tests__/rendezvous-nonce.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_GRANT_TTL_MS, RendezvousGrantLedger } from '../rendezvous-nonce.js';
+
+const NOW = 1_700_000_000_000;
+const GUARDED = '/run/user/1000/robota/peers';
+const OTHER = '/run/user/1000/robota/other';
+
+describe('SEC-010 — the nonce carries the kernel’s answer from the rendezvous to the channel', () => {
+  it('honours a grant presented at the rendezvous it was issued for', () => {
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW });
+
+    const result = ledger.redeem(grant.nonce, GUARDED, NOW + 1);
+
+    expect(result.honoured).toBe(true);
+    expect(result.grant?.rendezvous).toBe(GUARDED);
+    expect(grant.expiresAt).toBe(NOW + DEFAULT_GRANT_TTL_MS);
+  });
+
+  it('TC-04: a second presentation is refused, and named as a replay', () => {
+    // Single-use is the property that keeps the nonce from becoming what this whole item exists to
+    // avoid — a copyable credential. `replayed` rather than `unknown` because an operator seeing a
+    // value honoured twice is looking at a bug or an attack, not at a slow peer.
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW });
+
+    expect(ledger.redeem(grant.nonce, GUARDED, NOW + 1).honoured).toBe(true);
+    const second = ledger.redeem(grant.nonce, GUARDED, NOW + 2);
+
+    expect(second.honoured).toBe(false);
+    expect(second.rejection).toBe('replayed');
+  });
+
+  it('refuses a nonce nobody issued, without claiming it was replayed', () => {
+    const ledger = new RendezvousGrantLedger();
+
+    expect(ledger.redeem('never-issued', GUARDED, NOW).rejection).toBe('unknown');
+  });
+
+  it('TC-05: refuses once the window has closed', () => {
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW, ttlMs: 1_000 });
+
+    expect(ledger.redeem(grant.nonce, GUARDED, NOW + 1_000).rejection).toBe('expired');
+  });
+
+  it('a refused presentation still spends the nonce', () => {
+    // Otherwise single-use would hold only for peers that got everything right first time: a holder
+    // could probe with a wrong rendezvous, learn nothing, and keep the value for a real attempt.
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW });
+
+    expect(ledger.redeem(grant.nonce, OTHER, NOW + 1).rejection).toBe('wrong-rendezvous');
+    expect(ledger.redeem(grant.nonce, GUARDED, NOW + 2).rejection).toBe('replayed');
+  });
+
+  it('a grant is not portable between rendezvous', () => {
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW });
+
+    expect(ledger.redeem(grant.nonce, OTHER, NOW + 1).honoured).toBe(false);
+  });
+});
+
+describe('SEC-010 — concurrency, revocation and cleanup are asserted, not assumed', () => {
+  it('TC-06: two peers presenting the same nonce cannot both be admitted', () => {
+    // An admission race resolved by timing is an admission decision nobody made. Exactly one wins,
+    // and the loser is refused rather than queued.
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW });
+
+    const attempts = [
+      ledger.redeem(grant.nonce, GUARDED, NOW + 1),
+      ledger.redeem(grant.nonce, GUARDED, NOW + 1),
+    ];
+
+    expect(attempts.filter((a) => a.honoured)).toHaveLength(1);
+    expect(attempts.find((a) => !a.honoured)?.rejection).toBe('replayed');
+  });
+
+  it('TC-07: revoking a rendezvous ends admissibility for its outstanding grants', () => {
+    // SEC-010: the entry IS the grant. Once the owning session is gone, nothing it handed out may
+    // still open a channel.
+    const ledger = new RendezvousGrantLedger();
+    const mine = ledger.issue({ rendezvous: GUARDED, now: NOW });
+    const elsewhere = ledger.issue({ rendezvous: OTHER, now: NOW });
+
+    expect(ledger.revokeRendezvous(GUARDED)).toBe(1);
+
+    expect(ledger.redeem(mine.nonce, GUARDED, NOW + 1).rejection).toBe('unknown');
+    expect(ledger.redeem(elsewhere.nonce, OTHER, NOW + 1).honoured).toBe(true);
+  });
+
+  it('revoking a rendezvous with nothing outstanding reports zero rather than pretending', () => {
+    expect(new RendezvousGrantLedger().revokeRendezvous(GUARDED)).toBe(0);
+  });
+
+  it('expiry sweeps the live grants and reports what it dropped', () => {
+    const ledger = new RendezvousGrantLedger();
+    ledger.issue({ rendezvous: GUARDED, now: NOW, ttlMs: 1_000 });
+    ledger.issue({ rendezvous: GUARDED, now: NOW, ttlMs: 10_000 });
+
+    expect(ledger.expire(NOW + 1_000)).toBe(1);
+    expect(ledger.outstanding).toBe(1);
+  });
+
+  it('the spent set does not grow without bound', () => {
+    // A ledger that leaks is a ledger that gets disabled. After a nonce ages out, the ledger
+    // genuinely no longer knows it — `unknown` is then the honest answer, not a downgrade.
+    const ledger = new RendezvousGrantLedger();
+    const grant = ledger.issue({ rendezvous: GUARDED, now: NOW, ttlMs: 1_000 });
+    ledger.redeem(grant.nonce, GUARDED, NOW + 1);
+
+    expect(ledger.redeem(grant.nonce, GUARDED, NOW + 2).rejection).toBe('replayed');
+    ledger.expire(NOW + 1_000);
+    expect(ledger.redeem(grant.nonce, GUARDED, NOW + 1_001).rejection).toBe('unknown');
+  });
+
+  it('a colliding generator never overwrites a live grant', () => {
+    // Not going to happen with 32 random bytes; cheap to make impossible rather than improbable,
+    // and the failure it would cause is refusing a peer that did nothing wrong.
+    const ledger = new RendezvousGrantLedger();
+    const values = ['same', 'same', 'different'];
+    let i = 0;
+    const generate = () => values[i++] ?? 'exhausted';
+
+    const first = ledger.issue({ rendezvous: GUARDED, now: NOW, generate });
+    const second = ledger.issue({ rendezvous: GUARDED, now: NOW, generate });
+
+    expect(first.nonce).toBe('same');
+    expect(second.nonce).toBe('different');
+    expect(ledger.outstanding).toBe(2);
+  });
+
+  it('issues values that differ without an injected generator', () => {
+    const ledger = new RendezvousGrantLedger();
+
+    const nonces = new Set(
+      Array.from({ length: 50 }, () => ledger.issue({ rendezvous: GUARDED, now: NOW }).nonce),
+    );
+
+    expect(nonces.size).toBe(50);
+  });
+});

--- a/packages/agent-remote-pairing/src/local/index.ts
+++ b/packages/agent-remote-pairing/src/local/index.ts
@@ -16,3 +16,10 @@ export type {
   ILocalPeerBinding,
   TLocalPeerTrust,
 } from './peer-credential.js';
+export { DEFAULT_GRANT_TTL_MS, RendezvousGrantLedger } from './rendezvous-nonce.js';
+export type {
+  IIssueOptions,
+  IRendezvousGrant,
+  IRendezvousRedemption,
+  TNonceRejection,
+} from './rendezvous-nonce.js';

--- a/packages/agent-remote-pairing/src/local/rendezvous-nonce.ts
+++ b/packages/agent-remote-pairing/src/local/rendezvous-nonce.ts
@@ -1,0 +1,215 @@
+/**
+ * SEC-010, second half: carrying the kernel's answer from the rendezvous to the channel.
+ *
+ * `peer-credential.ts` establishes the environment — a peer that reached a 0700 directory owned by
+ * this user could only have come from this machine, as this user. But that fact is about the
+ * RENDEZVOUS, and the session's messages travel over a different carrier. Without a binding between
+ * the two, a peer could prove itself at the guarded socket and then hand the channel to somebody
+ * else, and the admission would still read as `same-user-same-host`. The environment proof would be
+ * true and useless.
+ *
+ * So the rendezvous issues a nonce, and the pairing confirmation on the channel has to present it
+ * back. What the nonce carries is not secrecy — it is the STATEMENT "the party on this channel is
+ * the party the kernel vouched for at that rendezvous, on this attempt".
+ *
+ * ## Why this is a grant ledger and not a random string
+ *
+ * The SEC-010 failure semantics are specific, and each one is a rule about the nonce's lifetime
+ * rather than about its bytes:
+ *
+ * - **Single use.** A second presentation is a rejection, never a re-admission. A nonce that admits
+ *   twice binds nothing on the second attempt — it has become a copyable credential, which is the
+ *   exact failure the whole item exists to avoid.
+ * - **Bounded window.** Admission expires. An indefinitely valid nonce left in a log or a crashed
+ *   process's memory is a standing invitation.
+ * - **Revocation is the entry's existence.** The rendezvous grant IS the entry; removing it (session
+ *   exit, explicit revoke) ends admissibility for new attempts immediately.
+ * - **Concurrency is deterministic.** Two peers presenting the same nonce cannot both win, and the
+ *   loser must be refused rather than queued — an admission race resolved by timing is an admission
+ *   decision nobody made.
+ *
+ * ## What this deliberately does not do
+ *
+ * It does not generate the nonce's randomness policy or hash it — `crypto.getRandomValues` is the
+ * source and the value is compared whole. It does not touch the filesystem: the guarded directory is
+ * `peer-credential.ts`'s subject, and a module that both judged the directory and held the ledger
+ * would make the two failure modes hard to tell apart in a test.
+ *
+ * Time is injected. A ledger whose expiry is read from the ambient clock cannot be tested for the
+ * window it claims to enforce, and "it expires eventually" is not the property SEC-010 asks for.
+ */
+
+/** Why a presented nonce was not honoured. A closed vocabulary — the caller acts on which one. */
+export type TNonceRejection =
+  /** No grant with this value: never issued, already consumed, or revoked. */
+  | 'unknown'
+  /** Issued, but its window has closed. */
+  | 'expired'
+  /** Presented a second time. The first presentation consumed it. */
+  | 'replayed'
+  /** Presented against a different rendezvous than the one it was issued for. */
+  | 'wrong-rendezvous';
+
+export interface IRendezvousGrant {
+  /** The value the peer must present back on the channel. */
+  readonly nonce: string;
+  /** The guarded directory this grant was issued at — a nonce is not portable between rendezvous. */
+  readonly rendezvous: string;
+  /** When admission stops being possible, in epoch milliseconds. */
+  readonly expiresAt: number;
+}
+
+export interface IRendezvousRedemption {
+  readonly honoured: boolean;
+  /** Present when honoured — what the grant established, for the channel gate to carry forward. */
+  readonly grant?: IRendezvousGrant;
+  /** Present when refused. */
+  readonly rejection?: TNonceRejection;
+}
+
+export interface IIssueOptions {
+  /** The guarded rendezvous this grant belongs to (`ILocalPeerBinding.guardedDirectory`). */
+  readonly rendezvous: string;
+  /** Now, in epoch milliseconds. Injected so the window is testable. */
+  readonly now: number;
+  /** How long the grant stays admissible. */
+  readonly ttlMs?: number;
+  /** Nonce source, injected only so a test can make a collision reproducible. */
+  readonly generate?: () => string;
+}
+
+/**
+ * How long a rendezvous grant stays admissible.
+ *
+ * Thirty seconds is a connection setup, not a session: the peer has already reached the guarded
+ * socket when the grant is issued, so the only thing that has to fit in the window is the channel
+ * handshake. A longer default would buy nothing and widen the interval in which a leaked value is
+ * still worth something.
+ */
+export const DEFAULT_GRANT_TTL_MS = 30_000;
+
+function randomNonce(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * The set of grants a rendezvous will still honour.
+ *
+ * A live object rather than a pure function because single-use and revocation are STATE — the second
+ * presentation of a nonce differs from the first only in what happened in between, and nothing
+ * stateless can tell them apart.
+ */
+export class RendezvousGrantLedger {
+  private readonly grants = new Map<string, IRendezvousGrant>();
+  /**
+   * Nonces already spent, held until their original window closes.
+   *
+   * Kept so a second presentation reports `replayed` rather than `unknown`. That distinction is
+   * worth the memory: `unknown` is consistent with a peer that was slow or a grant that was revoked,
+   * while `replayed` means a value that was honoured once is being presented again — a bug or an
+   * attack, and an operator who cannot tell those apart cannot act on either.
+   *
+   * There is no information-leak argument against it HERE, which is why this differs from a public
+   * endpoint: the only party that can reach this rendezvous already passed the kernel's check as
+   * this user, and could read the process's memory outright.
+   *
+   * Bounded by `expire()`, which sweeps this alongside the live grants. Without that it would be a
+   * set that only ever grows — a ledger that leaks is a ledger that gets disabled.
+   */
+  private readonly spent = new Map<string, number>();
+
+  /** Issue a grant for a peer the kernel has already vouched for at `rendezvous`. */
+  issue(options: IIssueOptions): IRendezvousGrant {
+    const generate = options.generate ?? randomNonce;
+    let nonce = generate();
+    // A collision would silently overwrite a live grant, refusing a peer that did nothing wrong. It
+    // is not going to happen with 32 random bytes; it is cheap to make impossible rather than
+    // improbable, and a test can force the case by injecting a generator that repeats.
+    while (this.grants.has(nonce)) nonce = generate();
+
+    const grant: IRendezvousGrant = {
+      nonce,
+      rendezvous: options.rendezvous,
+      expiresAt: options.now + (options.ttlMs ?? DEFAULT_GRANT_TTL_MS),
+    };
+    this.grants.set(nonce, grant);
+    return grant;
+  }
+
+  /**
+   * Present a nonce on the channel. Honoured at most once, ever.
+   *
+   * The grant is removed BEFORE the expiry check rather than after: an expired grant is finished
+   * either way, and leaving it in the map would let a caller that retries on `expired` keep a dead
+   * entry alive in memory for as long as it cared to.
+   */
+  redeem(nonce: string, rendezvous: string, now: number): IRendezvousRedemption {
+    const grant = this.grants.get(nonce);
+    if (grant === undefined) {
+      // A value we have already honoured is a different fact from one we have never seen, and the
+      // refusal says which. Revoked and never-issued DO share `unknown` — the caller's next step is
+      // the same for both, and neither indicates anything went wrong.
+      return { honoured: false, rejection: this.spent.has(nonce) ? 'replayed' : 'unknown' };
+    }
+    // Spent the moment it is presented, before any other check. Every path below this line is a
+    // refusal, and a nonce that could be presented again after a failed check would be single-use
+    // only for peers that got everything right the first time.
+    this.grants.delete(nonce);
+    this.spent.set(nonce, grant.expiresAt);
+
+    if (grant.rendezvous !== rendezvous) {
+      // A nonce presented at the wrong rendezvous has travelled somewhere it was not meant to go.
+      // Consuming it is the point: the holder does not get to try again at the right one.
+      return { honoured: false, rejection: 'wrong-rendezvous' };
+    }
+    if (now >= grant.expiresAt) return { honoured: false, rejection: 'expired' };
+
+    return { honoured: true, grant };
+  }
+
+  /**
+   * Revoke every grant for a rendezvous — the owning session exited, or revoked explicitly.
+   *
+   * Returns how many were live, so a caller can report rather than assume. SEC-010 says the entry IS
+   * the grant: once this runs, no new attempt at that rendezvous can be admitted.
+   */
+  revokeRendezvous(rendezvous: string): number {
+    let revoked = 0;
+    for (const [nonce, grant] of this.grants) {
+      if (grant.rendezvous !== rendezvous) continue;
+      this.grants.delete(nonce);
+      revoked += 1;
+    }
+    return revoked;
+  }
+
+  /**
+   * Drop grants whose window has closed, and forget spent nonces past theirs. Returns how many live
+   * grants were dropped — the spent-side sweep is bookkeeping, not an event a caller reports.
+   *
+   * Both sides are swept here because both grow: the live map with grants nobody redeemed, and the
+   * spent map with every nonce ever honoured. A replay arriving after its nonce ages out reads as
+   * `unknown` rather than `replayed`, which is the honest answer — by then the ledger genuinely does
+   * not know.
+   */
+  expire(now: number): number {
+    let dropped = 0;
+    for (const [nonce, grant] of this.grants) {
+      if (now < grant.expiresAt) continue;
+      this.grants.delete(nonce);
+      dropped += 1;
+    }
+    for (const [nonce, expiresAt] of this.spent) {
+      if (now < expiresAt) continue;
+      this.spent.delete(nonce);
+    }
+    return dropped;
+  }
+
+  /** How many grants are still admissible, for a caller asserting cleanup rather than trusting it. */
+  get outstanding(): number {
+    return this.grants.size;
+  }
+}


### PR DESCRIPTION
Advances #1810 (SEC-010). The kernel-enforced directory check already landed; this is the binding that makes it useful. **Not closed** — the WebRTC channel gate that consumes this (TC-08) is the next piece.

## Why a nonce at all

`admitLocalPeerDirectory` establishes the environment: a peer that reached a 0700 directory owned by this user could only have come from this machine, as this user, because the kernel refuses the traversal to anyone else.

But that fact is about the **rendezvous**, and the session's messages travel over a different carrier. With nothing binding the two, a peer could pass the kernel's check at the socket and then hand the channel to somebody else — and the admission would still read `same-user-same-host`. **The environment proof would be true and useless.**

So the rendezvous issues a nonce, and the channel's pairing confirmation has to present it back. What it carries is not secrecy; it is the statement *"the party on this channel is the party the kernel vouched for at that rendezvous, on this attempt."*

## The lifetime rules ARE the security properties

SEC-010 names each one, and each is about the grant's life rather than its bytes:

- **Single use.** A nonce honoured twice has become a copyable credential — the exact failure this item exists to prevent. A presentation **spends the value even when that presentation is then refused**: otherwise single-use would hold only for peers that got everything right first time, and a holder could probe with a wrong rendezvous, learn nothing, and keep the value for a real attempt.
- **Bounded window** — 30s. The peer has already reached the guarded socket when the grant is issued, so the only thing that must fit is the channel handshake. Longer buys nothing and widens the interval in which a leaked value is still worth something.
- **Revocation is the entry's existence.** A departing session's grants stop being admissible when it revokes, not when they expire.
- **Deterministic under concurrency.** Two peers presenting one nonce cannot both win, and the loser is refused rather than queued — a race resolved by timing is an admission decision nobody made.

## A replay is named, not folded into `unknown`

The usual argument for merging them — not telling a prober which values once existed — **does not apply at this boundary**. The only party who can reach this rendezvous already passed the kernel's check as this user, and could read the process's memory outright. An operator who cannot tell a replayed value from a slow peer cannot act on either.

That distinction costs a second map, so it is swept: live grants and spent nonces age out together. A ledger that leaks is a ledger that gets disabled, and once a nonce ages out `unknown` is the honest answer — by then it genuinely is not known.

## Found in self-review

The first draft declared a `'replayed'` rejection **no path returned**, and a `wasIssued()` reading a set nothing populated. Both looked implemented and neither was. Fixed by making replay real rather than by deleting the vocabulary.

## Coverage

TC-04 (replay), TC-05 (timeout), TC-06 (concurrent attempts), TC-07 (revocation) from SEC-010's test plan. **TC-08 — the nonce bound into the pairing confirmation on the WebRTC channel — is not claimed here.**

Time is injected throughout: a ledger whose expiry reads the ambient clock cannot be tested for the window it claims to enforce, and "it expires eventually" is not the property SEC-010 asks for.

## Verification

- 13 unit tests, all green
- `pnpm harness:scan` — 123 passed, 1 skipped
- `pnpm typecheck` clean; `verify-like-ci.mjs --only format-check` green
- SPEC `/local` section documents the ledger, its lifetime rules, and the replay-naming rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD