### PR TITLE
fix(harness): a failed GitHub read says what it asked, and which gh asked it (#1846)

### DIFF
--- a/scripts/harness/__tests__/api-pagination.test.mjs
+++ b/scripts/harness/__tests__/api-pagination.test.mjs
@@ -299,6 +299,33 @@ describe('a rate-limited read waits and retries (github-api)', () => {
     ).toThrow(/attempts must be a positive integer/);
   });
 
+  it('INFRA-103: a failure reports WHAT IT ASKED, not only which endpoint', () => {
+    // The message that cost an afternoon said the endpoint and the status and nothing about the
+    // request. Two steps of one CI job read the SAME endpoint seconds apart — one with these flags
+    // and one without — and only one failed. The flags were the only difference, and they were the
+    // one thing the error did not carry.
+    expect(() =>
+      readWithBackoff(
+        () => ({ status: 1, stderr: 'gh: Validation Failed (HTTP 422)' }),
+        ['api', '--paginate', '--slurp', 'repos/o/r/issues/1/labels?per_page=100'],
+        'repos/o/r/issues/1/labels',
+      ),
+    ).toThrow(/requested: gh api --paginate --slurp repos\/o\/r\/issues\/1\/labels\?per_page=100/);
+  });
+
+  it('INFRA-103: and which gh produced it, since the same read succeeds elsewhere', () => {
+    let threw;
+    try {
+      readWithBackoff(() => ({ status: 1, stderr: 'boom' }), ['api', 'x'], 'x');
+    } catch (error) {
+      threw = error;
+    }
+
+    // Not asserting a version string — the point is that the line is present and answered, so
+    // "which gh was this" stops being a question somebody has to ask by hand.
+    expect(threw?.message).toMatch(/\n {2}gh: .+/);
+  });
+
   it('does NOT retry an ordinary failure — that would hide a real error behind a wait', () => {
     let calls = 0;
     const runner = () => {

--- a/scripts/harness/github-api.mjs
+++ b/scripts/harness/github-api.mjs
@@ -120,6 +120,23 @@ function ghRunner(args) {
 }
 
 /**
+ * The `gh` build that produced a failure, for the error message only.
+ *
+ * Read ONLY on the failure path: a version probe on every successful read would spend a process per
+ * call to answer a question nobody asked. It matters when a read fails in CI and succeeds on a
+ * developer machine, which is the shape INFRA-103 is stuck on — "which gh" was unanswerable from the
+ * log, so it stayed a hypothesis for as long as it took to ask by hand.
+ *
+ * Its own failure is not an error. This runs while reporting one, and a diagnostic that can throw
+ * would replace the real message with its own.
+ */
+function ghVersion() {
+  const probe = spawnSync('gh', ['--version'], { encoding: 'utf8' });
+  if (probe.status !== 0) return 'unknown';
+  return (probe.stdout ?? '').split('\n')[0]?.trim() || 'unknown';
+}
+
+/**
  * A rate-limited response is not a failed read — it is a read that must be repeated later.
  *
  * The API answers an exhausted budget with 403 (not 429) plus a rate-limit signature, and the
@@ -180,7 +197,14 @@ export function readWithBackoff(
   }
   throw new Error(
     `${endpoint}: \`gh api\` failed (exit ${response.status}): ` +
-      `${(response.stderr ?? '').trim() || 'no stderr'}`,
+      `${(response.stderr ?? '').trim() || 'no stderr'}` +
+      // INFRA-103: the failure said WHICH endpoint but never WHAT IT ASKED. A 422 on this repo's
+      // `issues/{n}/labels` read cost an afternoon precisely because the message could not
+      // distinguish this reader's request from the plain `gh api --paginate` call one step earlier
+      // that succeeded on the same endpoint in the same job — the flags are the only difference and
+      // they were the one thing not reported. Args cost a line and are the first thing anyone asks.
+      `\n  requested: gh ${(args ?? []).join(' ')}` +
+      `\n  gh: ${ghVersion()}`,
   );
 }
 


### PR DESCRIPTION
**INFRA-103 (#1846), first step.** Two PRs (#1843, #1845) are blocked by `review-gate` on a 422 from an endpoint that has nothing to validate, and the cause is still unknown — because the error message could not narrow it.

## What made it unnarrowable

One CI job read the **same endpoint twice, seconds apart**:

| Step | Call | Result |
| --- | --- | --- |
| withdrawal check | `gh api --paginate <endpoint>` | **succeeded** |
| collect review output | this reader: `gh api --paginate --slurp <endpoint>?per_page=100` | **422** |

The flags are the only difference between them — and the flags were the one thing the error did not carry. It named the endpoint, the exit code, and gh's message, all of which were *identical* between the two calls.

So the failure now prints the argv it ran. That is one line, and it is the first thing anyone asks.

## It also prints the gh build — on the failure path only

The read succeeds on a developer machine and fails in CI, which makes *"which gh"* the obvious next question. It was unanswerable from the log: the runner **image** is recorded, the tool version is not.

A version probe on every successful read would spend a process per call answering a question nobody asked. On the path where the answer matters, it costs one.

**The probe cannot throw.** It runs while reporting an error, and a diagnostic that failed would replace the real message with its own — which is the exact failure mode this change exists to stop.

## What this is not

**It does not diagnose the 422.** The cause is unestablished, and #1846 records why guessing is worse than measuring — including two hypotheses already tested and rejected (the job's permissions; this reader's request construction). This change makes the *next run* able to answer.

## Verification

- 39 tests in `api-pagination.test.mjs`, all green
- **Red-proofed**: removing the added detail fails exactly the two new tests and no others
- No behaviour on the success path changed
- `pnpm harness:scan` — 123 passed, 2 skipped; format-check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD