### PR TITLE
docs(tasks): complete HARNESS-112/113/114 and archive their records

### DIFF
--- a/.agents/spec-docs/done/HARNESS-112-a-loop-run-leaves-no-record.md
+++ b/.agents/spec-docs/done/HARNESS-112-a-loop-run-leaves-no-record.md
@@ -1,5 +1,5 @@
 ---
-status: verifying
+status: done
 type: OBSERVABILITY
 tags: [node]
 ---
@@ -369,3 +369,24 @@ the TC commands are `node scripts/harness/…` invocations and `pnpm harness:sca
 - Deliberately not done, and recorded so its absence is not read as an oversight: **no ledger entry was
   fabricated.** The corpus ships empty. Writing a record for a run that did not happen is the defect
   this item exists to prevent, and the empty-corpus path is the tested one.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-19
+
+**Status upgrade:** verifying → done
+
+- Prior gate GATE-VERIFY passed; status was `verifying`.
+- Merged as part of pull request #1881 (`715ff40248f1a55e68569c773abfbec5bd2da206`) into `develop`.
+  Landing verified against the REMOTE, not the local tree: `origin/develop` is at `715ff4024`, and the
+  four new modules plus `.agents/loop-runs/README.md` and the new rule clause are present in
+  `git ls-tree origin/develop`.
+- Merge gate satisfied in full: CI green on the exact head, a reviewer verdict quoting **BASE
+  `b0b4e6619` / HEAD `a14741b45`** — both matching the live values at merge time — `ACTIONABLE
+FINDINGS: 0`, and every review thread answered and resolved.
+- The one review finding raised on this pull request was a claimed SyntaxError from nested template
+  literals. It was REFUTED with reproducible evidence (`node --check` exit 0, the entry point running,
+  and ten passing cases including one that cannot pass without the module executing), and the construct
+  was rewritten anyway because a line whose correctness must be argued is worse than one that does not
+  raise the question. Both the summary comment and the inline thread carry that answer.
+- One CI failure was infrastructure and not a finding: `Secret scan (gitleaks)` failed on
+  `curl: (35) Recv failure: Connection reset by peer` while downloading the gitleaks binary. Re-run,
+  green, and no code change was made for it.

--- a/.agents/spec-docs/done/HARNESS-113-a-new-orchestration-ships-unproven.md
+++ b/.agents/spec-docs/done/HARNESS-113-a-new-orchestration-ships-unproven.md
@@ -1,5 +1,5 @@
 ---
-status: verifying
+status: done
 type: RULE
 tags: [node]
 ---
@@ -323,3 +323,24 @@ the TC commands are `node scripts/harness/…` invocations and `pnpm harness:sca
 - TC-07 ran `scan-new-rule-declares-enforcement.mjs` against the committed diff: the new rule clause
   carries its `Enforced by:` line.
 - Pinned in `scan-guard-scope-fail-closed.mjs` as proven fail-closed by execution.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-19
+
+**Status upgrade:** verifying → done
+
+- Prior gate GATE-VERIFY passed; status was `verifying`.
+- Merged as part of pull request #1881 (`715ff40248f1a55e68569c773abfbec5bd2da206`) into `develop`.
+  Landing verified against the REMOTE, not the local tree: `origin/develop` is at `715ff4024`, and the
+  four new modules plus `.agents/loop-runs/README.md` and the new rule clause are present in
+  `git ls-tree origin/develop`.
+- Merge gate satisfied in full: CI green on the exact head, a reviewer verdict quoting **BASE
+  `b0b4e6619` / HEAD `a14741b45`** — both matching the live values at merge time — `ACTIONABLE
+FINDINGS: 0`, and every review thread answered and resolved.
+- The one review finding raised on this pull request was a claimed SyntaxError from nested template
+  literals. It was REFUTED with reproducible evidence (`node --check` exit 0, the entry point running,
+  and ten passing cases including one that cannot pass without the module executing), and the construct
+  was rewritten anyway because a line whose correctness must be argued is worse than one that does not
+  raise the question. Both the summary comment and the inline thread carry that answer.
+- One CI failure was infrastructure and not a finding: `Secret scan (gitleaks)` failed on
+  `curl: (35) Recv failure: Connection reset by peer` while downloading the gitleaks binary. Re-run,
+  green, and no code change was made for it.

--- a/.agents/spec-docs/done/HARNESS-114-no-metric-answers-whether-a-loop-earned-its-cost.md
+++ b/.agents/spec-docs/done/HARNESS-114-no-metric-answers-whether-a-loop-earned-its-cost.md
@@ -1,5 +1,5 @@
 ---
-status: verifying
+status: done
 type: OBSERVABILITY
 tags: [node]
 ---
@@ -311,3 +311,24 @@ the TC commands are `node scripts/harness/…` invocations and `pnpm harness:sca
   absence of the substring `0%`, which failed because the NO DATA line explains _"a rate over zero runs
   is not 0%"_ in prose. The property is that no RATE is reported, so the assertion was tightened to
   `rework <n>%` — the shape a reader acts on. The message was not weakened to satisfy the test.
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-19
+
+**Status upgrade:** verifying → done
+
+- Prior gate GATE-VERIFY passed; status was `verifying`.
+- Merged as part of pull request #1881 (`715ff40248f1a55e68569c773abfbec5bd2da206`) into `develop`.
+  Landing verified against the REMOTE, not the local tree: `origin/develop` is at `715ff4024`, and the
+  four new modules plus `.agents/loop-runs/README.md` and the new rule clause are present in
+  `git ls-tree origin/develop`.
+- Merge gate satisfied in full: CI green on the exact head, a reviewer verdict quoting **BASE
+  `b0b4e6619` / HEAD `a14741b45`** — both matching the live values at merge time — `ACTIONABLE
+FINDINGS: 0`, and every review thread answered and resolved.
+- The one review finding raised on this pull request was a claimed SyntaxError from nested template
+  literals. It was REFUTED with reproducible evidence (`node --check` exit 0, the entry point running,
+  and ten passing cases including one that cannot pass without the module executing), and the construct
+  was rewritten anyway because a line whose correctness must be argued is worse than one that does not
+  raise the question. Both the summary comment and the inline thread carry that answer.
+- One CI failure was infrastructure and not a finding: `Secret scan (gitleaks)` failed on
+  `curl: (35) Recv failure: Connection reset by peer` while downloading the gitleaks binary. Re-run,
+  green, and no code change was made for it.

--- a/.agents/tasks/completed/HARNESS-112-a-loop-run-leaves-no-record.md
+++ b/.agents/tasks/completed/HARNESS-112-a-loop-run-leaves-no-record.md
@@ -1,7 +1,8 @@
 ---
 title: 'HARNESS-112: a loop run leaves no record, so escape=no-progress is a claim nothing can check'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-19
 priority: high
 urgency: now
 area: scripts/harness, .agents/loop-runs, .agents/rules, .agents/skills
@@ -23,7 +24,7 @@ converged, one that exhausted, and one that was abandoned at round 1 leave a byt
 
 ## Spec
 
-`.agents/spec-docs/active/HARNESS-112-a-loop-run-leaves-no-record.md`
+`.agents/spec-docs/done/HARNESS-112-a-loop-run-leaves-no-record.md`
 
 ## Plan
 
@@ -72,3 +73,6 @@ header, and HARNESS-113 is what converts it into a requirement for new loops.
   the two would have made the guard refuse on a correct state.
 - **No ledger entries were fabricated.** The corpus is empty, and the empty path is the tested one.
   Writing a record for a run that did not happen is precisely what this item exists to prevent.
+
+- Merged in pull request #1881 as `715ff40248f1a55e68569c773abfbec5bd2da206`; landing verified against
+  `origin/develop` rather than the local tree. Complete.

--- a/.agents/tasks/completed/HARNESS-113-a-new-orchestration-ships-unproven.md
+++ b/.agents/tasks/completed/HARNESS-113-a-new-orchestration-ships-unproven.md
@@ -1,7 +1,8 @@
 ---
 title: 'HARNESS-113: a new scan must be proven red-then-green; a new orchestration ships unproven'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-19
 priority: high
 urgency: now
 area: scripts/harness, .agents/rules
@@ -24,7 +25,7 @@ by DISPATCHING, spending a fan-out before anyone learns the routing was wrong.
 
 ## Spec
 
-`.agents/spec-docs/active/HARNESS-113-a-new-orchestration-ships-unproven.md`
+`.agents/spec-docs/done/HARNESS-113-a-new-orchestration-ships-unproven.md`
 
 ## Plan
 
@@ -64,3 +65,6 @@ reached once, not that the run exercised the loop's hard path.
   away — the exact shape `abandoned` exists to make visible.
 - Pinned in `scripts/harness/scan-guard-scope-fail-closed.mjs` as proven fail-closed by execution (76
   guards now proven there).
+
+- Merged in pull request #1881 as `715ff40248f1a55e68569c773abfbec5bd2da206`; landing verified against
+  `origin/develop` rather than the local tree. Complete.

--- a/.agents/tasks/completed/HARNESS-114-no-metric-answers-whether-a-loop-earned-its-cost.md
+++ b/.agents/tasks/completed/HARNESS-114-no-metric-answers-whether-a-loop-earned-its-cost.md
@@ -1,7 +1,8 @@
 ---
 title: 'HARNESS-114: no metric answers whether a convergence loop earned its cost'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-19
 priority: medium
 urgency: soon
 area: scripts/harness, .agents/evals
@@ -26,7 +27,7 @@ Publish the derivable half as an explicit proxy, and say what it cannot see.
 
 ## Spec
 
-`.agents/spec-docs/active/HARNESS-114-no-metric-answers-whether-a-loop-earned-its-cost.md`
+`.agents/spec-docs/done/HARNESS-114-no-metric-answers-whether-a-loop-earned-its-cost.md`
 
 ## Plan
 
@@ -67,3 +68,6 @@ tautology `measurement-provenance.md` refuses.
   what it substitutes for and what it cannot see published beside the number.
 - One test asserts `metrics.md` itself carries the proxy relationship, the unobservable quantities and
   the advisory status. A ceiling published with the number is part of the deliverable.
+
+- Merged in pull request #1881 as `715ff40248f1a55e68569c773abfbec5bd2da206`; landing verified against
+  `origin/develop` rather than the local tree. Complete.


### PR DESCRIPTION
Completion records for the loop-observability unit, merged as #1881
(`715ff40248f1a55e68569c773abfbec5bd2da206`).

Docs only. No source change.

## What this does

- `GATE-COMPLETE` recorded in each of the three Evidence Logs.
- `status: verifying → done` on the three specs, `status: in-progress → done` plus `completed:` on the
  three Tasks.
- Both sets `git mv`'d into `.agents/spec-docs/done/` and `.agents/tasks/completed/` **in the same
  commit as the status change**, which is what the completion steps require and what
  `check-backlog-placement.mjs` enforces.

## Landing verified against the remote, not the local tree

```
$ git ls-tree origin/develop --name-only scripts/harness/ | grep loop
scripts/harness/loop-economics.mjs
scripts/harness/loop-proof-baseline.json
scripts/harness/loop-run.mjs
scripts/harness/scan-loop-proof.mjs
scripts/harness/scan-loop-run-records.mjs
```

plus `.agents/loop-runs/README.md` and the **Prove the loop** clause in `.agents/rules/learning-loop.md`.

## Two things recorded in the Evidence Logs rather than left to be re-derived

- **The one review finding was refuted, not accepted.** It claimed a SyntaxError from nested template
  literals in `loop-economics.mjs`. Measured on that code: `node --check` exit 0, `pnpm
  harness:loop:report` printing, and ten passing cases — one of which (`rework 50% (2/4)`) cannot pass
  without the module executing. The backticks were inside a single-quoted string. The construct was
  rewritten anyway, because a line whose correctness has to be *argued* is worse than one that does not
  raise the question.
- **One CI failure was infrastructure.** `Secret scan (gitleaks)` failed with `curl: (35) Recv failure:
  Connection reset by peer` while downloading its own binary. Re-run green; no code changed for it.

## Issues

`Closes #1874`, `Closes #1875` and `Closes #1876` were written on #1881, whose base is `develop` — so
GitHub did not act on them, which is the exact defect INFRA-104 (#1860) exists to fix. They will be
closed explicitly, and the next `develop → main` promotion carries the derived keyword block via the
`promotion closes` required check.

## Verification

`pnpm harness:scan` — 125 passed, 3 skipped. `backlog-placement` passes with all six documents in their
terminal folders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtPyjdqCDpbb54XQ8HoP3m
