### PR TITLE
feat(agent-cli): decide where the guarded rendezvous lives, and verify it there (#1862)

### DIFF
--- a/packages/agent-cli/src/remote-control/__tests__/local-peer-rendezvous.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/local-peer-rendezvous.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ensureRendezvousDirectory, resolveRendezvousDirectory } from '../local-peer-rendezvous.js';
+
+/**
+ * SEC-010 composition (#1862) — choosing WHERE the guarded rendezvous lives.
+ *
+ * The location decision is this package's; what `guarded` means is the security leaf's. These tests
+ * pin the first and confirm the second still runs — a location decision must not be able to become
+ * a security decision by accident.
+ */
+const made: string[] = [];
+
+function scratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'robota-rv-'));
+  made.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (made.length > 0) {
+    const dir = made.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('#1862 — where the rendezvous goes', () => {
+  it('prefers the runtime directory, which the system already keeps 0700 and cleans up', () => {
+    const path = resolveRendezvousDirectory({ env: { XDG_RUNTIME_DIR: '/run/user/1000' } });
+
+    expect(path).toBe('/run/user/1000/robota/peers');
+  });
+
+  it('falls back to the home directory where this package already keeps its state', () => {
+    const path = resolveRendezvousDirectory({ env: {}, home: () => '/home/alice' });
+
+    expect(path).toBe('/home/alice/.robota/peers');
+  });
+
+  it('treats a blank runtime directory as absent rather than as a root', () => {
+    // `XDG_RUNTIME_DIR=''` would otherwise produce `robota/peers` — a RELATIVE path, created
+    // wherever the process happens to be running.
+    const path = resolveRendezvousDirectory({
+      env: { XDG_RUNTIME_DIR: '  ' },
+      home: () => '/home/alice',
+    });
+
+    expect(path).toBe('/home/alice/.robota/peers');
+  });
+});
+
+describe('#1862 — the chosen path still goes through the security leaf', () => {
+  it('creates it 0700 and returns the admission, not a boolean', () => {
+    const home = scratch();
+
+    const result = ensureRendezvousDirectory({ env: {}, home: () => home });
+
+    expect(result.admitted).toBe(true);
+    expect(result.trust).toBe('same-user-same-host');
+    expect(result.binding?.guardedDirectory).toContain('.robota/peers');
+    expect(statSync(join(home, '.robota', 'peers')).mode & 0o777).toBe(0o700);
+  });
+
+  it('a location that cannot be made is a refusal, never an unguarded fallback', () => {
+    // Falling back to a directory that is merely writable would be the copyable-credential failure
+    // SEC-010 exists to prevent, wearing a path.
+    // A file, not a directory: `mkdir` under it cannot succeed, and the refusal is the security
+    // leaf's own rather than a special case here.
+    const home = scratch();
+    const asFile = join(home, 'not-a-directory');
+    writeFileSync(asFile, 'x', 'utf8');
+
+    const result = ensureRendezvousDirectory({ env: { XDG_RUNTIME_DIR: asFile } });
+
+    expect(result.admitted).toBe(false);
+    expect(result.trust).toBe('unproven');
+  });
+});

--- a/packages/agent-cli/src/remote-control/local-peer-rendezvous.ts
+++ b/packages/agent-cli/src/remote-control/local-peer-rendezvous.ts
@@ -1,0 +1,73 @@
+/**
+ * SEC-010 composition (#1862): WHERE the guarded rendezvous lives, and who tears it down.
+ *
+ * The security leaf owns what `guarded` MEANS and how to build one; it deliberately knows nothing
+ * about this host's layout. Choosing the path is composition, and composition is this package.
+ *
+ * ## Why the runtime directory is preferred over the home directory
+ *
+ * `XDG_RUNTIME_DIR` is created by the system per login session, already `0700`, and — the part that
+ * matters — it is REMOVED when the last session of that user ends. A rendezvous is only meaningful
+ * while a session is alive, so a location the system cleans up is a better fit than one that
+ * accumulates: a stale socket under `~/.robota` outlives the process that made it and the next run
+ * has to reason about whether it is live.
+ *
+ * The home directory is the fallback rather than the default for the same reason it is the right
+ * fallback: this package already keeps host identity and trusted devices under `~/.robota`, so a
+ * host with no runtime directory (a bare container, a non-systemd Unix, Windows) still has a
+ * per-user place that exists. `ensureGuardedDirectory` then does the work the runtime directory
+ * would have done for free — create it, force the mode, and verify.
+ *
+ * Neither branch is trusted: whichever path is chosen goes through the same judge. That is the
+ * point of choosing here and validating there — a location decision cannot accidentally become a
+ * security decision.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  ensureGuardedDirectory,
+  type ILocalPeerAdmission,
+} from '@robota-sdk/agent-remote-pairing/local';
+
+/** Directory name under whichever root is chosen. */
+const RENDEZVOUS_DIR = 'peers';
+
+export interface IRendezvousLocationOptions {
+  /** Environment to read `XDG_RUNTIME_DIR` from. Injected so the choice is testable. */
+  readonly env?: NodeJS.ProcessEnv;
+  /** Home directory resolver, injected for the same reason. */
+  readonly home?: () => string;
+}
+
+/**
+ * The path this host should use, without creating anything.
+ *
+ * Separate from creation so a diagnostic can report where the rendezvous WOULD be without the side
+ * effect of making it — `robota diagnose` should be able to say what it inspected.
+ */
+export function resolveRendezvousDirectory(options: IRendezvousLocationOptions = {}): string {
+  const env = options.env ?? process.env;
+  const runtimeDir = env['XDG_RUNTIME_DIR'];
+  if (runtimeDir !== undefined && runtimeDir.trim().length > 0) {
+    return join(runtimeDir, 'robota', RENDEZVOUS_DIR);
+  }
+  return join((options.home ?? homedir)(), '.robota', RENDEZVOUS_DIR);
+}
+
+/**
+ * Create the rendezvous directory for this host and verify it, or say why it is not usable.
+ *
+ * Returns the security leaf's own admission shape rather than a boolean, so a caller cannot lose
+ * the distinction between "usable" and "usable, and here is what was established". A refusal here
+ * means local peering is unavailable — it is not a reason to fall back to an unguarded directory,
+ * which would be the copyable-credential failure SEC-010 exists to prevent, wearing a path.
+ */
+export function ensureRendezvousDirectory(
+  options: IRendezvousLocationOptions = {},
+): ILocalPeerAdmission {
+  return ensureGuardedDirectory(resolveRendezvousDirectory(options), {
+    expectedUid: process.getuid?.() ?? 0,
+  });
+}


### PR DESCRIPTION
First half of #1862 — the location decision, which is the one that had to be made before anything else in that issue can be built.

The security leaf owns what `guarded` **means** and how to build one, and deliberately knows nothing about this host's layout. Choosing the path is composition, and composition is this package.

## Why the runtime directory wins, and it is not about permissions

`XDG_RUNTIME_DIR` is already `0700` — but so is a directory we create ourselves. What decides it is **lifetime**: the system removes it when the user's last session ends.

A rendezvous is only meaningful while a session is alive. A location the system cleans up beats one that accumulates: a stale socket under `~/.robota` outlives the process that made it, and the next run has to reason about whether it is live.

The home directory is the **fallback**, for the same reason it is the right fallback — this package already keeps host identity and trusted devices there, so a host with no runtime directory (a bare container, a non-systemd Unix, Windows) still has a per-user place that exists. `ensureGuardedDirectory` then does by hand what the runtime directory would have done for free.

## Neither branch is trusted

Whichever path is chosen goes through **the same judge**. That is the point of choosing here and validating there: a location decision must not be able to become a security decision by accident.

## A refusal is terminal

If the directory cannot be made or does not verify, local peering is unavailable. It is **not** a reason to fall back to a merely-writable directory — that would be the copyable-credential failure SEC-010 exists to prevent, wearing a path.

## Two details worth the lines

- **Resolution is separate from creation**, so a diagnostic can report where the rendezvous *would* be without the side effect of making it.
- **A blank `XDG_RUNTIME_DIR` is treated as absent**, not as a root. `join('', 'robota', 'peers')` is a *relative* path — it would be created wherever the process happened to be running. Found while writing the test for it.

## Still open on #1862

Issuing grants at the rendezvous, wiring `localPeer` into the transport, the peer side that presents the proof frame, and revocation on shutdown.

## Verification

5 new tests; 311 `agent-cli` tests green; `pnpm harness:scan` — 124 passed, 2 skipped; typecheck and format-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD