### PR TITLE
fix(agent-cli): /provider switch could not construct the provider it switches to (#1844)

### DIFF
--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -34,6 +34,7 @@ import {
   loadReplayProvider,
   reportUnknownPresetModules,
   selectProductCommandModules,
+  createChannelReadyHandler,
 } from './product/robota-plumbing.js';
 import {
   ensureConfig,
@@ -425,13 +426,8 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   }
 
   await renderApp({
-    onChannelReady: (channel) => {
-      setLiveChannel(channel);
-      // REMOTE-008: keep the remote-control controller pointed at the current live channel (incl.
-      // session-switch re-creations) so an enable attaches the session the user is actually driving and
-      // async failures surface into that channel's history.
-      setRemoteControlChannel(channel);
-    },
+    providerDefinitions,
+    onChannelReady: createChannelReadyHandler(setLiveChannel, setRemoteControlChannel),
     cwd,
     provider,
     providerOverride: args.provider,

--- a/packages/agent-cli/src/product/robota-plumbing.ts
+++ b/packages/agent-cli/src/product/robota-plumbing.ts
@@ -229,3 +229,23 @@ export function buildRobotaRuntimeOptions(input: IRobotaRuntimeSeamInput): IRobo
     },
   };
 }
+
+/**
+ * The channel-ready handler the TUI calls on every live-channel creation.
+ *
+ * A factory rather than a literal at the call site, because the two things it does are the same
+ * subject — keeping process-level and remote-control state pointed at the channel the user is
+ * actually driving — and neither is about assembling CLI options. It is called again on a
+ * session-switch re-creation, which is why both targets are re-pointed rather than set once: an
+ * enable that attached the previous channel would surface its async failures into a history nobody
+ * is reading.
+ */
+export function createChannelReadyHandler<TChannel extends TLive & TRemote, TLive, TRemote>(
+  setLive: (channel: TLive) => void,
+  setRemoteControl: (channel: TRemote) => void,
+): (channel: TChannel) => void {
+  return (channel) => {
+    setLive(channel);
+    setRemoteControl(channel);
+  };
+}

--- a/packages/agent-transport-tui/src/__tests__/provider-definitions-reach-the-session.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/provider-definitions-reach-the-session.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { toChannelOptions } from '../render.js';
+import { buildTuiSessionOptions } from '../tui-session-options.js';
+
+import type { IRenderOptions } from '../render.js';
+import type { ITuiInteractionChannelOptions } from '../TuiInteractionChannel.js';
+import type { IProviderDefinition } from '@robota-sdk/agent-core';
+
+/**
+ * #1844 — the provider definitions must survive the whole mapping chain.
+ *
+ * `providerDefinitions` was declared on the session options and read by `/provider switch`, and no
+ * production code set it. The consequence is not a dormant field: with an empty list the hot-swap
+ * throws `Unknown provider: <name>. Currently supported: ` — an empty supported-list, which is both
+ * wrong and unactionable. Measured, not inferred.
+ *
+ * Each hop is asserted separately because a forward that stops at any one of them restores exactly
+ * the bug, and an end-to-end assertion alone would not say WHERE it stopped.
+ */
+const DEFINITIONS = [
+  { type: 'anthropic', displayName: 'Anthropic' },
+] as unknown as readonly IProviderDefinition[];
+
+const renderOptions = (over: Partial<IRenderOptions> = {}): IRenderOptions =>
+  ({ cwd: '/w', provider: {}, ...over }) as IRenderOptions;
+
+describe('#1844 — provider definitions reach the session', () => {
+  it('render options carry them into the channel options', () => {
+    const channel = toChannelOptions(renderOptions({ providerDefinitions: DEFINITIONS }));
+
+    expect(channel.providerDefinitions).toBe(DEFINITIONS);
+  });
+
+  it('channel options carry them into the session options', () => {
+    const session = buildTuiSessionOptions({
+      cwd: '/w',
+      provider: {},
+      providerDefinitions: DEFINITIONS,
+    } as unknown as ITuiInteractionChannelOptions);
+
+    expect(session).toHaveProperty('providerDefinitions', DEFINITIONS);
+  });
+
+  it('the whole chain preserves them', () => {
+    const session = buildTuiSessionOptions(
+      toChannelOptions(
+        renderOptions({ providerDefinitions: DEFINITIONS }),
+      ) as unknown as ITuiInteractionChannelOptions,
+    );
+
+    expect(session).toHaveProperty('providerDefinitions', DEFINITIONS);
+  });
+
+  it('omits the key entirely when none were supplied, rather than setting an empty list', () => {
+    // An explicit `[]` would look like "the caller supplied none" and read as configured. Absent is
+    // the honest shape for "this surface did not provide them", and it also keeps
+    // `exactOptionalPropertyTypes` callers from having to pass undefined.
+    const session = buildTuiSessionOptions({
+      cwd: '/w',
+      provider: {},
+    } as unknown as ITuiInteractionChannelOptions);
+
+    expect('providerDefinitions' in session).toBe(false);
+  });
+});

--- a/packages/agent-transport-tui/src/render.tsx
+++ b/packages/agent-transport-tui/src/render.tsx
@@ -13,7 +13,11 @@ import { TuiInteractionChannel } from './TuiInteractionChannel.js';
 
 import type { ITuiCliAdapter } from './tui-cli-adapter.js';
 import type { ITuiInteractionChannelOptions } from './TuiInteractionChannel.js';
-import type { IAIProvider, IToolWithEventService } from '@robota-sdk/agent-core';
+import type {
+  IAIProvider,
+  IToolWithEventService,
+  IProviderDefinition,
+} from '@robota-sdk/agent-core';
 import type { TPermissionMode } from '@robota-sdk/agent-core';
 import type {
   IBackgroundTaskRunner,
@@ -38,6 +42,14 @@ export interface IRenderOptions {
   cwd: string;
   provider: IAIProvider;
   providerOverride?: string | undefined;
+  /**
+   * #1844: forwarded to the session so `/provider switch` can construct the provider it switches TO.
+   *
+   * The session cannot discover these — they are assembled at the composition root from the provider
+   * packages. Without them the hot-swap throws with an empty supported-list, which is the failure
+   * this option exists to prevent rather than a nicety.
+   */
+  providerDefinitions?: readonly IProviderDefinition[];
   providerType?: string | undefined;
   modelId?: string;
   /** ARCH-013: resolved preset effort, forwarded to the session's `effort` seam. */
@@ -109,6 +121,7 @@ export function toChannelOptions(
   return {
     cwd: options.cwd,
     provider: options.provider,
+    ...(options.providerDefinitions ? { providerDefinitions: options.providerDefinitions } : {}),
     // CLI-076: the display model id doubles as the session's model override so `--model` actually reaches
     // the provider chat call (header/status line == the model actually called).
     ...(options.modelId !== undefined ? { model: options.modelId } : {}),

--- a/packages/agent-transport-tui/src/tui-channel-options.ts
+++ b/packages/agent-transport-tui/src/tui-channel-options.ts
@@ -1,5 +1,10 @@
 import type { TerminalHandoffController } from './terminal-handoff-controller.js';
-import type { IAIProvider, IToolWithEventService, TPermissionMode } from '@robota-sdk/agent-core';
+import type {
+  IAIProvider,
+  IProviderDefinition,
+  IToolWithEventService,
+  TPermissionMode,
+} from '@robota-sdk/agent-core';
 import type {
   IAgentDefinition,
   IAutomaticMemoryConfig,
@@ -31,6 +36,15 @@ import type {
  * interactive surface at all, and a surface nobody can find is a surface people forget.
  */
 export interface ITuiInteractionChannelOptions {
+  /**
+   * Provider definitions, forwarded to the session so `/provider switch` can construct the provider
+   * it switches TO.
+   *
+   * Not optional-by-accident: without it the session holds an empty list, and the hot-swap fails with
+   * "Unknown provider: <name>. Currently supported: " — an empty supported-list, which is both wrong
+   * and unactionable. The definitions live in the composition root; the session cannot discover them.
+   */
+  providerDefinitions?: readonly IProviderDefinition[];
   cwd: string;
   provider: IAIProvider;
   /**

--- a/packages/agent-transport-tui/src/tui-session-options.ts
+++ b/packages/agent-transport-tui/src/tui-session-options.ts
@@ -50,6 +50,9 @@ export function buildTuiSessionOptions(
     enableParallelSubagents: opts.enableParallelSubagents,
     selfVerification: opts.selfVerification,
     terminalHandoff: opts.terminalHandoff,
+    // #1844: the session reads these when `/provider switch` hot-swaps. Absent, the switch throws
+    // "Unknown provider: <name>. Currently supported: " with an EMPTY list — measured, not inferred.
+    ...(opts.providerDefinitions ? { providerDefinitions: opts.providerDefinitions } : {}),
     // SELFHOST-008 P6: forward the surface-resolved memory fields only when present (absent ⇒ OFF).
     ...(opts.memoryStore ? { memoryStore: opts.memoryStore } : {}),
     ...(opts.automaticMemory ? { automaticMemory: opts.automaticMemory } : {}),

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "apps/agent-server/src/websocket-server.ts": 363,
   "apps/remote-signaling/src/relay.ts": 311,
-  "packages/agent-cli/src/cli.ts": 474,
+  "packages/agent-cli/src/cli.ts": 470,
   "packages/agent-cli/src/remote-control/remote-control-controller.ts": 485,
   "packages/agent-cli/src/utils/cli-args.ts": 316,
   "packages/agent-command/src/context/context-command.ts": 306,


### PR DESCRIPTION
Closes #1844.

The issue reported `providerDefinitions` as declared and consumed with nothing setting it, and asked whoever picked it up to **re-run the search rather than trust the sentence** — the same class of mistake had been made three times on that axis. Re-ran it, and it holds: no production path assigns it, and neither does the pass-through construction seam (`buildRuntimeSession` forwards whole options, which is exactly what an assignment-shaped search misses).

## It is not a dormant option

The consumer is `switchProvider` — the `/provider switch` hot-swap. With an empty list it reaches `createProviderFromConfig`, which throws:

```
Unknown provider: anthropic. Currently supported:
```

…with the supported list **empty**. Measured by driving the real function, not read off the code.

So this is a **broken user-facing command** whose cause is a value that never arrived — not a contract waiting for a product decision about removal. That distinction matters: #1844 correctly noted that removing an unconsumed public contract is a product decision and not a grep result, but this one is consumed, and consumed on a path a user takes.

## Wired end to end, and asserted at each hop

The definitions are assembled at the composition root — the session cannot discover them — so they travel:

`cli.ts` → `IRenderOptions` → channel options → session options

**Each hop has its own assertion.** A forward that stops at any one of them restores the bug exactly, and an end-to-end test alone would say it broke without saying where. Red-proofed: cutting the session-options hop fails 2 of the 4 tests.

## One shape decision

The key is **omitted** rather than set to `[]` when a surface supplies none. An explicit empty list reads as *"the caller supplied none, deliberately"* — which is indistinguishable from the bug being fixed here.

## Why a file moved

`cli.ts` was exactly at its size baseline, so the one added line needed room. The channel-ready handler moved to `robota-plumbing.ts`, which is where this package already keeps that kind of wiring — it is about keeping process-level and remote-control state pointed at the live channel, not about assembling options. The file ended up **shorter** than it started, so the ratchet is re-frozen in the same change.

## Verification

- 4 new tests, red-proofed
- 572 `agent-transport-tui` tests and 306 `agent-cli` tests green
- `pnpm harness:scan` — 124 passed, 2 skipped; `typecheck` clean; format-check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD