### PR TITLE
fix(agent-framework): the shutdown bound was itself delaying exit by its full length (#1852)

### DIFF
--- a/packages/agent-framework/src/runtime/__tests__/runtime-host.test.ts
+++ b/packages/agent-framework/src/runtime/__tests__/runtime-host.test.ts
@@ -84,6 +84,30 @@ describe('startRuntimeHost (RUNTIME-001 TC-01)', () => {
     await host.shutdown();
   });
 
+  it('shutdown() leaves no timer holding the event loop open (#1852)', async () => {
+    // The bound exists so a WEDGED subsystem cannot block exit. Its own timer must therefore not
+    // become a reason to stay alive: the losing side of a `Promise.race` is not cancelled, so an
+    // un-unref'd bound keeps the process alive for its full 5s even when shutdown finished in 1ms.
+    //
+    // Measured on `robota --serve` before the fix: teardown done at 1ms, process exit at 5006ms,
+    // with zero handles and a single `Timeout` as the only live resource. The bintest's 8s budget
+    // was passing with a 3s margin over a cost paid on every shutdown.
+    //
+    // Asserted on `getActiveResourcesInfo` rather than on elapsed time, because a timing assertion
+    // would pass on a fast machine for the wrong reason.
+    const registry = stubRegistry();
+    const host = await startRuntimeHost({
+      session: { cwd, provider: stubProvider() },
+      transportRegistry: registry,
+    });
+
+    const before = process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length;
+    await host.shutdown();
+    const after = process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length;
+
+    expect(after).toBeLessThanOrEqual(before);
+  });
+
   it('shutdown() stops the transports and is idempotent', async () => {
     const registry = stubRegistry();
     const host = await startRuntimeHost({

--- a/packages/agent-framework/src/runtime/runtime-host.ts
+++ b/packages/agent-framework/src/runtime/runtime-host.ts
@@ -77,11 +77,26 @@ export async function startRuntimeHost(opts: IRuntimeHostOptions): Promise<IRunt
         // allow-fallback: best-effort transport teardown — the process is exiting.
         await opts.transportRegistry.stopAll().catch(() => undefined);
       }
+      // The losing side of a `Promise.race` is not cancelled, so the bound's timer outlives the race
+      // it lost. An un-unref'd one keeps the event loop alive for its full duration: measured on
+      // `robota --serve`, teardown finished in 1ms and the process then sat for 5006ms with no
+      // handles and a single `Timeout` as its only live resource. The bound exists so a wedged
+      // subsystem cannot block exit — a bound that DELAYS exit by its own length in the normal case
+      // is the opposite of that.
+      //
+      // Cancelling it is enough, and is what the bound means: once the race has an answer the bound
+      // has done its job, whichever side won. `unref()` would also work — measured, either alone
+      // fixes it — but it leaves the timer armed and merely non-blocking, which is a weaker
+      // statement than "this is finished".
+      let bound: ReturnType<typeof setTimeout> | undefined;
       await Promise.race([
         // allow-fallback: best-effort session shutdown — a wedged subsystem must not block exit.
         session.shutdown({ reason: 'other', message }).catch(() => undefined),
-        new Promise((resolve) => setTimeout(resolve, RUNTIME_SHUTDOWN_TIMEOUT_MS)),
+        new Promise((resolve) => {
+          bound = setTimeout(resolve, RUNTIME_SHUTDOWN_TIMEOUT_MS);
+        }),
       ]);
+      if (bound !== undefined) clearTimeout(bound);
     },
   };
 }


### PR DESCRIPTION
Closes #1852.

`robota --serve` finished its teardown in **~1ms** and then sat for **~5006ms** before the process exited. The bintest's 8s budget was passing with a 3s margin over a cost paid on *every* shutdown — which is exactly why it flipped from always-green to always-red on a slower host with no code change in between.

## The cause

**The losing side of a `Promise.race` is not cancelled.** `shutdown()` raced the session teardown against a five-second bound; the teardown won in 1ms; the bound's timer kept running. An un-cancelled `setTimeout` is a reason for Node to stay alive, so the process waited out the full five seconds with nothing left to do.

The bound exists so a **wedged** subsystem cannot block exit. A bound that *delays* exit by its own length in the normal case is the opposite of that.

## Measured, not reasoned

| Probe | Result |
| --- | --- |
| Instrumented every `await` in the shutdown path | teardown done at **1ms** |
| `process.getActiveResourcesInfo()` during the wait | zero handles, a single **`Timeout`** |
| Six-line script: resolved promise raced against a 5s timer | `process exit at 5006ms` |

That last one is the whole bug in isolation, and it reproduces the exact figure the bintest reported.

## Two 5000ms constants sit beside this, and neither is the cause

- `WS_STOP_TERMINATE_DEADLINE_MS` — cleared correctly; its `wss.close()` callback fires at 1ms.
- The npm-registry socket from the startup update check — a **real** second lingering handle, but it costs nothing: disabling the check removes the socket and leaves the five seconds unchanged.

Both coincidences sent an earlier reading of this wrong (twice), which is why they are named in the commit rather than quietly dropped.

## Why cancel rather than `unref`

Both work — measured, either alone fixes it. `unref` leaves the timer **armed and merely non-blocking**, which is a weaker statement than *"this is finished"*. Once the race has an answer, the bound has done its job regardless of which side won.

## Result

```
serve-mode.bintest.ts   5661ms  →  910ms
```

The regression test asserts on `getActiveResourcesInfo` rather than elapsed time, so it cannot pass on a fast machine for the wrong reason. **Red-proofed**: removing the cancellation fails it.

`pnpm harness:scan` — 124 passed, 2 skipped. `typecheck` clean; format-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD