### PR TITLE
feat(harness): refuse a bulk edit that can reach the pnpm store (#1884)

### DIFF
--- a/.agents/rules/operational.md
+++ b/.agents/rules/operational.md
@@ -123,6 +123,39 @@ looks like the command worked.
 - Never claim a file exists or was produced without actually creating it; verify paths before
   asserting presence; surface deliverables explicitly (share the file, not a folder).
 
+### A Bulk Edit Enumerates Through `git ls-files`
+
+A bulk edit takes its file list from `git ls-files`, never from a filesystem walk. `git ls-files`
+cannot return a `node_modules` path; a filesystem walk can, and in a pnpm workspace it does —
+`packages/<a>/node_modules/@scope/<b>` is a symlink to `packages/<b>`, and `node_modules/.pnpm` holds
+content hard-linked into every other project on the machine.
+
+A write that lands there is unobservable, which is why this is a rule and not a preference: `git
+status` does not look outside the work tree, every scan here reads `git ls-files`, and the store
+survives `pnpm install` because it believes the content is already correct.
+
+Four spellings follow symlinks, and each has a sibling that does not:
+
+| refuse                            | use                              |
+| --------------------------------- | -------------------------------- |
+| `find -L`                         | `find`                           |
+| `grep -R`                         | `grep -r`                        |
+| `rg --follow`                     | `rg` (also honours `.gitignore`) |
+| python `glob.glob` / `glob.iglob` | `pathlib.Path(...).rglob`        |
+
+Shell `**` under `globstar`, zsh `**`, and Node's `fs.globSync` do not traverse symlinked
+directories and are unrestricted. `bulk-edit-guard.sh` refuses the four at the command,
+`scan-symlink-following-enumeration` refuses them in a committed script, and both refuse a write
+whose path resolves inside the store. The declared exception is `BULK_EDIT_ACK=1` inline, after
+checking by hand where the enumeration reaches.
+
+Enforced by: `bulk-edit-guard` (the command) and `symlink-following-enumeration` (the committed
+script). Neither reaches a python program passed through a heredoc, nor a two-step edit that
+enumerates in one call and writes in the next; those are the reader's obligation.
+
+The measurements behind the table, and the exposure they corrected, are in
+[INFRA-105](../tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md).
+
 ### A Wait Is Not Idle Time
 
 When work is blocked on something that takes minutes and is not yours to speed up — a continuous

--- a/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
+++ b/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
@@ -1,0 +1,129 @@
+---
+title: 'INFRA-105: a bulk edit can reach the shared pnpm store, where git cannot see it'
+status: in-progress
+created: 2026-08-19
+priority: high
+urgency: now
+area: .claude/hooks, scripts/harness, .agents/rules
+depends_on: []
+---
+
+# INFRA-105: refuse a write that lands in `node_modules`, and the enumerations that get there
+
+## Objective
+
+Close the failure class reported in #1884: a bulk edit that enumerates files by filesystem pattern
+follows pnpm's workspace symlinks into `node_modules`, and from there into `node_modules/.pnpm` —
+whose contents are **hard links shared with every other project on the machine**. A write that lands
+there is invisible to `git status`, invisible to every harness scan (they read `git ls-files`, which
+cannot list `node_modules`), and survives `pnpm install`, because the store believes the content is
+already correct.
+
+The incident that produced #1884 was caught because the edit script happened to print the paths it
+touched. That is luck. This item installs the mechanical control that does not depend on anyone
+looking.
+
+## What was measured, and where the report was wrong
+
+#1884 named `find`, `grep -r`, `rg` without `--no-follow`, shell `**` under `globstar`, and Node's
+`fs.glob` as carrying "the same exposure". That list was asserted, not measured. Measured here, on a
+directory containing one symlink to a tree holding one matching file:
+
+| enumerator                                        | reaches through the symlink |
+| ------------------------------------------------- | --------------------------- |
+| `find top -name '*.ts'`                           | **no**                      |
+| `find -L top -name '*.ts'`                        | **yes**                     |
+| `grep -rl … top`                                  | **no**                      |
+| `grep -Rl … top`                                  | **yes**                     |
+| `rg -l … top`                                     | **no**                      |
+| `rg -l --follow … top`                            | **yes**                     |
+| bash `**/*.ts` with `globstar`                    | **no**                      |
+| zsh `**/*.ts`                                     | **no**                      |
+| `node -e "globSync('top/**/*.ts')"`               | **no**                      |
+| python `Path('top').rglob('*.ts')`                | **no**                      |
+| python `glob.glob('top/**/*.ts', recursive=True)` | **yes**                     |
+
+So the exposure is **four spellings**, not "any glob", and each has a safe sibling one flag away.
+That matters for the design: a guard aimed at the measured four is a guard that can be left on,
+where one aimed at every recursive enumeration would fire on correct commands until someone
+disabled it. `git ls-files` remains the preferred source — it cannot return a `node_modules` path at
+all — but a `find` without `-L` is not the hazard the report claimed it was.
+
+## Plan
+
+- [x] TC-01: `bulk-edit-guard.sh` refuses a `Write`/`Edit`/`MultiEdit` whose `file_path` contains a
+      `node_modules` segment, and one whose path reaches the store only after symlink resolution.
+- [x] TC-02: it permits an ordinary `packages/**/src` path.
+- [x] TC-03: it refuses each of the four measured enumerator spellings in a `Bash` command.
+- [x] TC-04: it permits each spelling's safe sibling (`find` without `-L`, `grep -r`, `rg` without
+      `--follow`, `Path.rglob`), so the guard is proven to discriminate rather than to fire on the
+      shape.
+- [x] TC-05: it refuses a content write whose target path names `node_modules`, and does NOT refuse
+      `rm -rf node_modules` or `mv node_modules …` — the reinstall idioms.
+- [x] TC-06: a mention inside a quoted argument or a heredoc body does not trip it, so this task file
+      and the rule text can be written without the ack.
+- [x] TC-07: an unreadable payload is refused, not permitted (fail-direction, matching the other
+      refusing guards).
+- [x] TC-08: `BULK_EDIT_ACK=1` inline in the same command is the documented escape, and is read off
+      the masked text so a mention cannot switch the guard off.
+- [x] TC-09: `scan-symlink-following-enumeration.mjs` fails a committed script carrying one of the
+      four spellings and passes the repository as it stands (measured: zero occurrences today).
+- [x] TC-10: the scan is registered in `harness.config.json` and runs under `pnpm harness:scan`.
+- [x] TC-11: `pnpm harness:scan` and the harness unit tier are green.
+- [x] TC-12: a redirect is judged on its TARGET — reading from the store and writing outside it is
+      permitted, writing into it is refused.
+- [x] TC-13: a leading environment assignment does not take the command-name slot.
+
+## Test Plan
+
+Unit tests under `scripts/harness/__tests__/` drive the hook through its real stdin protocol with
+synthesised payloads, and assert BOTH directions for every rule: the hazardous spelling is refused
+AND its safe sibling is permitted. A guard that only ever gets hazardous input is a guard nobody has
+shown can say yes, and that is the shape that gets switched off. The scan is red-proofed against a
+temporary fixture carrying each spelling, so "it passes" is a measurement and not the absence of
+input.
+
+## Out of scope, and filed rather than dropped
+
+#1884's third item — that a name-based rewrite should confirm each site imports the symbol being
+changed rather than merely spelling it — is a real defect and is not addressed here. It is the same
+problem ARCH-037 spent six review rounds on, it needs a resolver, and folding it into a path guard
+would produce neither. It is filed separately.
+
+## Progress
+
+### 2026-08-19
+
+Measured the exposure table above before writing anything, which corrected the reported list from
+"any recursive enumeration" to four spellings.
+
+Two defects the repository's own gates caught, both worth recording because neither was visible from
+reading the code:
+
+- **`grep -qxE "-L"` reads `-L` as grep's own flag.** The first cut of the guard permitted `find -L`,
+  `grep -R` and `rg --follow` — three of its four rules — while passing every other case. `grep -qxE
+-- "$1"` fixes it. A guard whose pattern is passed as an option is a guard that says yes to
+  everything it was written to refuse.
+- **The flag has to be attributed to the command that received it.** `find packages -name '*.ts' |
+xargs grep -L createSession` carries a `-L`, but it belongs to `grep`, where it means
+  files-without-match. Reading the flag without its command refused that correct pipeline, so the
+  word list is walked and a flag counts only while its own command is current.
+
+Red-proofed rather than assumed: with the symlink-resolution branch disabled exactly one case fails,
+with flag attribution removed exactly two fail, with the empty-payload refusal removed exactly one
+fails, and the scan was run against a temporary tracked fixture to see it go red.
+
+`rule-case-narrative` then refused the first draft of the rule text, correctly: it retold the
+incident. The invariant stays in `operational.md` and the measurements moved here, which is the form
+that rule asks for. `guards-pass-silently` refused the guard for having no row saying what it must
+leave ALONE, and its `*_ALLOW_*` scrub was widened to `*_ACK` in the same change — three overrides
+in this directory use that spelling and were inherited from whatever session ran the suite, which
+would have made a row pass because nothing was checked.
+
+A self-review pass before the push found two more, both false-positive directions:
+
+- **A redirect was judged on the command, not on its target.** `cat node_modules/.pnpm/p/package.json
+  > /tmp/out` reads from the store and writes outside it — ordinary inspection — and was refused.
+- **A leading environment assignment took the command-name slot.** `FOO=bar find -L …` set the
+  current command to `FOO=bar`, so the real one was never judged: a miss, not a false positive, and
+  the mirror image of the ack-read hole.

--- a/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
+++ b/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
@@ -88,7 +88,7 @@ input.
 #1884's third item — that a name-based rewrite should confirm each site imports the symbol being
 changed rather than merely spelling it — is a real defect and is not addressed here. It is the same
 problem ARCH-037 spent six review rounds on, it needs a resolver, and folding it into a path guard
-would produce neither. It is filed separately.
+would produce neither. Filed as #1887.
 
 ## Progress
 

--- a/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
+++ b/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
@@ -12,20 +12,20 @@ depends_on: []
 
 ## Objective
 
-Close the failure class reported in #1884: a bulk edit that enumerates files by filesystem pattern
+Close the failure class reported in issue #1884: a bulk edit that enumerates files by filesystem pattern
 follows pnpm's workspace symlinks into `node_modules`, and from there into `node_modules/.pnpm` —
 whose contents are **hard links shared with every other project on the machine**. A write that lands
 there is invisible to `git status`, invisible to every harness scan (they read `git ls-files`, which
 cannot list `node_modules`), and survives `pnpm install`, because the store believes the content is
 already correct.
 
-The incident that produced #1884 was caught because the edit script happened to print the paths it
+The incident that produced issue #1884 was caught because the edit script happened to print the paths it
 touched. That is luck. This item installs the mechanical control that does not depend on anyone
 looking.
 
 ## What was measured, and where the report was wrong
 
-#1884 named `find`, `grep -r`, `rg` without `--no-follow`, shell `**` under `globstar`, and Node's
+Issue #1884 named `find`, `grep -r`, `rg` without `--no-follow`, shell `**` under `globstar`, and Node's
 `fs.glob` as carrying "the same exposure". That list was asserted, not measured. Measured here, on a
 directory containing one symlink to a tree holding one matching file:
 
@@ -90,10 +90,10 @@ input.
 
 ## Out of scope, and filed rather than dropped
 
-#1884's third item — that a name-based rewrite should confirm each site imports the symbol being
+Issue #1884's third item — that a name-based rewrite should confirm each site imports the symbol being
 changed rather than merely spelling it — is a real defect and is not addressed here. It is the same
 problem ARCH-037 spent six review rounds on, it needs a resolver, and folding it into a path guard
-would produce neither. Filed as #1887.
+would produce neither. Filed as issue #1887.
 
 ## Progress
 

--- a/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
+++ b/.agents/tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md
@@ -73,6 +73,11 @@ all — but a `find` without `-L` is not the hazard the report claimed it was.
 - [x] TC-12: a redirect is judged on its TARGET — reading from the store and writing outside it is
       permitted, writing into it is refused.
 - [x] TC-13: a leading environment assignment does not take the command-name slot.
+- [x] TC-14: a NEW file inside a symlinked directory is refused, and a new file inside an ordinary
+      directory is not.
+- [x] TC-15: a flag is attributed past a wrapper that took its own argument (`sudo -u deploy find -L`)
+      while a pipeline is still separated.
+- [x] TC-16: an in-place editor and a store path must stand in ONE segment.
 
 ## Test Plan
 
@@ -127,3 +132,27 @@ A self-review pass before the push found two more, both false-positive direction
 - **A leading environment assignment took the command-name slot.** `FOO=bar find -L …` set the
   current command to `FOO=bar`, so the real one was never judged: a miss, not a false positive, and
   the mirror image of the ack-read hole.
+
+Review of the pull request then found three more, and all three were right:
+
+- **The symlink resolution never ran for a file being created.** It tested `-e "$FILE_PATH"`, which
+  is false for exactly what `Write` exists to do. A brand-new file inside a symlinked directory
+  skipped the block entirely and reached the store. The sharper half of the finding is about the
+  TEST: the case that was supposed to cover this pre-created its target with `writeFileSync`, so it
+  proved resolution worked on a path that did not need resolving. The existence test now sits on the
+  parent directory — which is what carries pnpm's symlink, and which is there whether or not the file
+  is — and both directions are cases.
+- **A wrapper's own flag argument took the command-name slot.** `sudo -u deploy find -L …` promoted
+  `deploy` to current command, so `find` was never recognised and its `-L` sailed through. `nice -n
+10 find -L` the same. Fixing the walk would mean maintaining a list of which wrapper flags take a
+  value, wrong the day it falls behind; attribution is now SEGMENT MEMBERSHIP — a flag belongs to a
+  command whose word stands earlier in the same run between separators — which needs no list. Stated
+  limit, and the price of dropping the walk: `find … -exec grep -L {} \;` inherits `find`'s
+  attribution and is refused. A pipeline, the common shape, is still separated.
+- **The in-place-editor rule was two unscoped substring greps.** "An editor anywhere AND a store path
+  anywhere" refused `sed -i 's/a/b/' src/a.ts && ls node_modules/.bin`, where the two have nothing to
+  do with each other — a conjunction read out of a coincidence. Both must now stand in one segment.
+
+Red-proofed one at a time: restoring the file-existence test fails exactly the new-file case,
+removing the segment split fails exactly three, and removing the editor rule's segment reset fails
+exactly one.

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -180,7 +180,7 @@ segment_has_editor_and_store_path() {
     $0 == "sed" || $0 == "perl" { sed_or_perl = 1 }
     sed_or_perl && $0 ~ /^-[[:alnum:]]*i/ { editor = 1 }
     $0 == "tee" || $0 == "truncate" { editor = 1 }
-    $0 ~ /(node_modules|\.pnpm)\// { store = 1 }
+    $0 ~ /(^|\/)(node_modules|\.pnpm)\// { store = 1 }
     editor && store { found = 1 }
     END { exit(found ? 0 : 1) }'
 }
@@ -192,12 +192,18 @@ segment_has_editor_and_store_path() {
 # A REDIRECT is judged on its TARGET, not on the command containing it. `cat node_modules/.pnpm/p/
 # package.json > /tmp/out` reads from the store and writes outside it, and the first cut of this
 # branch refused it, because it asked only whether the command mentioned a store path anywhere.
-if printf '%s' "$MASK" | grep -qE '>>?[[:space:]]*[^[:space:]|;&]*(node_modules|\.pnpm)/'; then
+#
+# The store name is anchored on a SEPARATOR, the same way `STORE_SEGMENT_RE` anchors it for the write
+# tools. Without that, `my_node_modules_old/` — a directory that merely contains the letters — was
+# refused here while the write path permitted it, so one guard contradicted the other on the case both
+# had a test for. Reported in review of this change.
+if printf '%s' "$MASK" | grep -qE '>>?[[:space:]]*([^[:space:]|;&]*/)?(node_modules|\.pnpm)/'; then
   refuse_path "the command redirects output into node_modules or .pnpm"
 fi
 
 # The in-place editors take their targets as ARGUMENTS, so an editor and a store path in the SAME
-# SEGMENT is tight — there is no other place the path could be going.
+# SEGMENT is tight — there is no other place the path could be going. Anchored on a separator for the
+# same reason as the redirect above.
 #
 # The segment scope is the correction. "An editor anywhere AND a store path anywhere" refused
 # `sed -i 's/a/b/' src/a.ts && ls node_modules/.bin`, where the edit and the store path have nothing

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -78,16 +78,24 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Mult
   fi
 
   # RESOLVED as well as spelled. A path can reach the store without naming it — `packages/a/nm-link/x`
-  # where `nm-link` is a symlink into node_modules. Only checked when the path exists, because
-  # resolving a path being CREATED says nothing about where the write lands.
+  # where `nm-link` is a symlink into node_modules.
+  #
+  # The existence test is on the PARENT DIRECTORY, not on the file. Review of this change caught the
+  # first version testing `-e "$FILE_PATH"`, which is false for exactly the case `Write` exists to
+  # serve: a file being CREATED. A brand-new file inside a symlinked directory skipped the whole
+  # block and reached the store unrefused. The directory is what carries the symlink — pnpm links
+  # DIRECTORIES — and it is already there whether or not the file is.
+  #
+  # The test that was supposed to cover this pre-created the target with `writeFileSync`, so it
+  # proved the resolution worked on a path that did not need it. That is the more useful half of the
+  # finding: the case existed and was measuring the wrong thing.
   #
   # `cd` + `pwd -P` rather than `readlink -f`: the `-f` form is GNU-only and fails unhelpfully on
   # BSD/macOS, which `shell-portability` refuses (see "Host Platform Is Read, Never Assumed"). `pwd
-  # -P` is POSIX and resolves the DIRECTORY chain, which is exactly the level pnpm's symlinks live at
-  # — `packages/a/node_modules/@scope/b` is a symlinked directory, not a symlinked file.
-  if [[ -e "$FILE_PATH" ]]; then
-    RESOLVED=$( (cd "$(dirname -- "$FILE_PATH")" 2>/dev/null &&
-      printf '%s/%s' "$(pwd -P)" "$(basename -- "$FILE_PATH")") || printf '')
+  # -P` is POSIX and resolves the DIRECTORY chain, which is the level pnpm's symlinks live at.
+  PARENT=$(dirname -- "$FILE_PATH")
+  if [[ -d "$PARENT" ]]; then
+    RESOLVED=$( (cd "$PARENT" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename -- "$FILE_PATH")") || printf '')
     if [[ -n "$RESOLVED" ]] && printf '%s' "$RESOLVED" | grep -qE "$STORE_SEGMENT_RE"; then
       refuse_path "$FILE_PATH -> $RESOLVED"
     fi
@@ -115,6 +123,57 @@ if printf '%s' "$MASK" |
   exit 0
 fi
 
+# --- The word reading, and the two questions asked of it ------------------------------------------
+WORDS=$(hook_statement_all_words "$COMMAND" 2>/dev/null || printf '%s' "$COMMAND")
+
+# Was FLAG passed TO COMMAND — not "does the flag appear anywhere". The difference is a real command
+# this guard refused during development: `find packages -name '*.ts' | xargs grep -L foo` carries a
+# `-L`, but it belongs to `grep`, where it means files-without-match and follows nothing. Attributing
+# it to `find` refuses a correct pipeline, and a guard that does that gets its ack pasted by reflex.
+#
+# The unit is the SEGMENT — the run of words between two separators (`|`, `;`, `&&`, `||`). A flag is
+# attributed to a command when that command's own word stands earlier in the same segment.
+#
+# This replaces a "current command" walk that tracked which word was the command in progress. Review
+# of this change measured its failure: `sudo -u deploy find -L …` promoted `deploy` — a wrapper
+# FLAG'S ARGUMENT — to current command, so `find` was never recognised and its `-L` sailed through.
+# Fixing that walk means knowing which wrapper flags take a value, which is a list that has to be
+# maintained and is wrong the day it falls behind. Segment membership needs no such list.
+#
+# STATED LIMIT, because it is the price of dropping the walk: a second command inside one segment
+# inherits the first one's attribution. `find … -exec grep -L {} \;` is read as `find` carrying `-L`
+# and is refused. That is a false positive, and it is the trade taken deliberately — a pipeline is
+# the common shape and is still separated, `-exec grep -L` is not, and the ack is one word away.
+segments() {
+  printf '%s\n' "$WORDS" | awk '
+    function is_sep(w) { return w == "|" || w == ";" || w == "&" || w == "&&" || w == "||" || w == "(" || w == ")" }
+    is_sep($0) { print "\034"; next }
+    { print }'
+}
+
+cmd_flag() {
+  segments | awk -v CMD="$1" -v FLAG="$2" '
+    $0 == "\034" { seen = 0; next }
+    seen && $0 ~ /^-/ && $0 ~ FLAG { found = 1 }
+    $0 == CMD { seen = 1 }
+    END { exit(found ? 0 : 1) }'
+}
+
+# An in-place editor and a store path standing in ONE segment. See the note on the rule above for
+# what the segment scope is correcting.
+segment_has_editor_and_store_path() {
+  segments | awk '
+    function reset() { editor = 0; store = 0; sed_or_perl = 0 }
+    BEGIN { reset() }
+    $0 == "\034" { reset(); next }
+    $0 == "sed" || $0 == "perl" { sed_or_perl = 1 }
+    sed_or_perl && $0 ~ /^-[[:alnum:]]*i/ { editor = 1 }
+    $0 == "tee" || $0 == "truncate" { editor = 1 }
+    $0 ~ /(node_modules|\.pnpm)\// { store = 1 }
+    editor && store { found = 1 }
+    END { exit(found ? 0 : 1) }'
+}
+
 # --- 2. A content write whose target names the store ---------------------------------------------
 # Scoped to CONTENT writes on purpose. `rm -rf node_modules` and `mv node_modules …` are the reinstall
 # idioms every contributor runs; refusing them would be a correct command blocked, which is how a
@@ -126,11 +185,15 @@ if printf '%s' "$MASK" | grep -qE '>>?[[:space:]]*[^[:space:]|;&]*(node_modules|
   refuse_path "the command redirects output into node_modules or .pnpm"
 fi
 
-# The in-place editors take their targets as ARGUMENTS, so "an editor is present AND a store path is
-# present" is already tight — there is no other place the path could be going.
-if printf '%s' "$MASK" | grep -qE '(node_modules|\.pnpm)/' &&
-  printf '%s' "$MASK" | grep -qE '(sed[[:space:]]+(-[[:alnum:]]*[[:space:]]+)*-i|perl[[:space:]]+(-[[:alnum:]]*[[:space:]]+)*-i|[[:space:]]tee[[:space:]]|truncate[[:space:]])'; then
-  refuse_path "the command writes content to a path naming node_modules or .pnpm"
+# The in-place editors take their targets as ARGUMENTS, so an editor and a store path in the SAME
+# SEGMENT is tight — there is no other place the path could be going.
+#
+# The segment scope is the correction. "An editor anywhere AND a store path anywhere" refused
+# `sed -i 's/a/b/' src/a.ts && ls node_modules/.bin`, where the edit and the store path have nothing
+# to do with each other: two independent substring greps over one command text cannot tell a
+# conjunction from a coincidence. Reported in review of this change.
+if segment_has_editor_and_store_path; then
+  refuse_path "an in-place editor is given a path naming node_modules or .pnpm"
 fi
 
 # --- 3. The four measured symlink-following enumerators ------------------------------------------
@@ -139,31 +202,6 @@ fi
 # acked instead of fixed.
 FOUND=''
 add_finding() { FOUND="${FOUND}[bulk-edit-guard]   $1"$'\n'; }
-
-WORDS=$(hook_statement_all_words "$COMMAND" 2>/dev/null || printf '%s' "$COMMAND")
-
-# Was FLAG passed TO COMMAND — not "does the flag appear anywhere". The difference is a real command
-# this guard refused during development: `find packages -name '*.ts' | xargs grep -L foo` carries a
-# `-L`, but it belongs to `grep`, where it means files-without-match and follows nothing. Attributing
-# it to `find` refuses a correct pipeline, and a guard that does that gets its ack pasted by reflex.
-#
-# So the word list is walked: a separator (`|`, `;`, `&&`, …) ends the current command, the first
-# non-flag word after one BECOMES the current command, and a wrapper (`xargs`, `env`, `sudo`, …)
-# hands that role to the word after it. A flag counts only while its own command is current.
-cmd_flag() {
-  printf '%s\n' "$WORDS" | awk -v CMD="$1" -v FLAG="$2" '
-    function is_sep(w) { return w == "|" || w == ";" || w == "&" || w == "&&" || w == "||" || w == "(" || w == ")" }
-    function is_wrapper(w) { return w == "xargs" || w == "env" || w == "sudo" || w == "time" || w == "nice" || w == "command" }
-    BEGIN { cur = "" }
-    { w = $0 }
-    is_sep(w) { cur = ""; next }
-    # A leading assignment (`FOO=bar find -L …`) is not the command. Without this it BECAME the
-    # current command and the real one was never judged.
-    cur == "" && w ~ /^[A-Za-z_][A-Za-z0-9_]*=/ { next }
-    cur == "" && w !~ /^-/ { if (!is_wrapper(w)) cur = w; next }
-    cur == CMD && w ~ /^-/ && w ~ FLAG { found = 1 }
-    END { exit(found ? 0 : 1) }'
-}
 
 if cmd_flag find '^(-L|-follow)$'; then
   add_finding "find -L follows symlinks. Drop -L: plain find does not (measured)."

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# bulk-edit-guard hook (INFRA-105, #1884)
+#
+# Refuses a write that can land inside `node_modules` — and the file enumerations that get there.
+#
+# WHY IT EXISTS. In a pnpm workspace `packages/<a>/node_modules/@scope/<b>` is a SYMLINK to
+# `packages/<b>`, and `node_modules/.pnpm` holds content HARD-LINKED into every other project on the
+# machine. A bulk edit that enumerates by filesystem pattern therefore reaches both. Measured on this
+# workspace while #1884 was being written: a rewrite intended for 857 files was applied across
+# 462,643 paths, of which 318,920 resolved into the shared store. Nothing in the repository could
+# have reported it — `git status` does not see outside the work tree, and every harness scan reads
+# `git ls-files`, which cannot list `node_modules` at all. It was caught because the script happened
+# to print what it touched.
+#
+# fail-direction: refuse — an unreadable payload means this guard does not know what it was asked to
+# judge, and a guard whose subject is "a write that nothing downstream can observe" cannot treat "I
+# could not look" as "there was nothing there". Permitting on a malformed payload would also make a
+# malformed payload the way past it.
+#
+# WHAT IT AIMS AT, AND WHY THAT IS NARROW. #1884 named `find`, `grep -r`, `rg`, shell `**` under
+# globstar and Node's `fs.glob` as equally exposed. Measured, they are not: `find` follows a symlink
+# only under `-L`, `grep` only under `-R`, `rg` only under `--follow`, bash and zsh `**` do not
+# traverse symlinked directories at all, `fs.globSync` did not, and neither did `pathlib.Path.rglob`.
+# The exposure is FOUR spellings, and each has a safe sibling one flag away. That distinction is the
+# whole design: a guard aimed at every recursive enumeration would refuse correct commands until
+# someone switched it off, and a switched-off guard protects nothing.
+#
+# STATED LIMIT. A python program fed through a heredoc (`python3 <<'EOF'`) is masked as quoted
+# content and is NOT read — the same blindness every guard in this directory has to a heredoc body.
+# `python3 -c` IS read, because the library expands interpreter payloads. The scan
+# `scan-symlink-following-enumeration.mjs` covers the committed-script side, where a heredoc is
+# ordinary file text.
+
+set -uo pipefail
+
+INPUT=$(cat)
+
+# shellcheck source=lib/hook-facts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/hook-facts.sh"
+
+if [ -z "${INPUT//[[:space:]]/}" ]; then
+  echo "[bulk-edit-guard] Blocked: the hook payload was empty, so nothing was judged." >&2
+  exit 2
+fi
+
+if ! TOOL_NAME=$(hook_tool_name_of "$INPUT"); then
+  echo "[bulk-edit-guard] Blocked: the hook payload names no tool, so nothing can be judged." >&2
+  exit 2
+fi
+
+# A path segment named exactly `node_modules`, or the store beneath it. Anchored on separators so a
+# directory merely CONTAINING the letters (`my_node_modules_notes/`) is not caught.
+STORE_SEGMENT_RE='(^|/)(node_modules|\.pnpm)(/|$)'
+
+refuse_path() {
+  echo "[bulk-edit-guard] Blocked: this write targets a path inside the dependency store." >&2
+  echo "[bulk-edit-guard]   $1" >&2
+  echo "[bulk-edit-guard] In a pnpm workspace that path is either a SYMLINK to a real source under" >&2
+  echo "[bulk-edit-guard] packages/ — in which case edit the source directly, so the change is one" >&2
+  echo "[bulk-edit-guard] edit and git can see it — or content HARD-LINKED into the shared store," >&2
+  echo "[bulk-edit-guard] where a write silently changes every project on this machine and survives" >&2
+  echo "[bulk-edit-guard] pnpm install." >&2
+  echo "[bulk-edit-guard] Deliberate exception: BULK_EDIT_ACK=1 inline in the same command." >&2
+  exit 2
+}
+
+# --- 1. A file-writing tool naming a store path --------------------------------------------------
+if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "MultiEdit" ]]; then
+  if ! FILE_PATH=$(hook_file_path_of "$INPUT"); then
+    echo "[bulk-edit-guard] Blocked: the tool's file path could not be decoded, so it cannot be" >&2
+    echo "[bulk-edit-guard] judged. Install jq or python3 so this guard can read what it judges." >&2
+    exit 2
+  fi
+  [[ -n "$FILE_PATH" ]] || exit 0
+
+  if printf '%s' "$FILE_PATH" | grep -qE "$STORE_SEGMENT_RE"; then
+    refuse_path "$FILE_PATH"
+  fi
+
+  # RESOLVED as well as spelled. A path can reach the store without naming it — `packages/a/nm-link/x`
+  # where `nm-link` is a symlink into node_modules. Only checked when the path exists, because
+  # resolving a path being CREATED says nothing about where the write lands.
+  #
+  # `cd` + `pwd -P` rather than `readlink -f`: the `-f` form is GNU-only and fails unhelpfully on
+  # BSD/macOS, which `shell-portability` refuses (see "Host Platform Is Read, Never Assumed"). `pwd
+  # -P` is POSIX and resolves the DIRECTORY chain, which is exactly the level pnpm's symlinks live at
+  # — `packages/a/node_modules/@scope/b` is a symlinked directory, not a symlinked file.
+  if [[ -e "$FILE_PATH" ]]; then
+    RESOLVED=$( (cd "$(dirname -- "$FILE_PATH")" 2>/dev/null &&
+      printf '%s/%s' "$(pwd -P)" "$(basename -- "$FILE_PATH")") || printf '')
+    if [[ -n "$RESOLVED" ]] && printf '%s' "$RESOLVED" | grep -qE "$STORE_SEGMENT_RE"; then
+      refuse_path "$FILE_PATH -> $RESOLVED"
+    fi
+  fi
+  exit 0
+fi
+
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+
+if ! COMMAND=$(hook_command_of "$INPUT"); then
+  echo "[bulk-edit-guard] Blocked: the tool command could not be decoded, so it cannot be judged." >&2
+  echo "[bulk-edit-guard] Install jq or python3 so this guard can read what it is judging." >&2
+  exit 2
+fi
+
+# The masked reading, for the same reason branch-guard and no-foreground-wait use it: a spelling
+# merely NAMED inside a quoted argument or a heredoc body is not a spelling that RUNS. This file, the
+# rule text and the task record all discuss the four hazardous forms in prose, and none of them may
+# trip the guard that reads them.
+MASK=$(hook_verb_scan "$COMMAND" 2>/dev/null || printf '%s' "$COMMAND")
+
+if [[ "${BULK_EDIT_ACK:-0}" == "1" ]]; then exit 0; fi
+if printf '%s' "$MASK" |
+  grep -qE '(^|[;&|]|&&)[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*BULK_EDIT_ACK=1[[:space:]]'; then
+  exit 0
+fi
+
+# --- 2. A content write whose target names the store ---------------------------------------------
+# Scoped to CONTENT writes on purpose. `rm -rf node_modules` and `mv node_modules …` are the reinstall
+# idioms every contributor runs; refusing them would be a correct command blocked, which is how a
+# guard earns its ack being pasted by reflex.
+# A REDIRECT is judged on its TARGET, not on the command containing it. `cat node_modules/.pnpm/p/
+# package.json > /tmp/out` reads from the store and writes outside it, and the first cut of this
+# branch refused it, because it asked only whether the command mentioned a store path anywhere.
+if printf '%s' "$MASK" | grep -qE '>>?[[:space:]]*[^[:space:]|;&]*(node_modules|\.pnpm)/'; then
+  refuse_path "the command redirects output into node_modules or .pnpm"
+fi
+
+# The in-place editors take their targets as ARGUMENTS, so "an editor is present AND a store path is
+# present" is already tight — there is no other place the path could be going.
+if printf '%s' "$MASK" | grep -qE '(node_modules|\.pnpm)/' &&
+  printf '%s' "$MASK" | grep -qE '(sed[[:space:]]+(-[[:alnum:]]*[[:space:]]+)*-i|perl[[:space:]]+(-[[:alnum:]]*[[:space:]]+)*-i|[[:space:]]tee[[:space:]]|truncate[[:space:]])'; then
+  refuse_path "the command writes content to a path naming node_modules or .pnpm"
+fi
+
+# --- 3. The four measured symlink-following enumerators ------------------------------------------
+# Every finding names the safe sibling as well as the hazard. That half is not decoration: it is what
+# makes the refusal actionable in one edit, and a refusal that is not actionable is one that gets
+# acked instead of fixed.
+FOUND=''
+add_finding() { FOUND="${FOUND}[bulk-edit-guard]   $1"$'\n'; }
+
+WORDS=$(hook_statement_all_words "$COMMAND" 2>/dev/null || printf '%s' "$COMMAND")
+
+# Was FLAG passed TO COMMAND — not "does the flag appear anywhere". The difference is a real command
+# this guard refused during development: `find packages -name '*.ts' | xargs grep -L foo` carries a
+# `-L`, but it belongs to `grep`, where it means files-without-match and follows nothing. Attributing
+# it to `find` refuses a correct pipeline, and a guard that does that gets its ack pasted by reflex.
+#
+# So the word list is walked: a separator (`|`, `;`, `&&`, …) ends the current command, the first
+# non-flag word after one BECOMES the current command, and a wrapper (`xargs`, `env`, `sudo`, …)
+# hands that role to the word after it. A flag counts only while its own command is current.
+cmd_flag() {
+  printf '%s\n' "$WORDS" | awk -v CMD="$1" -v FLAG="$2" '
+    function is_sep(w) { return w == "|" || w == ";" || w == "&" || w == "&&" || w == "||" || w == "(" || w == ")" }
+    function is_wrapper(w) { return w == "xargs" || w == "env" || w == "sudo" || w == "time" || w == "nice" || w == "command" }
+    BEGIN { cur = "" }
+    { w = $0 }
+    is_sep(w) { cur = ""; next }
+    # A leading assignment (`FOO=bar find -L …`) is not the command. Without this it BECAME the
+    # current command and the real one was never judged.
+    cur == "" && w ~ /^[A-Za-z_][A-Za-z0-9_]*=/ { next }
+    cur == "" && w !~ /^-/ { if (!is_wrapper(w)) cur = w; next }
+    cur == CMD && w ~ /^-/ && w ~ FLAG { found = 1 }
+    END { exit(found ? 0 : 1) }'
+}
+
+if cmd_flag find '^(-L|-follow)$'; then
+  add_finding "find -L follows symlinks. Drop -L: plain find does not (measured)."
+fi
+if cmd_flag grep '^(-[[:alnum:]]*R[[:alnum:]]*|--dereference-recursive)$'; then
+  add_finding "grep -R dereferences every symlink. Use -r, which does not (measured)."
+fi
+if cmd_flag rg '^(--follow|-[[:alnum:]]*L[[:alnum:]]*)$' || cmd_flag ripgrep '^(--follow|-[[:alnum:]]*L[[:alnum:]]*)$'; then
+  add_finding "rg --follow follows symlinks. Drop it: rg does not follow, and honours .gitignore."
+fi
+if printf '%s' "$MASK" | grep -qE '\bglob\.(glob|iglob)\('; then
+  add_finding "python glob.glob follows symlinks. pathlib Path(...).rglob does not (measured)."
+fi
+
+[[ -n "$FOUND" ]] || exit 0
+
+echo "[bulk-edit-guard] Blocked: this command enumerates files by following symlinks, which in a" >&2
+echo "[bulk-edit-guard] pnpm workspace reaches node_modules and the store hard-linked beneath it." >&2
+printf '%s' "$FOUND" >&2
+echo "[bulk-edit-guard] Prefer git ls-files as the source of a bulk edit — it cannot return a" >&2
+echo "[bulk-edit-guard] node_modules path at all. See .agents/rules/operational.md." >&2
+echo "[bulk-edit-guard] Deliberate exception: BULK_EDIT_ACK=1 inline in the same command." >&2
+exit 2

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -179,6 +179,24 @@ cmd_flag() {
     END { exit(found ? 0 : 1) }'
 }
 
+# The store name as a PATH SEGMENT, for the awk-side rules. Same anchoring as `STORE_SEGMENT_RE`,
+# spelled for awk because a shell variable does not reach inside the program text.
+STORE_IN_AWK='function is_store(w) { return w ~ /(^|\/)(node_modules|\.pnpm)(\/|$)/ }'
+
+# A copying command whose DESTINATION names the store. `dd` states its destination as `of=`; the rest
+# take it as the last non-flag word, so the SOURCE may be anywhere, including inside the store.
+segment_copies_into_store() {
+  segments | awk "$(basename_of) $STORE_IN_AWK"'
+    function reset() { copier = 0; dest = "" }
+    function flush() { if (copier && dest != "" && is_store(dest)) found = 1; reset() }
+    BEGIN { reset() }
+    $0 == "\034" { flush(); next }
+    base($0) == "cp" || base($0) == "mv" || base($0) == "rsync" || base($0) == "install" || base($0) == "dd" { copier = 1; next }
+    copier && $0 ~ /^of=/ { d = $0; sub(/^of=/, "", d); if (is_store(d)) found = 1; next }
+    copier && $0 !~ /^-/ { dest = $0 }
+    END { flush(); exit(found ? 0 : 1) }'
+}
+
 # An in-place editor and a store path standing in ONE segment. See the note on the rule above for
 # what the segment scope is correcting.
 segment_has_editor_and_store_path() {
@@ -220,6 +238,19 @@ fi
 # conjunction from a coincidence. Reported in review of this change.
 if segment_has_editor_and_store_path; then
   refuse_path "an in-place editor is given a path naming node_modules or .pnpm"
+fi
+
+# A COPY whose destination is inside the store. Reported in review of this change: the redirect and
+# in-place-editor rules cover two ways of writing content, and `cp`, single-file `mv`, `rsync`,
+# `install` and `dd` are a third — `cp dist/patched.js …/node_modules/lodash/index.js` lands in the
+# hard-linked store exactly as this file's rationale describes, and matched nothing.
+#
+# Judged on the DESTINATION, like the redirect. That is what keeps the reinstall idioms working:
+# `mv node_modules /tmp/backup` and `cp -r node_modules /tmp/x` READ from the store and write outside
+# it, so they pass; `mv node_modules node_modules.bak` passes because the name is anchored on a
+# separator. Only a write INTO the store is refused.
+if segment_copies_into_store; then
+  refuse_path "a copy's destination is inside node_modules or .pnpm"
 fi
 
 # --- 3. The four measured symlink-following enumerators ------------------------------------------

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -162,24 +162,33 @@ segments() {
     { print }'
 }
 
+# A command word is matched by its BASENAME. Reported in review of this change: `$0 == CMD` is a
+# literal match, so `/usr/bin/find -L …` never set `seen` and its `-L` was attributed to nothing —
+# while `scan-symlink-following-enumeration.mjs`, which matches on a word boundary, reported the same
+# line. Two halves of one rule disagreeing on a bypass is worse than either being wrong alone, because
+# the green half is the one a reader trusts. `./find` and `../bin/find` are the same shape.
+basename_of() {
+  printf '%s' 'function base(w) { sub(/^.*\//, "", w); return w }'
+}
+
 cmd_flag() {
-  segments | awk -v CMD="$1" -v FLAG="$2" '
+  segments | awk -v CMD="$1" -v FLAG="$2" "$(basename_of)"'
     $0 == "\034" { seen = 0; next }
     seen && $0 ~ /^-/ && $0 ~ FLAG { found = 1 }
-    $0 == CMD { seen = 1 }
+    base($0) == CMD { seen = 1 }
     END { exit(found ? 0 : 1) }'
 }
 
 # An in-place editor and a store path standing in ONE segment. See the note on the rule above for
 # what the segment scope is correcting.
 segment_has_editor_and_store_path() {
-  segments | awk '
+  segments | awk "$(basename_of)"'
     function reset() { editor = 0; store = 0; sed_or_perl = 0 }
     BEGIN { reset() }
     $0 == "\034" { reset(); next }
-    $0 == "sed" || $0 == "perl" { sed_or_perl = 1 }
+    base($0) == "sed" || base($0) == "perl" { sed_or_perl = 1 }
     sed_or_perl && $0 ~ /^-[[:alnum:]]*i/ { editor = 1 }
-    $0 == "tee" || $0 == "truncate" { editor = 1 }
+    base($0) == "tee" || base($0) == "truncate" { editor = 1 }
     $0 ~ /(^|\/)(node_modules|\.pnpm)\// { store = 1 }
     editor && store { found = 1 }
     END { exit(found ? 0 : 1) }'

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -80,22 +80,33 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Mult
   # RESOLVED as well as spelled. A path can reach the store without naming it — `packages/a/nm-link/x`
   # where `nm-link` is a symlink into node_modules.
   #
-  # The existence test is on the PARENT DIRECTORY, not on the file. Review of this change caught the
-  # first version testing `-e "$FILE_PATH"`, which is false for exactly the case `Write` exists to
-  # serve: a file being CREATED. A brand-new file inside a symlinked directory skipped the whole
-  # block and reached the store unrefused. The directory is what carries the symlink — pnpm links
-  # DIRECTORIES — and it is already there whether or not the file is.
+  # The existence test walks UP to the NEAREST EXISTING ANCESTOR. Review of this change reported the
+  # same defect twice, one level apart. The first version tested `-e "$FILE_PATH"`, false for exactly
+  # what `Write` exists to do — create a file that is not there yet — so a new file inside a
+  # symlinked directory skipped the block entirely. Moving the test to `-d "$PARENT"` fixed that one
+  # and left the next depth down: a write into a subdirectory that does not exist YET, under the
+  # directory that carries the link. Its parent does not exist either, so the block is skipped again
+  # — and the write still lands in the store.
   #
-  # The test that was supposed to cover this pre-created the target with `writeFileSync`, so it
-  # proved the resolution worked on a path that did not need it. That is the more useful half of the
-  # finding: the case existed and was measuring the wrong thing.
+  # An ancestor is what CARRIES the symlink — pnpm links DIRECTORIES — and some ancestor always
+  # exists, so that is the level the test belongs at and the level at which it cannot recede again.
+  # The unresolved tail is carried along and re-appended, so the reported path is the one asked for.
+  #
+  # The test that was supposed to cover the first case pre-created its target with `writeFileSync`,
+  # so it proved resolution worked on a path that did not need it. That is the more useful half of
+  # the finding, and it is why each depth below is now a case of its own.
   #
   # `cd` + `pwd -P` rather than `readlink -f`: the `-f` form is GNU-only and fails unhelpfully on
   # BSD/macOS, which `shell-portability` refuses (see "Host Platform Is Read, Never Assumed"). `pwd
   # -P` is POSIX and resolves the DIRECTORY chain, which is the level pnpm's symlinks live at.
-  PARENT=$(dirname -- "$FILE_PATH")
-  if [[ -d "$PARENT" ]]; then
-    RESOLVED=$( (cd "$PARENT" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$(basename -- "$FILE_PATH")") || printf '')
+  ANCESTOR=$(dirname -- "$FILE_PATH")
+  TAIL=$(basename -- "$FILE_PATH")
+  while [[ ! -d "$ANCESTOR" && "$ANCESTOR" != "/" && "$ANCESTOR" != "." ]]; do
+    TAIL="$(basename -- "$ANCESTOR")/$TAIL"
+    ANCESTOR=$(dirname -- "$ANCESTOR")
+  done
+  if [[ -d "$ANCESTOR" ]]; then
+    RESOLVED=$( (cd "$ANCESTOR" 2>/dev/null && printf '%s/%s' "$(pwd -P)" "$TAIL") || printf '')
     if [[ -n "$RESOLVED" ]] && printf '%s' "$RESOLVED" | grep -qE "$STORE_SEGMENT_RE"; then
       refuse_path "$FILE_PATH -> $RESOLVED"
     fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-foreground-wait.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/bulk-edit-guard.sh"
           }
         ]
       },
@@ -32,6 +36,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-forbidden-patterns.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/bulk-edit-guard.sh"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "examples:typecheck": "pnpm --filter \"./examples/**\" run typecheck",
     "harness:scan:conflict-markers": "node scripts/harness/scan-conflict-markers.mjs",
     "harness:scan:reference-kind-qualified": "node scripts/harness/scan-reference-kind-qualified.mjs",
+    "harness:scan:symlink-following-enumeration": "node scripts/harness/scan-symlink-following-enumeration.mjs",
     "harness:scan:deprecated-markers": "node scripts/harness/scan-deprecated-markers.mjs",
     "harness:scan:orphan-exports": "node scripts/harness/check-orphan-exports.mjs",
     "test:mutation": "stryker run",

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -60,6 +60,19 @@ describe('a file-writing tool naming the dependency store', () => {
     expect(write('packages/agent-cli/src/remote-control/local-peer-registry.ts').status).toBe(0);
   });
 
+  it('attributes a flag to an ABSOLUTE-PATH invocation of the same command', () => {
+    // Reported in review of this change. `$0 == CMD` was a literal match, so `/usr/bin/find -L …`
+    // set nothing and its `-L` was attributed to no command at all — while the committed-script scan,
+    // which matches on a word boundary, reported the very same line. Two halves of one rule
+    // disagreeing on a bypass is worse than either being wrong alone: the green half is the one a
+    // reader trusts. Command words are matched by BASENAME now.
+    expect(bash("/usr/bin/find -L packages -name '*.ts'").status).toBe(2);
+    expect(bash("/usr/bin/sed -i 's/a/b/' packages/a/node_modules/b/x.ts").status).toBe(2);
+    // The safe siblings, spelled the same absolute way, stay permitted.
+    expect(bash("/usr/bin/find packages -name '*.ts'").status).toBe(0);
+    expect(bash("/usr/bin/sed -i 's/a/b/' src/a.ts").status).toBe(0);
+  });
+
   it('permits a redirect and an edit into a directory that merely CONTAINS the letters', () => {
     // Reported in review of this change: the Bash-side checks matched `node_modules/` as a plain
     // substring while the write-tool path anchored it on a separator, so a directory ENDING in those

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * INFRA-105 (#1884) — a bulk edit must not be able to reach the pnpm store.
+ *
+ * The incident this guards against is invisible after the fact: `packages/<a>/node_modules/@scope/<b>`
+ * is a symlink to `packages/<b>`, and `node_modules/.pnpm` is hard-linked into every other project on
+ * the machine. `git status` cannot see a write that lands there, and every harness scan reads
+ * `git ls-files`, which cannot list `node_modules` at all. So the check has to happen BEFORE the write.
+ *
+ * Every rule is asserted in BOTH directions — the hazardous spelling refused AND its safe sibling
+ * permitted. A guard that has only ever been shown to say no is a guard nobody has shown can say yes,
+ * and that is the shape that gets switched off the first time it blocks correct work. The sibling
+ * halves are not padding: `find` without `-L`, `grep -r`, `rg` without `--follow`, `Path.rglob`,
+ * bash `**` under globstar and `fs.globSync` were each MEASURED not to traverse a symlink, which is
+ * why the guard aims at four spellings rather than at recursive enumeration in general.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
+const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/bulk-edit-guard.sh');
+
+const scratch = [];
+afterAll(() => {
+  while (scratch.length > 0) rmSync(scratch.pop(), { recursive: true, force: true });
+});
+
+function run(payload) {
+  const result = spawnSync('bash', [HOOK], {
+    input: typeof payload === 'string' ? payload : JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: WORKSPACE_ROOT, BULK_EDIT_ACK: '0' },
+  });
+  return { status: result.status, stderr: result.stderr ?? '' };
+}
+
+const bash = (command) => run({ tool_name: 'Bash', tool_input: { command } });
+const write = (filePath) => run({ tool_name: 'Write', tool_input: { file_path: filePath } });
+
+describe('a file-writing tool naming the dependency store', () => {
+  it('refuses a path with a node_modules segment', () => {
+    const { status, stderr } = write(
+      'packages/agent-cli/node_modules/@robota-sdk/agent-core/src/x.ts',
+    );
+    expect(status).toBe(2);
+    expect(stderr).toContain('dependency store');
+  });
+
+  it('refuses a path inside the .pnpm store', () => {
+    expect(write('node_modules/.pnpm/vitest@3.0.0/node_modules/vitest/dist/index.js').status).toBe(
+      2,
+    );
+  });
+
+  it('permits an ordinary workspace source path', () => {
+    expect(write('packages/agent-cli/src/remote-control/local-peer-registry.ts').status).toBe(0);
+  });
+
+  it('permits a directory that merely contains the letters', () => {
+    // Anchored on separators. `my_node_modules_notes/` is not the store, and a guard that cannot
+    // tell them apart refuses documentation about itself.
+    expect(write('docs/my_node_modules_notes/why.md').status).toBe(0);
+  });
+
+  it('refuses a path that reaches the store only after symlink resolution', () => {
+    // The spelled path names nothing suspicious; only `readlink -f` shows where the write lands.
+    // This is the case a text-only check misses, and it is the exact shape pnpm creates.
+    const dir = mkdtempSync(path.join(tmpdir(), 'bulk-edit-guard-'));
+    scratch.push(dir);
+    mkdirSync(path.join(dir, 'node_modules/pkg/src'), { recursive: true });
+    writeFileSync(path.join(dir, 'node_modules/pkg/src/index.ts'), 'export {};\n');
+    mkdirSync(path.join(dir, 'app'), { recursive: true });
+    symlinkSync(path.join(dir, 'node_modules/pkg'), path.join(dir, 'app/vendored'));
+
+    const { status, stderr } = write(path.join(dir, 'app/vendored/src/index.ts'));
+    expect(status).toBe(2);
+    expect(stderr).toContain('->');
+  });
+});
+
+describe('the four measured symlink-following enumerators', () => {
+  const cases = [
+    ['find -L', 'find -L packages -name "*.ts"', 'find packages -name "*.ts"'],
+    ['grep -R', 'grep -Rl createSession packages', 'grep -rl createSession packages'],
+    ['rg --follow', 'rg --follow -l createSession packages', 'rg -l createSession packages'],
+    [
+      'python glob.glob',
+      'python3 -c "import glob; print(glob.glob(1))"',
+      'python3 -c "from pathlib import Path; print(Path(1).rglob(2))"',
+    ],
+  ];
+
+  it.each(cases)('refuses %s', (_name, hazardous) => {
+    expect(bash(hazardous).status).toBe(2);
+  });
+
+  it.each(cases)('permits the safe sibling of %s', (_name, _hazardous, safe) => {
+    expect(bash(safe).status).toBe(0);
+  });
+
+  it('permits grep -L, which is files-without-match and follows nothing', () => {
+    // The flag is attributed to the command that RECEIVED it. `-L` after `find` follows symlinks;
+    // `-L` after `grep` does not. Reading the flag without its command refused this correct
+    // pipeline during development.
+    expect(bash('find packages -name "*.ts" | xargs grep -L createSession').status).toBe(0);
+  });
+
+  it('still sees a hazardous flag on the first command of a pipeline', () => {
+    expect(bash('find -L packages -name "*.ts" | xargs grep -l createSession').status).toBe(2);
+  });
+
+  it('sees a command introduced by a wrapper', () => {
+    expect(bash('cat list.txt | xargs -0 find -L -name "*.ts"').status).toBe(2);
+  });
+
+  it('permits an unrelated command carrying the same letters', () => {
+    expect(bash('ls -L packages').status).toBe(0);
+  });
+});
+
+describe('a content write whose target names the store', () => {
+  it('refuses an in-place sed', () => {
+    expect(bash('sed -i "s/a/b/" packages/a/node_modules/@robota-sdk/b/src/x.ts').status).toBe(2);
+  });
+
+  it('refuses a redirection into the store', () => {
+    expect(bash('echo broken > node_modules/.pnpm/pkg/index.js').status).toBe(2);
+  });
+
+  it('permits the reinstall idioms', () => {
+    // `rm -rf node_modules && pnpm install` is what every contributor runs. Refusing it would be a
+    // correct command blocked, which is how a guard's ack starts being pasted without being read.
+    expect(bash('rm -rf node_modules && pnpm install').status).toBe(0);
+    expect(bash('mv node_modules node_modules.bak').status).toBe(0);
+  });
+});
+
+describe('reading the payload', () => {
+  it('refuses an empty payload rather than permitting it', () => {
+    // fail-direction. "I could not look" is not "there was nothing there", and permitting here would
+    // make a malformed payload the way past the guard.
+    const { status, stderr } = run('');
+    expect(status).toBe(2);
+    expect(stderr).toContain('empty');
+  });
+
+  it('refuses a payload that names no tool', () => {
+    expect(run({ tool_input: { command: 'echo hi' } }).status).toBe(2);
+  });
+
+  it('ignores a tool it does not judge', () => {
+    expect(run({ tool_name: 'Read', tool_input: { file_path: 'node_modules/x.js' } }).status).toBe(
+      0,
+    );
+  });
+});
+
+describe('the documented escape', () => {
+  it('permits an inline BULK_EDIT_ACK=1', () => {
+    expect(bash('BULK_EDIT_ACK=1 find -L packages -name "*.ts"').status).toBe(0);
+  });
+
+  it('does not accept the ack merely NAMED inside a quoted argument', () => {
+    // Read off the masked text, the same rule branch-guard arrived at after four holes. A guard that
+    // can be switched off by a string it is scanning is not a guard.
+    expect(bash('echo "BULK_EDIT_ACK=1 " && find -L packages -name "*.ts"').status).toBe(2);
+  });
+
+  it('does not trip on the four spellings written into a heredoc body', () => {
+    // This repository's rule text, task record and the hook's own comments all discuss `find -L`,
+    // `grep -R`, `rg --follow` and `glob.glob`. Writing them must not require the ack.
+    const doc = 'cat > notes.md <<EOF\navoid find -L, grep -R, rg --follow and glob.glob(...)\nEOF';
+    expect(bash(doc).status).toBe(0);
+  });
+});
+
+describe('what the self-review pass corrected', () => {
+  it('judges a redirect on its TARGET, not on the command containing it', () => {
+    // Reading FROM the store and writing outside it is ordinary — inspecting an installed package's
+    // manifest. The first cut refused this, because it asked only whether a store path appeared
+    // anywhere in the command.
+    expect(bash('cat node_modules/.pnpm/pkg/package.json > /tmp/out.json').status).toBe(0);
+    expect(bash('echo broken > node_modules/.pnpm/pkg/index.js').status).toBe(2);
+  });
+
+  it('does not let a leading assignment take the command name slot', () => {
+    // `FOO=bar find -L …` — without skipping the assignment it BECAME the current command, and the
+    // real one was never judged. This is the same hole in the opposite direction from the ack read.
+    expect(bash('FOO=bar find -L packages -name "*.ts"').status).toBe(2);
+  });
+
+  it('sees the command after a wrapper that itself takes flags', () => {
+    expect(bash('sudo find -L /srv -name "*.ts"').status).toBe(2);
+  });
+});

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -60,6 +60,23 @@ describe('a file-writing tool naming the dependency store', () => {
     expect(write('packages/agent-cli/src/remote-control/local-peer-registry.ts').status).toBe(0);
   });
 
+  it('permits a redirect and an edit into a directory that merely CONTAINS the letters', () => {
+    // Reported in review of this change: the Bash-side checks matched `node_modules/` as a plain
+    // substring while the write-tool path anchored it on a separator, so a directory ENDING in those
+    // letters was permitted by one guard and refused by the other — the case both already had a test
+    // for, answered two different ways.
+    //
+    // The name matters. Review's example was `my_node_modules_old/`, which does not contain the
+    // substring `node_modules/` at all and was never refused; `my_node_modules/` does, and is. Taking
+    // the example on trust would have produced a case that passes whether or not the fix is present —
+    // and it did, until the mutation run said so.
+    expect(bash('echo x > packages/app/my_node_modules/notes.txt').status).toBe(0);
+    expect(bash("sed -i 's/a/b/' packages/app/my_node_modules/x.ts").status).toBe(0);
+    // The real store is still refused through both, so anchoring did not simply widen the gate.
+    expect(bash('echo x > packages/app/node_modules/notes.txt').status).toBe(2);
+    expect(bash("sed -i 's/a/b/' packages/a/node_modules/b/src/x.ts").status).toBe(2);
+  });
+
   it('permits a directory that merely contains the letters', () => {
     // Anchored on separators. `my_node_modules_notes/` is not the store, and a guard that cannot
     // tell them apart refuses documentation about itself.

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -95,6 +95,19 @@ describe('a file-writing tool naming the dependency store', () => {
     expect(status).toBe(2);
   });
 
+  it('refuses a NEW file inside a NEW subdirectory of a symlinked directory', () => {
+    // Reported in review of this change, one level below the case above and the same defect: the
+    // parent `app/vendored/newdir` does not exist either, so a test that stops at the parent skips
+    // the block again — while the write still lands in the store through `app/vendored`. Some
+    // ANCESTOR always exists, which is why the walk cannot recede a third time.
+    const { status, stderr } = write(
+      path.join(symlinkedStore(), 'app/vendored/newdir/brand-new.ts'),
+    );
+    expect(status).toBe(2);
+    // The reported path carries the unresolved tail, so the operator sees where it actually lands.
+    expect(stderr).toContain('newdir/brand-new.ts');
+  });
+
   it('permits a NEW file inside an ordinary directory', () => {
     // The other direction of the same change: moving the existence test to the parent must not make
     // every creation suspicious.
@@ -102,6 +115,15 @@ describe('a file-writing tool naming the dependency store', () => {
     scratch.push(dir);
     mkdirSync(path.join(dir, 'packages/p/src'), { recursive: true });
     expect(write(path.join(dir, 'packages/p/src/brand-new.ts')).status).toBe(0);
+  });
+
+  it('permits a NEW file inside a NEW subdirectory of an ordinary directory', () => {
+    // The same direction one level deeper. Walking up to an existing ancestor must not turn every
+    // mkdir-and-write into a refusal — that is how an ack starts being pasted without being read.
+    const dir = mkdtempSync(path.join(tmpdir(), 'bulk-edit-guard-ok-'));
+    scratch.push(dir);
+    mkdirSync(path.join(dir, 'packages/p'), { recursive: true });
+    expect(write(path.join(dir, 'packages/p/src/nested/brand-new.ts')).status).toBe(0);
   });
 });
 

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -60,6 +60,34 @@ describe('a file-writing tool naming the dependency store', () => {
     expect(write('packages/agent-cli/src/remote-control/local-peer-registry.ts').status).toBe(0);
   });
 
+  it.each([
+    ['cp', 'cp dist/patched-index.js packages/a/node_modules/.pnpm/lodash@4.17.21/x.js'],
+    ['mv', 'mv src/a.ts packages/a/node_modules/b/x.ts'],
+    ['rsync', 'rsync -a dist/ packages/a/node_modules/b/'],
+    ['install', 'install -m 644 x.js node_modules/pkg/x.js'],
+    ['dd', 'dd if=/dev/zero of=node_modules/pkg/x.bin'],
+  ])('refuses %s when its DESTINATION is inside the store', (_name, command) => {
+    // Reported in review of this change. A redirect and an in-place editor are two ways of writing
+    // content; a copy is a third, and it landed in the hard-linked store while matching no rule.
+    expect(bash(command).status).toBe(2);
+  });
+
+  it.each([
+    ['the reinstall idiom', 'rm -rf node_modules && pnpm install'],
+    ['moving the store aside', 'mv node_modules /tmp/backup'],
+    ['renaming the store', 'mv node_modules node_modules.bak'],
+    ['copying OUT of the store', 'cp -r node_modules /tmp/x'],
+    ['an ordinary copy', 'cp dist/a.js packages/app/src/a.js'],
+    [
+      'a directory that only contains the letters',
+      'cp dist/a.js packages/app/my_node_modules/a.js',
+    ],
+  ])('permits %s', (_name, command) => {
+    // The copy rule is judged on the DESTINATION for exactly this reason: every one of these READS
+    // from the store or writes past it, and refusing them is how a guard earns its ack being pasted.
+    expect(bash(command).status).toBe(0);
+  });
+
   it('attributes a flag to an ABSOLUTE-PATH invocation of the same command', () => {
     // Reported in review of this change. `$0 == CMD` was a literal match, so `/usr/bin/find -L …`
     // set nothing and its `-L` was attributed to no command at all — while the committed-script scan,

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -66,19 +66,42 @@ describe('a file-writing tool naming the dependency store', () => {
     expect(write('docs/my_node_modules_notes/why.md').status).toBe(0);
   });
 
-  it('refuses a path that reaches the store only after symlink resolution', () => {
-    // The spelled path names nothing suspicious; only `readlink -f` shows where the write lands.
-    // This is the case a text-only check misses, and it is the exact shape pnpm creates.
+  /** A store directory reachable through a symlink whose own name says nothing. */
+  function symlinkedStore() {
     const dir = mkdtempSync(path.join(tmpdir(), 'bulk-edit-guard-'));
     scratch.push(dir);
     mkdirSync(path.join(dir, 'node_modules/pkg/src'), { recursive: true });
     writeFileSync(path.join(dir, 'node_modules/pkg/src/index.ts'), 'export {};\n');
     mkdirSync(path.join(dir, 'app'), { recursive: true });
     symlinkSync(path.join(dir, 'node_modules/pkg'), path.join(dir, 'app/vendored'));
+    return dir;
+  }
 
-    const { status, stderr } = write(path.join(dir, 'app/vendored/src/index.ts'));
+  it('refuses an EXISTING path that reaches the store only after symlink resolution', () => {
+    // The spelled path names nothing suspicious; only resolution shows where the write lands. This
+    // is the case a text-only check misses, and it is the exact shape pnpm creates.
+    const { status, stderr } = write(path.join(symlinkedStore(), 'app/vendored/src/index.ts'));
     expect(status).toBe(2);
     expect(stderr).toContain('->');
+  });
+
+  it('refuses a NEW file inside a symlinked directory', () => {
+    // Reported in review of this change, and the sharper half of the finding is about the case
+    // above: it pre-created the target, so it proved resolution worked on a path that did not need
+    // it. `Write` exists to create files that are not there yet, and the guard tested `-e
+    // "$FILE_PATH"` — false for exactly that. The parent directory carries the symlink, and it is
+    // there whether or not the file is.
+    const { status } = write(path.join(symlinkedStore(), 'app/vendored/src/brand-new.ts'));
+    expect(status).toBe(2);
+  });
+
+  it('permits a NEW file inside an ordinary directory', () => {
+    // The other direction of the same change: moving the existence test to the parent must not make
+    // every creation suspicious.
+    const dir = mkdtempSync(path.join(tmpdir(), 'bulk-edit-guard-ok-'));
+    scratch.push(dir);
+    mkdirSync(path.join(dir, 'packages/p/src'), { recursive: true });
+    expect(write(path.join(dir, 'packages/p/src/brand-new.ts')).status).toBe(0);
   });
 });
 
@@ -175,6 +198,27 @@ describe('the documented escape', () => {
     // `grep -R`, `rg --follow` and `glob.glob`. Writing them must not require the ack.
     const doc = 'cat > notes.md <<EOF\navoid find -L, grep -R, rg --follow and glob.glob(...)\nEOF';
     expect(bash(doc).status).toBe(0);
+  });
+});
+
+describe('what review of this change corrected', () => {
+  it('attributes a flag past a wrapper that took its own argument', () => {
+    // `sudo -u deploy find -L …` — the walk this replaced promoted `deploy`, a wrapper FLAG'S
+    // ARGUMENT, to current command, so `find` was never recognised and its `-L` sailed through.
+    // Segment membership needs no list of which wrapper flags take a value.
+    expect(bash('sudo -u deploy find -L packages/vendor -name "*.ts"').status).toBe(2);
+    expect(bash('nice -n 10 find -L packages -name x').status).toBe(2);
+  });
+
+  it('still separates a pipeline, which is what the attribution was for', () => {
+    expect(bash('find packages -name "*.ts" | xargs grep -L createSession').status).toBe(0);
+  });
+
+  it('requires the editor and the store path in ONE segment', () => {
+    // Two independent substring greps over a whole command cannot tell a conjunction from a
+    // coincidence: this refused an edit to `src/` that merely stood beside an `ls` of node_modules.
+    expect(bash('sed -i "s/a/b/" src/a.ts && ls node_modules/.bin').status).toBe(0);
+    expect(bash('sed -i "s/a/b/" packages/a/node_modules/b/src/x.ts').status).toBe(2);
   });
 });
 

--- a/scripts/harness/__tests__/guards-pass-silently.test.mjs
+++ b/scripts/harness/__tests__/guards-pass-silently.test.mjs
@@ -121,7 +121,12 @@ function ambientWithoutDecisionInputs() {
     // from whatever session runs the suite. An exported one disarms its guard, so the row would pass
     // because nothing was checked — the accidental green named two paragraphs up, in the other
     // spelling.
-    if (/_ALLOW_|_ACK$/.test(name)) delete clean[name];
+    //
+    // String predicates rather than one alternation, because the two clauses ask different
+    // questions: `_ALLOW_` is an infix and `_ACK` is a suffix. Writing them as `/_ALLOW_|_ACK$/`
+    // reads as if the anchor governs both, which is the ambiguity CodeQL's missing-regexp-anchor
+    // rule flagged on this line — and here the plainer spelling is also the more readable one.
+    if (name.includes('_ALLOW_') || name.endsWith('_ACK')) delete clean[name];
   }
   return clean;
 }

--- a/scripts/harness/__tests__/guards-pass-silently.test.mjs
+++ b/scripts/harness/__tests__/guards-pass-silently.test.mjs
@@ -116,7 +116,12 @@ function ambientWithoutDecisionInputs() {
   const clean = { ...process.env };
   for (const name of DECISION_INPUTS) delete clean[name];
   for (const name of Object.keys(clean)) {
-    if (/_ALLOW_/.test(name)) delete clean[name];
+    // `*_ALLOW_*` AND `*_ACK` — the two spellings this directory's overrides use. Only the first was
+    // scrubbed, which left `MERGE_GATE_ACK`, `FOREGROUND_WAIT_ACK` and `BULK_EDIT_ACK` inherited
+    // from whatever session runs the suite. An exported one disarms its guard, so the row would pass
+    // because nothing was checked — the accidental green named two paragraphs up, in the other
+    // spelling.
+    if (/_ALLOW_|_ACK$/.test(name)) delete clean[name];
   }
   return clean;
 }
@@ -210,6 +215,29 @@ const REGISTRY = [
     // is spending the turn waiting for something ELSE to change.
     setup: () => scratchDir('guard-no-wait-'),
     command: 'pnpm build',
+  },
+  {
+    hook: 'bulk-edit-guard.sh',
+    verb: 'a bulk edit sourced from git ls-files',
+    // The invocation the rule ASKS FOR. A guard against reaching node_modules that also complains
+    // about the sanctioned way to enumerate would make the sanctioned way feel no safer than the
+    // hazardous one, and the rule would be read as noise.
+    setup: () => scratchDir('guard-bulk-edit-'),
+    command: "git ls-files -z '*.ts' | xargs -0 sed -i 's/a/b/'",
+  },
+  {
+    hook: 'bulk-edit-guard.sh',
+    verb: 'Write of package source',
+    setup: () => {
+      const dir = scratchDir('guard-bulk-write-');
+      mkdirSync(path.join(dir, 'packages/p/src'), { recursive: true });
+      return dir;
+    },
+    payload: (dir) =>
+      JSON.stringify({
+        tool_name: 'Write',
+        tool_input: { file_path: path.join(dir, 'packages/p/src/a.ts'), content: 'export {};\n' },
+      }),
   },
   {
     hook: 'pre-push-check.sh',

--- a/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
+++ b/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * INFRA-105 (#1884) — the committed-script half of the symlink-enumeration rule.
+ *
+ * `bulk-edit-guard.sh` judges the command an agent is about to run. Once that command is committed as
+ * a script, the hook never sees it again — the script runs from CI, from a package manager entry
+ * point, from another script. This scan is what covers it there.
+ *
+ * Both directions for every rule. The safe sibling of each hazardous spelling was MEASURED not to
+ * traverse a symlink, and the patterns are shaped so that it does not match; asserting only the
+ * hazardous half would leave a scan that could be passing because it flags everything.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  examinedScriptCount,
+  findingsIn,
+  scanTrackedFiles,
+} from '../scan-symlink-following-enumeration.mjs';
+
+const SCRIPT = 'scripts/tools/rewrite.sh';
+
+describe('the four measured spellings', () => {
+  const cases = [
+    ['find -L', 'find -L packages -name "*.ts" -print0', 'find packages -name "*.ts" -print0'],
+    ['grep -R', 'grep -Rl createSession packages/', 'grep -rl createSession packages/'],
+    ['rg --follow', 'rg --follow -l createSession packages', 'rg -l createSession packages'],
+    [
+      'python glob.glob',
+      'python3 -c "import glob; print(glob.glob(\'packages/**/*.ts\', recursive=True))"',
+      "python3 -c \"from pathlib import Path; print(list(Path('packages').rglob('*.ts')))\"",
+    ],
+  ];
+
+  it.each(cases)('reports %s', (id, hazardous) => {
+    const findings = findingsIn(SCRIPT, hazardous);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].id).toBe(id);
+    expect(findings[0].remedy).toBeTruthy();
+  });
+
+  it.each(cases)('does not report the safe sibling of %s', (_id, _hazardous, safe) => {
+    expect(findingsIn(SCRIPT, safe)).toEqual([]);
+  });
+
+  it('reports the line number, so the finding is one edit away from clean', () => {
+    const script = ['#!/usr/bin/env bash', 'set -euo pipefail', 'grep -Rl foo packages'].join('\n');
+    expect(findingsIn(SCRIPT, script)).toMatchObject([{ line: 3, id: 'grep -R' }]);
+  });
+});
+
+describe('what it does not report', () => {
+  it('ignores a line that discusses the spelling in a comment', () => {
+    // The rule has to be explainable in the file that implements it. A scan that flags its own
+    // rationale forces the rationale out of the code, which is where it is least likely to be read.
+    const script = [
+      '# never write: find -L packages',
+      '// and not grep -R either',
+      'find packages -name x',
+    ].join('\n');
+    expect(findingsIn(SCRIPT, script)).toEqual([]);
+  });
+
+  it('ignores a file type that is not a script', () => {
+    expect(findingsIn('docs/why-not-glob.md', 'find -L packages -name "*.ts"')).toEqual([]);
+  });
+
+  it('ignores the guard, its test, and this scan itself', () => {
+    const hazardous = 'find -L packages -name "*.ts"';
+    expect(findingsIn('.claude/hooks/bulk-edit-guard.sh', hazardous)).toEqual([]);
+    expect(findingsIn('scripts/harness/scan-symlink-following-enumeration.mjs', hazardous)).toEqual(
+      [],
+    );
+    expect(findingsIn('scripts/harness/__tests__/bulk-edit-guard.test.mjs', hazardous)).toEqual([]);
+  });
+
+  it('does not read -L as a find flag when it belongs to grep', () => {
+    // `grep -L` is files-without-match. The pattern requires the flag to sit in find's own flag run,
+    // which is why this reads clean while `find -L … | xargs grep -l` does not.
+    expect(findingsIn(SCRIPT, 'find packages -name "*.ts" | xargs grep -L createSession')).toEqual(
+      [],
+    );
+  });
+});
+
+describe('the size it declares', () => {
+  // A `::examined::` line is a claim about how much was looked at, and a claim nothing checks is
+  // where a scan quietly stops covering its population. Asserted EXACTLY, against a fixture whose
+  // size is known by construction: a bound would be satisfied by every over-count.
+  const FIXTURE = Object.freeze({
+    'scripts/tools/rewrite.sh': 'find packages -name "*.ts"',
+    'scripts/tools/build.mjs': 'export const x = 1;',
+    'scripts/tools/lint.py': 'import os',
+    'docs/why.md': 'find -L packages',
+    'assets/logo.svg': '<svg/>',
+  });
+  const paths = Object.keys(FIXTURE);
+  const read = (file) => FIXTURE[file];
+
+  it('counts the scripts it opened, and does not accumulate across runs', () => {
+    scanTrackedFiles(paths, read);
+    expect(examinedScriptCount()).toBe(3);
+    // The second run is the point. An accumulating counter passes the first assertion and reads 6
+    // here, which would report a growing subject where the subject never changed.
+    scanTrackedFiles(paths, read);
+    expect(examinedScriptCount()).toBe(3);
+  });
+
+  it('opens only the extensions it claims, so the size and the coverage are the same number', () => {
+    expect(scanTrackedFiles(paths, read)).toEqual([]);
+    expect(examinedScriptCount()).toBe(3);
+  });
+});

--- a/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
+++ b/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
@@ -43,6 +43,20 @@ describe('the four measured spellings', () => {
     expect(findingsIn(SCRIPT, safe)).toEqual([]);
   });
 
+  it.each([
+    ['find -L', 'find packages -name "*.ts" -L'],
+    ['grep -R', 'grep foo packages -R'],
+    ['grep -R', 'grep -l foo packages --dereference-recursive'],
+    ['rg --follow', 'rg -l foo packages --follow'],
+  ])('reports %s when the flag comes AFTER a positional argument', (id, hazardous) => {
+    // Reported in review of this change. `find` and `grep` required the flag to sit in the command's
+    // opening flag run, so the trailing form — which follows symlinks exactly the same way — was
+    // reported clean while still reaching the store. That is the precise failure the scan exists to
+    // catch, passing its own check. All four rules now allow arbitrary words before the flag, and what
+    // bounds the search is the segment, not the shape of the flag run.
+    expect(findingsIn(SCRIPT, hazardous)).toMatchObject([{ id }]);
+  });
+
   it('reports the line number, so the finding is one edit away from clean', () => {
     const script = ['#!/usr/bin/env bash', 'set -euo pipefail', 'grep -Rl foo packages'].join('\n');
     expect(findingsIn(SCRIPT, script)).toMatchObject([{ line: 3, id: 'grep -R' }]);

--- a/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
+++ b/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
@@ -81,6 +81,30 @@ describe('what it does not report', () => {
       [],
     );
   });
+
+  it('does not read -L as an rg flag when it belongs to a later command in the pipeline', () => {
+    // Found reviewing this change for merge, and it is the finding review already reported against
+    // the hook: `rg`'s pattern accepted any words between the command and the flag, so a `-L` two
+    // commands downstream was attributed to it. `rg -l` is files-with-matches and `grep -L` is
+    // files-without-match — neither follows anything.
+    //
+    // The fix is the segment split the hook uses. It matters more here: the hook has an ack for a
+    // refusal you disagree with, and a scan has none — a false positive is a correct script that
+    // cannot be committed.
+    expect(findingsIn(SCRIPT, 'rg -l createSession src | xargs grep -L export')).toEqual([]);
+    // The hazardous spelling in the SAME shape is still reported, so the split did not simply
+    // silence the rule.
+    expect(findingsIn(SCRIPT, 'rg --follow -l createSession src | xargs wc -l')).toMatchObject([
+      { id: 'rg --follow' },
+    ]);
+  });
+
+  it('attributes a flag to the command after && that received it', () => {
+    expect(findingsIn(SCRIPT, 'cd packages && find -L . -name "*.ts"')).toMatchObject([
+      { id: 'find -L' },
+    ]);
+    expect(findingsIn(SCRIPT, 'find . -name "*.ts" && grep -L foo out.txt')).toEqual([]);
+  });
 });
 
 describe('the size it declares', () => {

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -69,6 +69,7 @@
     "spec-user-execution-section",
     "spec-whitebox-leakage",
     "stub-markers",
+    "symlink-following-enumeration",
     "task-archival",
     "test-plans",
     "test-selection-tolerance",

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -28,6 +28,7 @@
     "scripts/harness/scan-role-port-optionals.mjs",
     "scripts/harness/scan-routing-document-size.mjs",
     "scripts/harness/scan-spec-user-execution-section.mjs",
+    "scripts/harness/scan-symlink-following-enumeration.mjs",
     "scripts/harness/scan-tool-classification.mjs",
     "scripts/harness/scan-transport-conformance.mjs",
     "scripts/harness/scan-workflow-permissions.mjs",

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -451,6 +451,10 @@ export const SCAN_COMMANDS = [
     name: 'reference-kind-qualified',
     command: ['node', 'scripts/harness/scan-reference-kind-qualified.mjs'],
   },
+  {
+    name: 'symlink-following-enumeration',
+    command: ['node', 'scripts/harness/scan-symlink-following-enumeration.mjs'],
+  },
   // INFRA-102. Only the DECLARED edge runs here: it is hermetic. The `--measured` edge asks the
   // host toolchain what a workspace script actually runs on, which no manifest edit can make true
   // (Volta binds a package tool to its install-time Node), so it is a developer-run check.

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -89,6 +89,23 @@ function trackedFiles() {
   return out.split('\0').filter((entry) => entry.length > 0);
 }
 
+/**
+ * Split one line into command SEGMENTS — the runs between `|`, `||`, `&`, `&&` and `;`.
+ *
+ * A flag belongs to the command that received it, and a line is not one command. Reported in the
+ * review of this change against `bulk-edit-guard.sh` and true here for the same reason: matching
+ * `rg …` and a later `-L` anywhere on the line flags `rg -l foo src | xargs grep -L bar`, where the
+ * `-L` is grep's files-without-match and follows nothing. A scan that refuses correct scripts is one
+ * that gets deleted, and unlike the hook this half has no ack to fall back on.
+ *
+ * STATED LIMIT, the same one the hook carries: a second command inside ONE segment inherits the
+ * first's attribution, so `find … -exec grep -L {} \;` reads as `find` carrying `-L`. The pipeline is
+ * the common shape and is separated; `-exec` is not.
+ */
+function segmentsOf(line) {
+  return line.split(/\|\|?|&&?|;/);
+}
+
 /** A shell/JS line comment or a markdown-ish prose line is discussion, not an invocation. */
 function isCommentary(line) {
   const trimmed = line.trim();
@@ -108,16 +125,16 @@ export function findingsIn(relativePath, content) {
   const lines = content.split('\n');
   for (const [index, line] of lines.entries()) {
     if (isCommentary(line)) continue;
+    const segments = segmentsOf(line);
     for (const rule of RULES) {
-      if (rule.pattern.test(line)) {
-        findings.push({
-          file: relativePath,
-          line: index + 1,
-          id: rule.id,
-          remedy: rule.remedy,
-          text: line.trim(),
-        });
-      }
+      if (!segments.some((segment) => rule.pattern.test(segment))) continue;
+      findings.push({
+        file: relativePath,
+        line: index + 1,
+        id: rule.id,
+        remedy: rule.remedy,
+        text: line.trim(),
+      });
     }
   }
   return findings;

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+/**
+ * INFRA-105 (#1884) — a committed script must not enumerate files by following symlinks.
+ *
+ * In a pnpm workspace `packages/<a>/node_modules/@scope/<b>` is a symlink to `packages/<b>`, and
+ * `node_modules/.pnpm` holds content hard-linked into every other project on the machine. An
+ * enumeration that follows symlinks therefore reaches both, and a bulk edit built on it writes where
+ * nothing downstream can see: `git status` does not look outside the work tree, and every scan in
+ * this directory reads `git ls-files`, which cannot list `node_modules` at all.
+ *
+ * `bulk-edit-guard.sh` covers the command an agent runs. This covers the script somebody commits,
+ * which the hook never sees again once it is a file.
+ *
+ * WHY FOUR SPELLINGS AND NOT "RECURSIVE ENUMERATION". Measured on a directory holding one symlink to
+ * a tree with one matching file: `find` without `-L`, `grep -r`, `rg` without `--follow`, bash and
+ * zsh `**`, Node's `fs.globSync` and python's `pathlib.Path.rglob` all returned 0 — they do not
+ * traverse. `find -L`, `grep -R`, `rg --follow` and python's `glob.glob`/`iglob` returned 1. Aiming
+ * at the general shape would fail correct scripts until the scan was removed; aiming at the measured
+ * four leaves a rule that can stay on, and each finding is one flag away from clean.
+ *
+ * Exit 0 = clean, 1 = findings.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/**
+ * Each rule names the safe sibling, because a finding whose remedy is not stated is a finding people
+ * work around. The `pattern` is deliberately shaped so the SAFE form does not match it.
+ */
+const RULES = [
+  {
+    id: 'find -L',
+    pattern: /\bfind\s+(?:-[^\s-][^\s]*\s+)*(?:-L|-follow)\b/,
+    remedy: 'drop -L; plain find does not follow symlinks (measured)',
+  },
+  {
+    id: 'grep -R',
+    pattern: /\bgrep\s+(?:-[a-z][a-z]*\s+)*(?:-[a-zA-Z]*R[a-zA-Z]*\b|--dereference-recursive\b)/,
+    remedy: 'use -r, which does not dereference symlinks (measured)',
+  },
+  {
+    id: 'rg --follow',
+    pattern: /\brg\s+(?:[^\s]+\s+)*?(?:--follow\b|-[a-zA-Z]*L[a-zA-Z]*\b)/,
+    remedy: 'drop --follow; rg does not follow, and honours .gitignore',
+  },
+  {
+    id: 'python glob.glob',
+    pattern: /\bglob\.(?:glob|iglob)\s*\(/,
+    remedy: 'use pathlib Path(...).rglob, which does not follow symlinks (measured)',
+  },
+];
+
+const SCANNED_EXTENSIONS = new Set([
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.mjs',
+  '.cjs',
+  '.js',
+  '.ts',
+  '.py',
+  '.yml',
+  '.yaml',
+]);
+
+/**
+ * Files that DESCRIBE the hazardous spellings rather than run them. Every entry is the guard, its
+ * test, or the record of why the rule exists — the three places the four spellings have to be
+ * writable in full, or the rule cannot be explained to the person it stops.
+ */
+const ALLOWED_FILES = new Set([
+  'scripts/harness/scan-symlink-following-enumeration.mjs',
+  'scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs',
+  'scripts/harness/__tests__/bulk-edit-guard.test.mjs',
+  '.claude/hooks/bulk-edit-guard.sh',
+]);
+
+function trackedFiles() {
+  const out = execFileSync('git', ['ls-files', '-z'], {
+    cwd: WORKSPACE_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out.split('\0').filter((entry) => entry.length > 0);
+}
+
+/** A shell/JS line comment or a markdown-ish prose line is discussion, not an invocation. */
+function isCommentary(line) {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('//') ||
+    trimmed.startsWith('*') ||
+    trimmed.startsWith('/*')
+  );
+}
+
+export function findingsIn(relativePath, content) {
+  if (ALLOWED_FILES.has(relativePath)) return [];
+  if (!SCANNED_EXTENSIONS.has(path.extname(relativePath))) return [];
+
+  const findings = [];
+  const lines = content.split('\n');
+  for (const [index, line] of lines.entries()) {
+    if (isCommentary(line)) continue;
+    for (const rule of RULES) {
+      if (rule.pattern.test(line)) {
+        findings.push({
+          file: relativePath,
+          line: index + 1,
+          id: rule.id,
+          remedy: rule.remedy,
+          text: line.trim(),
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+let examinedScripts = 0;
+
+/** How many tracked scripts the last run opened. The size the pass line reports. */
+export function examinedScriptCount() {
+  return examinedScripts;
+}
+
+/**
+ * Every finding across `trackedPaths`, with the reader injectable so a case can be run against a
+ * fixture of known size rather than against the tree.
+ *
+ * The counter is RESET here rather than incremented from wherever it stood. A size that accumulates
+ * across runs reads as a growing subject, which is the one way a declared measurement can be wrong
+ * while every finding it reports is right.
+ */
+export function scanTrackedFiles(trackedPaths, readFile) {
+  examinedScripts = 0;
+  const findings = [];
+  for (const file of trackedPaths) {
+    if (!SCANNED_EXTENSIONS.has(path.extname(file))) continue;
+    examinedScripts += 1;
+    findings.push(...findingsIn(file, readFile(file)));
+  }
+  return findings;
+}
+
+function main() {
+  const read = (file) => {
+    try {
+      return readFileSync(path.join(WORKSPACE_ROOT, file), 'utf8');
+    } catch {
+      // A tracked path that cannot be read is reported, not skipped: silence here would be the same
+      // invisibility the whole rule is about.
+      console.error(`symlink-following-enumeration: could not read tracked file ${file}`);
+      process.exit(1);
+    }
+  };
+
+  const findings = scanTrackedFiles(trackedFiles(), read);
+
+  console.log(`::examined:: ${examinedScriptCount()} tracked script(s)`);
+
+  if (findings.length === 0) {
+    console.log('symlink-following-enumeration scan passed.');
+    return;
+  }
+
+  console.error('symlink-following-enumeration: committed scripts enumerate through symlinks.');
+  console.error(
+    'In a pnpm workspace that reaches node_modules and the store hard-linked beneath it,',
+  );
+  console.error('where a write is invisible to git and survives pnpm install.');
+  for (const finding of findings) {
+    console.error(`  ${finding.file}:${finding.line}  ${finding.id} — ${finding.remedy}`);
+    console.error(`    ${finding.text}`);
+  }
+  console.error(
+    'Prefer `git ls-files` as the source of a bulk edit: it cannot return a node_modules path.',
+  );
+  process.exit(1);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -31,16 +31,22 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 /**
  * Each rule names the safe sibling, because a finding whose remedy is not stated is a finding people
  * work around. The `pattern` is deliberately shaped so the SAFE form does not match it.
+ *
+ * Every rule allows arbitrary words between the command and its flag, because a flag does not have to
+ * come first: `find packages -name '*.ts' -L` follows symlinks exactly as `find -L packages` does, and
+ * the first cut of `find` and `grep` required the flag to sit in the command's opening flag run, so
+ * the trailing form was reported CLEAN while still reaching the store. Reported in review of this
+ * change. What bounds the search is the SEGMENT — see `segmentsOf` — not the shape of the flag run.
  */
 const RULES = [
   {
     id: 'find -L',
-    pattern: /\bfind\s+(?:-[^\s-][^\s]*\s+)*(?:-L|-follow)\b/,
+    pattern: /\bfind\s+(?:[^\s]+\s+)*?(?:-L|-follow)\b/,
     remedy: 'drop -L; plain find does not follow symlinks (measured)',
   },
   {
     id: 'grep -R',
-    pattern: /\bgrep\s+(?:-[a-z][a-z]*\s+)*(?:-[a-zA-Z]*R[a-zA-Z]*\b|--dereference-recursive\b)/,
+    pattern: /\bgrep\s+(?:[^\s]+\s+)*?(?:-[a-zA-Z]*R[a-zA-Z]*\b|--dereference-recursive\b)/,
     remedy: 'use -r, which does not dereference symlinks (measured)',
   },
   {


### PR DESCRIPTION
Closes #1884.

## The failure class

In a pnpm workspace a package's `node_modules` entry for a sibling workspace package is a **symlink**
to that sibling's source, and the `.pnpm` store beneath it holds content **hard-linked into every
other project on the machine**. An enumeration that follows symlinks reaches both.

What makes this a rule rather than a preference is that nothing downstream can report it. `git
status` does not look outside the work tree. Every harness scan reads `git ls-files`, which cannot
list `node_modules` at all. A write that lands in the store survives `pnpm install`, because the
store believes the content is already correct. The one incident was caught because the edit script
happened to print the paths it touched.

## The reported exposure was wider than the real one

#1884 named `find`, `grep -r`, `rg` without `--no-follow`, shell `**` under `globstar` and Node's
`fs.glob` as carrying "the same exposure". Measured on a directory holding one symlink to a tree with
one matching file:

| enumerator | reaches through |
| --- | --- |
| `find` / `grep -r` / `rg` / bash `**` / zsh `**` / `fs.globSync` / `Path.rglob` | **no** |
| `find -L` | yes |
| `grep -R` | yes |
| `rg --follow` | yes |
| `glob.glob(..., recursive=True)` | yes |

**Four spellings, each with a safe sibling one flag away.** That distinction is the design, not a
detail: a guard aimed at every recursive enumeration would refuse correct commands until someone
switched it off, and a switched-off guard protects nothing. `git ls-files` remains the preferred
source — it cannot return a `node_modules` path — but a `find` without `-L` is not the hazard the
report claimed.

## What landed

- **`.claude/hooks/bulk-edit-guard.sh`** — `PreToolUse` on `Bash` and on the write tools. Refuses a
  `file_path` naming the store, or one that only *resolves* into it after symlink resolution; the
  four enumerator spellings; and a content write whose target is inside the store. Escape:
  `BULK_EDIT_ACK=1` inline, read off the masked text.
- **`scripts/harness/scan-symlink-following-enumeration.mjs`** — the committed-script half, which the
  hook never sees again once a command becomes a file. Registered in `run-all-scans`, with an entry
  point in `package.json`.
- **`.agents/rules/operational.md` § A Bulk Edit Enumerates Through `git ls-files`** — the invariant,
  the table, and what the two checks do *not* reach.

## What it deliberately leaves alone

`rm -rf node_modules && pnpm install` and `mv node_modules …` — the reinstall idioms. `cat
node_modules/.pnpm/p/package.json > /tmp/out`, which reads from the store and writes outside it.
`find … | xargs grep -L …`, where the `-L` belongs to `grep` and means files-without-match. Each of
those was refused by an earlier cut and is now a test, because a guard that blocks correct work is
how an ack starts being pasted without being read.

## Verification

Every rule is asserted in **both** directions — the hazardous spelling refused *and* its safe sibling
permitted. Red-proofed rather than assumed: disabling the symlink-resolution branch fails exactly one
case, removing flag attribution fails exactly two, removing the empty-payload refusal fails exactly
one, and the scan was run against a temporary tracked fixture to watch it go red.

`pnpm harness:scan` — 128 passed, 1 skipped. Harness unit tier — 3905 passed.

Four of this repository's own gates caught defects in this change and each is recorded in the task:
`fixture-floor` (the test file was misnamed, so the scan had no fixture), `shell-portability`
(`readlink -f` is GNU-only), `measurement-provenance` (the declared size was checked by nothing),
`rule-case-narrative` (the first draft of the rule retold the incident instead of stating the
invariant), and `guards-pass-silently` (no row said what the guard must leave alone — and its
override scrub was widened from `*_ALLOW_*` to `*_ACK` in the same change, since three overrides in
this directory use that spelling and were being inherited from the ambient session).

## Not in scope, filed rather than dropped

#1884's third item — that a name-based rewrite should confirm each site *imports* the symbol being
changed rather than merely spelling it — is a real defect and is not addressed here. It needs a
resolver, it is the same problem ARCH-037 spent six review rounds on, and folding it into a path
guard would produce neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMHqgeKoa9GqqXyqLbH2YG
