### PR TITLE
feat(agent-transport-protocol): move a session record that does not fit in one frame (#1811)

### DIFF
--- a/packages/agent-transport-protocol/docs/SPEC.md
+++ b/packages/agent-transport-protocol/docs/SPEC.md
@@ -166,6 +166,10 @@ once and the carriers stay dumb.
 | `buildHandoffManifest`                  | Function  | HANDOFF-001: classify the inventory and seal the payload, or REFUSE on in-flight work      |
 | `sealHandoffRecord`                     | Function  | HANDOFF-001: serialize once and describe those exact bytes, so send and digest agree       |
 | `verifyHandoffPayload`                  | Function  | HANDOFF-001: length before digest — a truncation must not be reported as tampering         |
+| `chunkHandoffPayload`                   | Function  | HANDOFF-001: cut a sealed payload on BYTES, so the channel's byte budget is exact          |
+| `HandoffChunkAssembler`                 | Class     | HANDOFF-001: reassemble one transfer under reordering and retries; refuse inconsistency    |
+| `chunkCountFor`                         | Function  | HANDOFF-001: how many chunks a payload takes, from the manifest, without building them     |
+| `DEFAULT_MAX_CHUNK_BYTES`               | const     | 16 KiB — what every SCTP implementation carries without negotiation                        |
 | `mintTransportToken`                    | Function  | SEC-008: mint a per-launch credential; throws rather than returning a weak one             |
 | `credentialMatches`                     | Function  | SEC-008: constant-time comparison of a presented credential against the required one       |
 | `bearerCredential`                      | Function  | SEC-008: extract a bearer credential from an `Authorization` header value                  |

--- a/packages/agent-transport-protocol/src/__tests__/handoff-chunking.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/handoff-chunking.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  chunkCountFor,
+  chunkHandoffPayload,
+  HandoffChunkAssembler,
+  type IHandoffChunk,
+} from '../handoff-chunking.js';
+import { sealHandoffRecord, verifyHandoffPayload } from '../handoff-manifest.js';
+
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+
+const ID = 'handoff_1';
+
+function assemble(chunks: readonly IHandoffChunk[], assembler = new HandoffChunkAssembler(ID)) {
+  let last;
+  for (const chunk of chunks) last = assembler.accept(chunk);
+  return { assembler, last };
+}
+
+describe('HANDOFF-001 — a payload larger than one frame travels in pieces', () => {
+  it('every chunk fits the byte budget', () => {
+    // The channel's limit is in bytes, so the budget has to be honoured in bytes. A payload of
+    // multi-byte characters is where a character-based cut overflows the frame.
+    const payload = '한글'.repeat(500);
+
+    const chunks = chunkHandoffPayload(ID, payload, 64);
+
+    for (const chunk of chunks) {
+      expect(Buffer.from(chunk.data, 'base64').byteLength).toBeLessThanOrEqual(64);
+    }
+  });
+
+  it('round-trips a payload whose characters do not align to the cut', () => {
+    // The cut lands mid-character by construction here. Reassembly is on bytes, so the boundary
+    // is invisible to the result — which is the property the byte-based design buys.
+    const payload = `${'a'.repeat(30)}😀${'b'.repeat(30)}`;
+
+    const { last } = assemble(chunkHandoffPayload(ID, payload, 16));
+
+    expect(last?.outcome).toBe('complete');
+    expect(last?.serialized).toBe(payload);
+  });
+
+  it('an empty payload is one chunk, not zero', () => {
+    // Zero chunks would leave a receiver unable to tell a completed empty transfer from one that
+    // never started.
+    const chunks = chunkHandoffPayload(ID, '', 64);
+
+    expect(chunks).toHaveLength(1);
+    expect(assemble(chunks).last?.serialized).toBe('');
+  });
+
+  it('every chunk carries the total, so no single lost frame hides the count', () => {
+    const chunks = chunkHandoffPayload(ID, 'x'.repeat(100), 10);
+
+    expect(chunks.every((c) => c.total === chunks.length)).toBe(true);
+  });
+
+  it('refuses a budget that would produce an endless sequence of empty chunks', () => {
+    expect(() => chunkHandoffPayload(ID, 'x', 0)).toThrow(/positive integer/);
+  });
+
+  it('predicts the chunk count from the manifest without building them', () => {
+    const { serialized, integrity } = sealHandoffRecord({
+      id: 's',
+      cwd: '/w',
+      createdAt: 'a',
+      updatedAt: 'b',
+      messages: [],
+    } as IInteractiveSessionRecord);
+
+    expect(chunkCountFor(integrity, 16)).toBe(chunkHandoffPayload(ID, serialized, 16).length);
+  });
+});
+
+describe('HANDOFF-001 — reordering and retries are normal; inconsistency is not', () => {
+  it('accepts chunks out of order', () => {
+    const chunks = [...chunkHandoffPayload(ID, 'x'.repeat(100), 10)].reverse();
+
+    const { last } = assemble(chunks);
+
+    expect(last?.outcome).toBe('complete');
+    expect(last?.serialized).toBe('x'.repeat(100));
+  });
+
+  it('a re-sent chunk is a duplicate, not a problem', () => {
+    const chunks = chunkHandoffPayload(ID, 'x'.repeat(100), 10);
+    const assembler = new HandoffChunkAssembler(ID);
+    assembler.accept(chunks[0]);
+
+    const again = assembler.accept(chunks[0]);
+
+    expect(again.outcome).toBe('duplicate');
+    expect(again.received).toBe(1);
+  });
+
+  it('different bytes for the same index is refused, not overwritten', () => {
+    const chunks = chunkHandoffPayload(ID, 'x'.repeat(100), 10);
+    const assembler = new HandoffChunkAssembler(ID);
+    assembler.accept(chunks[0]);
+
+    const conflicting = assembler.accept({
+      ...chunks[0],
+      data: Buffer.from('zz').toString('base64'),
+    });
+
+    expect(conflicting.outcome).toBe('refused');
+  });
+
+  it('a peer that changes its mind about the size is refused', () => {
+    // Either it restarted the transfer under the same id, or it is not the peer we started with.
+    // Both mean the pieces held so far can no longer be assumed to belong together.
+    const chunks = chunkHandoffPayload(ID, 'x'.repeat(100), 10);
+    const assembler = new HandoffChunkAssembler(ID);
+    assembler.accept(chunks[0]);
+
+    const result = assembler.accept({ ...chunks[1], total: 3 });
+
+    expect(result.rejection).toBe('inconsistent-total');
+  });
+
+  it('refuses a chunk belonging to a different transfer rather than routing it', () => {
+    const [chunk] = chunkHandoffPayload('other_handoff', 'x', 10);
+
+    expect(new HandoffChunkAssembler(ID).accept(chunk).rejection).toBe('wrong-handoff');
+  });
+
+  it.each([
+    ['a negative index', -1],
+    ['an index beyond the total', 99],
+  ])('refuses %s', (_label, index) => {
+    const [chunk] = chunkHandoffPayload(ID, 'x'.repeat(30), 10);
+
+    expect(new HandoffChunkAssembler(ID).accept({ ...chunk, index }).rejection).toBe(
+      'out-of-range',
+    );
+  });
+
+  it('reports which indices are still missing, so a caller can ask rather than restart', () => {
+    const chunks = chunkHandoffPayload(ID, 'x'.repeat(100), 10);
+    const assembler = new HandoffChunkAssembler(ID);
+    assembler.accept(chunks[0]);
+    assembler.accept(chunks[3]);
+
+    expect(assembler.missing()).toEqual([1, 2, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('knows nothing is missing before anything has declared a total', () => {
+    expect(new HandoffChunkAssembler(ID).missing()).toEqual([]);
+  });
+
+  it('discard drops what it held', () => {
+    const chunks = chunkHandoffPayload(ID, 'x'.repeat(100), 10);
+    const assembler = new HandoffChunkAssembler(ID);
+    assembler.accept(chunks[0]);
+
+    assembler.discard();
+
+    expect(assembler.received).toBe(0);
+    expect(assembler.expected).toBeUndefined();
+  });
+});
+
+describe('HANDOFF-001 TC-06 — a mangled chunk is caught where it arrives', () => {
+  it('refuses data that is not decodable base64', () => {
+    // Buffer.from is lenient: it drops what it cannot parse rather than throwing, so a mangled
+    // chunk would silently become a shorter one and corrupt the payload in a way only the final
+    // digest catches — after the whole transfer completed.
+    const [chunk] = chunkHandoffPayload(ID, 'x'.repeat(30), 10);
+
+    const result = new HandoffChunkAssembler(ID).accept({ ...chunk, data: 'not!valid!base64!' });
+
+    expect(result.rejection).toBe('undecodable');
+  });
+
+  it('a corrupt-but-decodable chunk survives here and is caught by the digest', () => {
+    // The two checks are deliberately different questions. This one asks "did the pieces arrive";
+    // the digest asks "are they the pieces that were sent". Asking the second one per chunk would
+    // report each piece intact while the set is not the set that was sent.
+    const record = {
+      id: 's',
+      cwd: '/w',
+      createdAt: 'a',
+      updatedAt: 'b',
+      messages: [],
+    } as IInteractiveSessionRecord;
+    const { serialized, integrity } = sealHandoffRecord(record);
+    const chunks = chunkHandoffPayload(ID, serialized, 16);
+    const swapped = chunks.map((c, i) =>
+      i === 0 ? { ...c, data: Buffer.from('0'.repeat(16)).toString('base64') } : c,
+    );
+
+    const { last } = assemble(swapped);
+
+    expect(last?.outcome).toBe('complete');
+    expect(verifyHandoffPayload(last?.serialized ?? '', integrity).intact).toBe(false);
+  });
+
+  it('the whole path holds: seal, chunk, reassemble, verify', () => {
+    const record = {
+      id: 'session_1',
+      cwd: '/home/alice/project',
+      createdAt: '2026-08-17T00:00:00.000Z',
+      updatedAt: '2026-08-17T01:00:00.000Z',
+      messages: [{ role: 'user', content: '안녕하세요 😀' }],
+    } as unknown as IInteractiveSessionRecord;
+    const { serialized, integrity } = sealHandoffRecord(record);
+
+    const { last } = assemble(chunkHandoffPayload(ID, serialized, 24));
+
+    expect(verifyHandoffPayload(last?.serialized ?? '', integrity).intact).toBe(true);
+    expect(JSON.parse(last?.serialized ?? '{}')).toEqual(record);
+  });
+});

--- a/packages/agent-transport-protocol/src/handoff-chunking.ts
+++ b/packages/agent-transport-protocol/src/handoff-chunking.ts
@@ -1,0 +1,235 @@
+/**
+ * HANDOFF-001 (#1811): moving a session record that does not fit in one frame.
+ *
+ * A data channel has a maximum message size; a session record is a whole conversation. So the
+ * payload travels in pieces, and this owns the two halves of that: cutting it up, and putting it
+ * back together in the face of retries, reordering and a peer that says something inconsistent.
+ *
+ * ## Why the cut is made on BYTES rather than on the string
+ *
+ * The channel's limit is in bytes, and the serialized record is a JavaScript string — UTF-16 code
+ * units, where one character can be one byte or four. Slicing by characters and hoping the pieces
+ * fit means either measuring each slice's encoded length anyway, or shipping frames that overflow
+ * the channel for anyone whose conversation contains an emoji or a non-Latin script.
+ *
+ * Cutting the encoded bytes makes the budget exact. It costs base64's third: a byte slice is not a
+ * valid string on its own — it can end mid-character — so it cannot ride in a JSON frame as text.
+ * That cost is deliberate and is the smaller risk. The alternative works only because
+ * `JSON.stringify` has escaped lone surrogates since ES2019; a transfer whose correctness rests on
+ * that, and which fails as silent corruption when something in the chain does not, is not a trade
+ * worth a third of the bandwidth.
+ *
+ * ## What this does NOT decide
+ *
+ * It does not verify the digest. `verifyHandoffPayload` owns that, and asking the same question in
+ * two places is how the two answers drift. This reports that all the pieces arrived; whether they
+ * are the RIGHT pieces is the next check, and it deliberately runs on the whole reassembled payload
+ * rather than per chunk — a per-chunk digest would say each piece is intact while the set is not the
+ * set that was sent.
+ */
+
+import type { IHandoffIntegrity } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * One piece of a payload in flight.
+ *
+ * `total` travels on every chunk rather than in a separate header frame: a header can be the frame
+ * that gets lost, and a receiver that learned the count from a message it never got would wait
+ * forever for a number it cannot ask for again.
+ */
+export interface IHandoffChunk {
+  readonly handoffId: string;
+  /** 0-based position in the sequence. */
+  readonly index: number;
+  /** How many chunks make up the whole payload. */
+  readonly total: number;
+  /** base64 of this slice of the UTF-8 encoded payload. */
+  readonly data: string;
+}
+
+/**
+ * Default frame budget, in bytes of encoded chunk data.
+ *
+ * 16 KiB because that is the size every SCTP implementation carries without negotiation. Larger
+ * works between two peers that both support it and fails between two that do not — and it fails at
+ * transfer time, on the user's session, not in a test.
+ */
+export const DEFAULT_MAX_CHUNK_BYTES = 16 * 1024;
+
+/**
+ * Cut a sealed payload into chunks.
+ *
+ * Takes the serialized string the seal produced, not the record — the digest is over those exact
+ * bytes, and re-serializing here would let a chunked payload differ from the one the manifest
+ * describes.
+ */
+export function chunkHandoffPayload(
+  handoffId: string,
+  serialized: string,
+  maxChunkBytes: number = DEFAULT_MAX_CHUNK_BYTES,
+): readonly IHandoffChunk[] {
+  if (!Number.isInteger(maxChunkBytes) || maxChunkBytes < 1) {
+    throw new Error(
+      `handoff chunking: maxChunkBytes must be a positive integer, got ${maxChunkBytes}. ` +
+        'A zero or negative budget produces an infinite sequence of empty chunks, which presents ' +
+        'as a hang rather than as the configuration error it is.',
+    );
+  }
+  const bytes = Buffer.from(serialized, 'utf8');
+  // An empty payload is still one chunk. Zero chunks would leave the receiver unable to tell a
+  // completed empty transfer from one that never started.
+  const total = Math.max(1, Math.ceil(bytes.byteLength / maxChunkBytes));
+  const chunks: IHandoffChunk[] = [];
+  for (let index = 0; index < total; index += 1) {
+    const slice = bytes.subarray(index * maxChunkBytes, (index + 1) * maxChunkBytes);
+    chunks.push({ handoffId, index, total, data: slice.toString('base64') });
+  }
+  return chunks;
+}
+
+/** Why a chunk was not accepted. */
+export type TChunkRejection =
+  /** Belongs to a different transfer. */
+  | 'wrong-handoff'
+  /** `index` is negative, or beyond the declared `total`. */
+  | 'out-of-range'
+  /** Its `total` disagrees with what earlier chunks declared. */
+  | 'inconsistent-total'
+  /** Its `data` is not decodable base64. */
+  | 'undecodable';
+
+export type TChunkOutcome =
+  /** Stored; more are still needed. */
+  | 'accepted'
+  /** Already had this index, and it matched. A retry, not a problem. */
+  | 'duplicate'
+  /** Stored, and that was the last one missing. */
+  | 'complete'
+  | 'refused';
+
+export interface IChunkResult {
+  readonly outcome: TChunkOutcome;
+  readonly rejection?: TChunkRejection;
+  /** Present when complete: the reassembled payload, ready for the integrity check. */
+  readonly serialized?: string;
+  /** How many distinct chunks are held. */
+  readonly received: number;
+  /** How many are expected, once anything has declared it. */
+  readonly expected?: number;
+}
+
+/**
+ * Collects the chunks of ONE transfer.
+ *
+ * One assembler per `handoffId`, because a shared one would have to key everything by transfer and
+ * would then be a place where two transfers can be confused for each other. A chunk naming a
+ * different transfer is refused rather than routed — routing is the caller's job and doing it here
+ * would make this a dispatcher as well as a buffer.
+ */
+export class HandoffChunkAssembler {
+  private readonly chunks = new Map<number, Buffer>();
+  private declaredTotal: number | undefined;
+
+  constructor(private readonly handoffId: string) {}
+
+  get received(): number {
+    return this.chunks.size;
+  }
+
+  get expected(): number | undefined {
+    return this.declaredTotal;
+  }
+
+  /** Take one chunk. Reordering and retries are normal; inconsistency is not. */
+  accept(chunk: IHandoffChunk): IChunkResult {
+    const refuse = (rejection: TChunkRejection): IChunkResult => ({
+      outcome: 'refused',
+      rejection,
+      received: this.chunks.size,
+      ...(this.declaredTotal !== undefined ? { expected: this.declaredTotal } : {}),
+    });
+
+    if (chunk.handoffId !== this.handoffId) return refuse('wrong-handoff');
+    if (!Number.isInteger(chunk.total) || chunk.total < 1) return refuse('inconsistent-total');
+    if (this.declaredTotal !== undefined && chunk.total !== this.declaredTotal) {
+      // A peer that changes its mind about the size has either restarted the transfer under the
+      // same id or is not the peer we started with. Either way the pieces held so far can no longer
+      // be assumed to belong together.
+      return refuse('inconsistent-total');
+    }
+    if (!Number.isInteger(chunk.index) || chunk.index < 0 || chunk.index >= chunk.total) {
+      return refuse('out-of-range');
+    }
+
+    const decoded = Buffer.from(chunk.data, 'base64');
+    // Buffer.from is lenient — it drops what it cannot parse rather than throwing, so a mangled
+    // chunk would silently become a shorter one and corrupt the payload in a way only the final
+    // digest would catch, after the whole transfer completed. Re-encoding is how the leniency is
+    // detected here instead.
+    if (decoded.toString('base64') !== chunk.data) return refuse('undecodable');
+
+    this.declaredTotal = chunk.total;
+    const held = this.chunks.get(chunk.index);
+    if (held !== undefined) {
+      // A retry re-sending the same bytes is normal. Different bytes for the same index is the
+      // inconsistent case again, and the same reasoning applies.
+      if (held.equals(decoded)) {
+        return { outcome: 'duplicate', received: this.chunks.size, expected: chunk.total };
+      }
+      return refuse('inconsistent-total');
+    }
+
+    this.chunks.set(chunk.index, decoded);
+    if (this.chunks.size < chunk.total) {
+      return { outcome: 'accepted', received: this.chunks.size, expected: chunk.total };
+    }
+    return {
+      outcome: 'complete',
+      serialized: this.reassemble(chunk.total),
+      received: this.chunks.size,
+      expected: chunk.total,
+    };
+  }
+
+  /** Which indices are still missing, so a caller can ask for them rather than restarting. */
+  missing(): readonly number[] {
+    if (this.declaredTotal === undefined) return [];
+    const gaps: number[] = [];
+    for (let i = 0; i < this.declaredTotal; i += 1) if (!this.chunks.has(i)) gaps.push(i);
+    return gaps;
+  }
+
+  /** Drop everything held. The transfer was abandoned, or its integrity check failed. */
+  discard(): void {
+    this.chunks.clear();
+    this.declaredTotal = undefined;
+  }
+
+  private reassemble(total: number): string {
+    const ordered: Buffer[] = [];
+    for (let i = 0; i < total; i += 1) {
+      const part = this.chunks.get(i);
+      if (part === undefined) {
+        // Unreachable: size equalled total and every index was range-checked on the way in. Stated
+        // as an error rather than a non-null assertion, because the assertion would be the thing
+        // that hid it if the invariant ever broke.
+        throw new Error(`handoff chunking: chunk ${i} of ${total} is missing at reassembly.`);
+      }
+      ordered.push(part);
+    }
+    return Buffer.concat(ordered).toString('utf8');
+  }
+}
+
+/**
+ * How many chunks a payload of this size will take, without building them.
+ *
+ * For a progress indicator at the sending end, and for a receiver deciding whether it is willing to
+ * hold that much before the first chunk arrives.
+ */
+export function chunkCountFor(
+  integrity: IHandoffIntegrity,
+  maxChunkBytes: number = DEFAULT_MAX_CHUNK_BYTES,
+): number {
+  return Math.max(1, Math.ceil(integrity.byteLength / maxChunkBytes));
+}

--- a/packages/agent-transport-protocol/src/index.ts
+++ b/packages/agent-transport-protocol/src/index.ts
@@ -67,6 +67,18 @@ export {
   sealHandoffRecord,
   verifyHandoffPayload,
 } from './handoff-manifest.js';
+export {
+  chunkCountFor,
+  chunkHandoffPayload,
+  DEFAULT_MAX_CHUNK_BYTES,
+  HandoffChunkAssembler,
+} from './handoff-chunking.js';
+export type {
+  IChunkResult,
+  IHandoffChunk,
+  TChunkOutcome,
+  TChunkRejection,
+} from './handoff-chunking.js';
 export type {
   IBuildManifestInput,
   IIntegrityVerdict,


### PR DESCRIPTION
HANDOFF-001 (#1811). A data channel has a maximum message size; a session record is a whole conversation.

## The cut is made on BYTES, and that is the decision here

The channel's limit is in bytes, while the serialized record is a JavaScript string — UTF-16 code units, where one character can be one byte or four. Slicing by characters and hoping the pieces fit means either measuring each slice's encoded length anyway, or shipping frames that overflow the channel for anyone whose conversation contains an emoji or a non-Latin script.

It costs base64's third, because a byte slice can end mid-character and so cannot ride in a JSON frame as text. **That cost is deliberate.** The alternative works only because `JSON.stringify` has escaped lone surrogates since ES2019, and a transfer whose correctness rests on that — failing as *silent corruption* if anything in the chain does not — is not worth a third of the bandwidth.

## The total travels on every chunk

Not in a header frame. A header can be the frame that gets lost, and a receiver that learned the count from a message it never got would wait forever for a number it cannot ask for again.

## Inconsistency is refused; retries are not

Reordering and re-sends are ordinary network behaviour and are handled as such. A peer that changes its mind about the size, or sends different bytes for an index already held, has either restarted under the same id or is not the peer we started with — either way the pieces held so far can no longer be assumed to belong together.

## base64 is re-encoded to check it

`Buffer.from(x, 'base64')` is **lenient**: it drops what it cannot parse rather than throwing. A mangled chunk would quietly become a shorter one and corrupt the payload in a way only the final digest catches — after the whole transfer completed.

## The digest is not asked here

This reports that all the pieces arrived; `verifyHandoffPayload` asks whether they are the pieces that were *sent*. A per-chunk digest would report each piece intact while the set is not the set that was sent — a test in this change demonstrates that rather than asserting it.

An empty payload is one chunk, not zero: otherwise a receiver cannot tell a completed empty transfer from one that never started.

## Verification

- 19 new tests; 173 in the package, all green after rebasing onto develop (#1843 merged, so the manifest commit is no longer duplicated here)
- `pnpm harness:scan` green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD