### PR TITLE
fix(harness): restore receipt eligibility, and file the scan-suite duplicate-run gap (HARNESS-109)

### DIFF
--- a/.agents/tasks/HARNESS-109-scan-suite-results-are-not-reusable.md
+++ b/.agents/tasks/HARNESS-109-scan-suite-results-are-not-reusable.md
@@ -1,0 +1,77 @@
+---
+title: 'HARNESS-109: the scan suite leaves no receipt, and one untracked file blocks the receipt that exists'
+status: todo
+created: 2026-08-19
+priority: high
+urgency: soon
+area: scripts/harness
+depends_on: []
+---
+
+# HARNESS-109: an identical tree is verified over and over, and nothing notices
+
+## The gap
+
+`verification-receipt.mjs` exists precisely so that an identical tree is not re-verified: it keys a
+receipt on `headCommit` + `headTree` + base + toolchain + lockfile + owner fingerprint, `verify-like-ci`
+writes it, and `pre-push` reuses it. Two holes make it miss the most repeated run in an agent session.
+
+**1. `pnpm harness:scan` neither writes nor reads a receipt.** The scan suite is the single most
+re-run local command — `pre-push` runs it on every push through `CI_SCANS_JOB_MIRROR`, the CI `scans`
+job runs it again, and an agent runs it by hand whenever it wants a signal. Nothing connects those
+runs. Scanning the same tree three times is indistinguishable, to the harness, from scanning three
+different trees.
+
+**2. One untracked file makes the whole clone receipt-ineligible.** `isCleanTree()` is false whenever
+`git status --porcelain --untracked-files=all` shows anything outside `AUTO_GENERATED_CHURN`, and
+`.claude/settings.local.json` — written by the agent harness itself, present in every agent clone,
+absent from `.gitignore` — is outside it. So `readVerificationReceipt()` returns `null` for the whole
+session and **every** push re-runs the full gate.
+
+This is the second instance of the failure class the module's own header records: the lessons churn
+left `readVerificationReceipt()` at `null` across five consecutive PASS runs. That instance was closed
+by naming the two files. Naming files one at a time is what made a second instance possible.
+
+## Measured — 2026-08-19, this clone
+
+```
+realDirtyLines: ["?? .claude/settings.local.json"]
+isCleanTree:    false
+receipt:        null
+```
+
+The only dirt in the tree is a file the agent harness writes and no one commits. Session evidence:
+resolving a three-line JSON conflict on PR #1860 ran the full 126-scan suite twice on trees whose
+scanned content was identical, and both runs were themselves redundant with the scan suite the push
+gate then ran a third time. No mechanism could see any of it.
+
+## Direction
+
+- **Ignore what the harness writes.** `.claude/settings.local.json` belongs in `.gitignore` — it is
+  per-clone agent configuration, never committed. This restores receipt eligibility for every agent
+  clone, and is independently measurable through `isCleanTree()` before and after.
+- **Prefer a rule over a list.** The receipt's cleanliness test should treat harness-owned, never-
+  committed paths as a declared CLASS, so the next such file does not silently re-open the hole.
+  `AUTO_GENERATED_CHURN` stays for tracked files that regenerate.
+- **Give the scan suite the receipt treatment.** `run-all-scans.mjs` writes a receipt on a clean pass
+  and reuses one whose identity matches, so `pre-push`'s scans mirror and a hand-run share one result.
+  The failure mode to design against is a receipt reused when the tree differs: identity must cover
+  what the suite actually reads, and an unreadable or partial receipt must re-run, never pass.
+
+## Not in scope
+
+Running a diff-scoped SUBSET of the suite. `pre-push.mjs` records the deliberate decision that the
+whole suite runs because it is cheap relative to CI; this item removes the DUPLICATE run, it does not
+reopen that trade-off.
+
+## Done when
+
+- [ ] `isCleanTree()` is true in a fresh agent clone whose only dirt is harness-written config, proved
+      by a test that plants the file and asserts eligibility.
+- [ ] A second `pnpm harness:scan` on an unchanged clean tree does not re-run the suite, and says so.
+- [ ] `pre-push` reuses a hand-run's scan receipt, and a changed tree provably does not — red-first.
+- [ ] A receipt that is missing, malformed, or written by a different toolchain re-runs the suite.
+
+## Result
+
+Pending.

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,10 @@ stryker.log
 # the only place that can say so is a file the next reader will actually see. Ignoring the
 # explanation along with the data is how a demoted artefact keeps looking authoritative.
 !.agents/local-reviews/README.md
+
+# HARNESS-109: per-clone agent-harness configuration, written by the tool and never committed.
+# Not merely noise: `verification-receipt.mjs` refuses to stand behind a receipt while the tree is
+# dirty, so an untracked file present in EVERY agent clone made `readVerificationReceipt()` return
+# null for whole sessions and every push re-ran the full gate — the same regression its header
+# records for the lessons churn.
+.claude/settings.local.json


### PR DESCRIPTION
## What was measured

`scripts/harness/verification-receipt.mjs` exists so an identical tree is not verified twice. In this
clone it could not do that job at all:

```
realDirtyLines: ["?? .claude/settings.local.json"]
isCleanTree:    false
receipt:        null
```

`isCleanTree()` counts every untracked path outside `AUTO_GENERATED_CHURN` as dirt, and
`.claude/settings.local.json` — written by the agent harness itself, present in every agent clone,
absent from `.gitignore` — is one. So the receipt was never written, and **every push re-ran the full
gate**.

This is the second instance of the failure class that file's own header records: the lessons churn
left the receipt null across five consecutive PASS runs. That instance was closed by naming two files.
Naming files one at a time is what made a second instance possible.

## What this PR does

- `.gitignore` — ignore `.claude/settings.local.json`. Measured effect: `isCleanTree()` **false → true**.
- `.agents/tasks/HARNESS-109-…` — files the two halves this one-line fix does NOT close:
  1. the cleanliness test should treat harness-owned never-committed paths as a declared **class**, so
     the next such file does not silently re-open the hole;
  2. `pnpm harness:scan` neither writes nor reads a receipt, so the most re-run command in a session
     cannot tell three scans of one tree from three different trees.

## Where it came from

Resolving a three-line JSON conflict on #1860 ran the full 126-scan suite twice on trees whose scanned
content was identical, and both runs were redundant with the suite the push gate then ran a third time.
No mechanism could see any of it. Explicitly **not** in scope: running a diff-scoped subset —
`scripts/harness/pre-push.mjs` records the deliberate decision that the whole suite runs because it is
cheap relative to CI. This removes the duplicate run, it does not reopen that trade-off.

## Verification

`isCleanTree()` before and after, quoted above. Sweep verification is this push's own scan run, not a
hand-run sweep — which is the behaviour the item is about.
