### PR TITLE
fix(agent-remote-pairing): collapse three byte-for-byte copies of one base64url encoder

### DIFF
--- a/packages/agent-remote-pairing/src/handoff-authorization.ts
+++ b/packages/agent-remote-pairing/src/handoff-authorization.ts
@@ -30,18 +30,12 @@
  * private key, and every field it could tamper with is signed.
  */
 
-import { ab } from './crypto-primitives.js';
+import { ab, toBase64Url } from './crypto-primitives.js';
 
 const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
 
 const webcrypto = globalThis.crypto;
 const encoder = new TextEncoder();
-
-function toBase64Url(bytes: Uint8Array): string {
-  let binary = '';
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
 
 function fromBase64Url(value: string): Uint8Array {
   const padded = value.replace(/-/g, '+').replace(/_/g, '/');

--- a/packages/agent-remote-pairing/src/user-identity.ts
+++ b/packages/agent-remote-pairing/src/user-identity.ts
@@ -31,7 +31,7 @@
  * primitives the reconnect challenge already uses.
  */
 
-import { ab } from './crypto-primitives.js';
+import { ab, toBase64Url } from './crypto-primitives.js';
 import { deriveIdentityId, exportPublicKey, importPublicKey } from './device-identity.js';
 
 const ECDSA_PARAMS = { name: 'ECDSA', namedCurve: 'P-256' } as const;
@@ -39,12 +39,6 @@ const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
 
 const webcrypto = globalThis.crypto;
 const encoder = new TextEncoder();
-
-function toBase64Url(bytes: Uint8Array): string {
-  let binary = '';
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
 
 function fromBase64Url(value: string): Uint8Array {
   const padded = value.replace(/-/g, '+').replace(/_/g, '/');


### PR DESCRIPTION
Noticed while working nearby. **Two of the three copies are mine** — SEC-011 added both private ones to files that were *already importing from the shared primitives module in the same import statement*. There was no reason for either; I did not look before writing.

## What this is not

It is not a merge of divergent behaviour. The three are identical down to the regex chain:

```ts
let binary = '';
for (const b of bytes) binary += String.fromCharCode(b);
return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
```

So the change is deleting two functions and widening an import that was already present.

## Why it is worth a PR anyway

A crypto encoder duplicated three ways is one review away from three different paddings — and the bug that produces verifies fine locally and fails only against the *other end*, which is the worst place to find it. The copies being identical today is exactly the window in which collapsing them is free.

## Verification

All 82 tests in the package pass unchanged. That is what establishes the three really were one function, rather than my reading of them.

`pnpm harness:scan` — 123 passed, 2 skipped. `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD