### PR TITLE
feat(agent-transport-protocol): build the hand-off offer and verify the payload (#1811)

### DIFF
--- a/packages/agent-interface-transport/src/handoff-contracts.ts
+++ b/packages/agent-interface-transport/src/handoff-contracts.ts
@@ -57,7 +57,19 @@ export type THandoffDisposition =
   /** Carried as a REFERENCE the destination must resolve locally (a path, a snapshot id). */
   | 'rehydrated'
   /** Stays on the source. Reported to the user rather than silently dropped. */
-  | 'source-local';
+  | 'source-local'
+  /**
+   * MUST NOT cross the boundary, by rule rather than by circumstance.
+   *
+   * Split from `source-local` because the two are not the same statement. Uncommitted working-tree
+   * changes stay behind as a product decision that could be revisited; a resolved provider
+   * credential stays behind because SEC-009 established that it must not cross a process boundary,
+   * and a machine boundary is strictly worse. Collapsing them would leave nothing in the type to
+   * stop a later change from helpfully starting to carry the credential along — and the destination
+   * resolving its OWN credential is what makes a hand-off to a machine without one fail loudly at
+   * commit instead of silently later.
+   */
+  | 'never-transferred';
 
 /**
  * One classified piece of state.

--- a/packages/agent-transport-protocol/docs/SPEC.md
+++ b/packages/agent-transport-protocol/docs/SPEC.md
@@ -163,6 +163,9 @@ once and the carriers stay dumb.
 | `commitHandoff`                         | Function  | HANDOFF-001: the only path to `committed`, and only on a durable acknowledgement           |
 | `sourceStillOwns`                       | Function  | HANDOFF-001: is the source authoritative? Delegates to the contract's predicate            |
 | `handoffOutcome`                        | Function  | HANDOFF-001: the reportable outcome, derived rather than assembled per call site           |
+| `buildHandoffManifest`                  | Function  | HANDOFF-001: classify the inventory and seal the payload, or REFUSE on in-flight work      |
+| `sealHandoffRecord`                     | Function  | HANDOFF-001: serialize once and describe those exact bytes, so send and digest agree       |
+| `verifyHandoffPayload`                  | Function  | HANDOFF-001: length before digest — a truncation must not be reported as tampering         |
 | `mintTransportToken`                    | Function  | SEC-008: mint a per-launch credential; throws rather than returning a weak one             |
 | `credentialMatches`                     | Function  | SEC-008: constant-time comparison of a presented credential against the required one       |
 | `bearerCredential`                      | Function  | SEC-008: extract a bearer credential from an `Authorization` header value                  |

--- a/packages/agent-transport-protocol/src/__tests__/handoff-manifest.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/handoff-manifest.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildHandoffManifest,
+  sealHandoffRecord,
+  verifyHandoffPayload,
+  type IBuildManifestInput,
+  type ISourceRuntimeState,
+} from '../handoff-manifest.js';
+
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+
+const NOW = 1_700_000_000_000;
+
+function aRecord(over: Partial<IInteractiveSessionRecord> = {}): IInteractiveSessionRecord {
+  return {
+    id: 'session_1',
+    cwd: '/home/alice/project',
+    createdAt: '2026-08-17T00:00:00.000Z',
+    updatedAt: '2026-08-17T01:00:00.000Z',
+    messages: [],
+    ...over,
+  };
+}
+
+function input(runtime: ISourceRuntimeState = {}, record = aRecord()): IBuildManifestInput {
+  return {
+    handoffId: 'handoff_1',
+    sessionId: 'session_1',
+    sourceDeviceId: 'device_a',
+    destinationDeviceId: 'device_b',
+    record,
+    runtime,
+    offeredAt: NOW,
+  };
+}
+
+/** Narrow a result to the built case so a failure reads as an assertion rather than a type error. */
+function built(result: ReturnType<typeof buildHandoffManifest>) {
+  if (!result.built) throw new Error(`expected a manifest, got refusal: ${result.refusal}`);
+  return result;
+}
+
+function itemFor(result: ReturnType<typeof built>, kind: string) {
+  return result.manifest.inventory.find((i) => i.kind === kind);
+}
+
+describe('HANDOFF-001 TC-01 — the inventory classifies every category, including what stays', () => {
+  it('carries the conversation and the session metadata', () => {
+    const result = built(buildHandoffManifest(input()));
+
+    expect(itemFor(result, 'conversation')?.disposition).toBe('transferred');
+    expect(itemFor(result, 'session-metadata')?.disposition).toBe('transferred');
+  });
+
+  it('marks provider credentials never-transferred, distinctly from what merely stays behind', () => {
+    // The distinction is the point. `source-local` is a product decision that could be revisited;
+    // this is a rule — SEC-009 established a resolved credential must not cross a process boundary,
+    // and a machine boundary is strictly worse.
+    const result = built(buildHandoffManifest(input({ uncommittedChanges: true })));
+
+    expect(itemFor(result, 'provider-credentials')?.disposition).toBe('never-transferred');
+    expect(itemFor(result, 'uncommitted-changes')?.disposition).toBe('source-local');
+  });
+
+  it('carries the working directory as a reference the destination must resolve', () => {
+    const result = built(buildHandoffManifest(input()));
+    const item = itemFor(result, 'working-directory');
+
+    expect(item?.disposition).toBe('rehydrated');
+    expect(item?.note).toContain('/home/alice/project');
+  });
+
+  it('reports subprocesses as staying, with how many', () => {
+    const result = built(buildHandoffManifest(input({ subprocesses: 2 })));
+    const item = itemFor(result, 'subprocesses');
+
+    expect(item?.disposition).toBe('source-local');
+    expect(item?.note).toContain('2 running process');
+  });
+
+  it('does not claim state stayed behind when there was none of it', () => {
+    // An inventory that listed every optional field regardless would tell a user their goal state
+    // stayed behind when they never had any — a report that is false in the direction of alarming.
+    const result = built(buildHandoffManifest(input()));
+
+    expect(itemFor(result, 'uncommitted-changes')).toBeUndefined();
+    expect(itemFor(result, 'subprocesses')).toBeUndefined();
+    expect(itemFor(result, 'goal-and-plan')).toBeUndefined();
+    expect(itemFor(result, 'sandbox-snapshot')).toBeUndefined();
+  });
+
+  it('includes goal, background work and the sandbox reference when present', () => {
+    const record = aRecord({
+      goal: { id: 'g' } as IInteractiveSessionRecord['goal'],
+      backgroundTasks: [{ id: 't' } as never],
+      sandboxSnapshotId: 'snap_1',
+    });
+
+    const result = built(buildHandoffManifest(input({}, record)));
+
+    expect(itemFor(result, 'goal-and-plan')?.disposition).toBe('transferred');
+    expect(itemFor(result, 'background-work')?.disposition).toBe('transferred');
+    expect(itemFor(result, 'sandbox-snapshot')?.disposition).toBe('rehydrated');
+  });
+});
+
+describe('HANDOFF-001 TC-08 — in-flight work is refused, not snapshotted', () => {
+  it.each([
+    ['a model call', { modelCallInFlight: true }],
+    ['a tool call', { toolCallsInFlight: 1 }],
+  ])('refuses while %s is in flight', (_label, runtime) => {
+    // A turn in flight has an outcome that belongs in the history being transferred. Snapshotting
+    // produces a digest that is correct for a session state that never settled.
+    const result = buildHandoffManifest(input(runtime));
+
+    expect(result.built).toBe(false);
+    if (!result.built) expect(result.refusal).toBe('in-flight-work');
+  });
+
+  it('says what the caller can do about it, since the choice is theirs', () => {
+    const result = buildHandoffManifest(input({ modelCallInFlight: true }));
+
+    if (!result.built) expect(result.detail).toMatch(/Wait for it, or cancel it/);
+  });
+
+  it('builds once nothing is in flight', () => {
+    expect(buildHandoffManifest(input({ toolCallsInFlight: 0 })).built).toBe(true);
+  });
+});
+
+describe('HANDOFF-001 TC-06 — a payload that did not arrive whole is refused', () => {
+  it('accepts the exact bytes that were sealed', () => {
+    const { serialized, integrity } = sealHandoffRecord(aRecord());
+
+    expect(verifyHandoffPayload(serialized, integrity).intact).toBe(true);
+  });
+
+  it('reports a truncated payload as truncated, not as corruption', () => {
+    // Checked BEFORE the digest. Hashing a short buffer to discover it was short wastes the work
+    // and reports a dropped connection as tampering.
+    const { serialized, integrity } = sealHandoffRecord(aRecord());
+
+    const verdict = verifyHandoffPayload(serialized.slice(0, -20), integrity);
+
+    expect(verdict.failure).toBe('truncated');
+    expect(verdict.expectedBytes).toBe(integrity.byteLength);
+    expect(verdict.actualBytes).toBeLessThan(integrity.byteLength);
+  });
+
+  it('reports a same-length substitution as a digest mismatch', () => {
+    // The case length alone cannot catch, which is why the digest is there at all.
+    const { serialized, integrity } = sealHandoffRecord(aRecord());
+    const tampered = serialized.replace('/home/alice/project', '/home/mallor/projec');
+
+    expect(tampered).toHaveLength(serialized.length);
+    expect(verifyHandoffPayload(tampered, integrity).failure).toBe('digest-mismatch');
+  });
+
+  it('the manifest digest covers the bytes the builder hands back', () => {
+    // The seal and the send must agree. A caller that re-serialized the record could produce a
+    // different key order and a digest mismatch on a payload that is perfectly correct.
+    const result = built(buildHandoffManifest(input()));
+
+    expect(verifyHandoffPayload(result.serialized, result.manifest.integrity).intact).toBe(true);
+  });
+
+  it('two different records do not seal to the same digest', () => {
+    const a = sealHandoffRecord(aRecord());
+    const b = sealHandoffRecord(aRecord({ cwd: '/elsewhere' }));
+
+    expect(a.integrity.digest).not.toBe(b.integrity.digest);
+  });
+});

--- a/packages/agent-transport-protocol/src/handoff-manifest.ts
+++ b/packages/agent-transport-protocol/src/handoff-manifest.ts
@@ -1,0 +1,227 @@
+/**
+ * HANDOFF-001 (#1811): what actually gets built and sent, and how the destination knows it arrived
+ * whole.
+ *
+ * `handoff-ownership.ts` owns the phase transitions — who is authoritative when. This owns the two
+ * things that have to be true before those transitions mean anything: the inventory is COMPLETE, and
+ * the payload is INTACT.
+ *
+ * ## The inventory is not a summary
+ *
+ * The issue requires every category to be classified explicitly rather than left to implementation,
+ * and the inventory carries the items that are NOT coming along as well as the ones that are. That
+ * is the whole reason it is a list of classified items instead of a boolean per feature: a user at
+ * either end has to be able to see that their uncommitted changes stayed behind, and a destination
+ * has to be able to see that a credential was never in the payload rather than missing from it.
+ *
+ * Two dispositions look similar and are not. `source-local` is a product decision — the working-tree
+ * changes could be moved, and moving them would make this a file-sync product. `never-transferred`
+ * is a rule: SEC-009 established that a resolved credential must not cross a process boundary, and
+ * a machine boundary is strictly worse.
+ *
+ * ## In-flight work is refused, not captured
+ *
+ * A turn in flight has an outcome that belongs in the history being transferred. Serializing the
+ * record mid-turn produces a manifest whose integrity digest is correct for a session state that
+ * never existed as a settled thing. So the builder REFUSES rather than snapshotting, and the caller
+ * decides whether to wait — a choice it can only make if it was told.
+ *
+ * ## Integrity is checked in a specific order
+ *
+ * Length first, then digest. A truncated transfer is the common failure and the cheap one to
+ * detect; hashing a short buffer to discover it was short wastes the work and, worse, reports it as
+ * a digest mismatch — which reads as corruption or tampering rather than a dropped connection.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type {
+  IHandoffIntegrity,
+  IHandoffManifest,
+  IHandoffStateItem,
+  IInteractiveSessionRecord,
+  THandoffRefusal,
+} from '@robota-sdk/agent-interface-transport';
+
+/** What the source knows about work that has not settled, and about state the record cannot see. */
+export interface ISourceRuntimeState {
+  /** A model call is in flight. */
+  readonly modelCallInFlight?: boolean;
+  /** How many tool calls have started and not finished. */
+  readonly toolCallsInFlight?: number;
+  /** Child processes the session started. They cannot migrate. */
+  readonly subprocesses?: number;
+  /** The working tree has changes that are not committed. */
+  readonly uncommittedChanges?: boolean;
+}
+
+export interface IBuildManifestInput {
+  readonly handoffId: string;
+  readonly sessionId: string;
+  readonly sourceDeviceId: string;
+  readonly destinationDeviceId: string;
+  readonly record: IInteractiveSessionRecord;
+  readonly runtime: ISourceRuntimeState;
+  readonly offeredAt: number;
+}
+
+export type TManifestResult =
+  | {
+      readonly built: true;
+      readonly manifest: IHandoffManifest;
+      /** The exact bytes whose digest is in the manifest. Send THESE, not a re-serialization. */
+      readonly serialized: string;
+    }
+  | { readonly built: false; readonly refusal: THandoffRefusal; readonly detail: string };
+
+/**
+ * Serialize a record and describe what was serialized.
+ *
+ * The string is returned alongside the integrity data because the digest is only meaningful for
+ * these exact bytes. A caller that re-serialized the record before sending could produce a
+ * different key order and a digest mismatch on a payload that is perfectly correct — a corruption
+ * report caused by the corruption check.
+ */
+export function sealHandoffRecord(record: IInteractiveSessionRecord): {
+  serialized: string;
+  integrity: IHandoffIntegrity;
+} {
+  const serialized = JSON.stringify(record);
+  const bytes = Buffer.from(serialized, 'utf8');
+  return {
+    serialized,
+    integrity: {
+      digest: createHash('sha256').update(bytes).digest('base64url'),
+      byteLength: bytes.byteLength,
+    },
+  };
+}
+
+/** Why a received payload was not accepted. */
+export type TIntegrityFailure = 'truncated' | 'digest-mismatch';
+
+export interface IIntegrityVerdict {
+  readonly intact: boolean;
+  readonly failure?: TIntegrityFailure;
+  /** What the manifest promised and what arrived, so a report can say more than "it failed". */
+  readonly expectedBytes?: number;
+  readonly actualBytes?: number;
+}
+
+/**
+ * Check a received payload against the manifest's integrity metadata.
+ *
+ * Nothing is parsed here. Parsing a payload to check it is well-formed would mean building the
+ * object graph before knowing whether the bytes are the ones that were sent, and a destination that
+ * has already parsed a corrupt payload has already spent the effort this check exists to avoid.
+ */
+export function verifyHandoffPayload(
+  serialized: string,
+  integrity: IHandoffIntegrity,
+): IIntegrityVerdict {
+  const bytes = Buffer.from(serialized, 'utf8');
+  if (bytes.byteLength !== integrity.byteLength) {
+    return {
+      intact: false,
+      failure: 'truncated',
+      expectedBytes: integrity.byteLength,
+      actualBytes: bytes.byteLength,
+    };
+  }
+  const digest = createHash('sha256').update(bytes).digest('base64url');
+  if (digest !== integrity.digest) return { intact: false, failure: 'digest-mismatch' };
+  return { intact: true };
+}
+
+/**
+ * Classify every category the issue names, including the ones staying behind.
+ *
+ * Built from the record and the runtime state together, because half the answer is not in the
+ * record: it cannot know whether a tool call is running or whether the working tree is dirty.
+ */
+function inventory(
+  record: IInteractiveSessionRecord,
+  runtime: ISourceRuntimeState,
+): IHandoffStateItem[] {
+  const items: IHandoffStateItem[] = [
+    { kind: 'conversation', disposition: 'transferred' },
+    { kind: 'session-metadata', disposition: 'transferred' },
+    {
+      kind: 'provider-credentials',
+      disposition: 'never-transferred',
+      note: 'The destination resolves its own credential. A hand-off to a machine without one fails at commit, loudly, rather than silently later.',
+    },
+    {
+      kind: 'working-directory',
+      disposition: 'rehydrated',
+      note: `The path '${record.cwd}' is meaningless on the destination; it is carried so the destination can locate or ask for the corresponding checkout. A mismatch is surfaced, not guessed.`,
+    },
+  ];
+
+  // Present-only entries: an inventory that listed every optional field regardless would tell a user
+  // that goal state "stayed behind" when there was never any goal state.
+  if (record.goal !== undefined || record.plan !== undefined) {
+    items.push({ kind: 'goal-and-plan', disposition: 'transferred' });
+  }
+  if (record.backgroundTasks?.length || record.backgroundJobGroups?.length) {
+    items.push({ kind: 'background-work', disposition: 'transferred' });
+  }
+  if (record.sandboxSnapshotId !== undefined) {
+    items.push({
+      kind: 'sandbox-snapshot',
+      disposition: 'rehydrated',
+      note: 'Carried as a reference. Its validity on the destination is checked, not assumed.',
+    });
+  }
+  if (runtime.uncommittedChanges === true) {
+    items.push({
+      kind: 'uncommitted-changes',
+      disposition: 'source-local',
+      note: 'Moving these would make the hand-off a file-sync product. Their existence is reported at both ends so the choice is yours.',
+    });
+  }
+  if ((runtime.subprocesses ?? 0) > 0) {
+    items.push({
+      kind: 'subprocesses',
+      disposition: 'source-local',
+      note: `${runtime.subprocesses} running process(es) stay here. A process cannot migrate, and pretending otherwise would resume a session whose tools point at dead pids.`,
+    });
+  }
+  return items;
+}
+
+/**
+ * Build the offer, or refuse to.
+ *
+ * Refusal comes first and is not a failure of the transfer — it is the transfer declining to start
+ * on state that is not settled. `handoff-ownership.ts` never sees an offer that should not have been
+ * made.
+ */
+export function buildHandoffManifest(input: IBuildManifestInput): TManifestResult {
+  const toolCalls = input.runtime.toolCallsInFlight ?? 0;
+  if (input.runtime.modelCallInFlight === true || toolCalls > 0) {
+    return {
+      built: false,
+      refusal: 'in-flight-work',
+      detail:
+        'A turn is still running, and its outcome belongs in the history being transferred. ' +
+        'Snapshotting now would produce a manifest whose digest is correct for a session state ' +
+        'that never settled. Wait for it, or cancel it.',
+    };
+  }
+
+  const { serialized, integrity } = sealHandoffRecord(input.record);
+  return {
+    built: true,
+    serialized,
+    manifest: {
+      handoffId: input.handoffId,
+      sessionId: input.sessionId,
+      sourceDeviceId: input.sourceDeviceId,
+      destinationDeviceId: input.destinationDeviceId,
+      inventory: inventory(input.record, input.runtime),
+      integrity,
+      offeredAt: input.offeredAt,
+    },
+  };
+}

--- a/packages/agent-transport-protocol/src/index.ts
+++ b/packages/agent-transport-protocol/src/index.ts
@@ -62,3 +62,15 @@ export {
   sourceStillOwns,
 } from './handoff-ownership.js';
 export type { ICommitResult, IHandoffTransaction, ITransitionResult } from './handoff-ownership.js';
+export {
+  buildHandoffManifest,
+  sealHandoffRecord,
+  verifyHandoffPayload,
+} from './handoff-manifest.js';
+export type {
+  IBuildManifestInput,
+  IIntegrityVerdict,
+  ISourceRuntimeState,
+  TIntegrityFailure,
+  TManifestResult,
+} from './handoff-manifest.js';


### PR DESCRIPTION
HANDOFF-001 **TC-01, TC-06, TC-08**. The ownership state machine already landed — who is authoritative when. This is the pair of things that must be true before those transitions mean anything: the inventory is **complete**, and the payload is **intact**.

## The inventory carries what is NOT coming

The issue requires every category classified explicitly rather than left to implementation, and that includes the items staying behind. A user at either end has to see that their uncommitted changes stayed; a destination has to see that a credential was *never in the payload* rather than *missing from it*.

It is also built only from what is present. An inventory that listed every optional field regardless would tell a user their goal state stayed behind when they never had any — a report that is false in the direction of alarming.

## A new disposition, because two different statements were sharing one word

`THandoffDisposition` had `source-local` doing double duty:

| Case | Why it stays | Revisitable? |
| --- | --- | --- |
| Uncommitted working-tree changes | moving them would make this a file-sync product | yes — a product decision |
| Resolved provider credential | SEC-009: must not cross a process boundary, and a machine boundary is strictly worse | **no — a rule** |

Collapsed together, nothing in the type would stop a later change from helpfully starting to carry the credential along. `never-transferred` now says the second thing, and the destination resolving its **own** credential is what makes a hand-off to a machine without one fail loudly at commit rather than silently later.

## In-flight work is refused, not snapshotted

A turn in flight has an outcome that belongs in the history being transferred. Serializing mid-turn produces a manifest whose digest is *correct* for a session state that never settled. The refusal names what the caller can do — waiting or cancelling is their choice, and they can only make it if they were told.

## Integrity is checked length-first

Truncation is the common failure and the cheap one to detect. Hashing a short buffer to discover it was short wastes the work and, worse, reports a dropped connection as a **digest mismatch** — which reads as tampering.

Two related properties the tests pin:

- **The seal hands back the exact bytes it hashed.** A caller that re-serialized the record could produce a different key order and a mismatch on a payload that is perfectly correct — a corruption report caused by the corruption check.
- **Nothing is parsed during verification.** A destination that has already built the object graph from a corrupt payload has already spent the effort the check exists to avoid.

## Still open on #1811

Wire chunking, the framework orchestration, and the CLI commands. TC-07 (destination has no credential) belongs with the commit path, not here.

## Verification

- 15 new tests; 154 in the package, all green
- `pnpm harness:scan` — 123 passed, 2 skipped
- `pnpm typecheck` clean; `verify-like-ci.mjs --only format-check` green

*(A typecheck error in `agent-provider-defaults` seen mid-work was a stale `dist/` on develop, not this change — rebuilding `agent-core` cleared it.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD