### PR TITLE
feat(agent-cli): local peer discovery, and how a crashed session is told from a live one (#1863)

### DIFF
--- a/packages/agent-cli/src/remote-control/__tests__/local-peer-registry.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/local-peer-registry.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  announcePeer,
+  listPeers,
+  listReachablePeers,
+  withdrawPeer,
+} from '../local-peer-registry.js';
+
+/**
+ * #1863 — discovery over the guarded rendezvous.
+ *
+ * The directory's permissions do the security work; these tests are about the part that is NOT
+ * security: telling a live session from a file a crashed one left behind.
+ */
+const made: string[] = [];
+
+function scratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'robota-reg-'));
+  made.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (made.length > 0) {
+    const dir = made.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** A start-time reader whose answers the test controls. */
+function starts(map: Record<number, string | undefined>) {
+  return (pid: number): string | undefined => map[pid];
+}
+
+describe('#1863 — announcing and withdrawing', () => {
+  it('publishes an entry a peer can read back', () => {
+    const guardedDirectory = scratch();
+    const opts = { guardedDirectory, readStartTime: starts({ 100: 'T1' }), now: () => 5 };
+
+    announcePeer(opts, { sessionId: 'session_a', name: 'alice', pid: 100 });
+
+    const [found] = listPeers(opts);
+    expect(found?.entry.sessionId).toBe('session_a');
+    expect(found?.entry.name).toBe('alice');
+    expect(found?.liveness).toBe('alive');
+  });
+
+  it('writes the entry owner-only', () => {
+    const guardedDirectory = scratch();
+    const opts = { guardedDirectory, readStartTime: starts({ 100: 'T1' }) };
+
+    announcePeer(opts, { sessionId: 'session_a', pid: 100 });
+
+    const file = readdirSync(guardedDirectory)[0];
+    expect(statSync(join(guardedDirectory, file)).mode & 0o777).toBe(0o600);
+  });
+
+  it('leaves no temporary file behind — a reader must never see a partial entry', () => {
+    const guardedDirectory = scratch();
+    const opts = { guardedDirectory, readStartTime: starts({ 100: 'T1' }) };
+
+    announcePeer(opts, { sessionId: 'session_a', pid: 100 });
+
+    expect(readdirSync(guardedDirectory).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('withdrawing removes it, and withdrawing again is not an error', () => {
+    const guardedDirectory = scratch();
+    const opts = { guardedDirectory, readStartTime: starts({ 100: 'T1' }) };
+    announcePeer(opts, { sessionId: 'session_a', pid: 100 });
+
+    withdrawPeer(opts, 'session_a');
+    withdrawPeer(opts, 'session_a');
+
+    expect(listPeers(opts)).toEqual([]);
+  });
+});
+
+describe('#1863 — telling a live session from a crashed one', () => {
+  it('a pid that is gone is dead', () => {
+    const guardedDirectory = scratch();
+    announcePeer(
+      { guardedDirectory, readStartTime: starts({ 100: 'T1' }) },
+      { sessionId: 'session_a', pid: 100 },
+    );
+
+    const [found] = listPeers({ guardedDirectory, readStartTime: starts({}) });
+
+    expect(found?.liveness).toBe('dead');
+  });
+
+  it('A RECYCLED PID IS DEAD, NOT ALIVE — the case a pid check alone gets wrong', () => {
+    // The dangerous direction: without the start time, an unrelated process that happened to
+    // inherit the pid would be treated as the peer that crashed.
+    const guardedDirectory = scratch();
+    announcePeer(
+      { guardedDirectory, readStartTime: starts({ 100: 'T1' }) },
+      { sessionId: 'session_a', pid: 100 },
+    );
+
+    const [found] = listPeers({ guardedDirectory, readStartTime: starts({ 100: 'T2' }) });
+
+    expect(found?.liveness).toBe('dead');
+  });
+
+  it('a platform that cannot answer reports unknown, not alive and not dead', () => {
+    // Collapsing "could not tell" into either verdict is how a non-Linux host reports every peer as
+    // dead, or how a peer that is gone gets offered as a destination.
+    const guardedDirectory = scratch();
+    announcePeer(
+      { guardedDirectory, readStartTime: starts({}) },
+      { sessionId: 'session_a', pid: 100 },
+    );
+
+    const [found] = listPeers({ guardedDirectory, readStartTime: starts({}) });
+
+    expect(found?.liveness).toBe('unknown');
+  });
+
+  it('only alive peers are offered as destinations', () => {
+    // An `unknown` peer must not be addressable: the message would be delivered to nothing while
+    // the sender holds an ack for it.
+    const guardedDirectory = scratch();
+    const known = { guardedDirectory, readStartTime: starts({ 100: 'T1' }) };
+    announcePeer(known, { sessionId: 'live', pid: 100 });
+    announcePeer({ guardedDirectory, readStartTime: starts({}) }, { sessionId: 'murky', pid: 200 });
+
+    const reachable = listReachablePeers(known).map((e) => e.sessionId);
+
+    expect(reachable).toEqual(['live']);
+  });
+});
+
+describe('#1863 — a malformed entry is not a peer', () => {
+  it('skips unparseable and shape-invalid files rather than surfacing them', () => {
+    const guardedDirectory = scratch();
+    writeFileSync(join(guardedDirectory, 'broken.peer.json'), '{not json', 'utf8');
+    writeFileSync(join(guardedDirectory, 'shapeless.peer.json'), '{"sessionId":1}', 'utf8');
+    writeFileSync(join(guardedDirectory, 'unrelated.txt'), 'x', 'utf8');
+
+    expect(listPeers({ guardedDirectory, readStartTime: starts({}) })).toEqual([]);
+  });
+});

--- a/packages/agent-cli/src/remote-control/local-peer-registry.ts
+++ b/packages/agent-cli/src/remote-control/local-peer-registry.ts
@@ -1,0 +1,158 @@
+/**
+ * #1863: how one live session learns another is reachable.
+ *
+ * A session announces itself by writing one file into the guarded rendezvous directory; discovery
+ * is reading that directory. The directory's permissions do the security work — only this user on
+ * this machine could have written there — so an entry's presence already carries `same-user-
+ * same-host`, and this module never re-decides that.
+ *
+ * ## The hard part is not writing entries, it is knowing which are dead
+ *
+ * A crashed session leaves its file behind. An entry is therefore a CLAIM about liveness, and the
+ * question is what evidence settles it. Three candidates, and why the third wins:
+ *
+ * 1. **A timestamp with a staleness window.** Cheap and wrong at both ends: a session that is idle
+ *    but alive looks dead, and one that died a second ago looks alive.
+ * 2. **The pid alone.** Pid reuse is real, and the failure it produces is the dangerous direction —
+ *    an unrelated process inherits a dead session's identity and is treated as a peer.
+ * 3. **The pid, checked with a start-time recorded at announce.** Pid reuse changes the start time,
+ *    so a recycled pid fails the check. This is what `/proc/<pid>/stat`'s start field is for on
+ *    Linux, and where it is unavailable the entry degrades to `unknown` rather than to `alive`.
+ *
+ * `unknown` is a real state and not a synonym for either answer. A caller may show it to an
+ * operator; what it must not do is treat it as reachable, which is why `listReachablePeers` filters
+ * to `alive` and the raw listing keeps the distinction.
+ *
+ * ## Writing is atomic
+ *
+ * A reader can arrive mid-write. Entries are written to a temporary name in the same directory and
+ * renamed into place, so a partial file is never a discoverable peer — `rename` within one
+ * directory is atomic on every filesystem this runs on.
+ */
+
+import { readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** What a session publishes about itself. */
+export interface IPeerEntry {
+  readonly sessionId: string;
+  /** Display name, if the session has one. Never an authorization input. */
+  readonly name?: string;
+  readonly pid: number;
+  /** Process start time, so a recycled pid does not inherit this entry. */
+  readonly startedAt: string;
+  readonly announcedAt: number;
+}
+
+/** Whether the process behind an entry is still running. */
+export type TPeerLiveness = 'alive' | 'dead' | 'unknown';
+
+export interface IDiscoveredPeer {
+  readonly entry: IPeerEntry;
+  readonly liveness: TPeerLiveness;
+}
+
+export interface IRegistryOptions {
+  /** The verified guarded directory. */
+  readonly guardedDirectory: string;
+  /** Reads a process's start time, or undefined when the platform cannot answer. Injected. */
+  readonly readStartTime?: (pid: number) => string | undefined;
+  readonly now?: () => number;
+}
+
+const ENTRY_SUFFIX = '.peer.json';
+
+/**
+ * Read a process's start time from `/proc`.
+ *
+ * Returns undefined rather than throwing when the process is gone or the platform has no `/proc` —
+ * "no answer" and "not running" are different, and collapsing them here would make a
+ * non-Linux host report every peer as dead.
+ */
+function readProcStartTime(pid: number): string | undefined {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    // Field 22 is starttime. The comm field can contain spaces and parentheses, so the split is
+    // anchored on the LAST ')' rather than on whitespace — splitting naively mis-indexes every
+    // field for a process whose name contains a space.
+    const afterComm = stat.slice(stat.lastIndexOf(')') + 2);
+    return afterComm.split(' ')[19];
+  } catch {
+    // allow-fallback: this substitutes no alternative value — undefined means "could not tell",
+    // which the caller maps to `unknown` rather than to either verdict.
+    return undefined;
+  }
+}
+
+/** Announce this session, atomically. Returns the entry as published. */
+export function announcePeer(
+  options: IRegistryOptions,
+  input: { sessionId: string; name?: string; pid?: number },
+): IPeerEntry {
+  const pid = input.pid ?? process.pid;
+  const readStartTime = options.readStartTime ?? readProcStartTime;
+  const entry: IPeerEntry = {
+    sessionId: input.sessionId,
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    pid,
+    startedAt: readStartTime(pid) ?? '',
+    announcedAt: (options.now ?? Date.now)(),
+  };
+  const target = join(options.guardedDirectory, `${input.sessionId}${ENTRY_SUFFIX}`);
+  const temporary = `${target}.${pid}.tmp`;
+  writeFileSync(temporary, JSON.stringify(entry), { encoding: 'utf8', mode: 0o600 });
+  renameSync(temporary, target);
+  return entry;
+}
+
+/** Withdraw this session's entry. Absent is success — the goal is that it is not there. */
+export function withdrawPeer(options: IRegistryOptions, sessionId: string): void {
+  rmSync(join(options.guardedDirectory, `${sessionId}${ENTRY_SUFFIX}`), { force: true });
+}
+
+function judgeLiveness(
+  entry: IPeerEntry,
+  readStartTime: (pid: number) => string | undefined,
+): TPeerLiveness {
+  const current = readStartTime(entry.pid);
+  if (current === undefined) return entry.startedAt === '' ? 'unknown' : 'dead';
+  if (entry.startedAt === '') return 'unknown';
+  return current === entry.startedAt ? 'alive' : 'dead';
+}
+
+/**
+ * Every entry in the rendezvous, with a liveness verdict for each.
+ *
+ * An unreadable or malformed entry is SKIPPED rather than reported as a peer: it is not evidence of
+ * anything, and surfacing it would invite a caller to act on a shape nobody wrote.
+ */
+export function listPeers(options: IRegistryOptions): readonly IDiscoveredPeer[] {
+  const readStartTime = options.readStartTime ?? readProcStartTime;
+  const out: IDiscoveredPeer[] = [];
+  for (const file of readdirSync(options.guardedDirectory)) {
+    if (!file.endsWith(ENTRY_SUFFIX)) continue;
+    let entry: IPeerEntry;
+    try {
+      entry = JSON.parse(readFileSync(join(options.guardedDirectory, file), 'utf8')) as IPeerEntry;
+    } catch {
+      // allow-fallback: a malformed entry is not a peer and not an alternative peer — it is skipped.
+      continue;
+    }
+    if (typeof entry?.sessionId !== 'string' || typeof entry?.pid !== 'number') continue;
+    out.push({ entry, liveness: judgeLiveness(entry, readStartTime) });
+  }
+  return out.sort((a, b) => a.entry.sessionId.localeCompare(b.entry.sessionId));
+}
+
+/**
+ * The peers a caller may actually address.
+ *
+ * `unknown` is deliberately excluded. A session that cannot be shown to be running must not be
+ * offered as a destination — the message would be delivered to nothing and the sender would hold an
+ * ack for it.
+ */
+export function listReachablePeers(options: IRegistryOptions): readonly IPeerEntry[] {
+  return listPeers(options)
+    .filter((p) => p.liveness === 'alive')
+    .map((p) => p.entry);
+}


### PR DESCRIPTION
First half of #1863. A session announces itself by writing one file into the guarded rendezvous; discovery is reading that directory.

The directory's permissions do the security work — only this user on this machine could have written there — so an entry's presence already carries the trust level, and this module never re-decides it.

## The hard part is not writing entries, it is knowing which are dead

A crashed session leaves its file behind, so an entry is a **claim** about liveness. Three ways to settle it:

| Approach | Why not |
| --- | --- |
| A timestamp with a staleness window | Wrong at **both** ends — an idle-but-alive session looks dead, one that died a second ago looks alive |
| The pid alone | Pid reuse is real, and it fails in the **dangerous** direction: an unrelated process inherits a dead session's identity and is treated as a peer |
| **The pid checked against a start time recorded at announce** | Reuse changes the start time, so a recycled pid fails the check |

**Red-proofed**: removing the start-time comparison fails exactly the recycled-pid test and nothing else.

## `unknown` is a real state, not a synonym

A platform with no `/proc` cannot tell. Collapsing that into `dead` makes every peer on such a host invisible; collapsing it into `alive` offers a destination that is not there.

`listReachablePeers` excludes it deliberately — a message to a session that cannot be shown to be running would be **delivered to nothing while its sender holds an ack for it**. The raw listing keeps the distinction so a caller can still show it to an operator.

## Two details worth the lines

- **Writes are atomic.** A reader can arrive mid-write, so entries are written under a temporary name in the same directory and renamed into place. A partial file is never a discoverable peer.
- **The `/proc/<pid>/stat` parse is anchored on the last `)`**, not split on whitespace. The `comm` field can contain spaces and parentheses, and a naive split mis-indexes every field after it for a process whose name has a space in it.

A malformed entry is skipped rather than surfaced: it is not evidence of anything, and reporting it would invite a caller to act on a shape nobody wrote.

## Still open on #1863

The `agent-cli` command that addresses a discovered session, TUI projection of peer origin, and the CLI documentation.

## Verification

9 new tests; `pnpm harness:scan` — 124 passed, 2 skipped; typecheck and format-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD