### PR TITLE
fix(harness): the UNAVAILABLE sentinel was a dead store on the path that never checks

### DIFF
--- a/scripts/harness/scan-promotion-closes.mjs
+++ b/scripts/harness/scan-promotion-closes.mjs
@@ -243,6 +243,12 @@ export async function main(argv = process.argv.slice(2)) {
   const { pr, repo, defaultBranch } = parseArgs(argv);
   const pull = readPull(repo, pr);
 
+  // UNAVAILABLE is the STARTING value, and it survives every path that does not actually derive a
+  // requirement: a base that is not the default branch (where `decidePromotionCloses` answers
+  // not-applicable before it reads this at all) and a derivation that threw. Assigning `[]` on the
+  // non-default-branch path — as this did — made the sentinel a dead store, which is what CodeQL
+  // reported, and left "nothing to close" one edit away from being the answer on a path that never
+  // looked.
   let requiredIssues = UNAVAILABLE;
   if (pull.base === defaultBranch) {
     try {
@@ -253,13 +259,11 @@ export async function main(argv = process.argv.slice(2)) {
         readIssueState: (n) => readIssueStateViaApi(repo, n),
       }).issues;
     } catch (error) {
-      // Deliberately NOT rethrown as a crash: the sentinel makes the decision module report the
-      // reason as a verdict on the pull request, rather than leaving it in a runner annotation only.
+      // Deliberately NOT rethrown as a crash: `requiredIssues` is left at UNAVAILABLE so the
+      // decision module reports the reason as a verdict on the pull request, rather than leaving it
+      // in a runner annotation only.
       console.error(`scan-promotion-closes: ${error.message}`);
-      requiredIssues = UNAVAILABLE;
     }
-  } else {
-    requiredIssues = [];
   }
 
   const verdict = decidePromotionCloses({


### PR DESCRIPTION
## Why this is a separate PR

This is a **review finding from #1860 that missed its own merge window.** The CodeQL thread on that PR
reported a dead store; the fix was committed and pushed at ~15:53Z, and #1860 had already been merged at
15:47Z. The reply on that thread says the finding was fixed — this PR is what makes that true on
`develop`. The commit is cherry-picked unchanged onto a fresh `develop`.

## The finding

CodeQL, on `scripts/harness/scan-promotion-closes.mjs`:

> Useless assignment to local variable — the initial value of `requiredIssues` is unused, since it is
> always overwritten.

Correct. `main()` assigned `[]` on the non-default-branch path, so both branches wrote and the
`UNAVAILABLE` sentinel initializer was never read.

## The fix, and why this direction

**The assignment is removed, not the initializer.** The two are not interchangeable here:
`decidePromotionCloses` answers not-applicable for a non-default base **before** it reads the requirement,
so the value on that path is not consumed today — and `[]` is the one value that would read as *"nothing
to close"* if it ever were. On a required `protect-main` context, that is the direction a wrong answer
passes silently. `UNAVAILABLE` now survives every path that does not actually derive a requirement, which
is what the sentinel is for.

The `catch` block's re-assignment goes for the same reason: nothing has written to the variable when the
call throws.

## Verification

- No behaviour change. `scan-promotion-closes.test.mjs` — 16 tests green, including the non-`main`-base
  verdict, unchanged.
- `node scripts/harness/scan-measurement-provenance.mjs` — still `covered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtPyjdqCDpbb54XQ8HoP3m
