### PR TITLE
docs(tasks): bring SEC-010 and HANDOFF-001 up to what actually landed

### DIFF
--- a/.agents/tasks/HANDOFF-001-cross-device-session-transfer.md
+++ b/.agents/tasks/HANDOFF-001-cross-device-session-transfer.md
@@ -1,6 +1,6 @@
 ---
 title: 'HANDOFF-001: moving a live session to another computer needs an ownership transaction, and there is no atomic commit across two machines'
-status: todo
+status: in-progress
 created: 2026-08-17
 priority: high
 urgency: soon
@@ -79,6 +79,28 @@ transferable half.
 Semantic SSOT `agent-interface-transport`; wire SSOT `agent-transport-protocol`; orchestration
 `agent-framework`; carrier `agent-transport-webrtc` consuming SEC-011's result; `agent-cli` owns
 commands, consent UX and composition only.
+
+## Implementation status
+
+The wire layer is complete; the orchestration is not. What has landed, and where:
+
+| Piece                                                                | Package                     | Change  |
+| -------------------------------------------------------------------- | --------------------------- | ------- |
+| Phase contracts and `sourceRetainsAuthority`                         | `agent-interface-transport` | earlier |
+| The ownership transaction — every failure keeps the source in charge | `agent-transport-protocol`  | #1835   |
+| Manifest, inventory classification, integrity seal/verify            | `agent-transport-protocol`  | #1843   |
+| Chunking and reassembly                                              | `agent-transport-protocol`  | #1856   |
+
+**TC-01, TC-05, TC-06, TC-08 and TC-09 are covered.** TC-02, TC-03, TC-04, TC-07 and TC-10 are not,
+and cannot be: they are about what the source and destination DO across a real transfer, not about
+the frames. They need the framework orchestration and the CLI commands, which are what remains.
+
+One classification changed during implementation and the table above still reflects the original
+wording. `THandoffDisposition` gained `never-transferred`, split from `source-local`, because the two
+were not the same statement: uncommitted working-tree changes stay behind as a product decision that
+could be revisited, while a provider credential stays behind because SEC-009 forbids a resolved
+secret crossing a process boundary — and a machine boundary is strictly worse. Collapsed together,
+nothing in the type would stop a later change from helpfully carrying the credential along.
 
 ## Test Plan
 

--- a/.agents/tasks/SEC-010-same-environment-proof-for-local-peers.md
+++ b/.agents/tasks/SEC-010-same-environment-proof-for-local-peers.md
@@ -15,9 +15,10 @@ Registered as [issue #1810](https://github.com/woojubb/robota/issues/1810), the 
 [#1809](https://github.com/woojubb/robota/issues/1809), which consumes the admission result this item
 defines and can proceed against an injected double until it exists.
 
-**The issue states the precondition this document answers**, and it is the reason nothing is
-implemented yet: _"The issue must define the exact environment proof and its failure/revocation
-semantics before implementation."_
+**The issue stated the precondition this document answers**, and it is why the design came before any
+code: _"The issue must define the exact environment proof and its failure/revocation semantics
+before implementation."_ That precondition is met and the recommendation was implemented — see
+**Implementation status** below for what has landed and what has not.
 
 ## The problem, stated precisely
 
@@ -149,7 +150,16 @@ are in, each where the ownership rules put it:
 | The grant       | `agent-remote-pairing/local` — `RendezvousGrantLedger`          | #1839   |
 | The binding     | `agent-transport-webrtc` — the gate's `local-proof` step        | #1841   |
 
-TC-01 through TC-08 are covered. What remains is composition, not security: `agent-cli` creating
+TC-01 through TC-08 are covered.
+
+**A correction worth keeping**, because the wrong reason was written down before it was caught.
+`ensureGuardedDirectory`'s chmod was first justified by the umask — that a umask of `0o022` turns a
+0700 request into 0755. It does not: a umask only ever CLEARS bits, so the request can come back
+tighter and never looser. Red-proofing exposed it, in the way that is worth noticing — the test
+asserting the umask case PASSED with the chmod removed, and an assertion that holds either way
+asserts nothing. The real reason is that `mkdir` with `recursive: true` leaves an EXISTING
+directory's mode untouched, so one left at 0777 by an earlier process is adopted as ours with a
+successful return and no signal. What remains is composition, not security: `agent-cli` creating
 the guarded runtime directory, issuing grants at the rendezvous, wiring `localPeer` into the
 transport, and the peer side that sends the proof frame. The user-execution scenario below is
 written for that step and is what closes this item.


### PR DESCRIPTION
Docs only. Both task documents described a state the tree had moved past.

`HANDOFF-001` still read `status: todo` with three of its layers merged, and `SEC-010`'s opening still said nothing was implemented yet. **A task that describes a decision as unmade, when it was made and built, sends the next reader to re-decide it.**

## What each now says

Where every landed piece lives and which change landed it — and, the part that matters more, **what remains separated from what is done**. For both items the remainder is *composition*, not security or protocol: the CLI deciding where the guarded directory goes, issuing grants, driving the transfer phases.

That "not started" claim is **verified rather than assumed** — nothing under `agent-cli` references `ensureGuardedDirectory`, `RendezvousGrantLedger`, `localPeer`, `beginHandoff`, `buildHandoffManifest` or `chunkHandoffPayload`.

## Two things kept on the record rather than quietly corrected

**HANDOFF-001**: its inventory table's wording predates a classification change. `THandoffDisposition` gained `never-transferred`, split from `source-local`, because the two were not the same statement — working-tree changes stay behind as a product decision that could be revisited, while a provider credential stays behind because SEC-009 forbids a resolved secret crossing a process boundary, and a machine boundary is strictly worse.

**SEC-010**: the chmod in `ensureGuardedDirectory` was first justified by the umask — that `0o022` turns a 0700 request into 0755. It does not; a umask only ever *clears* bits. Red-proofing exposed it: the test asserting that case **passed with the chmod removed**, and an assertion that holds either way asserts nothing. The real reason is that `mkdir` with `recursive: true` leaves an existing directory's mode untouched.

Kept because a plausible wrong reason gets re-adopted.

## Verification

`pnpm harness:scan` — 124 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD