### PR TITLE
docs(tasks): complete CMD-006 — the model gate is enforced, not just declared

### DIFF
--- a/.agents/tasks/completed/CMD-006-workflows-subcommand-model-gating-is-decorative.md
+++ b/.agents/tasks/completed/CMD-006-workflows-subcommand-model-gating-is-decorative.md
@@ -1,7 +1,8 @@
 ---
 title: 'CMD-006: /workflows per-subcommand modelInvocable:false is decorative — a model can auto-run an arbitrary on-disk workflow (LLM/http/file nodes) with no permission gate'
-status: in-progress
+status: done
 created: 2026-08-13
+completed: 2026-08-19
 priority: critical
 urgency: now
 area: packages/agent-command-workflows, packages/agent-framework
@@ -36,6 +37,23 @@ auto-approved and executes an arbitrary on-disk DAG.
   `executeWorkflowsRun` → `run-command.ts`, which resolves the path against cwd and executes the DAG
   (LLM/http/file/in-process-tool nodes) with no gate. The only permission seam is an opt-in
   `remoteCommandPolicy` that applies to `source === 'remote'`, not the model path.
+
+## Resolution
+
+Fixed in [#1877](https://github.com/woojubb/robota/pull/1877), filed as
+[issue #1872](https://github.com/woojubb/robota/issues/1872).
+
+The gate lives in `executeWorkflowsCommand` and reads `WORKFLOWS_SUBCOMMANDS` — the same registry
+that declares the flag. That is the part worth keeping: a subcommand added as
+`modelInvocable: false` is gated BY EXISTING TO BE FOUND, not by someone remembering to add a case
+to a second list. A gate with its own copy of the list would have been the same defect one layer up.
+
+`create` stays open (it is what the model is meant to use), a user-typed `run` is untouched (the
+gate is about who asked), and an unknown subcommand still gets the dispatcher's own answer.
+
+Two harness ratchets caught the test fixture and both were right — a hand-rolled partial cast to the
+host contract (contract-cast), and naming the aggregate in a return type (aggregate-naming). Both
+replaced with the published conformant double and an inferred type.
 
 ## Direction
 


### PR DESCRIPTION
Docs only. Lifecycle completion for CMD-006, fixed in #1877 and closed as #1872.

Status to `done` and moved to `completed/` in the same commit, per the lifecycle rule.

## What the Resolution section records

Not just that it was fixed — **the property that makes it a fix rather than another declaration**: the gate reads the *same registry that declares the flag*, so a subcommand added as `modelInvocable: false` is gated **by existing to be found**.

A gate carrying its own copy of the list would have been this exact defect one layer up — a declaration nothing checks against.

## And the two ratchet corrections

Both are reusable beyond this item, so they are recorded rather than left in a PR description:

- A hand-rolled partial cast to a contract keeps compiling after that contract gains a member it does not answer. Use the published conformant double.
- Naming an aggregate in a return type takes the whole surface instead of the role actually used.

`pnpm harness:scan` — 124 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQQwC79KAtQwUjD4QoTNPD