### PR TITLE
fix(agent-command-workflows): the model could run an arbitrary on-disk workflow (#1872)

### DIFF
--- a/.agents/tasks/CMD-006-workflows-subcommand-model-gating-is-decorative.md
+++ b/.agents/tasks/CMD-006-workflows-subcommand-model-gating-is-decorative.md
@@ -1,6 +1,6 @@
 ---
 title: 'CMD-006: /workflows per-subcommand modelInvocable:false is decorative — a model can auto-run an arbitrary on-disk workflow (LLM/http/file nodes) with no permission gate'
-status: todo
+status: in-progress
 created: 2026-08-13
 priority: critical
 urgency: now

--- a/packages/agent-command-workflows/src/__tests__/model-cannot-run-workflows.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/model-cannot-run-workflows.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createWorkflowsCommandModule } from '../workflows-command-module.js';
+
+import type { ICommandHostContext } from '@robota-sdk/agent-framework';
+import type { TCommandInvocationSource } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * CMD-006 — the per-subcommand `modelInvocable` flag must actually gate the model path.
+ *
+ * It was DECORATIVE: declared in the registry and read by nothing. The framework gates the model
+ * path per TOP-LEVEL command name, and `/workflows` is model-invocable because the model is meant
+ * to author workflows — so a model-issued `workflows run <file>` inherited that and executed an
+ * arbitrary on-disk DAG (LLM, http and file nodes) with no prompt.
+ *
+ * These assert the gate on the DISPATCHER, which is where the per-subcommand flag can be read at
+ * all — the framework only ever sees `robota_command_workflows` with a free-form args string.
+ */
+function hostContext(source: TCommandInvocationSource, cwd = '/w'): ICommandHostContext {
+  // The command's `execute` takes the FULL host context, while the dispatcher reads only the two
+  // workspace members. A double carrying just those is honest about what is exercised — the cast is
+  // to the signature, not to a pretence that this is a session.
+  return {
+    getCwd: () => cwd,
+    getCommandInvocationSource: () => source,
+  } as unknown as ICommandHostContext;
+}
+
+function systemCommand() {
+  const [command] = createWorkflowsCommandModule({}).systemCommands ?? [];
+  if (command === undefined) throw new Error('the workflows module registered no system command');
+  return command;
+}
+
+describe('CMD-006 — a model may not execute an on-disk workflow', () => {
+  it.each(['run', 'validate', 'list', 'catalog'])(
+    'refuses `workflows %s` from the model',
+    async (sub) => {
+      const result = await systemCommand().execute(hostContext('model'), `${sub} some.dag.json`);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('may not run');
+    },
+  );
+
+  it('the refusal says WHY, and what to do instead', async () => {
+    // A refusal an operator cannot act on is a dead end. This one names the reason (the subcommand
+    // executes or inspects an on-disk workflow) and the two ways forward.
+    const result = await systemCommand().execute(hostContext('model'), 'run some.dag.json');
+
+    expect(result.message).toContain('LLM, http and');
+    expect(result.message).toContain('workflows create');
+  });
+
+  it('the model may still AUTHOR — `create` is what it is meant to use', async () => {
+    const result = await systemCommand().execute(hostContext('model'), 'create');
+
+    expect(result.message ?? '').not.toContain('may not run');
+  });
+
+  it('a user-typed `workflows run` is NOT gated by this', async () => {
+    // The gate is about WHO asked, not about what the subcommand does. An operator running their
+    // own workflow is the feature.
+    const result = await systemCommand().execute(hostContext('user'), 'run missing.dag.json');
+
+    expect(result.message ?? '').not.toContain('may not run');
+  });
+
+  it('an unknown subcommand still gets the dispatcher’s own answer, not this gate', async () => {
+    // One place decides what exists. A gate that also answered "unknown" would be a second
+    // vocabulary to keep in step.
+    const result = await systemCommand().execute(hostContext('model'), 'nonsense');
+
+    expect(result.message).toContain('Unknown subcommand');
+  });
+});

--- a/packages/agent-command-workflows/src/__tests__/model-cannot-run-workflows.test.ts
+++ b/packages/agent-command-workflows/src/__tests__/model-cannot-run-workflows.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createWorkflowsCommandModule } from '../workflows-command-module.js';
 
-import type { ICommandHostContext } from '@robota-sdk/agent-framework';
+import { createTestCommandHost } from '@robota-sdk/agent-framework/testing';
+
 import type { TCommandInvocationSource } from '@robota-sdk/agent-interface-transport';
 
 /**
@@ -16,14 +17,17 @@ import type { TCommandInvocationSource } from '@robota-sdk/agent-interface-trans
  * These assert the gate on the DISPATCHER, which is where the per-subcommand flag can be read at
  * all — the framework only ever sees `robota_command_workflows` with a free-form args string.
  */
-function hostContext(source: TCommandInvocationSource, cwd = '/w'): ICommandHostContext {
-  // The command's `execute` takes the FULL host context, while the dispatcher reads only the two
-  // workspace members. A double carrying just those is honest about what is exercised — the cast is
-  // to the signature, not to a pretence that this is a session.
-  return {
-    getCwd: () => cwd,
-    getCommandInvocationSource: () => source,
-  } as unknown as ICommandHostContext;
+/**
+ * The published conformant double, with only the capability under test overridden.
+ *
+ * A hand-rolled partial cast to the host contract would be a re-implementation nothing checks
+ * against the real one — and the contract-cast ratchet says so, which is how the first draft of
+ * this file was caught. The return type is inferred rather than annotated with the aggregate, for
+ * the reason the aggregate-naming scan gives: naming it takes the whole surface instead of the role
+ * actually used.
+ */
+function hostContext(source: TCommandInvocationSource, cwd = '/w') {
+  return createTestCommandHost({ cwd, overrides: { getCommandInvocationSource: () => source } });
 }
 
 function systemCommand() {

--- a/packages/agent-command-workflows/src/workflows-command-module.ts
+++ b/packages/agent-command-workflows/src/workflows-command-module.ts
@@ -43,6 +43,31 @@ function splitSubcommand(args: string): { sub: string; rest: string } {
   return { sub: trimmed.slice(0, spaceIdx), rest: trimmed.slice(spaceIdx + 1).trim() };
 }
 
+/**
+ * Refuse a subcommand the registry marks non-model-invocable when the MODEL is the caller.
+ *
+ * Returns `undefined` when there is nothing to refuse, so the dispatcher reads as "gate, then
+ * dispatch" rather than as a branch a reader has to hold in their head.
+ *
+ * An unknown subcommand is NOT refused here — it falls through to the dispatcher's own "Unknown
+ * subcommand" answer, which is a better message and keeps one place deciding what exists.
+ */
+function refuseUngatedModelSubcommand(
+  sub: string,
+  context: ICommandHostWorkspace,
+): ICommandResult | undefined {
+  if (context.getCommandInvocationSource() !== 'model') return undefined;
+  const entry = WORKFLOWS_SUBCOMMANDS.find((candidate) => candidate.name === sub);
+  if (entry === undefined || entry.modelInvocable !== false) return undefined;
+  return {
+    success: false,
+    message:
+      `The model may not run \`workflows ${sub}\`. It is registered as non-model-invocable ` +
+      'because it executes or inspects an on-disk workflow, and a workflow can carry LLM, http and ' +
+      'file nodes. Ask the operator to run it, or use `workflows create` to author one.',
+  };
+}
+
 async function executeWorkflowsCommand(
   context: ICommandHostWorkspace,
   args: string,
@@ -51,6 +76,20 @@ async function executeWorkflowsCommand(
 ): Promise<ICommandResult> {
   const { sub, rest } = splitSubcommand(args);
   const cwd = context.getCwd();
+
+  // CMD-006: the per-subcommand `modelInvocable` flag was DECORATIVE — declared in the registry and
+  // read by nothing. The framework gates the model path per TOP-LEVEL command name, and this
+  // command is model-invocable (the model is meant to author workflows), so a model-issued
+  // `workflows run <file>` inherited that and executed an arbitrary on-disk DAG — LLM, http and
+  // file nodes — with no prompt.
+  //
+  // Enforced HERE rather than in the framework because the flag is per-subcommand and only this
+  // dispatcher knows which subcommand an args string names. Read from the same registry that
+  // declares it, so the two cannot drift: a subcommand added as `modelInvocable: false` is gated by
+  // existing to be found, not by someone remembering to add a case.
+  const refusal = refuseUngatedModelSubcommand(sub, context);
+  if (refusal !== undefined) return refusal;
+
   switch (sub) {
     case '':
       return { success: true, message: USAGE };


### PR DESCRIPTION
Closes #1872 (CMD-006 — `critical` / `now`, and the highest-urgency backlog item that had no issue against it).

## The defect

`run`, `validate`, `list` and `catalog` are registered `modelInvocable: false`. **Nothing read that flag.**

The framework gates the model path per **top-level** command name, and `/workflows` is model-invocable — deliberately, because the model is meant to *author* workflows. So a model-issued `workflows run <file>` inherited that, was auto-approved (`requiresPermission: false`), and executed an arbitrary on-disk DAG carrying **LLM, http and file nodes**. No prompt.

The declaration existed; the enforcement did not. Same shape as the comment promising a warning it never emitted (#1831) and the floor reporting "passed" while examining 4% of the tree (#1851) — except this one is a **security boundary**.

## Why it could not be fixed in the framework

The flag is **per-subcommand**, and the framework only ever sees `robota_command_workflows` with a free-form `args` string. It cannot know which subcommand that string names. The dispatcher is the first place that can.

## What the gate does and does not do

- **Reads from the registry that declares the flag**, so the two cannot drift. A subcommand added as `modelInvocable: false` is gated *by existing to be found*, not by someone remembering a second list.
- **The authoring path stays open.** `create` is what the model is meant to use; closing it would have removed the feature rather than secured it.
- **A user-typed `workflows run` is untouched.** The gate is about *who asked*.
- **An unknown subcommand falls through** to the dispatcher's own answer — one place decides what exists.
- **The refusal is actionable**: it names why, and the two ways forward.

## Two harness ratchets caught the test fixture, and both were right

Worth recording, because the fix is instructive rather than incidental:

1. **contract-cast** — the first draft hand-rolled a two-member partial and cast it to the host contract. That is a re-implementation nothing checks against the real one, so it keeps compiling after the contract gains a member it does not answer. Replaced with the published `createTestCommandHost` double, overriding only the invocation source.
2. **aggregate-naming** — annotating the helper's return type with the aggregate takes the whole surface instead of the role used. The type is now inferred.

## Verification

- 8 tests; **red-proofed** — removing the gate fails five, and the three that still pass are the paths the gate is not about
- `pnpm harness:scan` — 125 passed, 1 skipped; typecheck and format-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD