### PR TITLE
docs(tasks): close ARCH-013 and ARCH-036, and archive their records

### DIFF
--- a/.agents/spec-docs/active/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
+++ b/.agents/spec-docs/active/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
@@ -187,7 +187,7 @@ Execute the twelve existing records without redefining their scope:
 - [x] ARCH-010 — done — `.agents/tasks/completed/ARCH-010-execution-root-carried-by-no-contract.md`
 - [x] ARCH-011 — done — `.agents/tasks/completed/ARCH-011-transport-adapter-is-a-lifecycle-stub.md`
 - [x] ARCH-012 — done — `.agents/tasks/completed/ARCH-012-interactive-session-god-contract.md`
-- [ ] ARCH-013 — in-progress — `.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md`
+- [x] ARCH-013 — done — `.agents/tasks/completed/ARCH-013-preset-to-session-options-projection-has-no-owner.md`
 - [x] ARCH-019 — done — `.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md`
 - [x] ARCH-029 — done — `.agents/tasks/completed/ARCH-029-command-host-capability-contracts.md`
 - [x] INFRA-098 — done — `.agents/tasks/completed/INFRA-098-review-every-integration-base-child-pr.md`

--- a/.agents/tasks/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
+++ b/.agents/tasks/AGREEMENT-001-complete-arch-dag-runtime-backlog.md
@@ -57,7 +57,7 @@ projection is the section below.
 - [x] ARCH-010 — done — `.agents/tasks/completed/ARCH-010-execution-root-carried-by-no-contract.md`
 - [x] ARCH-011 — done — `.agents/tasks/completed/ARCH-011-transport-adapter-is-a-lifecycle-stub.md`
 - [x] ARCH-012 — done — `.agents/tasks/completed/ARCH-012-interactive-session-god-contract.md`
-- [ ] ARCH-013 — in-progress — `.agents/tasks/ARCH-013-preset-to-session-options-projection-has-no-owner.md`
+- [x] ARCH-013 — done — `.agents/tasks/completed/ARCH-013-preset-to-session-options-projection-has-no-owner.md`
 - [x] ARCH-019 — done — `.agents/tasks/completed/ARCH-019-interactive-session-getSession-contract-understated.md`
 - [x] ARCH-029 — done — `.agents/tasks/completed/ARCH-029-command-host-capability-contracts.md`
 - [x] INFRA-098 — done — `.agents/tasks/completed/INFRA-098-review-every-integration-base-child-pr.md`

--- a/.agents/tasks/completed/ARCH-013-preset-to-session-options-projection-has-no-owner.md
+++ b/.agents/tasks/completed/ARCH-013-preset-to-session-options-projection-has-no-owner.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-013: the (preset, CLI args) → session options projection chain has no owner — eleven assembly seams are unreachable and nine resolved preset fields are computed and discarded'
-status: in-progress
+status: done
+completed: 2026-08-18
 created: 2026-08-02
 priority: high
 urgency: soon
@@ -649,3 +650,36 @@ The hop it does not execute is `interactive-session.ts:341-342`, a straight pass
 `initializeInteractiveSessionAsync` — the group above drives that directly and red-proves it. Two
 readers checked that pass-through by hand. It is the one link here carried by review rather than by
 execution, and it is named rather than glossed.
+
+## Result
+
+All three stages delivered and merged: stage 1 (#1607), stage 2 (#1826), stage 3 (#1847).
+
+The item's cause was _"resolved intent is mapped to session options by hand at four sites and checked
+at none."_ Both ends of that chain are now mechanical:
+
+- `scan-option-reachability` (stage 1) — a declared `ICreateSessionOptions` key that no production
+  code assigns. Frozen at **9**, down from 11: `effort` in stage 1, `guardrails` and
+  `retrievalAdapter` in stage 3.
+- `scan-preset-projection` (stage 2) — every `IResolvedPresetOptions` field must appear in a DECLARED
+  projection, and the startup and live-`/preset` surfaces must not diverge.
+- `optionReachability` also watches `IInitOptions` now (stage 3), because the hand-map between the
+  published type and the projection was where stage 3's own first attempt dropped both ports.
+
+Capabilities restored, each red-proved rather than asserted: `effort` at startup (it had been applied
+mid-session by `/preset` and dropped at launch, so one session held two answers for one preset), and
+`guardrails` / `retrievalAdapter`, which no surface could turn on at all.
+
+**What is NOT closed by this item, and is filed rather than implied:** the ten resolved-preset fields
+that still reach no declared projection ([#1820](https://github.com/woojubb/robota/issues/1820)) —
+each needs a product decision with user-visible consequences, and five of them have no session seam at
+all. They are named, reasoned, expiring exemptions in `presetProjection.pendingProjection`, not an
+opaque baseline, and any movement out of their recorded state turns the floor red. Also filed:
+[#1844](https://github.com/woojubb/robota/issues/1844) (`providerDefinitions`).
+
+The most transferable output is not the scans. Across three stages, **six of my own mechanical claims
+were wrong**, every one of them asserted from a tool's output or a precedent without checking what
+that mechanism could see — including a ratchet entry that measured the wrong interface and would have
+pushed the next reader to manufacture the defect it guarded. Each was caught by the same cheap move:
+run the mutation, read what the tool actually prints. The record above keeps them rather than
+smoothing them, because the pattern is the lesson.

--- a/.agents/tasks/completed/ARCH-036-child-process-runner-drops-builtin-agents.md
+++ b/.agents/tasks/completed/ARCH-036-child-process-runner-drops-builtin-agents.md
@@ -1,6 +1,7 @@
 ---
 title: 'ARCH-036: the child-process subagent runner drops deps.builtInAgents (NEUT-003)'
-status: in-progress
+status: done
+completed: 2026-08-18
 created: 2026-08-16
 priority: medium
 urgency: later
@@ -34,4 +35,17 @@ the same shape ARCH-021 exists to remove.
 
 ## Result
 
-Pending.
+Delivered in #1804, and this record is the part that was left open — the code, the tests and the
+issue were all closed while the task file stayed `in-progress` in the active directory.
+
+`resolveAgentDefinition` in `packages/agent-subagent-runner/src/child-process-subagent-runner.ts`
+threads `deps.builtInAgents`, so the composition root's choice reaches BOTH runners rather than only
+the in-process one. NEUT-003's semantics are pinned by three cases in
+`packages/agent-subagent-runner/src/__tests__/child-process-subagent-runner.test.ts`: an injected set
+REPLACES the module built-ins, an empty array removes them entirely, and nothing injected leaves them
+in place. All 16 tests in that file pass.
+
+Verified before closing rather than taken from the issue state: the fix is present, the semantics
+match what NEUT-003 requires, and the tests drive the real runner rather than a helper — which the
+test file itself notes was necessary, because the defect was a field on a shared deps type that one
+runner never read.


### PR DESCRIPTION
Records-only. No source changes; closes and archives two completed items.

## ARCH-013 — all three stages merged

#1607 (stage 1), #1826 (stage 2), #1847 (stage 3). The item was filed against *"resolved intent is
mapped to session options by hand at four sites and checked at none."* Both ends of that chain are
mechanical now:

| Scan | Holds |
|---|---|
| `scan-option-reachability` (S1) | a declared `ICreateSessionOptions` key that no production code assigns — frozen at **9**, down from 11 |
| `scan-preset-projection` (S2) | every `IResolvedPresetOptions` field must reach a DECLARED projection, and the startup and live-`/preset` surfaces must not diverge |
| `optionReachability` on `IInitOptions` (S3) | the hand-map between the published type and the projection — where stage 3's own first attempt dropped both ports |

Three capabilities restored, each red-proved rather than asserted: **`effort`** at startup (it was
applied mid-session by `/preset` and dropped at launch, so one session held two answers for one
preset), and **`guardrails`** / **`retrievalAdapter`**, which no surface could turn on at all.

**Not closed, and filed rather than implied:** #1820 — ten resolved-preset fields that still reach no
declared projection, each needing a product decision, five with no session seam at all. They are
named, reasoned, expiring exemptions, not an opaque baseline: any movement out of their recorded state
turns the floor red. Also #1844 (`providerDefinitions`).

## ARCH-036 — delivered in #1804; only the record was open

Code, tests and issue #1788 were all closed while the task file stayed `in-progress` in the active
directory. **Verified before closing rather than taken from the issue state:**
`resolveAgentDefinition` threads `deps.builtInAgents`, so the composition root's choice reaches BOTH
runners rather than only the in-process one, and three cases pin NEUT-003's semantics — an injected
set replaces the module built-ins, an empty array removes them, nothing injected leaves them. 16 of 16
tests pass.

## The Result section keeps what is least flattering

Across ARCH-013's three stages, **six of my own mechanical claims were wrong** — every one asserted
from a tool's output or a precedent without checking what that mechanism could see. The worst was a
ratchet entry that measured the wrong interface and would have pushed the next reader to manufacture
the defect it guarded. Each was caught by the same cheap move: run the mutation, read what the tool
actually prints. The records keep them rather than smoothing them, because the pattern is the lesson
and the individual fixes are not.

## Verification

`pnpm harness:verify-like-ci` — PASS. 123 of 125 scans (2 skipped).

Two failures on the way were unrelated to this change and are worth noting so nobody re-derives them:
`@robota-sdk/agent-remote-pairing` needed a local build (it arrived on develop in #1839), and a stale
`agent-interface-transport` dist made a cross-package typecheck fail until `pnpm build` ran — the
exact situation the `dist` scan's advisory warns about.

AGREEMENT-001's Children and Tasks rows are updated in the same change, which the archival scan
required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyCUhhbMQjL7kL5hQ3pM1s
