### PR TITLE
feat(agent-remote-pairing): create the rendezvous directory, then check that we did (#1810)

### DIFF
--- a/packages/agent-remote-pairing/docs/SPEC.md
+++ b/packages/agent-remote-pairing/docs/SPEC.md
@@ -98,13 +98,15 @@ A SEPARATE entry point, not part of the surface above. The main entry is isomorp
 Node built-ins) and runs in the browser remote client; this needs the filesystem, and a browser has
 no local peers and no directory permissions to judge.
 
-| Export                    | Kind     | Purpose                                                                                                  |
-| ------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| `admitLocalPeerDirectory` | function | Establish that a rendezvous directory is user-owned and mode 0700 — the evidence the kernel enforces.    |
-| `admitLocalPeerSocket`    | function | The same, plus the socket path resolving INSIDE that directory.                                          |
-| `refuseLocalPeer`         | function | Build a refusal in one place, so no call site can construct an admitted-looking result without evidence. |
-| `RendezvousGrantLedger`   | class    | The single-use, time-bounded, revocable grants that carry the rendezvous proof onto the channel.         |
-| `DEFAULT_GRANT_TTL_MS`    | const    | How long a grant stays admissible (30s — a channel handshake, not a session).                            |
+| Export                    | Kind     | Purpose                                                                                                            |
+| ------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `admitLocalPeerDirectory` | function | Establish that a rendezvous directory is user-owned and mode 0700 — the evidence the kernel enforces.              |
+| `admitLocalPeerSocket`    | function | The same, plus the socket path resolving INSIDE that directory.                                                    |
+| `refuseLocalPeer`         | function | Build a refusal in one place, so no call site can construct an admitted-looking result without evidence.           |
+| `ensureGuardedDirectory`  | function | Create the rendezvous directory and VERIFY it afterwards with the same judge that validates one we did not create. |
+| `GUARDED_MODE`            | const    | 0700 — owner-only, which is the entire proof.                                                                      |
+| `RendezvousGrantLedger`   | class    | The single-use, time-bounded, revocable grants that carry the rendezvous proof onto the channel.                   |
+| `DEFAULT_GRANT_TTL_MS`    | const    | How long a grant stays admissible (30s — a channel handshake, not a session).                                      |
 
 **What this proves, and what it does not.** Reaching a socket inside a 0700 user-owned directory
 means the peer is on this machine as this user, because the kernel refuses the traversal to anyone

--- a/packages/agent-remote-pairing/src/local/__tests__/guarded-directory.test.ts
+++ b/packages/agent-remote-pairing/src/local/__tests__/guarded-directory.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync, statSync, mkdirSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ensureGuardedDirectory, GUARDED_MODE } from '../guarded-directory.js';
+
+/**
+ * SEC-010 — creating the directory whose permissions are the proof.
+ *
+ * The umask cases run against a REAL filesystem, deliberately. The whole defect being guarded
+ * against is that `mkdir(…, { mode: 0o700 })` returns successfully having produced 0755, and a
+ * mocked `mkdir` cannot exhibit that — it would assert the mock's behaviour, not the kernel's.
+ */
+const made: string[] = [];
+
+function scratch(): string {
+  // mkdtemp, not join(tmpdir(), name): the OS chooses the name and creates it 0700 (SEC-003).
+  const dir = mkdtempSync(path.join(tmpdir(), 'robota-guarded-'));
+  made.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (made.length > 0) {
+    const dir = made.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('SEC-010 — a created rendezvous directory is verified, not assumed', () => {
+  it('creates it 0700 and admits it', () => {
+    const target = path.join(scratch(), 'peers');
+
+    const result = ensureGuardedDirectory(target, { expectedUid: process.getuid?.() ?? 0 });
+
+    expect(result.admitted).toBe(true);
+    expect(result.trust).toBe('same-user-same-host');
+    expect(statSync(target).mode & 0o777).toBe(GUARDED_MODE);
+  });
+
+  it('a umask cannot widen the result, and this pins the reason the chmod is NOT for that', () => {
+    // This test previously claimed the umask could turn a 0700 request into 0755, and it passed
+    // with the chmod removed — an assertion that holds either way asserts nothing. A umask only
+    // ever CLEARS bits, so the request can come back tighter and never looser.
+    //
+    // Kept, restated, because the wrong reason is worth one test to keep from being re-adopted:
+    // if this ever fails, the platform's umask semantics changed and the module's justification
+    // needs re-reading.
+    const previous = process.umask(0o077);
+    try {
+      const target = path.join(scratch(), 'peers');
+
+      ensureGuardedDirectory(target, { expectedUid: process.getuid?.() ?? 0 });
+
+      expect(statSync(target).mode & 0o077).toBe(0);
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  it('tightens a directory that already existed with wider permissions', () => {
+    // `mkdir` with `recursive: true` succeeds on an existing directory WITHOUT touching its mode,
+    // so a directory somebody else created 0777 would otherwise be adopted as ours.
+    const target = path.join(scratch(), 'peers');
+    mkdirSync(target);
+    chmodSync(target, 0o777);
+
+    const result = ensureGuardedDirectory(target, { expectedUid: process.getuid?.() ?? 0 });
+
+    expect(result.admitted).toBe(true);
+    expect(statSync(target).mode & 0o777).toBe(GUARDED_MODE);
+  });
+
+  it('refuses when the post-creation check says the directory is not ours', () => {
+    // The validation is not a formality: it is the step that would catch a mode or owner the two
+    // calls above did not actually achieve. Driven here by claiming a uid we are not.
+    const target = path.join(scratch(), 'peers');
+
+    const result = ensureGuardedDirectory(target, { expectedUid: (process.getuid?.() ?? 0) + 1 });
+
+    expect(result.admitted).toBe(false);
+    expect(result.reason).toMatch(/belongs to uid/);
+  });
+});
+
+describe('SEC-010 — a directory that could not be made is a refusal, never a pass', () => {
+  it('refuses when creation throws', () => {
+    const result = ensureGuardedDirectory('/anywhere', {
+      expectedUid: 0,
+      makeDirectory: () => {
+        throw new Error('EACCES: permission denied');
+      },
+    });
+
+    expect(result.admitted).toBe(false);
+    expect(result.trust).toBe('unproven');
+    expect(result.reason).toMatch(/could not be created.*EACCES/);
+  });
+
+  it('refuses when the mode could not be set, rather than using whatever mode it has', () => {
+    const result = ensureGuardedDirectory('/anywhere', {
+      expectedUid: 0,
+      makeDirectory: () => {},
+      setMode: () => {
+        throw new Error('EPERM: operation not permitted');
+      },
+    });
+
+    expect(result.admitted).toBe(false);
+    expect(result.reason).toMatch(/could not be set to mode 0700/);
+  });
+
+  it('does not attempt a mode change on a directory that was never created', () => {
+    // Reporting a mode change on nothing would be a second, misleading failure — and the first one
+    // is the one that matters.
+    let setModeCalls = 0;
+
+    ensureGuardedDirectory('/anywhere', {
+      expectedUid: 0,
+      makeDirectory: () => {
+        throw new Error('EACCES');
+      },
+      setMode: () => {
+        setModeCalls += 1;
+      },
+    });
+
+    expect(setModeCalls).toBe(0);
+  });
+
+  it('asks for 0700 at creation as well as after, so the window is as small as it can be', () => {
+    // Belt and braces on purpose: the chmod is what guarantees it, but a directory that exists at
+    // 0755 for even an instant is reachable in that instant.
+    const requested: number[] = [];
+
+    ensureGuardedDirectory('/anywhere', {
+      expectedUid: 0,
+      makeDirectory: (_t, mode) => requested.push(mode),
+      setMode: () => {},
+      statAt: () => ({
+        uid: 0,
+        mode: GUARDED_MODE,
+        isDirectory: () => true,
+        isSymbolicLink: () => false,
+      }),
+      resolve: (t) => t,
+    });
+
+    expect(requested).toEqual([GUARDED_MODE]);
+  });
+});

--- a/packages/agent-remote-pairing/src/local/guarded-directory.ts
+++ b/packages/agent-remote-pairing/src/local/guarded-directory.ts
@@ -1,0 +1,102 @@
+/**
+ * SEC-010: CREATING the directory whose permissions are the proof.
+ *
+ * `peer-credential.ts` answers "is this directory one only this user can enter". This answers "make
+ * one, and tell me if you could not". They are two halves of a single fact, and they live beside
+ * each other because a repository where one module decides what `guarded` means and another decides
+ * how to build it has two definitions of `guarded` — and the day they disagree, the one that builds
+ * wins silently.
+ *
+ * WHERE the directory goes is NOT decided here. That is composition: `agent-cli` knows about
+ * `XDG_RUNTIME_DIR`, about the user's home, and about which of them exists on this host. This module
+ * knows only what has to be true of whatever path it is handed, which is why it can be tested
+ * without a filesystem layout.
+ *
+ * ## Creation is not the same as validation, and doing both is the point
+ *
+ * `mkdir(path, { mode: 0o700, recursive: true })` does not guarantee a 0700 directory, for one
+ * reason that survives scrutiny: **if the directory already exists, `mkdir` succeeds without
+ * touching its mode at all.** A directory some earlier process — or some other program — left at
+ * 0777 is then adopted as ours, with a successful return and no signal.
+ *
+ * A note on the reason that does NOT survive scrutiny, recorded because it was the first
+ * justification written here and it was wrong: the umask cannot widen this. It only ever CLEARS
+ * bits, so a requested 0700 can come back 0600 but never 0755. The test that claimed to prove the
+ * umask case passed with the `chmod` removed, which is what exposed it — an assertion that holds
+ * either way was asserting nothing.
+ *
+ * So: create, then `chmod` unconditionally, then VALIDATE with the same function that validates a
+ * directory we did not create. The last step is what makes the first two checkable rather than
+ * hopeful, and it is the only one that catches an owner we did not expect.
+ */
+
+import { chmodSync, mkdirSync } from 'node:fs';
+
+import {
+  admitLocalPeerDirectory,
+  refuseLocalPeer,
+  type IGuardedDirectoryOptions,
+  type ILocalPeerAdmission,
+} from './peer-credential.js';
+
+/** Owner-only. The whole proof is that no other account can traverse it. */
+export const GUARDED_MODE = 0o700;
+
+export interface IEnsureGuardedOptions extends IGuardedDirectoryOptions {
+  /** Directory creator, injected so the failure paths are reachable without a real filesystem. */
+  readonly makeDirectory?: (target: string, mode: number) => void;
+  /** Mode setter, injected for the same reason. */
+  readonly setMode?: (target: string, mode: number) => void;
+}
+
+/**
+ * Make a rendezvous directory that meets the guarantee, or say why it does not.
+ *
+ * Returns the same `ILocalPeerAdmission` shape a validation returns, so a caller never has to hold
+ * two vocabularies for one question. An admitted result means the directory exists AND was verified
+ * after creation — not that `mkdir` returned without throwing.
+ */
+export function ensureGuardedDirectory(
+  directory: string,
+  options: IEnsureGuardedOptions,
+): ILocalPeerAdmission {
+  const makeDirectory =
+    options.makeDirectory ??
+    ((target: string, mode: number): void => {
+      mkdirSync(target, { recursive: true, mode });
+    });
+  const setMode =
+    options.setMode ?? ((target: string, mode: number): void => chmodSync(target, mode));
+
+  try {
+    makeDirectory(directory, GUARDED_MODE);
+  } catch (error) {
+    // allow-fallback: this substitutes no alternative directory — it converts a failed creation
+    // into a REFUSAL, which is the same terminal answer the validator gives. Proceeding to chmod a
+    // directory that was not created would report a mode change on nothing.
+    return refuseLocalPeer(
+      `the rendezvous directory ${directory} could not be created: ` +
+        `${error instanceof Error ? error.message : 'unknown error'}`,
+    );
+  }
+
+  try {
+    // Unconditional, and this is the load-bearing line: `mkdir` with `recursive: true` succeeds on
+    // an EXISTING directory without touching its mode, so whatever it was left at — 0777 by some
+    // earlier process — would stand, with a successful return and no signal.
+    setMode(directory, GUARDED_MODE);
+  } catch (error) {
+    // allow-fallback: same shape — a directory whose mode could not be set is refused, never used
+    // at whatever mode it happens to have.
+    return refuseLocalPeer(
+      `the rendezvous directory ${directory} could not be set to mode 0700: ` +
+        `${error instanceof Error ? error.message : 'unknown error'}`,
+    );
+  }
+
+  // Validated with the SAME function that judges a directory we did not create. Trusting our own
+  // two calls would mean the create path is the one place the guarantee is assumed rather than
+  // checked — and it is the place a wrong umask, a mount option or a hostile pre-created directory
+  // would land.
+  return admitLocalPeerDirectory(directory, options);
+}

--- a/packages/agent-remote-pairing/src/local/index.ts
+++ b/packages/agent-remote-pairing/src/local/index.ts
@@ -16,6 +16,8 @@ export type {
   ILocalPeerBinding,
   TLocalPeerTrust,
 } from './peer-credential.js';
+export { ensureGuardedDirectory, GUARDED_MODE } from './guarded-directory.js';
+export type { IEnsureGuardedOptions } from './guarded-directory.js';
 export { DEFAULT_GRANT_TTL_MS, RendezvousGrantLedger } from './rendezvous-nonce.js';
 export type {
   IIssueOptions,


### PR DESCRIPTION
SEC-010 (#1810). The validator already answers *"is this directory one only this user can enter"*. This answers *"make one, and say so if you could not"* — and the two live in the same place because a repository where one module decides what `guarded` MEANS and another decides how to BUILD it has two definitions, and the day they disagree the builder wins silently.

**Where** the directory goes is not decided here. That is composition: `agent-cli` knows about the runtime directory, the user's home, and which exists on this host. This knows only what must be true of whatever path it is handed — which is why it is testable without a filesystem layout.

## Why the chmod is there — correctly this time

`mkdir` with `recursive: true` succeeds on an **existing** directory without touching its mode. One left at 0777 by some earlier process is adopted as ours: successful return, no signal.

The first version of this file justified the chmod by the **umask** instead, claiming a umask of `0o022` turns a 0700 request into 0755. **That is false** — a umask only ever *clears* bits, so the request can come back tighter and never looser.

What exposed it was red-proofing: the test asserting the umask case **passed with the chmod removed**. An assertion that holds either way asserts nothing, and it would have shipped as evidence for a reason that is not the reason.

The umask test is kept, restated to pin what is actually true. A wrong justification that has been written down once is worth one test to keep it from being re-adopted.

## The post-check is the point

It runs the **same judge** that validates a directory we did not create. Trusting our own two calls would make the create path the one place the guarantee is assumed rather than checked — and it is exactly where a mount option or a hostile pre-created directory would land.

Both failure paths refuse rather than continue: a directory that could not be created is not chmod'ed, and one whose mode could not be set is never used at whatever mode it happens to have.

## Verification

- 8 tests, including real-filesystem cases (a mocked `mkdir` cannot exhibit the defect being guarded against)
- Removing the chmod now fails exactly two tests — the pre-existing-directory case and the mode-set-failure refusal
- `pnpm harness:scan` green; 90 package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD