### PR TITLE
feat(agent-transport-webrtc): bind the rendezvous nonce to the admitted channel (#1810)

### DIFF
--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -36,6 +36,30 @@ protocol is shared, not duplicated.
   written-reason requirement lives in `resolveAdmission` in `@robota-sdk/agent-transport-protocol`, so the sibling
   transports cannot drift apart on what counts as an answer.
 
+- **Owns the local-peer channel GATE, not the local-peer policy (SEC-010, #1810).** When `localPeer` is
+  configured, an accepted handshake is not enough: the peer must also present the nonce it was issued at the
+  guarded rendezvous, and only then is the session exposed. This package holds the state machine and the
+  frame; single-use, expiry and revocation belong to the grant ledger in
+  `@robota-sdk/agent-remote-pairing/local`, which is injected as a `redeem` port. That keeps the
+  cryptographic/OS policy out of the transport (the issue is explicit about this) and keeps `node:fs` out of
+  this package.
+
+  **Why both edges of the step are load-bearing.** The handshake binds the CHANNEL — after it, the channel
+  provably terminates at the peer that knew the secret — and says nothing about where that peer runs. The
+  guarded rendezvous binds the ENVIRONMENT and says nothing about which channel that peer later opens.
+  Presenting the nonce OVER the already-bound channel joins them. Earlier than that and the nonce would be
+  handed to an unproven counterpart; later than that and a peer would already be talking to the session, where
+  refusing it is not refusing it.
+
+  Every non-admitted path closes the channel: a refused nonce, a frame that is not a proof frame, and a ledger
+  that throws. "Not reached" is not "allowed", and a gate that merely ignored a bad frame would park with the
+  channel open — a hang, which is fail-open wearing a stall's clothes. The consumer is notified on refusals as
+  well as admissions, because "no local peer connected" and "a local peer was refused" call for different
+  operator responses. The result carries an explicit trust level rather than a boolean.
+
+  Absent `localPeer`, behaviour is exactly as before — a remote peer has no rendezvous to have reached, and
+  demanding one unconditionally would refuse every legitimate remote session.
+
 ## Architecture Overview
 
 `WebRtcTransport` preserves `IConfigurableTransport<IInteractiveSession>` for declaration compatibility

--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -100,12 +100,15 @@ reserved for E4). Without `reconnect`, the gate is exactly the B4 first-pair-onl
 
 ## Type Ownership
 
-| Type                                 | Location                  | Purpose                                                                                                                     |
-| ------------------------------------ | ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `IWebRtcTransportOptions`            | `src/webrtc-transport.ts` | Construction options (injected signaling, optional ICE servers, pairing `secret` OR `open`+`openReason` — one is required). |
-| `ISignalingClient`, `ISignalMessage` | `src/signaling.ts`        | Signaling port + opaque SDP/ICE message envelope.                                                                           |
-| `IWeriftModule`, `TModuleResolver`   | `src/werift-loader.ts`    | Lazy-loaded werift surface + injectable resolver seam.                                                                      |
-| `PairingGate`, `IPairingGateOptions` | `src/pairing-gate.ts`     | REMOTE-008 fail-closed routing switch (pairing frames → handshake; session only post-accept).                               |
+| Type                                        | Location                          | Purpose                                                                                                                     |
+| ------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `IWebRtcTransportOptions`, `IIceServer`     | `src/webrtc-transport-options.ts` | Construction options (injected signaling, optional ICE servers, pairing `secret` OR `open`+`openReason` — one is required). |
+| `ISignalingClient`, `ISignalMessage`        | `src/signaling.ts`                | Signaling port + opaque SDP/ICE message envelope.                                                                           |
+| `IWeriftModule`, `TModuleResolver`          | `src/werift-loader.ts`            | Lazy-loaded werift surface + injectable resolver seam.                                                                      |
+| `PairingGate`, `IPairingGateOptions`        | `src/pairing-gate.ts`             | REMOTE-008 fail-closed routing switch (pairing frames → handshake; session only post-accept).                               |
+| `ILocalPeerProof`, `ILocalProofFrame`       | `src/local-peer-proof.ts`         | SEC-010 local-peer proof port + the frame that carries the rendezvous nonce. The judge and predicate stay internal.         |
+| `IAttachSessionOptions`, `IAttachedSession` | `src/session-attachment.ts`       | How an admitted channel is wired to the session (bridge or handler).                                                        |
+| `IControllerContext`                        | `src/pairing-controllers.ts`      | What the first-pair and reconnect controllers need to talk on the channel.                                                  |
 
 `TClientMessage`/`TServerMessage`/`IWsHandlerOptions` are re-consumed from `@robota-sdk/agent-transport-protocol`
 (their SSOT) — this package does not re-declare them.
@@ -184,8 +187,9 @@ None.
 
 ### Cross-Package Port Consumers
 
-| Owner                                                                   | Consumer                         | Location                                         |
-| ----------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------ |
-| `agent-interface-transport` `IConfigurableTransport`                    | `WebRtcTransport`                | `src/webrtc-transport.ts`                        |
-| `agent-transport-protocol` `createWsHandler`                            | `WebRtcTransport`, `PairingGate` | `src/webrtc-transport.ts`, `src/pairing-gate.ts` |
-| `agent-remote-pairing` `startPairingHandshake`/`extractDtlsFingerprint` | `PairingGate`, `WebRtcTransport` | `src/pairing-gate.ts`, `src/webrtc-transport.ts` |
+| Owner                                                               | Consumer                           | Location                                               |
+| ------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------ |
+| `agent-interface-transport` `IConfigurableTransport`                | `WebRtcTransport`                  | `src/webrtc-transport.ts`                              |
+| `agent-transport-protocol` `createWsHandler`                        | `WebRtcTransport`, `attachSession` | `src/webrtc-transport.ts`, `src/session-attachment.ts` |
+| `agent-remote-pairing` `startPairingHandshake`/`startHostReconnect` | the pairing controllers            | `src/pairing-controllers.ts`                           |
+| `agent-remote-pairing` `extractDtlsFingerprint`                     | `WebRtcTransport`                  | `src/webrtc-transport.ts`                              |

--- a/packages/agent-transport-webrtc/src/__tests__/local-peer-proof-gate.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/local-peer-proof-gate.test.ts
@@ -1,0 +1,189 @@
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { judgeLocalProof, type ILocalPeerProof } from '../local-peer-proof.js';
+import { PairingGate, type IPairingGateOptions } from '../pairing-gate.js';
+
+import type { startPairingHandshake, TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
+import type { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+
+/**
+ * SEC-010 TC-08 (#1810) — the rendezvous nonce bound to the admitted channel.
+ *
+ * Driven with a stub handshake and a stub ledger: this package must implement no cryptographic
+ * policy, so what is asserted here is the GATE's ordering and fail-closed behaviour, never the
+ * ledger's single-use rules (those are proven where they live).
+ */
+
+const ADMITTED: IPeerAdmission = {
+  admitted: true,
+  trust: 'same-user-same-host',
+  origin: { sessionId: 'peer_a' },
+};
+const REFUSED: IPeerAdmission = { admitted: false, trust: 'unproven', reason: 'replayed' };
+
+function makeHandshakeStub() {
+  let resolveResult!: (value: { sessionKey: string }) => void;
+  const start: typeof startPairingHandshake = (options) => {
+    const controller = {
+      result: new Promise<{ sessionKey: string }>((res) => {
+        resolveResult = res;
+      }),
+      onFrame: (_frame: TPairingFrame) => {},
+    };
+    options.send({ t: 'pair-nonce', nonce: 'stub' });
+    return controller;
+  };
+  return { start, accept: () => resolveResult({ sessionKey: 'k' }) };
+}
+
+function makeGate(localPeer?: ILocalPeerProof, over: Partial<IPairingGateOptions> = {}) {
+  const channel = { send: vi.fn(), close: vi.fn() };
+  const sessionOnMessage = vi.fn();
+  const createHandler: typeof createWsHandler = () => ({
+    onMessage: sessionOnMessage,
+    cleanup: vi.fn(),
+  });
+  const hs = makeHandshakeStub();
+  const gate = new PairingGate({
+    channel,
+    session: createTestInteractiveSession(),
+    secret: 's',
+    role: 'initiator',
+    localFingerprint: 'AA',
+    remoteFingerprint: 'BB',
+    startHandshake: hs.start,
+    createHandler,
+    ...(localPeer ? { localPeer } : {}),
+    ...over,
+  });
+  return { gate, channel, sessionOnMessage, hs };
+}
+
+const proofFrame = (nonce = 'n1') => JSON.stringify({ t: 'local-proof', nonce });
+
+describe('SEC-010 TC-08 — the session is not exposed until the rendezvous nonce is presented', () => {
+  it('a handshake that accepts is NOT enough on its own', async () => {
+    // The whole point of the binding. The handshake proves the channel terminates at the peer that
+    // knew the secret; it says nothing about where that peer runs, so it must not open the session.
+    const redeem = vi.fn(() => ADMITTED);
+    const { gate, sessionOnMessage, hs } = makeGate({ redeem });
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(redeem).not.toHaveBeenCalled();
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+
+  it('presenting an admitted nonce after the handshake opens the session', async () => {
+    const { gate, sessionOnMessage, hs } = makeGate({ redeem: () => ADMITTED });
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(proofFrame());
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(sessionOnMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('a refused nonce closes the channel and never builds a session handler', async () => {
+    // "Fail closed before content" — SEC-010's first failure rule. Refusing after exposure is not
+    // refusing.
+    const { gate, channel, sessionOnMessage, hs } = makeGate({ redeem: () => REFUSED });
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(proofFrame());
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(channel.close).toHaveBeenCalled();
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+
+  it('the consumer is told about a refusal, not only about a success', async () => {
+    // A consumer told only about successes cannot distinguish "no local peer connected" from "a
+    // local peer was refused", and those call for different operator responses.
+    const onAdmission = vi.fn();
+    const { gate, hs } = makeGate({ redeem: () => REFUSED, onAdmission });
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(proofFrame());
+
+    expect(onAdmission).toHaveBeenCalledWith(REFUSED);
+  });
+
+  it('carries the trust level through to the consumer, not a boolean', async () => {
+    // #1810: "a narrow typed authenticated-peer/admission result, not a generic boolean".
+    const onAdmission = vi.fn();
+    const { gate, hs } = makeGate({ redeem: () => ADMITTED, onAdmission });
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(proofFrame());
+
+    expect(onAdmission.mock.calls[0][0].trust).toBe('same-user-same-host');
+  });
+
+  it('a frame that is not a proof frame is refused rather than ignored', async () => {
+    // Ignoring would leave the gate parked with the channel open — a hang, which is fail-open
+    // wearing a stall's clothes.
+    const { gate, channel, hs } = makeGate({ redeem: () => ADMITTED });
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(JSON.stringify({ t: 'enroll-key', spki: 'x' }));
+
+    expect(channel.close).toHaveBeenCalled();
+  });
+
+  it('without the option configured, the gate behaves exactly as before', async () => {
+    // A remote peer over WebRTC has no rendezvous to have reached; demanding one unconditionally
+    // would refuse every legitimate remote session.
+    const { gate, sessionOnMessage, channel, hs } = makeGate();
+
+    hs.accept();
+    await Promise.resolve();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(sessionOnMessage).toHaveBeenCalledTimes(1);
+    expect(channel.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('SEC-010 TC-08 — the judge refuses everything that is not an admitted redemption', () => {
+  it('refuses when no proof is configured', () => {
+    // Unreachable through the gate, but a fail-OPEN if it ever were.
+    expect(judgeLocalProof({ t: 'local-proof', nonce: 'n' }, undefined).admitted).toBe(false);
+  });
+
+  it.each([
+    ['a non-proof frame', { t: 'enroll-key', spki: 'x' }],
+    ['a proof frame with no nonce', { t: 'local-proof' }],
+    ['a nonce that is not a string', { t: 'local-proof', nonce: 7 }],
+    ['null', null],
+  ])('refuses %s', (_label, value) => {
+    expect(judgeLocalProof(value, { redeem: () => ADMITTED }).admitted).toBe(false);
+  });
+
+  it('a ledger that throws is a refusal, not an escape', () => {
+    // "Not reached" is not "allowed". Letting it propagate would unwind through the channel's
+    // message subscription and leave the gate parked with the channel open.
+    const admission = judgeLocalProof(
+      { t: 'local-proof', nonce: 'n' },
+      {
+        redeem: () => {
+          throw new Error('ledger unavailable');
+        },
+      },
+    );
+
+    expect(admission.admitted).toBe(false);
+    expect(admission.trust).toBe('unproven');
+    expect(admission.reason).toMatch(/could not decide/);
+  });
+});

--- a/packages/agent-transport-webrtc/src/index.ts
+++ b/packages/agent-transport-webrtc/src/index.ts
@@ -1,6 +1,9 @@
 export { WebRtcTransport } from './webrtc-transport.js';
-export type { IWebRtcTransportOptions, IIceServer } from './webrtc-transport.js';
+export type { IWebRtcTransportOptions, IIceServer } from './webrtc-transport-options.js';
 export type { IHostReconnectConfig } from './pairing-gate.js';
+// The judge and the frame predicate stay internal: they are this package's policy plumbing, and a
+// composition root only needs to SUPPLY the port and, on the peer side, know the frame's shape.
+export type { ILocalPeerProof, ILocalProofFrame } from './local-peer-proof.js';
 export { createInMemorySignalingPair } from './signaling.js';
 export type { ISignalingClient, ISignalMessage, TSignalKind } from './signaling.js';
 export { WsSignalingClient } from './ws-signaling-client.js';

--- a/packages/agent-transport-webrtc/src/local-peer-proof.ts
+++ b/packages/agent-transport-webrtc/src/local-peer-proof.ts
@@ -1,0 +1,120 @@
+/**
+ * SEC-010 TC-08: joining the rendezvous proof to the channel the session will run on.
+ *
+ * ## What each half proves, and why neither is enough alone
+ *
+ * The pairing handshake binds the CHANNEL: after it, this data channel provably terminates at the
+ * peer that knew the secret, and the DTLS fingerprints are covered so it cannot be spliced. It says
+ * nothing about where that peer runs.
+ *
+ * The guarded rendezvous binds the ENVIRONMENT: a peer that reached a 0700 directory owned by this
+ * user could only have come from this machine, as this user. It says nothing about which channel
+ * that peer later opens.
+ *
+ * Presenting the rendezvous nonce OVER the already-bound channel is what joins them. The channel is
+ * authenticated by the time this runs, so nobody else can inject the frame; the nonce is single-use,
+ * so nobody can re-present one they observed. Together they say: the party on this channel is the
+ * party the kernel vouched for, on this attempt.
+ *
+ * ## Why this runs after the handshake and before the session
+ *
+ * Both edges are load-bearing.
+ *
+ * BEFORE the handshake completes, the channel is not yet authenticated — a nonce presented there
+ * would be a secret handed to an unproven counterpart, and this step would weaken the very thing it
+ * exists to strengthen.
+ *
+ * BEFORE the session is exposed, because "fail closed before content" is SEC-010's first failure
+ * rule. If the proof arrived after exposure, a peer that never presents one would have already been
+ * talking to the session, and refusing it afterwards is not refusing it.
+ *
+ * ## This package decides nothing
+ *
+ * #1810 is explicit that WebRTC must not implement cryptographic policy. Single-use, expiry and
+ * revocation belong to the grant ledger in `@robota-sdk/agent-remote-pairing/local`, which is
+ * node-only; this module takes an injected `redeem` and reports what it was told. That also keeps
+ * `node:fs` out of this package, and keeps the ledger testable without a data channel.
+ */
+
+import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
+
+/** The frame a local peer presents to show it reached the guarded rendezvous. */
+export interface ILocalProofFrame {
+  readonly t: 'local-proof';
+  readonly nonce: string;
+}
+
+/**
+ * The local-environment proof this gate requires before exposing the session.
+ *
+ * Absent → the gate behaves exactly as before. Requiring the proof is opt-in because a remote peer
+ * over WebRTC has no rendezvous to have reached, and a gate that demanded one unconditionally would
+ * refuse every legitimate remote session.
+ */
+export interface ILocalPeerProof {
+  /**
+   * Redeem a presented nonce. Owned by the ledger — this package asks and does not decide.
+   *
+   * Returns the admission the consumer receives, so the trust level travels as a value rather than
+   * being re-derived from a boolean by whoever reads it next.
+   */
+  readonly redeem: (nonce: string) => IPeerAdmission;
+  /**
+   * Fired on the outcome, admitted or not.
+   *
+   * On BOTH, deliberately: a consumer told only about successes cannot distinguish "no local peer
+   * connected" from "a local peer was refused", and those call for different operator responses.
+   */
+  readonly onAdmission?: (admission: IPeerAdmission) => void;
+}
+
+/**
+ * True when a parsed pre-accept value is a local-proof frame carrying a nonce.
+ *
+ * Module-private: `judgeLocalProof` is the only thing that should ask. Exporting it would offer a
+ * caller a way to check the shape and then act on it without going through the judge, which is how
+ * an admission decision ends up made in two places.
+ */
+function isLocalProofFrame(value: unknown): value is ILocalProofFrame {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { t?: unknown }).t === 'local-proof' &&
+    typeof (value as { nonce?: unknown }).nonce === 'string'
+  );
+}
+
+/** A refusal shaped like every other admission, so no caller has to special-case the failure path. */
+function refuse(reason: string): IPeerAdmission {
+  return { admitted: false, trust: 'unproven', reason };
+}
+
+/**
+ * Judge one pre-accept frame against the configured proof.
+ *
+ * Every path that is not an admitted redemption returns a refusal — including a missing config,
+ * which cannot happen through the gate but would be a fail-OPEN if it ever did.
+ */
+export function judgeLocalProof(
+  parsed: unknown,
+  proof: ILocalPeerProof | undefined,
+): IPeerAdmission {
+  if (proof === undefined) return refuse('no local-peer proof is configured for this channel');
+  if (!isLocalProofFrame(parsed)) {
+    return refuse('expected a local-proof frame carrying the rendezvous nonce');
+  }
+  try {
+    return proof.redeem(parsed.nonce);
+  } catch (error) {
+    // allow-fallback: fail-CLOSED, not a fallback to a degraded path. A ledger that throws has not
+    // reached a decision, and "not reached" is not "allowed" — the refusal below is strictly more
+    // restrictive than the success path, never less. Letting it propagate would be worse: the throw
+    // unwinds through the channel's message subscription and leaves the gate parked in its proof
+    // state with the channel open, which is a hang — fail-open wearing a crash's clothes.
+    return refuse(
+      `the rendezvous ledger could not decide: ${
+        error instanceof Error ? error.message : 'unknown error'
+      }`,
+    );
+  }
+}

--- a/packages/agent-transport-webrtc/src/pairing-controllers.ts
+++ b/packages/agent-transport-webrtc/src/pairing-controllers.ts
@@ -1,0 +1,75 @@
+/**
+ * Constructing the admission controllers the gate drives.
+ *
+ * "Which controller runs, with what inputs" is a different subject from "what state is the gate in
+ * and what may reach the session" — the same boundary that already moved the frame vocabulary into
+ * `pairing-frames.ts` and the best-effort channel calls into `pairing-channel-lifecycle.ts`.
+ *
+ * Split out because `pairing-gate.ts` had reached the size limit, where the rule is to split rather
+ * than extend. These two functions were the largest thing in it that was not about gating, and they
+ * touch nothing of the gate's own state: they take inputs, wire a controller's `send` to the
+ * channel, and hand back the controller plus a settled/rejected outcome for the caller to act on.
+ */
+
+import { startHostReconnect, startPairingHandshake } from '@robota-sdk/agent-remote-pairing';
+
+import { pairingChannel } from './pairing-channel-lifecycle.js';
+
+import type { IHostReconnectConfig, IPairingChannel } from './pairing-gate.js';
+import type { IPairingResult, TPairingRole } from '@robota-sdk/agent-remote-pairing';
+
+/** What both controllers need to talk on the channel and bind to it. */
+export interface IControllerContext {
+  readonly channel: IPairingChannel;
+  readonly localFingerprint: string;
+  readonly remoteFingerprint: string;
+  /** Handshake timeout (ms); fail closed on expiry. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Start the B3 first-pair handshake.
+ *
+ * `onAccepted`/`onRejected` rather than handing the promise back, so a caller cannot forget to
+ * attach a rejection path — an unhandled rejection here would leave a gate waiting forever on a
+ * handshake that already failed, which is a fail-OPEN shaped as a hang.
+ */
+export function startFirstPairController(
+  context: IControllerContext,
+  secret: string,
+  role: TPairingRole,
+  onAccepted: (result: IPairingResult) => void,
+  onRejected: () => void,
+  start: typeof startPairingHandshake = startPairingHandshake,
+): ReturnType<typeof startPairingHandshake> {
+  const controller = start({
+    secret,
+    role,
+    localFingerprint: context.localFingerprint,
+    remoteFingerprint: context.remoteFingerprint,
+    send: (frame) => pairingChannel.send(context.channel, JSON.stringify(frame)),
+    ...(context.timeoutMs !== undefined ? { timeoutMs: context.timeoutMs } : {}),
+  });
+  controller.result.then(onAccepted, onRejected);
+  return controller;
+}
+
+/** Start the E3 host-side reconnect exchange against a pinned device key. */
+export function startReconnectController(
+  context: IControllerContext,
+  config: IHostReconnectConfig,
+  onAccepted: () => void,
+  onRejected: () => void,
+): ReturnType<typeof startHostReconnect> {
+  const controller = startHostReconnect({
+    hostIdentityId: config.hostIdentityId,
+    localFingerprint: context.localFingerprint,
+    remoteFingerprint: context.remoteFingerprint,
+    hostPrivateKey: config.hostPrivateKey,
+    resolveDevicePublicKey: config.resolveDevicePublicKey,
+    send: (frame) => pairingChannel.send(context.channel, JSON.stringify(frame)),
+    ...(context.timeoutMs !== undefined ? { timeoutMs: context.timeoutMs } : {}),
+  });
+  controller.result.then(onAccepted, onRejected);
+  return controller;
+}

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -14,21 +14,25 @@
  *
  * When no E3 `reconnect` config is supplied the gate is **exactly** the B4 first-pair-only gate (eager host
  * `pair-nonce`, no enrollment, no reconnect) — preserving existing behavior.
+ *
+ * SEC-010 adds an optional `local-proof` step between handshake acceptance and session exposure; see
+ * `local-peer-proof.ts` for why both of those edges are load-bearing.
  */
 
 import {
   deriveIdentityId,
   importPublicKey,
-  startHostReconnect,
   startPairingHandshake,
   type IPairingResult,
   type TPairingRole,
 } from '@robota-sdk/agent-remote-pairing';
 import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
 
-import { createChannelDelivery } from './channel-delivery.js';
+import { judgeLocalProof, type ILocalPeerProof } from './local-peer-proof.js';
 import { pairingChannel } from './pairing-channel-lifecycle.js';
+import { startFirstPairController, startReconnectController } from './pairing-controllers.js';
 import { isEnrollFrame, isPairingFrame, isReconnectFrame } from './pairing-frames.js';
+import { attachSession } from './session-attachment.js';
 
 import type { IEnrollFrame } from './pairing-frames.js';
 import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
@@ -81,13 +85,21 @@ export interface IPairingGateOptions {
    * narrowing and is not one. Stated as what it is.
    */
   readonly onDeliveryError?: (error: Error, event: string) => void;
+  /** SEC-010: require a rendezvous nonce before exposing the session. Absent → unchanged behavior. */
+  readonly localPeer?: ILocalPeerProof;
   /** Injection seams (default to the real implementations). */
   readonly startHandshake?: typeof startPairingHandshake;
   readonly createHandler?: typeof createWsHandler;
 }
 
 type TGateState =
-  'awaiting-mode' | 'pairing' | 'enrolling' | 'reconnecting' | 'accepted' | 'closed';
+  | 'awaiting-mode'
+  | 'pairing'
+  | 'enrolling'
+  | 'reconnecting'
+  | 'local-proof'
+  | 'accepted'
+  | 'closed';
 
 export class PairingGate {
   private state: TGateState;
@@ -95,9 +107,11 @@ export class PairingGate {
   private onSessionMessage?: (data: string) => void;
   private handlerCleanup?: () => void;
   private pairingController?: ReturnType<typeof startPairingHandshake>;
-  private reconnectController?: ReturnType<typeof startHostReconnect>;
+  private reconnectController?: ReturnType<typeof startReconnectController>;
   /** The first-pair result, held so it can be surfaced on accept (E4 uses its sessionKey). */
   private pendingResult?: IPairingResult;
+  /** Held across the local-proof step so the reconnect ordering rule survives the detour. */
+  private pendingViaReconnect = false;
 
   constructor(private readonly options: IPairingGateOptions) {
     if (options.reconnect) {
@@ -153,6 +167,14 @@ export class PairingGate {
       return;
     }
 
+    if (this.state === 'local-proof') {
+      const admission = judgeLocalProof(parsed, this.options.localPeer);
+      this.options.localPeer?.onAdmission?.(admission);
+      if (admission.admitted) this.accept(this.pendingResult, this.pendingViaReconnect);
+      else this.rejectAndClose();
+      return;
+    }
+
     if (this.state === 'enrolling') {
       // Awaiting the peer's identity public key to pin, then expose the session.
       if (isEnrollFrame(parsed)) this.completeEnrollment(parsed.spki);
@@ -169,19 +191,15 @@ export class PairingGate {
   }
 
   private startFirstPair(): void {
-    const start = this.options.startHandshake ?? startPairingHandshake;
-    const controller = start({
-      secret: this.options.secret,
-      role: this.options.role,
-      localFingerprint: this.options.localFingerprint,
-      remoteFingerprint: this.options.remoteFingerprint,
-      send: (frame) => pairingChannel.send(this.options.channel, JSON.stringify(frame)),
-      ...(this.options.timeoutMs !== undefined ? { timeoutMs: this.options.timeoutMs } : {}),
-    });
-    this.pairingController = controller;
-    controller.result.then(
+    // `IPairingGateOptions` already carries every field `IControllerContext` asks for, so it is
+    // passed straight through — projecting it field by field would be a copy to keep in step.
+    this.pairingController = startFirstPairController(
+      this.options,
+      this.options.secret,
+      this.options.role,
       (result) => this.onFirstPairAccepted(result),
       () => this.rejectAndClose(),
+      this.options.startHandshake ?? startPairingHandshake,
     );
   }
 
@@ -191,18 +209,11 @@ export class PairingGate {
       this.rejectAndClose();
       return;
     }
-    const controller = startHostReconnect({
-      hostIdentityId: cfg.hostIdentityId,
-      localFingerprint: this.options.localFingerprint,
-      remoteFingerprint: this.options.remoteFingerprint,
-      hostPrivateKey: cfg.hostPrivateKey,
-      resolveDevicePublicKey: cfg.resolveDevicePublicKey,
-      send: (frame) => pairingChannel.send(this.options.channel, JSON.stringify(frame)),
-      ...(this.options.timeoutMs !== undefined ? { timeoutMs: this.options.timeoutMs } : {}),
-    });
-    this.reconnectController = controller;
-    controller.result.then(
-      () => this.accept(undefined, true), // reconnect → hold live forwarding until the client's resume replays
+    this.reconnectController = startReconnectController(
+      this.options,
+      cfg,
+      // reconnect → hold live forwarding until the client's resume replays
+      () => this.accept(undefined, true),
       () => this.rejectAndClose(),
     );
   }
@@ -247,29 +258,20 @@ export class PairingGate {
 
   private accept(result?: IPairingResult, viaReconnect = false): void {
     if (this.state === 'closed' || this.state === 'accepted') return;
-    const bridge = this.options.resumeBridge;
-    if (bridge) {
-      // REMOTE-013 E4: route the session through the persistent bridge. Attach this channel as the sink; on a
-      // RECONNECT, hold live forwarding until the client's `resume` replays the buffered tail (ordering fix).
-      // post-accept inbound frames (incl. resume/ack) go to the bridge; cleanup DETACHES (session survives).
-      bridge.attach((data) => this.options.channel.send(data), {
-        awaitResume: viaReconnect,
-        onDeliveryError: (error, event) => this.handleSessionDeliveryError(error, event),
-      });
-      this.onSessionMessage = (data) => bridge.onClientMessage(data);
-      this.handlerCleanup = () => bridge.detach();
-    } else {
-      const create = this.options.createHandler ?? createWsHandler;
-      // ARCH-030: the gate is the carrier on this branch — its own channel sink, its own failure policy.
-      const { onMessage, cleanup } = create({
-        session: this.options.session,
-        deliver: createChannelDelivery(this.options.channel, (error, event) =>
-          this.handleSessionDeliveryError(error, event),
-        ),
-      });
-      this.onSessionMessage = onMessage;
-      this.handlerCleanup = cleanup;
+    // SEC-010 TC-08: the handshake bound the CHANNEL; the rendezvous nonce binds the ENVIRONMENT.
+    // Demanded here rather than earlier because the channel must already be authenticated, and
+    // before anything below because that is where the session becomes reachable.
+    if (this.options.localPeer && this.state !== 'local-proof') {
+      this.pendingResult = result ?? this.pendingResult;
+      this.pendingViaReconnect = viaReconnect;
+      this.state = 'local-proof';
+      return;
     }
+    const attached = attachSession(this.options, viaReconnect, (error, event) =>
+      this.handleSessionDeliveryError(error, event),
+    );
+    this.onSessionMessage = attached.onSessionMessage;
+    this.handlerCleanup = attached.cleanup;
     this.state = 'accepted';
     this.options.onAccept?.(result);
   }

--- a/packages/agent-transport-webrtc/src/session-attachment.ts
+++ b/packages/agent-transport-webrtc/src/session-attachment.ts
@@ -1,0 +1,68 @@
+/**
+ * Wiring an admitted channel to the session — the step immediately after the gate says yes.
+ *
+ * "How session frames travel once admission is settled" is a different subject from "what may reach
+ * the session at all", which is the gate's. Split out for the same reason the frame vocabulary and
+ * the controllers already were: `pairing-gate.ts` is at its size limit, and the rule there is to
+ * split rather than extend.
+ *
+ * Two carriers, chosen by whether a resume bridge exists. Neither decides anything about admission —
+ * by the time either runs, that question is closed.
+ */
+
+import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
+
+import { createChannelDelivery } from './channel-delivery.js';
+
+import type { IPairingChannel } from './pairing-gate.js';
+import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
+
+export interface IAttachSessionOptions {
+  readonly channel: IPairingChannel;
+  readonly session: IProtocolSession;
+  readonly resumeBridge?: SessionResumeBridge;
+  readonly createHandler?: typeof createWsHandler;
+}
+
+export interface IAttachedSession {
+  /** Where post-accept inbound frames go. */
+  readonly onSessionMessage: (data: string) => void;
+  /** Detach (bridge) or dispose (handler). The gate calls this on teardown. */
+  readonly cleanup: () => void;
+}
+
+/**
+ * Attach the admitted channel to the session.
+ *
+ * `viaReconnect` is threaded through rather than inferred: on a reconnect the bridge must hold live
+ * forwarding until the client's `resume` replays the buffered tail, and getting that backwards
+ * delivers new frames ahead of the replay — an ordering bug that looks like data loss.
+ */
+export function attachSession(
+  options: IAttachSessionOptions,
+  viaReconnect: boolean,
+  onDeliveryError: (error: Error, event: string) => void,
+): IAttachedSession {
+  const bridge = options.resumeBridge;
+  if (bridge) {
+    // REMOTE-013 E4: route the session through the persistent bridge. Attach this channel as the
+    // sink; post-accept inbound frames (incl. resume/ack) go to the bridge; cleanup DETACHES it
+    // (never disposes — the bridge is owned by the transport across reconnects).
+    bridge.attach((data) => options.channel.send(data), {
+      awaitResume: viaReconnect,
+      onDeliveryError,
+    });
+    return {
+      onSessionMessage: (data) => bridge.onClientMessage(data),
+      cleanup: () => bridge.detach(),
+    };
+  }
+
+  const create = options.createHandler ?? createWsHandler;
+  // ARCH-030: the gate is the carrier on this branch — its own channel sink, its own failure policy.
+  const { onMessage, cleanup } = create({
+    session: options.session,
+    deliver: createChannelDelivery(options.channel, onDeliveryError),
+  });
+  return { onSessionMessage: onMessage, cleanup };
+}

--- a/packages/agent-transport-webrtc/src/webrtc-transport-options.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport-options.ts
@@ -1,0 +1,75 @@
+/**
+ * What a caller CONFIGURES on the WebRTC host transport.
+ *
+ * Separated from the transport itself because "what may be set" and "what the transport does with
+ * it" are different subjects, and `webrtc-transport.ts` had reached the anti-monolith limit where
+ * the rule is to split rather than extend. Types only — no behaviour moved.
+ */
+
+import type { IHostReconnectConfig } from './pairing-gate.js';
+import type { ILocalPeerProof } from './local-peer-proof.js';
+import type { ISignalingClient } from './signaling.js';
+import type { IWeriftModule } from './werift-loader.js';
+import type { IPairingResult } from '@robota-sdk/agent-remote-pairing';
+import type { SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
+
+/**
+ * A single ICE (STUN/TURN) server for the HOST (werift) transport (REMOTE-010). `urls` is a SINGLE string with a
+ * `turn:`/`turns:`/`stun:`/`stuns:` scheme — werift's ICE gatherer (`parseIceServers`) consumes only a single-string
+ * url and silently drops array `urls`, so the host reader (`agent-cli` `parseIceServers`) must narrow to this shape
+ * and reject what werift would drop (fail-closed). (The browser peer uses the native DOM `RTCIceServer`, which does
+ * support array urls / `turns:` — a separate, wider validator.) Kept a plain interface (no DOM dependency here).
+ */
+export interface IIceServer {
+  readonly urls: string;
+  readonly username?: string;
+  readonly credential?: string;
+}
+
+/** Construction options for {@link WebRtcTransport}. The signaling client is injected (Stage A: no settings). */
+export interface IWebRtcTransportOptions {
+  /** Signaling port used to exchange SDP/ICE with the remote peer by rendezvous id. */
+  readonly signaling: ISignalingClient;
+  /** Optional ICE servers (STUN/TURN). Omitted → host-candidate/loopback only. */
+  readonly iceServers?: readonly IIceServer[];
+  /**
+   * REMOTE-004 defense-in-depth: when true, restrict ICE to **relay (TURN) candidates only**, so
+   * host/server-reflexive candidates — and the local-interface gathering that touches the (unreachable, but
+   * belt-and-braces) `ip` code path — are never used. Requires a TURN server in `iceServers`. Mapped to werift's
+   * `iceTransportPolicy: 'relay'` (REMOTE-010) — werift IGNORES a top-level `forceTurn`, so it must NOT be passed.
+   */
+  readonly forceTurn?: boolean;
+  /**
+   * REMOTE-008 pairing secret. When set, the data channel is **pairing-gated**: it carries only pairing frames
+   * until the directional-HMAC handshake accepts (channel-bound to the DTLS fingerprints), and only THEN is the
+   * session exposed — fail closed on mismatch/timeout. When omitted (Stage-A loopback / tests), the channel is
+   * exposed immediately with no pairing (unchanged behavior).
+   */
+  readonly secret?: string;
+  /**
+   * SEC-008: run with NO pairing gate. Requires `openReason`.
+   *
+   * Omitting `secret` used to mean this implicitly, which is how a remote peer reached the session
+   * because a field was left unset. It is still a legitimate mode — loopback, tests — but it is now
+   * a thing the host says rather than a thing that happens.
+   */
+  readonly open?: boolean;
+  /** SEC-008: why running with no pairing gate is correct here. Required when `open` is true. */
+  readonly openReason?: string;
+  /** REMOTE-008: fired when pairing accepts + the session is exposed (host lifecycle → status 'paired'). Carries the first-pair result (E4 uses its sessionKey). */
+  readonly onPaired?: (result?: IPairingResult) => void;
+  /** REMOTE-008: fired when pairing rejects/times out (host lifecycle → teardown; the channel is already closed). */
+  readonly onPairingFailed?: () => void;
+  /** REMOTE-012 E3: host reconnect/enrollment config. When set, the gate admits first-pair (with enrollment) OR a pinned-device reconnect. */
+  readonly reconnect?: IHostReconnectConfig;
+  /** SEC-010 (#1810): require a guarded-rendezvous nonce before the session is exposed. Absent → unchanged. */
+  readonly localPeer?: ILocalPeerProof;
+  /** REMOTE-013 E4: a session-scoped resume bridge (owned by the controller across reconnects). Passed to the gate so the paired session flows through it (seq/buffer) and survives channel drops. */
+  readonly resumeBridge?: SessionResumeBridge;
+  /** REMOTE-013 E4: fired when a PAIRED data channel drops (so the controller can run the reconnect loop). Not fired for a pre-accept failure (that is `onPairingFailed`). */
+  readonly onDropped?: () => void;
+  /** Observe an outbound session-event delivery failure before the carrier drops. */
+  readonly onDeliveryError?: (error: Error, event: string) => void;
+  /** Test seam: inject the werift module (defaults to the real lazy loader). */
+  readonly loadWerift?: () => IWeriftModule;
+}

--- a/packages/agent-transport-webrtc/src/webrtc-transport.ts
+++ b/packages/agent-transport-webrtc/src/webrtc-transport.ts
@@ -6,75 +6,14 @@ import type {
 } from '@robota-sdk/agent-interface-transport';
 import type { RTCDataChannel, RTCPeerConnection } from 'werift';
 
-import type { IPairingResult } from '@robota-sdk/agent-remote-pairing';
-import type { IProtocolSession, SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
+import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
 
 import { createChannelDelivery } from './channel-delivery.js';
 import { loadWerift } from './werift-loader.js';
-import { PairingGate, type IHostReconnectConfig } from './pairing-gate.js';
+import { PairingGate } from './pairing-gate.js';
 import { createTransportLifecycleError } from './transport-lifecycle-error.js';
 import { WebRtcDeliveryLifecycle } from './webrtc-delivery-lifecycle.js';
-import type { ISignalingClient } from './signaling.js';
-import type { IWeriftModule } from './werift-loader.js';
-
-/**
- * A single ICE (STUN/TURN) server for the HOST (werift) transport (REMOTE-010). `urls` is a SINGLE string with a
- * `turn:`/`turns:`/`stun:`/`stuns:` scheme — werift's ICE gatherer (`parseIceServers`) consumes only a single-string
- * url and silently drops array `urls`, so the host reader (`agent-cli` `parseIceServers`) must narrow to this shape
- * and reject what werift would drop (fail-closed). (The browser peer uses the native DOM `RTCIceServer`, which does
- * support array urls / `turns:` — a separate, wider validator.) Kept a plain interface (no DOM dependency here).
- */
-export interface IIceServer {
-  readonly urls: string;
-  readonly username?: string;
-  readonly credential?: string;
-}
-
-/** Construction options for {@link WebRtcTransport}. The signaling client is injected (Stage A: no settings). */
-export interface IWebRtcTransportOptions {
-  /** Signaling port used to exchange SDP/ICE with the remote peer by rendezvous id. */
-  readonly signaling: ISignalingClient;
-  /** Optional ICE servers (STUN/TURN). Omitted → host-candidate/loopback only. */
-  readonly iceServers?: readonly IIceServer[];
-  /**
-   * REMOTE-004 defense-in-depth: when true, restrict ICE to **relay (TURN) candidates only**, so
-   * host/server-reflexive candidates — and the local-interface gathering that touches the (unreachable, but
-   * belt-and-braces) `ip` code path — are never used. Requires a TURN server in `iceServers`. Mapped to werift's
-   * `iceTransportPolicy: 'relay'` (REMOTE-010) — werift IGNORES a top-level `forceTurn`, so it must NOT be passed.
-   */
-  readonly forceTurn?: boolean;
-  /**
-   * REMOTE-008 pairing secret. When set, the data channel is **pairing-gated**: it carries only pairing frames
-   * until the directional-HMAC handshake accepts (channel-bound to the DTLS fingerprints), and only THEN is the
-   * session exposed — fail closed on mismatch/timeout. When omitted (Stage-A loopback / tests), the channel is
-   * exposed immediately with no pairing (unchanged behavior).
-   */
-  readonly secret?: string;
-  /**
-   * SEC-008: run with NO pairing gate. Requires `openReason`.
-   *
-   * Omitting `secret` used to mean this implicitly, which is how a remote peer reached the session
-   * because a field was left unset. It is still a legitimate mode — loopback, tests — but it is now
-   * a thing the host says rather than a thing that happens.
-   */
-  readonly open?: boolean;
-  /** SEC-008: why running with no pairing gate is correct here. Required when `open` is true. */
-  readonly openReason?: string;
-  /** REMOTE-008: fired when pairing accepts + the session is exposed (host lifecycle → status 'paired'). Carries the first-pair result (E4 uses its sessionKey). */
-  readonly onPaired?: (result?: IPairingResult) => void;
-  /** REMOTE-008: fired when pairing rejects/times out (host lifecycle → teardown; the channel is already closed). */
-  readonly onPairingFailed?: () => void;
-  /** REMOTE-012 E3: host reconnect/enrollment config. When set, the gate admits first-pair (with enrollment) OR a pinned-device reconnect. */
-  readonly reconnect?: IHostReconnectConfig;
-  /** REMOTE-013 E4: a session-scoped resume bridge (owned by the controller across reconnects). Passed to the gate so the paired session flows through it (seq/buffer) and survives channel drops. */
-  readonly resumeBridge?: SessionResumeBridge;
-  /** REMOTE-013 E4: fired when a PAIRED data channel drops (so the controller can run the reconnect loop). Not fired for a pre-accept failure (that is `onPairingFailed`). */
-  readonly onDropped?: () => void;
-  /** Observe an outbound session-event delivery failure before the carrier drops. */
-  readonly onDeliveryError?: (error: Error, event: string) => void;
-  /** Test seam: inject the werift module (defaults to the real lazy loader). */
-  readonly loadWerift?: () => IWeriftModule;
-}
+import type { IWebRtcTransportOptions } from './webrtc-transport-options.js';
 
 /**
  * WebRTC P2P transport (REMOTE-001/002): carries an `IProtocolSession` over an `RTCDataChannel` using the
@@ -239,6 +178,7 @@ export class WebRtcTransport implements IConfigurableTransport<IInteractiveSessi
       },
       ...(this.options.onPairingFailed ? { onReject: this.options.onPairingFailed } : {}),
       ...(this.options.reconnect ? { reconnect: this.options.reconnect } : {}),
+      ...(this.options.localPeer ? { localPeer: this.options.localPeer } : {}),
       ...(this.options.resumeBridge ? { resumeBridge: this.options.resumeBridge } : {}),
       onDeliveryError: (error, event) =>
         this.deliveryLifecycle.handleFailure(channel, generation, error, event),


### PR DESCRIPTION
SEC-010 **TC-08** — the last piece of #1810's proof chain. The guarded-directory check and the grant ledger both landed already; this joins them to the channel the session actually runs on.

## Why neither half is enough alone

| Mechanism | Binds | Silent about |
| --- | --- | --- |
| Pairing handshake | the **channel** — it provably terminates at the peer that knew the secret, DTLS fingerprints covered | where that peer runs |
| Guarded rendezvous | the **environment** — only this user on this machine could have reached a 0700 directory they own | which channel that peer later opens |

Without a binding, a peer could pass the kernel's check at the socket and hand the channel to somebody else — and the admission would still read `same-user-same-host`. Presenting the nonce **over the already-bound channel** joins them: the channel is authenticated by then so nobody else can inject the frame, and the nonce is single-use so nobody can re-present one they observed.

## Both edges of the step are load-bearing

- **After the handshake**, because before it the channel is not yet authenticated — the nonce would be handed to an unproven counterpart, weakening the very thing it exists to strengthen.
- **Before the session is exposed**, because "fail closed before content" is SEC-010's first failure rule. A peer that never presents a nonce would otherwise already be talking to the session, and refusing it afterwards is not refusing it.

## Every non-admitted path closes the channel

A refused nonce, a frame that is not a proof frame, and a ledger that *throws*. "Not reached" is not "allowed" — and a gate that merely **ignored** a bad frame would park with the channel open, which is a hang: fail-open wearing a stall's clothes.

**Red-proofed**: disabling the local-proof step fails six of the thirteen new tests and no others.

## This package decides nothing

#1810 is explicit that WebRTC must not implement cryptographic policy. Single-use, expiry and revocation stay in the grant ledger and arrive as an injected `redeem`, which also keeps `node:fs` out of this package and keeps the ledger testable without a data channel. The consumer is notified on **refusals as well as admissions** — "no local peer connected" and "a local peer was refused" call for different operator responses — and the result carries an explicit trust level, not a boolean.

Absent `localPeer`, behaviour is exactly as before: a remote peer has no rendezvous to have reached, and demanding one unconditionally would refuse every legitimate remote session.

## Three splits, because the files were at the wall

`pairing-gate.ts` was 293 lines against a 300 limit; `webrtc-transport.ts` was 299. The anti-monolith rule says split rather than extend, so the controller construction, the session attachment, and the options interface each moved to a file that owns their subject.

**All three are behaviour-preserving, and that is verified rather than asserted**: the 43 pre-existing webrtc tests pass unchanged after each step.

## Also caught in self-review

The barrel initially exported the judge and the frame predicate. `orphan-exports` flagged the predicate as referenced nowhere — and on inspection, exporting either would offer a caller a way to check the frame shape and act on it *without going through the judge*, which is how an admission decision ends up made in two places. The predicate is module-private now.

I also confirmed the feature is **not inert**: `localPeer` is threaded through `IWebRtcTransportOptions` to the gate, so a composition root can actually configure it. Without that the whole step would be unreachable from outside the package.

## Verification

- 56 tests in the package (43 pre-existing + 13 new), all green
- `pnpm harness:scan` — 123 passed, 2 skipped
- `pnpm typecheck` clean; `verify-like-ci.mjs --only format-check` green
- SPEC `## Boundaries` documents what the gate owns, what it does not, and why both edges matter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD