### PR TITLE
feat(agent-framework): let a consumer supply guardrails and the retrieval adapter (ARCH-013 stage 3)

### DIFF
--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -369,6 +369,12 @@
       "file": "packages/agent-framework/src/assembly/create-session-types.ts",
       "constructors": ["createSession"],
       "reason": "The session-construction option surface. `guardrails` (SELFHOST-005) and `retrievalAdapter` (SELFHOST-003) were declared, read at the consuming end, and set by no production call to createSession — two documented capabilities no shipped surface could turn on."
+    },
+    {
+      "name": "IInteractiveSessionStandardOptions",
+      "file": "packages/agent-framework/src/interactive/interactive-session-options.ts",
+      "constructors": ["createInteractiveSession"],
+      "reason": "The PUBLISHED construction surface, added by ARCH-013 stage 3 after review measured the gap it leaves. Watching only ICreateSessionOptions could not see a key declared on the public type and forwarded by nothing — which is exactly what stage 3's first attempt created: both new fields were accepted by this type and dropped by the ~40-field hand-map in initializeInteractiveSessionAsync, so the ratchet certified a 11-to-9 gain the code did not deliver. A consumer can only set what this type declares, so this is where unreachability is user-visible."
     }
   ],
   "productIdentity": {

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -371,10 +371,10 @@
       "reason": "The session-construction option surface. `guardrails` (SELFHOST-005) and `retrievalAdapter` (SELFHOST-003) were declared, read at the consuming end, and set by no production call to createSession — two documented capabilities no shipped surface could turn on."
     },
     {
-      "name": "IInteractiveSessionStandardOptions",
+      "name": "IInitOptions",
       "file": "packages/agent-framework/src/interactive/interactive-session-options.ts",
       "constructors": ["createInteractiveSession"],
-      "reason": "The PUBLISHED construction surface, added by ARCH-013 stage 3 after review measured the gap it leaves. Watching only ICreateSessionOptions could not see a key declared on the public type and forwarded by nothing — which is exactly what stage 3's first attempt created: both new fields were accepted by this type and dropped by the ~40-field hand-map in initializeInteractiveSessionAsync, so the ratchet certified a 11-to-9 gain the code did not deliver. A consumer can only set what this type declares, so this is where unreachability is user-visible."
+      "reason": "The INIT option shape, watched because ARCH-013 stage 3 dropped two fields in the ~40-field hand-map that builds it and stage 1's ICreateSessionOptions-only ratchet could not see the drop. Named IInitOptions rather than the published IInteractiveSessionStandardOptions because that is literally what it measures: the single production literal it reads is the createInteractiveSession(...) call, which takes IInitOptions. An earlier revision named the published type, and review measured the difference — 8 of the 10 keys it then reported ARE set by production code through buildRuntimeSession and the surface option builders, so the entry asserted unreachability it had not established, and burning it down would have pushed class-consumed options into the very hand-map this stage fixed."
     }
   ],
   "productIdentity": {

--- a/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
+++ b/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
@@ -556,9 +556,11 @@ one hop later. That is this item's own defect, restated one hop above where I wa
 the change meant to fix it. Nothing excuses it; the lesson is that "the surfaces spread it" was a
 guess about a mechanism I had the means to check in one command.
 
-Conditional spreads rather than `key: undefined`, because `create-session.ts` branches on
-`options.guardrails && Object.keys(...).length > 0` and an explicitly-undefined key is how a spread
-reintroduces an absent member — ARCH-029's lesson, one package over.
+Conditional spreads for consistency with the ~15 optional keys around them, **not** because the
+ARCH-029 spread hazard applies. Review measured that it cannot fire at that site:
+`exactOptionalPropertyTypes` is set nowhere, the consumer branches on truthiness, and the object goes
+straight into `createSession` rather than over a base. An earlier revision of this paragraph cited
+that hazard as the reason — the right shape justified by a mechanism that does not reach it.
 
 ### The chain is proven to COMPLETE, not just to type-check
 
@@ -590,3 +592,56 @@ the same change (_"or the gain is a licence to drop them again"_), which is the 
 exactly as its author intended.
 
 Verified: 122 of 123 scans pass (1 skipped). agent-framework 1380 tests.
+
+### Review rounds 1 and 2 — three of my own claims were wrong, and one would have done harm
+
+**Round 1's first finding is the one to record.** After the first two commits, NEITHER capability was
+reachable from any surface. The fields were added to the published option type and projected into
+`ICreateSessionOptions`, and the ~40-field hand-map in `initializeInteractiveSessionAsync` between
+them was left untouched — so a consumer could set them and get silence. This item's own defect, one
+hop above where it was being fixed, inside the change meant to fix it.
+
+Two supporting claims of mine were false and are corrected where they were made:
+
+- _"The three surfaces spread those options, so all of them gain it at once."_ Inferred from
+  `additionalTools` without measuring. `additionalTools` is spread nowhere — it is re-declared and
+  explicitly forwarded at **eight** sites.
+- The `createSession`-level tests, written to prove the chain completes, were **accidentally green**:
+  all six passed on the pre-fix merge-base because they enter below the hop the change touched. They
+  cover assembler behaviour that genuinely had no test, so they stay — relabelled to say what they
+  guard — and the cases that guard the fix drive `initializeInteractiveSessionAsync`.
+
+**Round 2 found the worst of the three, and it was a fix I had added in response to round 1.** To stop
+the ratchet missing that hop again, I added `IInteractiveSessionStandardOptions` to
+`optionReachability` and reported that it "immediately found TEN more options declared and set by
+nothing", filing them as an issue. That was false for **eight of the ten**. The entry named the
+published type but gave `createInteractiveSession` as its constructor — and that function takes
+`IInitOptions`, so the scan read the hand-map's literal and reported what the hand-map forwards, not
+what a consumer can set. Eight of the ten are set by production code through `buildRuntimeSession` and
+the surface option builders, which the entry never looked at.
+
+The harm was not the wrong count. **Anyone burning that list down would have been pushed to forward
+class-consumed options into the very hand-map this stage had just fixed a drop in — the ratchet would
+have manufactured the defect shape it was added to prevent.** The entry is renamed to `IInitOptions`,
+which is literally what it measures; its baseline is **zero**, not ten; it still catches the real
+defect (removing the two forwarding lines makes it fire); and the issue is closed with the
+measurement corrected.
+
+**The pattern across all three: a mechanical claim asserted from a scan's or a precedent's output
+without checking what that mechanism could see.** Three times in one item, twice after being warned.
+The cheap defence is the one that worked every time it was applied — run the mutation, read what the
+tool actually prints.
+
+### What the seam-level test does and does not prove
+
+`buildRuntimeSession` is the single construction seam the SPEC names for the TUI, print and `--serve`.
+Driving it to a constructed session needs a Session double far past this fixture's scope, so that case
+asserts the type instead: the literal is annotated rather than cast, so it fails to compile if either
+port is missing from the published construction type, and it is assignable with no cast to exactly
+what the seam takes. Removing either field from the published interface produces five typecheck
+errors, so the assertion is load-bearing.
+
+The hop it does not execute is `interactive-session.ts:341-342`, a straight pass-through into
+`initializeInteractiveSessionAsync` — the group above drives that directly and red-proves it. Two
+readers checked that pass-through by hand. It is the one link here carried by review rather than by
+execution, and it is named rather than glossed.

--- a/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
+++ b/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
@@ -542,9 +542,19 @@ had no way to hand it over. `additionalTools` is the working precedent for the s
 
 Both fields added to `IInitOptions` **and** `IInteractiveSessionStandardOptions` — the two
 hand-duplicate ~40 fields, and adding a field to one is exactly how the next silent drop starts (L2
-F16, which this item already flagged as needing inclusion) — and projected in
-`buildCreateSessionOptions`, the single owner stage 1 extracted. The three surfaces spread those
-options, so all of them gain it at once.
+F16, which this item already flagged as needing inclusion) — projected in `buildCreateSessionOptions`,
+and **forwarded through the ~40-field hand-map in `initializeInteractiveSessionAsync`**, which is the
+hop that actually made the capability reachable.
+
+**A false claim of mine, corrected here rather than quietly dropped.** The first attempt at this stage
+asserted that "the three surfaces spread those options, so all of them gain it at once", inferred from
+`additionalTools`' precedent without measuring it. Review refuted both halves: `additionalTools` is not
+spread anywhere — it is re-declared and explicitly forwarded at **eight** sites — and the hand-map
+inside `initializeInteractiveSessionAsync` omitted both new fields, so **after that commit neither
+capability was reachable from any surface**. The published option type accepted them and dropped them
+one hop later. That is this item's own defect, restated one hop above where I was fixing it, inside
+the change meant to fix it. Nothing excuses it; the lesson is that "the surfaces spread it" was a
+guess about a mechanism I had the means to check in one command.
 
 Conditional spreads rather than `key: undefined`, because `create-session.ts` branches on
 `options.guardrails && Object.keys(...).length > 0` and an explicitly-undefined key is how a spread
@@ -579,4 +589,4 @@ it detected that the unreachable set had SHRUNK and refused to pass until the ga
 the same change (_"or the gain is a licence to drop them again"_), which is the mechanism working
 exactly as its author intended.
 
-Verified: 121 of 123 scans pass (2 skipped). agent-framework 1371 tests.
+Verified: 122 of 123 scans pass (1 skipped). agent-framework 1380 tests.

--- a/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
+++ b/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
@@ -614,11 +614,14 @@ Two supporting claims of mine were false and are corrected where they were made:
 **Round 2 found the worst of the three, and it was a fix I had added in response to round 1.** To stop
 the ratchet missing that hop again, I added `IInteractiveSessionStandardOptions` to
 `optionReachability` and reported that it "immediately found TEN more options declared and set by
-nothing", filing them as an issue. That was false for **eight of the ten**. The entry named the
+nothing", filing them as an issue. That was false for **nine of the ten**. The entry named the
 published type but gave `createInteractiveSession` as its constructor — and that function takes
 `IInitOptions`, so the scan read the hand-map's literal and reported what the hand-map forwards, not
-what a consumer can set. Eight of the ten are set by production code through `buildRuntimeSession` and
-the surface option builders, which the entry never looked at.
+what a consumer can set. Nine of the ten are set by production code through `buildRuntimeSession`, the surface option
+builders, and a `new InteractiveSession({…})` literal — none of which the entry looked at. (Eight was
+review's own count, corrected a round later when `orgPolicy` turned out to be set at
+`packages/agent-framework/src/runtime/agent-runtime.ts:121`; the same assignment-shaped search that
+produced my false ten missed it. The only key with no setter anywhere is `providerDefinitions`.)
 
 The harm was not the wrong count. **Anyone burning that list down would have been pushed to forward
 class-consumed options into the very hand-map this stage had just fixed a drop in — the ratchet would
@@ -639,7 +642,8 @@ Driving it to a constructed session needs a Session double far past this fixture
 asserts the type instead: the literal is annotated rather than cast, so it fails to compile if either
 port is missing from the published construction type, and it is assignable with no cast to exactly
 what the seam takes. Removing either field from the published interface produces five typecheck
-errors, so the assertion is load-bearing.
+errors — two of them from that case, three of them borrowed from sites that would fail anyway — so
+the assertion is load-bearing, but by less than the raw count suggests.
 
 The hop it does not execute is `interactive-session.ts:341-342`, a straight pass-through into
 `initializeInteractiveSessionAsync` — the group above drives that directly and red-proves it. Two

--- a/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
+++ b/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
@@ -505,3 +505,57 @@ both directions.
 
 Unchanged: `guardrails` and `retrievalAdapter`, both advertised capabilities (SELFHOST-005,
 SELFHOST-003) that no surface can turn on, plus the two unbridged `guardrails` shapes.
+
+## Implementation — stage 3 of 3
+
+`guardrails` (SELFHOST-005) and `retrievalAdapter` (SELFHOST-003) now reach the session, and stage 1's
+frozen unreachable set falls from **11 keys to 9**.
+
+### A correction to this item's own analysis
+
+The task recorded that the two `guardrails` shapes — `ICreateSessionOptions.guardrails` as a
+`Record<string, TGuardrail>` and the config schema's `guardrails` as a `string[]` — "cannot satisfy
+each other, no code bridges them", and that reconciling them was part of stage 3. **That is wrong, and
+it is recorded rather than quietly dropped, because a plan built on a wrong map is worse than no
+plan.**
+
+They are not rivals. The config array sits on a guardrail HOOK definition
+(`GuardrailHookDefinitionSchema`) and selects WHICH registered guardrails that hook runs, by name —
+its own comment says so: _"Names of registered guardrails to run; omitted = run ALL registered
+guardrails."_ The session option is the REGISTRY that supplies the functions. And
+`resolveGuardrailHooks` (`create-session.ts:78-91`) is the bridge, which has existed all along: given
+a non-empty registry and no already-declared guardrail hook, it installs a `PreToolUse` one.
+
+So nothing needed reconciling. The defect was narrower and entirely mechanical: **the registry had no
+way in.** Both consuming ends already worked; the option stopped at `createSession` and no public
+surface carried it.
+
+### Why that made them unreachable rather than merely unused
+
+Neither has any implementation in this repo — they are consumer-supplied extension ports. That is
+what turns a broken chain into a removed capability: an SDK consumer with a guardrail function in hand
+had no way to hand it over. `additionalTools` is the working precedent for the same shape (product →
+`IInitOptions` → all three surfaces → `createSession`), and both of these were absent from
+`IInitOptions` entirely.
+
+### The change
+
+Both fields added to `IInitOptions` **and** `IInteractiveSessionStandardOptions` — the two
+hand-duplicate ~40 fields, and adding a field to one is exactly how the next silent drop starts (L2
+F16, which this item already flagged as needing inclusion) — and projected in
+`buildCreateSessionOptions`, the single owner stage 1 extracted. The three surfaces spread those
+options, so all of them gain it at once.
+
+Conditional spreads rather than `key: undefined`, because `create-session.ts` branches on
+`options.guardrails && Object.keys(...).length > 0` and an explicitly-undefined key is how a spread
+reintroduces an absent member — ARCH-029's lesson, one package over.
+
+### Falsification
+
+Red-proved by deletion rather than asserted: removing the two projection lines turns 2 of the 4 new
+cases red, and restoring them turns them green. Stage 1's ratchet then did its own job unprompted —
+it detected that the unreachable set had SHRUNK and refused to pass until the gain was re-frozen in
+the same change (_"or the gain is a licence to drop them again"_), which is the mechanism working
+exactly as its author intended.
+
+Verified: 121 of 123 scans pass (2 skipped). agent-framework 1371 tests.

--- a/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
+++ b/.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md
@@ -550,10 +550,31 @@ Conditional spreads rather than `key: undefined`, because `create-session.ts` br
 `options.guardrails && Object.keys(...).length > 0` and an explicitly-undefined key is how a spread
 reintroduces an absent member — ARCH-029's lesson, one package over.
 
+### The chain is proven to COMPLETE, not just to type-check
+
+The projection test alone would have let this change claim a capability it had not restored: a
+projection can carry a field into an option bag that then drops it again. So the assembled session is
+asserted directly, and the gap that made this necessary was real —
+**`guardrails` appeared in no `createSession` test before this one.**
+
+- A supplied registry makes `createSession` auto-inject the `PreToolUse` guardrail group; omitting it,
+  and supplying an EMPTY registry, both inject nothing. Those two negatives are what make the
+  positive mean something.
+- Idempotence is pinned too: a consumer who declares their own guardrail hook gets exactly one, and it
+  is theirs — that branch is what makes auto-injection safe to ship.
+- For retrieval, `create-tools.test.ts:98` already covered the last hop. The hop nothing covered was
+  `createSession` → `assemble-session-tools` → `createDefaultTools`, so "the adapter reaches the
+  session" was an inference across two separately-tested halves rather than a measured fact. It is
+  measured now.
+
+The negative retrieval assertion also asserts the tool list is populated. A `not.toContain` over an
+empty list passes for the wrong reason, and checking that was not idle: it is the same vacuous-check
+shape this repo has now shipped three times.
+
 ### Falsification
 
-Red-proved by deletion rather than asserted: removing the two projection lines turns 2 of the 4 new
-cases red, and restoring them turns them green. Stage 1's ratchet then did its own job unprompted —
+Red-proved by deletion rather than asserted: removing the two projection lines turns 2 of the 4
+projection cases red, and restoring them turns them green. Stage 1's ratchet then did its own job unprompted —
 it detected that the unreachable set had SHRUNK and refused to pass until the gain was re-frozen in
 the same change (_"or the gain is a licence to drop them again"_), which is the mechanism working
 exactly as its author intended.

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -2506,6 +2506,31 @@ tier: the FIRST entry for a name wins and later duplicates are dropped, so a pac
 shadows a built-in yields one roster entry, never two. (For a tier with no duplicate names — the
 historic `BUILT_IN_AGENTS` alone — the dedupe is a no-op.)
 
+### Consumer-supplied extension ports (`guardrails` / `retrievalAdapter`, ARCH-013 stage 3)
+
+Two ports the framework READS but ships no implementation of. Both are available on
+`IInteractiveSessionStandardOptions` / `IInitOptions` / `ICreateSessionOptions`, and both were
+declared and settable by nothing until ARCH-013 stage 3 — a documented capability no surface could
+turn on, which is a different state from one nobody had used.
+
+| Port               | Consumed at                                   | Effect when supplied                                                        |
+| ------------------ | --------------------------------------------- | --------------------------------------------------------------------------- |
+| `guardrails`       | `createSession` → `GuardrailExecutor`         | Registers the executor AND auto-injects a `PreToolUse` guardrail hook       |
+| `retrievalAdapter` | `assembleSessionTools` → `createDefaultTools` | Surfaces the `CodebaseRetrieval` tool; absent ⇒ the tool is absent entirely |
+
+**`guardrails` is a REGISTRY, not a selector, and the two are easy to confuse because they share a
+name.** `ICreateSessionOptions.guardrails` is `Record<string, TGuardrail>` — name → function. A
+`{ type: 'guardrail' }` hook definition in config carries its own `guardrails?: string[]`, which
+SELECTS which registered guardrails that hook runs (omitted = all). They are complementary:
+`resolveGuardrailHooks` is the bridge, and it auto-injects a blanket `PreToolUse` group only when a
+non-empty registry is supplied and the config declares no guardrail hook of its own. Registering a
+registry alone does nothing — the executor needs a hook definition on an enforcing event to fire.
+
+**`retrievalAdapter` interacts with `defaultTools`.** The adapter is passed to `createDefaultTools`,
+so a consumer who REPLACES that tier via `defaultTools` (ARCH-006, below) owns the retrieval tool too
+and the adapter reaches nothing. The two options are independent seams and this interaction is not
+mediated.
+
 ### Session-level tool composition (`defaultTools` / `additionalTools`, ARCH-006)
 
 The tool axis has the same two-seam shape as the subagent axis above, and the same precedence

--- a/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
+++ b/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
@@ -1,25 +1,26 @@
 /**
- * ARCH-013 stage 3 — a supplied guardrail registry actually reaches the assembled session.
+ * ARCH-013 stage 3 — the guardrail registry and retrieval adapter, from the PUBLIC surface in.
  *
- * The stage-3 projection test proves the registry survives `IInitOptions → ICreateSessionOptions`.
- * That is a type-level hop, and on its own it would let this change claim a capability it had not
- * restored: a projection can carry a field into an option bag that then drops it again.
+ * ## What each group here guards, stated because an earlier revision got it wrong
  *
- * This is the other half, asserted on the ASSEMBLED session rather than on the option bag. The
- * property that matters is the one `create-session.ts` documents in its own comment — registering a
- * registry only adds the EXECUTOR, and the guardrails fire only if a `{ type: 'guardrail' }` hook
- * definition exists on an enforcing event, so `createSession` auto-injects a `PreToolUse` group when
- * the config declares none. Nothing had ever tested that from the option in: `guardrails` appeared in
- * no `createSession` test before this one.
+ * The `createSession` group covers pre-existing behaviour: registering a registry adds the EXECUTOR,
+ * and the guardrails only fire if a `{ type: 'guardrail' }` hook exists on an enforcing event, so
+ * `createSession` auto-injects a `PreToolUse` group when the config declares none. That behaviour was
+ * genuinely untested from the option in — `guardrails` appeared in no `createSession` test before
+ * this file — so the coverage is worth having. But review measured all of it passing on the pre-fix
+ * merge-base, because it enters BELOW the hop this change touches. It guards the assembler, not the
+ * fix, and the previous revision of this docblock claimed otherwise.
  *
- * It also pins the idempotence half — a consumer who declares their own guardrail hook must not get a
- * second, auto-injected one — because that branch is what makes the auto-injection safe to ship.
+ * The `initializeInteractiveSessionAsync` group is the one that guards the fix. It drives the
+ * published option type, which is the only thing a consumer can actually reach, and it fails on the
+ * pre-fix tree. Both halves are kept: one pins the mechanism, the other pins the wiring.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import type { IResolvedConfig } from '../config/config-types.js';
 import type { TGuardrail } from '@robota-sdk/agent-core';
+import type { IRetrievalAdapter } from '@robota-sdk/agent-tools';
 
 const sessionCtorCalls: Array<Record<string, unknown>> = [];
 
@@ -98,13 +99,19 @@ function guardrailHooksOf(sessionOptions: Record<string, unknown>): unknown[] {
 
 const NEVER_PASSES: TGuardrail = () => ({ pass: false, reason: 'blocked by test' });
 
+/** Hook-executor types registered on the assembled session. */
+function executorTypesOf(sessionOptions: Record<string, unknown>): string[] {
+  const executors = (sessionOptions.hookTypeExecutors ?? []) as Array<{ type?: string }>;
+  return executors.map((executor) => executor.type ?? '').filter(Boolean);
+}
+
 /** Tool names on the assembled session. */
 function toolNamesOf(sessionOptions: Record<string, unknown>): string[] {
   const tools = (sessionOptions.tools ?? []) as Array<{ getName?: () => string }>;
   return tools.map((tool) => tool.getName?.() ?? '').filter(Boolean);
 }
 
-describe('ARCH-013 stage 3 — a supplied guardrail registry reaches the assembled session', () => {
+describe('createSession registers the guardrail machinery (pre-existing, previously untested)', () => {
   beforeEach(() => {
     sessionCtorCalls.length = 0;
   });
@@ -122,6 +129,9 @@ describe('ARCH-013 stage 3 — a supplied guardrail registry reaches the assembl
 
     expect(sessionCtorCalls).toHaveLength(1);
     expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(1);
+    // The EXECUTOR half, which this file's own docblock names and an earlier revision left unasserted:
+    // the hook is inert without it, so asserting only the hook proved half the mechanism.
+    expect(executorTypesOf(sessionCtorCalls[0]!)).toContain('guardrail');
   });
 
   it('injects NOTHING when no registry is supplied — the state before this change', async () => {
@@ -176,7 +186,7 @@ describe('ARCH-013 stage 3 — a supplied guardrail registry reaches the assembl
   });
 });
 
-describe('ARCH-013 stage 3 — a supplied retrieval adapter reaches the assembled tool surface', () => {
+describe('createSession gates CodebaseRetrieval on the adapter (pre-existing behaviour)', () => {
   beforeEach(() => {
     sessionCtorCalls.length = 0;
   });
@@ -187,9 +197,11 @@ describe('ARCH-013 stage 3 — a supplied retrieval adapter reaches the assemble
     // → `createDefaultTools`. Without it, "the adapter reaches the session" was an inference across
     // two separately-tested halves rather than a measured fact.
     const { createSession } = await import('../assembly/create-session.js');
-    const retrievalAdapter = {
-      search: () => Promise.resolve([]),
-    } as unknown as Parameters<typeof createSession>[0]['retrievalAdapter'];
+    // `retrieve`, not `search`: the gate is truthiness-only so a wrong member name would still pass,
+    // which is exactly why encoding one in a cast is worth avoiding.
+    const retrievalAdapter: IRetrievalAdapter = {
+      retrieve: async () => ({ symbols: [], totalTokens: 0 }),
+    };
 
     createSession({
       config: baseConfig(),
@@ -217,5 +229,99 @@ describe('ARCH-013 stage 3 — a supplied retrieval adapter reaches the assemble
     // an empty list passes for the wrong reason, which is how a negative assertion goes vacuous.
     expect(names.length).toBeGreaterThan(3);
     expect(names).not.toContain('CodebaseRetrieval');
+  });
+});
+
+describe('ARCH-013 stage 3 — the PUBLIC surface carries both ports (this is what guards the fix)', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  /**
+   * Everything `initializeInteractiveSessionAsync` needs that is not under test. Review drove this
+   * entry point and found the fields dropped at the ~40-field hand-map inside it — a hop ABOVE the
+   * projection the first commit fixed, so every `createSession`-level case passed on the pre-fix tree
+   * while a consumer still got silence.
+   */
+  function asyncInitDeps(): Parameters<
+    typeof import('../interactive/interactive-session-init.js').initializeInteractiveSessionAsync
+  >[1] {
+    return {
+      sandboxSnapshotId: undefined,
+      resumeSessionId: undefined,
+      pendingRestoreMessages: null,
+      permissionHandler: undefined,
+      askHandler: undefined,
+      onTextDelta: () => {},
+      onContextUpdate: () => {},
+      onCompactEvent: () => {},
+      onToolExecution: () => {},
+      executeModelCommand: () => Promise.resolve(null),
+      isModelCommandInvocable: () => false,
+      commandDescriptors: [],
+      commandSemanticRoles: undefined,
+      setEditCheckpointStore: () => {},
+    } as never;
+  }
+
+  it('carries a guardrail registry set on the published option type all the way to the session', async () => {
+    const { initializeInteractiveSessionAsync } =
+      await import('../interactive/interactive-session-init.js');
+
+    await initializeInteractiveSessionAsync(
+      {
+        cwd: '/arch-013-stage-3-public',
+        provider: createMockProvider(),
+        bare: true,
+        config: baseConfig(),
+        guardrails: { neverPasses: NEVER_PASSES },
+      },
+      asyncInitDeps(),
+    );
+
+    expect(sessionCtorCalls).toHaveLength(1);
+    expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(1);
+    expect(executorTypesOf(sessionCtorCalls[0]!)).toContain('guardrail');
+  });
+
+  it('carries a retrieval adapter set on the published option type through to the tool surface', async () => {
+    const { initializeInteractiveSessionAsync } =
+      await import('../interactive/interactive-session-init.js');
+    const retrievalAdapter: IRetrievalAdapter = {
+      retrieve: async () => ({ symbols: [], totalTokens: 0 }),
+    };
+
+    await initializeInteractiveSessionAsync(
+      {
+        cwd: '/arch-013-stage-3-public',
+        provider: createMockProvider(),
+        bare: true,
+        config: baseConfig(),
+        retrievalAdapter,
+      },
+      asyncInitDeps(),
+    );
+
+    const names = toolNamesOf(sessionCtorCalls[0]!);
+    expect(names.length).toBeGreaterThan(3);
+    expect(names).toContain('CodebaseRetrieval');
+  });
+
+  it('carries neither when neither is set — the contrast that makes the two above mean something', async () => {
+    const { initializeInteractiveSessionAsync } =
+      await import('../interactive/interactive-session-init.js');
+
+    await initializeInteractiveSessionAsync(
+      {
+        cwd: '/arch-013-stage-3-public',
+        provider: createMockProvider(),
+        bare: true,
+        config: baseConfig(),
+      },
+      asyncInitDeps(),
+    );
+
+    expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(0);
+    expect(toolNamesOf(sessionCtorCalls[0]!)).not.toContain('CodebaseRetrieval');
   });
 });

--- a/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
+++ b/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
@@ -21,10 +21,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { IResolvedConfig } from '../config/config-types.js';
 import type { TGuardrail } from '@robota-sdk/agent-core';
 import type { IRetrievalAdapter } from '@robota-sdk/agent-tools';
-import type {
-  IInteractiveSessionStandardOptions,
-  TInteractiveSessionOptions,
-} from '../interactive/interactive-session-options.js';
+import type { IInteractiveSessionStandardOptions } from '../interactive/interactive-session-options.js';
 
 const sessionCtorCalls: Array<Record<string, unknown>> = [];
 
@@ -334,24 +331,29 @@ describe('ARCH-013 stage 3 — the PUBLIC surface carries both ports (this is wh
   });
 });
 
-describe('ARCH-013 stage 3 — buildRuntimeSession, the seam every presentation actually calls', () => {
-  it('accepts both ports on the option type it publishes', () => {
-    // What this proves and what it does not, stated because the distinction is the whole point.
+describe('ARCH-013 stage 3 — the ports are pinned to the PUBLISHED construction type', () => {
+  it('accepts both ports on `IInteractiveSessionStandardOptions` itself', () => {
+    // WHAT THIS ADDS, stated narrowly because an earlier docblock here claimed more than it does.
     //
-    // PROVES: `TInteractiveSessionOptions` — the type `buildRuntimeSession` publishes, and the one
-    // the TUI, print and --serve all construct through — accepts both ports. Written with NO cast, so
-    // it fails to COMPILE if either field is missing from that type. An earlier revision passed
-    // `as never` here, which would have made it pass whether or not the type carried them: a cast in
-    // a type-level assertion asserts nothing.
+    // The one guard distinct to this case: both ports are pinned to the PUBLISHED construction type
+    // independently of `initializeInteractiveSessionAsync`'s parameter type. Everything else that
+    // could fail here already fails elsewhere — review measured that of the five typecheck errors
+    // produced by removing a port, three come from other sites that would break anyway.
     //
-    // DOES NOT PROVE: that the value arrives. `new InteractiveSession(...)` initialises
+    // It is enforced by `pnpm typecheck`, never by `vitest`, which is unlike every other case in this
+    // file. The runtime expectations below are incidental; the annotation is the assertion.
+    //
+    // An earlier revision also wrote `const seamOptions: TInteractiveSessionOptions = options` and
+    // asserted `toBe(options)`. That is a widening that cannot fail once the annotation above holds,
+    // followed by a tautology — the same shape as the `as never` this case started with, which is
+    // what makes it worth deleting rather than keeping as belt-and-braces.
+    //
+    // NOT proven here: that a value set this way arrives. `new InteractiveSession(...)` initialises
     // asynchronously with no public await point, and driving it to completion needs a Session double
-    // far beyond this file's fixture. The hop from there is `interactive-session.ts:341-342`, a
-    // straight pass-through into `initializeInteractiveSessionAsync` — which the group above drives
-    // directly and red-proves. Two readers checked that pass-through by hand; it is the one link here
-    // carried by review rather than by execution, and it is named rather than glossed.
-    // The literal is annotated, not cast, so excess-property checking rejects it if either field is
-    // absent from the published construction type.
+    // far past this fixture. The next hop is `interactive-session.ts:341-342`, a straight
+    // pass-through into `initializeInteractiveSessionAsync` — which the group above drives directly
+    // and red-proves. Two readers checked that pass-through by hand; it is the one link in this file
+    // carried by review rather than by execution.
     const options: IInteractiveSessionStandardOptions = {
       cwd: '/arch-013-stage-3-seam',
       provider: createMockProvider(),
@@ -360,11 +362,8 @@ describe('ARCH-013 stage 3 — buildRuntimeSession, the seam every presentation 
       guardrails: { neverPasses: NEVER_PASSES },
       retrievalAdapter: { retrieve: async () => ({ symbols: [], totalTokens: 0 }) },
     };
-    // …and assignable, with no cast, to exactly what `buildRuntimeSession` takes.
-    const seamOptions: TInteractiveSessionOptions = options;
 
     expect(options.guardrails).toBeDefined();
     expect(options.retrievalAdapter).toBeDefined();
-    expect(seamOptions).toBe(options);
   });
 });

--- a/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
+++ b/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
@@ -1,0 +1,221 @@
+/**
+ * ARCH-013 stage 3 — a supplied guardrail registry actually reaches the assembled session.
+ *
+ * The stage-3 projection test proves the registry survives `IInitOptions → ICreateSessionOptions`.
+ * That is a type-level hop, and on its own it would let this change claim a capability it had not
+ * restored: a projection can carry a field into an option bag that then drops it again.
+ *
+ * This is the other half, asserted on the ASSEMBLED session rather than on the option bag. The
+ * property that matters is the one `create-session.ts` documents in its own comment — registering a
+ * registry only adds the EXECUTOR, and the guardrails fire only if a `{ type: 'guardrail' }` hook
+ * definition exists on an enforcing event, so `createSession` auto-injects a `PreToolUse` group when
+ * the config declares none. Nothing had ever tested that from the option in: `guardrails` appeared in
+ * no `createSession` test before this one.
+ *
+ * It also pins the idempotence half — a consumer who declares their own guardrail hook must not get a
+ * second, auto-injected one — because that branch is what makes the auto-injection safe to ship.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { IResolvedConfig } from '../config/config-types.js';
+import type { TGuardrail } from '@robota-sdk/agent-core';
+
+const sessionCtorCalls: Array<Record<string, unknown>> = [];
+
+vi.mock('@robota-sdk/agent-session', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-session');
+  return {
+    ...actual,
+    Session: vi.fn().mockImplementation((options: Record<string, unknown>) => {
+      sessionCtorCalls.push(options);
+      return {
+        getSessionId: vi.fn().mockReturnValue('test-session-id'),
+        run: vi.fn().mockResolvedValue('mock response'),
+        abort: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        clearHistory: vi.fn(),
+        injectMessage: vi.fn(),
+      };
+    }),
+    FileSessionLogger: vi.fn().mockImplementation(() => ({})),
+  };
+});
+
+vi.mock('@robota-sdk/agent-core', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-core');
+  return {
+    ...actual,
+    Robota: vi.fn().mockImplementation(() => ({
+      run: vi.fn().mockResolvedValue('mock AI response'),
+      getHistory: vi.fn().mockReturnValue([]),
+      clearHistory: vi.fn(),
+      injectMessage: vi.fn(),
+    })),
+    runHooks: vi.fn().mockResolvedValue({ blocked: false }),
+  };
+});
+
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  spinner: vi.fn().mockReturnValue({ stop: vi.fn(), update: vi.fn() }),
+} as never;
+
+function createMockProvider() {
+  return {
+    name: 'mock',
+    chat: vi.fn().mockResolvedValue({ role: 'assistant', content: 'x', timestamp: new Date() }),
+  } as never;
+}
+
+function baseConfig(hooks?: IResolvedConfig['hooks']): IResolvedConfig {
+  return {
+    defaultTrustLevel: 'moderate' as const,
+    provider: { name: 'mock', apiKey: 'test-key', model: 'test-model' },
+    permissions: { allow: [], deny: [] },
+    language: 'en' as const,
+    env: {},
+    ...(hooks ? { hooks } : {}),
+  };
+}
+
+/** Every `{ type: 'guardrail' }` hook the assembled session received, across all events. */
+function guardrailHooksOf(sessionOptions: Record<string, unknown>): unknown[] {
+  const hooks = (sessionOptions.hooks ?? {}) as Record<
+    string,
+    Array<{ hooks: Array<{ type: string }> }> | undefined
+  >;
+  return Object.values(hooks)
+    .flatMap((groups) => groups ?? [])
+    .flatMap((group) => group.hooks)
+    .filter((hook) => hook.type === 'guardrail');
+}
+
+const NEVER_PASSES: TGuardrail = () => ({ pass: false, reason: 'blocked by test' });
+
+/** Tool names on the assembled session. */
+function toolNamesOf(sessionOptions: Record<string, unknown>): string[] {
+  const tools = (sessionOptions.tools ?? []) as Array<{ getName?: () => string }>;
+  return tools.map((tool) => tool.getName?.() ?? '').filter(Boolean);
+}
+
+describe('ARCH-013 stage 3 — a supplied guardrail registry reaches the assembled session', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('auto-injects a PreToolUse guardrail hook when a registry is supplied', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', projectNotesMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      guardrails: { neverPasses: NEVER_PASSES },
+    });
+
+    expect(sessionCtorCalls).toHaveLength(1);
+    expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(1);
+  });
+
+  it('injects NOTHING when no registry is supplied — the state before this change', async () => {
+    // The contrast that makes the case above mean something: identical call, registry omitted.
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', projectNotesMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+    });
+
+    expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(0);
+  });
+
+  it('injects nothing for an EMPTY registry, which is not the same as a supplied one', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', projectNotesMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      guardrails: {},
+    });
+
+    expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(0);
+  });
+
+  it('does NOT add a second hook when the consumer already declared one', async () => {
+    // Idempotence is what makes auto-injection safe: a consumer who placed their own guardrail hook
+    // on a chosen event must not silently also get a blanket PreToolUse one.
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig({
+        PreToolUse: [
+          { matcher: 'Bash', hooks: [{ type: 'guardrail', guardrails: ['neverPasses'] }] },
+        ],
+      } as IResolvedConfig['hooks']),
+      context: { agentsMd: '', projectNotesMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      guardrails: { neverPasses: NEVER_PASSES },
+    });
+
+    const declared = guardrailHooksOf(sessionCtorCalls[0]!);
+    expect(declared).toHaveLength(1);
+    // The consumer's own hook survived, rather than being replaced by the blanket one.
+    expect((declared[0] as { guardrails?: string[] }).guardrails).toEqual(['neverPasses']);
+  });
+});
+
+describe('ARCH-013 stage 3 — a supplied retrieval adapter reaches the assembled tool surface', () => {
+  beforeEach(() => {
+    sessionCtorCalls.length = 0;
+  });
+
+  it('surfaces CodebaseRetrieval when an adapter is supplied', async () => {
+    // `create-tools.test.ts` already covers the last hop (adapter in `createDefaultTools`'s options →
+    // tool present). The hop nothing covered is this one: `createSession` → `assemble-session-tools`
+    // → `createDefaultTools`. Without it, "the adapter reaches the session" was an inference across
+    // two separately-tested halves rather than a measured fact.
+    const { createSession } = await import('../assembly/create-session.js');
+    const retrievalAdapter = {
+      search: () => Promise.resolve([]),
+    } as unknown as Parameters<typeof createSession>[0]['retrievalAdapter'];
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', projectNotesMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+      retrievalAdapter,
+    });
+
+    expect(toolNamesOf(sessionCtorCalls[0]!)).toContain('CodebaseRetrieval');
+  });
+
+  it('does NOT surface it without an adapter — there is no host fallback', async () => {
+    const { createSession } = await import('../assembly/create-session.js');
+
+    createSession({
+      config: baseConfig(),
+      context: { agentsMd: '', projectNotesMd: '' },
+      terminal: MOCK_TERMINAL,
+      provider: createMockProvider(),
+    });
+
+    const names = toolNamesOf(sessionCtorCalls[0]!);
+    // Both halves: the tool is absent, AND the list is genuinely populated — a `not.toContain` over
+    // an empty list passes for the wrong reason, which is how a negative assertion goes vacuous.
+    expect(names.length).toBeGreaterThan(3);
+    expect(names).not.toContain('CodebaseRetrieval');
+  });
+});

--- a/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
+++ b/packages/agent-framework/src/__tests__/guardrail-registry-reaches-session.test.ts
@@ -21,6 +21,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { IResolvedConfig } from '../config/config-types.js';
 import type { TGuardrail } from '@robota-sdk/agent-core';
 import type { IRetrievalAdapter } from '@robota-sdk/agent-tools';
+import type {
+  IInteractiveSessionStandardOptions,
+  TInteractiveSessionOptions,
+} from '../interactive/interactive-session-options.js';
 
 const sessionCtorCalls: Array<Record<string, unknown>> = [];
 
@@ -322,6 +326,45 @@ describe('ARCH-013 stage 3 — the PUBLIC surface carries both ports (this is wh
     );
 
     expect(guardrailHooksOf(sessionCtorCalls[0]!)).toHaveLength(0);
-    expect(toolNamesOf(sessionCtorCalls[0]!)).not.toContain('CodebaseRetrieval');
+    const names = toolNamesOf(sessionCtorCalls[0]!);
+    // Populated-list guard, like its siblings: a `not.toContain` over an empty list passes for the
+    // wrong reason, and this file argues that everywhere else.
+    expect(names.length).toBeGreaterThan(3);
+    expect(names).not.toContain('CodebaseRetrieval');
+  });
+});
+
+describe('ARCH-013 stage 3 — buildRuntimeSession, the seam every presentation actually calls', () => {
+  it('accepts both ports on the option type it publishes', () => {
+    // What this proves and what it does not, stated because the distinction is the whole point.
+    //
+    // PROVES: `TInteractiveSessionOptions` — the type `buildRuntimeSession` publishes, and the one
+    // the TUI, print and --serve all construct through — accepts both ports. Written with NO cast, so
+    // it fails to COMPILE if either field is missing from that type. An earlier revision passed
+    // `as never` here, which would have made it pass whether or not the type carried them: a cast in
+    // a type-level assertion asserts nothing.
+    //
+    // DOES NOT PROVE: that the value arrives. `new InteractiveSession(...)` initialises
+    // asynchronously with no public await point, and driving it to completion needs a Session double
+    // far beyond this file's fixture. The hop from there is `interactive-session.ts:341-342`, a
+    // straight pass-through into `initializeInteractiveSessionAsync` — which the group above drives
+    // directly and red-proves. Two readers checked that pass-through by hand; it is the one link here
+    // carried by review rather than by execution, and it is named rather than glossed.
+    // The literal is annotated, not cast, so excess-property checking rejects it if either field is
+    // absent from the published construction type.
+    const options: IInteractiveSessionStandardOptions = {
+      cwd: '/arch-013-stage-3-seam',
+      provider: createMockProvider(),
+      bare: true,
+      config: baseConfig(),
+      guardrails: { neverPasses: NEVER_PASSES },
+      retrievalAdapter: { retrieve: async () => ({ symbols: [], totalTokens: 0 }) },
+    };
+    // …and assignable, with no cast, to exactly what `buildRuntimeSession` takes.
+    const seamOptions: TInteractiveSessionOptions = options;
+
+    expect(options.guardrails).toBeDefined();
+    expect(options.retrievalAdapter).toBeDefined();
+    expect(seamOptions).toBe(options);
   });
 });

--- a/packages/agent-framework/src/interactive/__tests__/extension-port-projection.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/extension-port-projection.test.ts
@@ -57,7 +57,10 @@ describe('ARCH-013 stage 3 — a consumer can supply the guardrail registry', ()
 
 describe('ARCH-013 stage 3 — a consumer can supply the retrieval adapter', () => {
   it('projects the adapter that gates CodebaseRetrieval', () => {
-    const adapter = { search: () => Promise.resolve([]) } as unknown as IRetrievalAdapter;
+    // The real member is `retrieve` returning `IRetrievalResult`, and it is written cast-free for a
+    // reason: an `as unknown as` here would encode a member name and a return shape that do not
+    // exist, and the gate is truthiness-only so nothing would ever catch it.
+    const adapter: IRetrievalAdapter = { retrieve: async () => ({ symbols: [], totalTokens: 0 }) };
 
     const built = buildCreateSessionOptions(initOptions({ retrievalAdapter: adapter }), DEPS);
 

--- a/packages/agent-framework/src/interactive/__tests__/extension-port-projection.test.ts
+++ b/packages/agent-framework/src/interactive/__tests__/extension-port-projection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCreateSessionOptions } from '../create-session-projection.js';
+
+import type { ICreateSessionProjectionDeps } from '../create-session-projection.js';
+import type { IInitOptions } from '../interactive-session-options.js';
+import type { TGuardrail } from '@robota-sdk/agent-core';
+import type { IRetrievalAdapter } from '@robota-sdk/agent-tools';
+
+/**
+ * ARCH-013 stage 3 — the two consumer-supplied extension ports reach the session.
+ *
+ * `guardrails` and `retrievalAdapter` were both READ all along: `create-session.ts` installs a
+ * `PreToolUse` guardrail hook whenever the registry is non-empty, and `create-tools.ts` gates the
+ * `CodebaseRetrieval` tool on the adapter. Neither could be SET, because this projection dropped
+ * them — so two documented capabilities (SELFHOST-005, SELFHOST-003) were unreachable from every
+ * public surface rather than merely unused.
+ *
+ * Both are consumer-supplied ports: the repo ships no implementation of either, which is what makes
+ * "the chain is broken" the whole defect. Stage 1's `scan-option-reachability` froze both as
+ * unreachable keys; this change removes them from that baseline, and the scan is what stops them
+ * silently returning to it.
+ */
+const DEPS: ICreateSessionProjectionDeps = {
+  mergedConfig: { provider: { name: 'test', model: 'test-model' } } as never,
+  cwd: '/arch-013-stage-3',
+  context: {} as ICreateSessionProjectionDeps['context'],
+  projectInfo: {} as ICreateSessionProjectionDeps['projectInfo'],
+  sessionId: 'test-session',
+  logsDir: '/arch-013-stage-3/logs',
+  contextCapacityHint: undefined,
+};
+
+function initOptions(extra: Partial<IInitOptions>): IInitOptions {
+  return { cwd: '/arch-013-stage-3', provider: {} as never, ...extra } as IInitOptions;
+}
+
+describe('ARCH-013 stage 3 — a consumer can supply the guardrail registry', () => {
+  it('projects the registry onto the session options the assembler reads', () => {
+    const blockEverything: TGuardrail = () => ({ pass: false, reason: 'blocked by test' });
+
+    const built = buildCreateSessionOptions(initOptions({ guardrails: { blockEverything } }), DEPS);
+
+    expect(built.guardrails).toBeDefined();
+    expect(built.guardrails?.['blockEverything']).toBe(blockEverything);
+  });
+
+  it('omits the key entirely when no registry is supplied', () => {
+    // A conditional spread rather than `guardrails: undefined`: `create-session.ts` branches on
+    // `options.guardrails && Object.keys(...).length > 0`, and an explicitly-undefined key is the
+    // shape that reintroduces an absent member through a spread (ARCH-029's lesson, one package over).
+    const built = buildCreateSessionOptions(initOptions({}), DEPS);
+
+    expect('guardrails' in built).toBe(false);
+  });
+});
+
+describe('ARCH-013 stage 3 — a consumer can supply the retrieval adapter', () => {
+  it('projects the adapter that gates CodebaseRetrieval', () => {
+    const adapter = { search: () => Promise.resolve([]) } as unknown as IRetrievalAdapter;
+
+    const built = buildCreateSessionOptions(initOptions({ retrievalAdapter: adapter }), DEPS);
+
+    expect(built.retrievalAdapter).toBe(adapter);
+  });
+
+  it('omits the key entirely when no adapter is supplied', () => {
+    const built = buildCreateSessionOptions(initOptions({}), DEPS);
+
+    expect('retrievalAdapter' in built).toBe(false);
+  });
+});

--- a/packages/agent-framework/src/interactive/create-session-projection.ts
+++ b/packages/agent-framework/src/interactive/create-session-projection.ts
@@ -56,6 +56,30 @@ export function buildCreateSessionOptions(
     appendSystemPrompt: options.appendSystemPrompt,
     ...(options.persona !== undefined ? { persona: options.persona } : {}),
     ...(options.systemPrompt ? { systemPromptBuilder: () => options.systemPrompt! } : {}),
+    // ARCH-013 stage 3 — the two consumer-supplied extension ports, and the one place they were lost.
+    //
+    // Both CONSUMING ends already worked: `create-session.ts` installs a `PreToolUse` guardrail hook
+    // whenever the registry is non-empty, and `create-tools.ts` gates `CodebaseRetrieval` on the
+    // adapter. Neither could be SET, because this projection dropped them — so two documented
+    // capabilities (SELFHOST-005, SELFHOST-003) were UNREACHABLE from every public surface rather
+    // than merely unused. The repo ships no implementation of either; they are extension ports, which
+    // is precisely why a broken chain removed the capability instead of leaving it idle.
+    //
+    // A correction to this item's own analysis, recorded because a plan built on a wrong map is worse
+    // than no plan: the task states that `ICreateSessionOptions.guardrails` (a name → function map)
+    // and the config schema's `guardrails` (a string array) "cannot satisfy each other, no code
+    // bridges them". They are not rivals. The config array sits on a guardrail HOOK definition and
+    // selects WHICH registered guardrails run; this option is the registry that supplies them; and
+    // `resolveGuardrailHooks` at `create-session.ts` is the bridge, which has existed all along.
+    // Nothing needed reconciling — the registry simply had no way in.
+    //
+    // Conditional spreads, not `key: undefined`: `create-session.ts` branches on
+    // `options.guardrails && Object.keys(...).length > 0`, and an explicitly-undefined key is how a
+    // spread reintroduces an absent member (ARCH-029's lesson, one package over).
+    ...(options.guardrails !== undefined ? { guardrails: options.guardrails } : {}),
+    ...(options.retrievalAdapter !== undefined
+      ? { retrievalAdapter: options.retrievalAdapter }
+      : {}),
     backgroundTaskRunners: options.backgroundTaskRunners,
     subagentRunnerFactory: options.subagentRunnerFactory,
     // ARCH-005: composition-root-contributed subagent definitions (capability packs).

--- a/packages/agent-framework/src/interactive/create-session-projection.ts
+++ b/packages/agent-framework/src/interactive/create-session-projection.ts
@@ -73,9 +73,12 @@ export function buildCreateSessionOptions(
     // `resolveGuardrailHooks` at `create-session.ts` is the bridge, which has existed all along.
     // Nothing needed reconciling — the registry simply had no way in.
     //
-    // Conditional spreads, not `key: undefined`: `create-session.ts` branches on
-    // `options.guardrails && Object.keys(...).length > 0`, and an explicitly-undefined key is how a
-    // spread reintroduces an absent member (ARCH-029's lesson, one package over).
+    // Conditional spreads for consistency with the ~15 optional keys around them, NOT because the
+    // ARCH-029 spread hazard applies: review measured that it cannot fire here.
+    // `exactOptionalPropertyTypes` is set nowhere in this repo, the consumer branches on truthiness,
+    // and this object is passed straight into `createSession` rather than spread over a base. An
+    // earlier revision of this comment cited that hazard as the reason — the right shape justified by
+    // a mechanism that does not reach it, which is a claim to correct rather than keep.
     ...(options.guardrails !== undefined ? { guardrails: options.guardrails } : {}),
     ...(options.retrievalAdapter !== undefined
       ? { retrievalAdapter: options.retrievalAdapter }

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -271,6 +271,7 @@ export async function initializeInteractiveSessionAsync(
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
     ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}), // ARCH-006
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
+    // ARCH-013 S3: both extension ports; dropping either here is the defect this stage fixed.
     ...(options.guardrails ? { guardrails: options.guardrails } : {}),
     ...(options.retrievalAdapter ? { retrievalAdapter: options.retrievalAdapter } : {}),
     commandDescriptors: deps.commandDescriptors,

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -271,6 +271,8 @@ export async function initializeInteractiveSessionAsync(
     ...(options.additionalTools ? { additionalTools: options.additionalTools } : {}),
     ...(options.defaultTools ? { defaultTools: options.defaultTools } : {}), // ARCH-006
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
+    ...(options.guardrails ? { guardrails: options.guardrails } : {}),
+    ...(options.retrievalAdapter ? { retrievalAdapter: options.retrievalAdapter } : {}),
     commandDescriptors: deps.commandDescriptors,
     ...(deps.commandSemanticRoles ? { commandSemanticRoles: deps.commandSemanticRoles } : {}),
     ...(deps.commandDescriptors.length > 0

--- a/packages/agent-framework/src/interactive/interactive-session-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-options.ts
@@ -27,6 +27,7 @@ import type { IMemoryStore, IPerTurnRecallConfig } from '../memory/types.js';
 import type { IReversibleExecutionOptions } from '../reversible-execution/index.js';
 import type { TSubagentRunnerFactory } from '../subagents/index.js';
 import type { TShellExecFn } from '../utils/skill-prompt.js';
+import type { TGuardrail } from '@robota-sdk/agent-core';
 import type {
   IAIProvider,
   IContextWindowState,
@@ -37,6 +38,7 @@ import type {
 import type { ITerminalHandoff } from '@robota-sdk/agent-interface-transport';
 import type { ICompactEvent } from '@robota-sdk/agent-interface-transport';
 import type { Session } from '@robota-sdk/agent-session';
+import type { IRetrievalAdapter } from '@robota-sdk/agent-tools';
 import type { ISandboxClient, IWorkspaceManifest } from '@robota-sdk/agent-tools';
 
 /** Standard construction: cwd + provider. Config/context loaded internally. */
@@ -153,6 +155,10 @@ export interface IInteractiveSessionStandardOptions {
    * `builtInAgents` seam for subagents. Absent ⇒ unchanged behavior.
    */
   defaultTools?: readonly IToolWithEventService[];
+  /** SELFHOST-005 guardrail REGISTRY (name → function). ARCH-013 S3; see create-session-projection. */
+  guardrails?: Record<string, TGuardrail>;
+  /** SELFHOST-003 retrieval adapter gating `CodebaseRetrieval`. ARCH-013 S3; same seam as above. */
+  retrievalAdapter?: IRetrievalAdapter;
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
 }
@@ -275,6 +281,10 @@ export interface IInitOptions {
    * `builtInAgents` seam for subagents. Absent ⇒ unchanged behavior.
    */
   defaultTools?: readonly IToolWithEventService[];
+  /** SELFHOST-005 guardrail REGISTRY (name → function). ARCH-013 S3; see create-session-projection. */
+  guardrails?: Record<string, TGuardrail>;
+  /** SELFHOST-003 retrieval adapter gating `CodebaseRetrieval`. ARCH-013 S3; same seam as above. */
+  retrievalAdapter?: IRetrievalAdapter;
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
 }

--- a/scripts/harness/__tests__/scan-option-reachability.test.mjs
+++ b/scripts/harness/__tests__/scan-option-reachability.test.mjs
@@ -196,18 +196,27 @@ describe('scan-option-reachability', () => {
     expect(reported).toBe(Object.values(frozen).flat().length);
   });
 
-  it('the frozen set still names the two capabilities this exists for', () => {
-    // ARCH-013 is not closed by this scan — `guardrails` and `retrievalAdapter` are still
-    // unreachable. Pinning them here means a future change that silently drops them FROM the
-    // baseline (rather than wiring them) has to explain itself.
+  it('the three capabilities this scan was built for are all WIRED, not baselined', () => {
+    // This case used to pin `guardrails` and `retrievalAdapter` INTO the frozen set, because stage 1
+    // wired only `effort` and the other two were still unreachable. Its comment said a future change
+    // that dropped them from the baseline "rather than wiring them" would have to explain itself.
+    //
+    // ARCH-013 stage 3 is that change, and it wired them: both are now forwarded through
+    // `initializeInteractiveSessionAsync` and projected in `buildCreateSessionOptions`, with the
+    // chain red-proved from the published surface. So the assertion is inverted rather than deleted —
+    // the scan's subject is unchanged, and what it now pins is that none of the three may return.
     const root = path.resolve(import.meta.dirname, '../../..');
     const frozen = JSON.parse(
       readFileSync(path.join(root, 'scripts/harness/option-reachability-baseline.json'), 'utf8'),
     );
-    expect(frozen['ICreateSessionOptions']).toEqual(
-      expect.arrayContaining(['guardrails', 'retrievalAdapter']),
-    );
-    // `effort` was wired by this same change, so it must NOT be here.
-    expect(frozen['ICreateSessionOptions']).not.toContain('effort');
+    for (const wired of ['effort', 'guardrails', 'retrievalAdapter']) {
+      expect(
+        frozen['ICreateSessionOptions'],
+        `${wired} regressed into the frozen set`,
+      ).not.toContain(wired);
+    }
+    // The set is not empty — nine keys remain unreachable, and an empty baseline would make the
+    // assertion above pass for the wrong reason.
+    expect(frozen['ICreateSessionOptions'].length).toBeGreaterThan(0);
   });
 });

--- a/scripts/harness/option-reachability-baseline.json
+++ b/scripts/harness/option-reachability-baseline.json
@@ -9,17 +9,5 @@
     "sessionFactory",
     "sessionStore",
     "toolDescriptions"
-  ],
-  "IInteractiveSessionStandardOptions": [
-    "automaticMemory",
-    "commandHostAdapters",
-    "orgPolicy",
-    "providerDefinitions",
-    "recallMemory",
-    "remoteCommandPolicy",
-    "sessionName",
-    "sessionStore",
-    "shellExec",
-    "terminalHandoff"
   ]
 }

--- a/scripts/harness/option-reachability-baseline.json
+++ b/scripts/harness/option-reachability-baseline.json
@@ -3,11 +3,9 @@
     "additionalHookExecutors",
     "autoCompactThreshold",
     "compactInstructions",
-    "guardrails",
     "onCompact",
     "promptForApproval",
     "providerFactory",
-    "retrievalAdapter",
     "sessionFactory",
     "sessionStore",
     "toolDescriptions"

--- a/scripts/harness/option-reachability-baseline.json
+++ b/scripts/harness/option-reachability-baseline.json
@@ -9,5 +9,17 @@
     "sessionFactory",
     "sessionStore",
     "toolDescriptions"
+  ],
+  "IInteractiveSessionStandardOptions": [
+    "automaticMemory",
+    "commandHostAdapters",
+    "orgPolicy",
+    "providerDefinitions",
+    "recallMemory",
+    "remoteCommandPolicy",
+    "sessionName",
+    "sessionStore",
+    "shellExec",
+    "terminalHandoff"
   ]
 }


### PR DESCRIPTION
ARCH-013 stage 3 of 3, which closes the item. Task:
[`.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md`](.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md).
Stages 1 (#1607) and 2 (#1826) are merged.

## What this delivers

`guardrails` (SELFHOST-005) and `retrievalAdapter` (SELFHOST-003) could not be turned on by anything.
Both consuming ends already worked — `create-session.ts` installs a `PreToolUse` guardrail hook when
the registry is non-empty, `create-tools.ts` gates `CodebaseRetrieval` on the adapter — and neither
was carried by any public surface. Since the repo ships no implementation of either (they are
consumer-supplied extension ports), the broken chain **removed** a documented capability rather than
leaving one idle.

Stage 1's frozen unreachable set falls **11 → 9**.

## A correction to the task's own analysis

The task recorded that the two `guardrails` shapes — `ICreateSessionOptions.guardrails` as a
`Record<string, TGuardrail>` and the config schema's `guardrails: z.array(z.string())` — "cannot
satisfy each other, no code bridges them", and that reconciling them was part of this stage.

**They are not rivals.** The config array sits on a guardrail *hook definition* and selects WHICH
registered guardrails that hook runs, by name — its own comment says so. The session option is the
REGISTRY of functions. `resolveGuardrailHooks` is the bridge, and it has existed all along. Nothing
needed reconciling; the registry simply had no way in.

Verified by an independent reviewer against the code, because the whole framing of this change rests
on it.

## Three of my own claims in this stage were wrong

Recorded in the task file rather than quietly dropped, because the pattern matters more than any one
instance.

1. **After my first two commits, neither capability was reachable from any surface.** I fixed the
   projection and left the ~40-field hand-map directly above it untouched — ARCH-013's own defect, one
   hop above where I was fixing it, inside the change meant to fix it.
2. **"The three surfaces spread those options, so all of them gain it at once"** — false. I inferred it
   from `additionalTools` without measuring; `additionalTools` is spread nowhere and forwarded at
   **eight** explicit sites. I had told the reviewer I hadn't measured it.
3. **My fix for (1) was itself wrong, and would have caused harm.** I added
   `IInteractiveSessionStandardOptions` to `optionReachability` and reported "ten more options declared
   and set by nothing", filing them as an issue. The entry named the published type but gave
   `createInteractiveSession` as its constructor — a function taking `IInitOptions` — so it measured
   what the hand-map *forwards*, not what a consumer *can set*. **Nine of the ten** are set by
   production code. Burning that list down would have pushed class-consumed options into the very
   hand-map this stage had just fixed a drop in: the ratchet would have manufactured the defect shape
   it was added to prevent.

The common thread: **a mechanical claim asserted from a tool's output without checking what that tool
could see.** The defence that worked every time it was applied was the cheap one — run the mutation,
read what the tool prints.

The ratchet entry is now named `IInitOptions`, which is literally what it measures. Baseline **zero**,
and it still catches the real regression.

## Verification

- `pnpm harness:verify-like-ci` — **PASS, all 12 stages**. It caught a failure `harness:scan` did not:
  stage 1 had pinned these two keys INTO the frozen set, with a comment saying a change that dropped
  them "rather than wiring them" must explain itself. This is that change; the assertion is inverted
  with the explanation, and now pins that none of the three may return.
- 122 of 123 scans (1 skipped). agent-framework 173 files / **1381 tests**. Typecheck clean.
- Red-proved by deletion at both hops: removing the projection lines reddens 2 cases; removing the
  forwarding lines reddens 2 more.
- `SPEC.md` gains a section for both ports, recording registry-vs-selector and the `defaultTools`
  interaction that silently owns retrieval.

Three review rounds: **5 → 1 → 0** actionable findings.

## Filed, not folded in

#1820 (stage 2's ten product decisions), #1831 (hook-runner promises a warning it never emits — since
fixed on develop by #1836), #1844 (`providerDefinitions`, the one key genuinely set by nothing).
#1828 is closed with its measurement corrected twice, in public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyCUhhbMQjL7kL5hQ3pM1s
