### PR TITLE
fix(harness): verify an action manifest over the authenticated API

### DIFF
--- a/.agents/tasks/INFRA-107-action-references-is-rate-limited-into-a-red-gate.md
+++ b/.agents/tasks/INFRA-107-action-references-is-rate-limited-into-a-red-gate.md
@@ -1,0 +1,97 @@
+---
+title: 'INFRA-107: action-references probes an anonymous endpoint, so a shared CI address turns it red'
+status: in-progress
+created: 2026-08-19
+priority: high
+urgency: now
+area: scripts/harness
+depends_on: []
+---
+
+# INFRA-107: verify an action manifest over the authenticated API, not an anonymous one
+
+## Objective
+
+`action-references` confirms that every pinned action SHA carries a real manifest. It reads that
+manifest from `raw.githubusercontent.com` with an unauthenticated `fetch`. That endpoint is
+rate-limited per source address, GitHub-hosted runners share their egress addresses, and the scan is
+fail-closed by design — so when the address is over budget the gate goes red for a reason no change
+to this repository can affect.
+
+Observed on the pull request for INFRA-105, on two consecutive runs of the same unchanged workflow
+files:
+
+| run   | findings               |
+| ----- | ---------------------- |
+| first | 2, both `HTTP 429`     |
+| rerun | **15**, all `HTTP 429` |
+
+The rerun being worse is the shape that matters: a retry does not recover the budget, it spends more
+of it. The scan's own message is right that "unreachable is a failure, not a skip" — the defect is
+not the verdict, it is asking a question over a channel that cannot answer it.
+
+## Measured, not assumed
+
+| probe                                                                 | result                                                          |
+| --------------------------------------------------------------------- | --------------------------------------------------------------- |
+| authenticated `repos/{o}/{r}/contents/action.yml?ref={sha}` — present | `200`, manifest metadata returned                               |
+| the same, absent path                                                 | clean `404 Not Found`                                           |
+| authenticated core budget                                             | **4,982 / 5,000 per hour**                                      |
+| anonymous `raw.githubusercontent.com`                                 | serves the file, and publishes **no** rate-limit headers at all |
+
+So the authenticated endpoint gives exactly the two answers this scan needs — present and absent —
+carries a budget large enough for a workflow tree of this size many times over, and unlike the
+anonymous one it _reports_ what is left, which is the difference between a limit that can be
+diagnosed and one that can only be suffered.
+
+## Approach
+
+Probe through `gh api`, the runner this harness already uses everywhere else, so the request is
+authenticated by construction and `readWithBackoff` — which already reads `retry-after` and
+`x-ratelimit-reset` and fails closed after a bounded wait — applies unchanged. A second network path
+with its own retry rules would be a second place for this to go wrong.
+
+A 404 must stay a NEGATIVE ANSWER and not an error: "this SHA has no manifest" is the finding the
+scan exists to report, and collapsing it into the transport's error channel would turn a real finding
+into an outage report.
+
+## Plan
+
+- [x] TC-01: a present manifest resolves through the authenticated probe.
+- [x] TC-02: an absent manifest returns "no manifest" — a finding, not a thrown error.
+- [x] TC-03: a rate-limited response is retried on the delay the API names and, past the bound, fails
+      closed with a message saying it is a budget to wait out.
+- [x] TC-04: a transport error that is NOT a 404 and NOT a rate limit still fails closed.
+- [x] TC-05: the reusable-workflow reference form (whose subpath IS the manifest) still resolves.
+- [x] TC-06: `pnpm harness:scan` and the harness unit tier are green.
+
+## Test Plan
+
+The probe takes its runner by injection, so every case above is driven against a stubbed runner
+returning the exact status the real endpoint returns — including the two that cannot be produced on
+demand against the live API, a 429 and a transport failure. Both directions for each: the answer is
+asserted AND the failure is asserted, because a probe that can only succeed is one nobody has shown
+can report a missing manifest.
+
+## Progress
+
+### 2026-08-19
+
+Measured both endpoints before changing anything; the table above is that measurement. The live
+probe then confirmed both directions against the real endpoint: `action.yml` at that SHA reads
+`true`, `nope.yml` reads `false` — a value, not a thrown error.
+
+One defect the first cut carried, and it is the same one this item is about, one layer down. A killed
+runner reported `gh exited null`, which names neither the cause nor the remedy — the exact shape of a
+failure that cannot be acted on. `describeExit` now distinguishes a spawn error, a signal, and a
+missing status, and it earned its keep immediately: a flaky local connection produced `gh could not
+run: spawnSync gh ETIMEDOUT`, which is a diagnosis rather than a mystery.
+
+Red-proofed one at a time: treating a 404 as an error fails exactly the negative-answer case,
+removing the rate-limit retry fails exactly two, and restoring the old exit message fails exactly
+one.
+
+NOT caused by this change, recorded so the next reader does not re-derive it: five hook tests
+(`hook-command-parsing`, `branch-guard-aliases`) time out at ~10s each while the local connection is
+dropping. Measured with this change STASHED, on `origin/develop` alone: the same tests fail the same
+way.

--- a/scripts/harness/__tests__/scan-action-references.test.mjs
+++ b/scripts/harness/__tests__/scan-action-references.test.mjs
@@ -28,6 +28,7 @@ import {
   findStaticFindings,
   liveModeFor,
   parseReferences,
+  pathExistsAtCommit,
   readWorkflowSources,
   resolveAll,
   unverifiedResolvabilityLine,
@@ -487,5 +488,85 @@ describe('unverifiedResolvabilityLine', () => {
     expect(advisory).toContain('--offline');
     expect(advisory).toContain('12 reference(s)');
     expect(advisory).toContain('does not exist passes this run');
+  });
+});
+
+describe('the manifest probe runs over the authenticated endpoint (INFRA-107)', () => {
+  // Driven against a STUBBED runner, so the two answers that cannot be produced on demand against
+  // the live API — a rate limit and a killed process — are cases rather than hopes. The live-endpoint
+  // runs are recorded in the INFRA-107 backlog item.
+  const REF = { owner: 'pnpm', repo: 'action-setup' };
+  const SHA = 'eae0cfeb286e66ffb5155f1a79b90583a127a68b';
+  const noWait = () => Promise.resolve();
+
+  const runner = (...responses) => {
+    const queue = [...responses];
+    const calls = [];
+    const run = (args) => {
+      calls.push(args);
+      return queue.length > 1 ? queue.shift() : queue[0];
+    };
+    run.calls = calls;
+    return run;
+  };
+
+  it('reads a present path as true, through `gh api`', async () => {
+    const run = runner({ status: 0, stdout: '', stderr: '' });
+    await expect(pathExistsAtCommit(REF, SHA, 'action.yml', { runner: run })).resolves.toBe(true);
+    // The endpoint, not a raw host: the whole point is that the request carries credentials.
+    expect(run.calls[0]).toEqual([
+      'api',
+      `repos/pnpm/action-setup/contents/action.yml?ref=${SHA}`,
+      '--silent',
+    ]);
+  });
+
+  it('reads a 404 as FALSE, not as an error', async () => {
+    // "This SHA carries no manifest" is the finding the scan exists to report. Folding it into the
+    // transport's error channel would turn a real finding into an outage report — the same collapse,
+    // one level down, that the rate limit produced.
+    const run = runner({ status: 1, stdout: '', stderr: 'gh: Not Found (HTTP 404)' });
+    await expect(pathExistsAtCommit(REF, SHA, 'nope.yml', { runner: run })).resolves.toBe(false);
+  });
+
+  it('retries a rate limit and succeeds when the budget returns', async () => {
+    const run = runner(
+      { status: 1, stdout: '', stderr: 'API rate limit exceeded\nretry-after: 1' },
+      { status: 0, stdout: '', stderr: '' },
+    );
+    await expect(
+      pathExistsAtCommit(REF, SHA, 'action.yml', { runner: run, sleep: noWait }),
+    ).resolves.toBe(true);
+    expect(run.calls).toHaveLength(2);
+  });
+
+  it('fails CLOSED when the budget does not return within the bound', async () => {
+    // Unreachable is a failure, not a skip — the scan's own rule, and the reason it went red on a
+    // shared runner address. Moving to an authenticated endpoint raises the budget; it does not make
+    // exhausting it a pass.
+    const run = runner({
+      status: 1,
+      stdout: '',
+      stderr: 'API rate limit exceeded\nretry-after: 1',
+    });
+    await expect(
+      pathExistsAtCommit(REF, SHA, 'action.yml', { runner: run, attempts: 2, sleep: noWait }),
+    ).rejects.toThrow(/budget to wait out/);
+  });
+
+  it('fails closed on a transport error that is neither 404 nor a rate limit', async () => {
+    const run = runner({ status: 1, stdout: '', stderr: 'dial tcp: i/o timeout' });
+    await expect(pathExistsAtCommit(REF, SHA, 'action.yml', { runner: run })).rejects.toThrow(
+      /i\/o timeout/,
+    );
+  });
+
+  it('names the timeout when the runner was KILLED and left no stderr', async () => {
+    // The first version reported this as `gh exited null`, which names neither the cause nor the
+    // remedy. A probe whose failure cannot be acted on is the same defect one layer up.
+    const run = runner({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' });
+    await expect(pathExistsAtCommit(REF, SHA, 'action.yml', { runner: run })).rejects.toThrow(
+      /killed by SIGTERM/,
+    );
   });
 });

--- a/scripts/harness/scan-action-references.mjs
+++ b/scripts/harness/scan-action-references.mjs
@@ -60,12 +60,13 @@
  * not, or could not be checked.
  */
 
-import { execFile } from 'node:child_process';
+import { execFile, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
 import { ADVISORY_MARKER } from './run-all-scans.mjs';
+import { isRateLimited, retryDelaySeconds } from './github-api.mjs';
 import { envWithoutGitVars } from './shared.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -326,23 +327,103 @@ function oneLine(value) {
   return text.length > 200 ? `${text.slice(0, 200)}…` : text;
 }
 
+/**
+ * One authenticated read of a repository path at a commit — 200, 404, or throw.
+ *
+ * INFRA-107. This used an unauthenticated `fetch` of `raw.githubusercontent.com`, which is
+ * rate-limited per source address while GitHub-hosted runners share theirs. Measured on two
+ * consecutive runs of unchanged workflow files: 2 findings, then 15, every one `HTTP 429`. The rerun
+ * being WORSE is the point — a retry does not recover that budget, it spends more of it — and this
+ * scan is fail-closed by design, so the gate went red for a reason no change here could affect.
+ *
+ * Measured before the switch: the authenticated contents endpoint answers 200 for a present manifest
+ * and a clean 404 for an absent one, on a 5,000-per-hour budget, and reports what is left. The
+ * anonymous endpoint publishes no rate-limit headers at all, which is the difference between a limit
+ * that can be diagnosed and one that can only be suffered.
+ *
+ * It goes through `gh`, the runner this harness uses everywhere else, so the request is authenticated
+ * by construction and the rate-limit reading in `github-api.mjs` applies unchanged. A second network
+ * path with its own retry rules would be a second place for this to go wrong.
+ */
+function ghContentsRunner(args) {
+  return spawnSync('gh', args, {
+    encoding: 'utf8',
+    timeout: HTTP_TIMEOUT_MS,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+/** Whether the failure the runner reported is the endpoint saying "no such path". */
+function isNotFound(stderr) {
+  return /HTTP 404|Not Found/i.test(stderr ?? '');
+}
+
+/**
+ * `true` when the path exists at that commit, `false` when it does not, throw otherwise.
+ *
+ * A 404 is a NEGATIVE ANSWER, not an error. "This SHA carries no manifest" is the finding this scan
+ * exists to report, and folding it into the transport's error channel would turn a real finding into
+ * an outage report — the same collapse, one level down, that the rate limit produced.
+ */
+export async function pathExistsAtCommit(
+  reference,
+  sha,
+  filePath,
+  { runner = ghContentsRunner, attempts = 3, sleep = sleepSeconds } = {},
+) {
+  const endpoint = `repos/${reference.owner}/${reference.repo}/contents/${filePath}?ref=${sha}`;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = runner(['api', endpoint, '--silent']);
+    if (response.status === 0) return true;
+    const stderr = (response.stderr ?? '').trim();
+    if (isNotFound(stderr)) return false;
+    if (!isRateLimited(stderr)) {
+      throw new Error(`${endpoint}: ${oneLine(stderr || describeExit(response))}`);
+    }
+    if (attempt === attempts) {
+      throw new Error(
+        `${endpoint}: rate limited by the GitHub API and still limited after ${attempts} attempts. ` +
+          'This is a budget to wait out, not a defect to work around. Last response: ' +
+          `${oneLine(stderr || 'no stderr')}`,
+      );
+    }
+    await sleep(retryDelaySeconds(stderr));
+  }
+  // Unreachable: the loop either returns or throws on its final attempt. Stated rather than left to
+  // an implicit `undefined`, which a caller would read as "no manifest".
+  throw new Error(`${endpoint}: exhausted ${attempts} attempts without a verdict.`);
+}
+
+/**
+ * Why the runner produced no stderr to quote.
+ *
+ * `status: null` means the process was KILLED — by the timeout here, or by a signal — and the first
+ * version of this reported it as `gh exited null`, which names neither the cause nor the remedy. A
+ * probe whose failure message cannot be acted on is the same defect as one that fails for an
+ * unreadable reason, one layer up.
+ */
+function describeExit(response) {
+  if (response.error) return `gh could not run: ${response.error.message}`;
+  if (response.signal) return `gh was killed by ${response.signal} (timeout ${HTTP_TIMEOUT_MS}ms)`;
+  if (response.status === null) return `gh produced no exit status (timeout ${HTTP_TIMEOUT_MS}ms)`;
+  return `gh exited ${response.status} with no stderr`;
+}
+
+function sleepSeconds(seconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, Math.max(0, seconds) * 1000);
+  });
+}
+
 /** The manifest the runner itself needs, at the exact commit the ref resolved to. */
-async function manifestExists(reference, sha) {
-  const base = `https://raw.githubusercontent.com/${reference.owner}/${reference.repo}/${sha}`;
+async function manifestExists(reference, sha, options = {}) {
   const prefix = reference.subpath ? `${reference.subpath}/` : '';
   // A reusable workflow reference IS its own manifest — its subpath names the file.
   const candidates = /\.ya?ml$/.test(reference.subpath ?? '')
-    ? [`${base}/${reference.subpath}`]
-    : MANIFEST_NAMES.map((name) => `${base}/${prefix}${name}`);
+    ? [reference.subpath]
+    : MANIFEST_NAMES.map((name) => `${prefix}${name}`);
   for (const candidate of candidates) {
-    const response = await fetch(candidate, {
-      method: 'HEAD',
-      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
-    });
-    if (response.ok) return true;
-    if (response.status !== 404) {
-      throw new Error(`HTTP ${response.status} for ${candidate}`);
-    }
+    if (await pathExistsAtCommit(reference, sha, candidate, options)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## What was blocking

`action-references` confirms that every pinned action SHA carries a real manifest. It read that
manifest from `raw.githubusercontent.com` with an **unauthenticated** `fetch`. That endpoint is
rate-limited per source address, GitHub-hosted runners share their egress addresses, and this scan is
fail-closed by design — so on a busy address the gate went red for a reason no change to this
repository could affect.

Observed on PR #1886, on two consecutive runs of the same unchanged workflow files:

| run | findings |
| --- | --- |
| first | 2, both `HTTP 429` |
| rerun | **15**, all `HTTP 429` |

**The rerun being worse is the point.** A retry does not recover that budget, it spends more of it,
so "re-run the job" is not a remedy — it is the thing making it worse. The scan's own message is
right that "unreachable is a failure, not a skip"; the defect is not the verdict, it is asking the
question over a channel that cannot answer it.

## Measured before changing anything

| probe | result |
| --- | --- |
| authenticated `repos/{o}/{r}/contents/action.yml?ref={sha}` — present | `200` |
| the same, absent path | clean `404 Not Found` |
| authenticated core budget | **4,982 / 5,000 per hour** |
| anonymous `raw.githubusercontent.com` | serves the file, publishes **no** rate-limit headers |

The authenticated endpoint gives exactly the two answers this scan needs, carries a budget large
enough for a workflow tree of this size many times over, and — unlike the anonymous one — *reports*
what is left. That last difference is between a limit that can be diagnosed and one that can only be
suffered.

## The change

The probe goes through `gh`, the runner this harness uses everywhere else, so the request is
authenticated by construction and the rate-limit reading already in `scripts/harness/github-api.mjs`
applies unchanged. A second network path with its own retry rules would be a second place for this to
go wrong.

**A 404 stays a negative answer.** "This SHA carries no manifest" is the finding the scan exists to
report; folding it into the transport's error channel would turn a real finding into an outage
report — the same collapse, one level down, that the rate limit produced.

**Raising the budget does not make exhausting it a pass.** Past the retry bound it still fails
closed, with a message saying it is a budget to wait out rather than a defect to work around.

## One defect the first cut carried

A killed runner reported `gh exited null` — naming neither the cause nor the remedy, which is exactly
the shape of failure this item is about, one layer down. `describeExit` now distinguishes a spawn
error, a signal, and a missing status, and it earned its keep immediately: a flaky local connection
produced `gh could not run: spawnSync gh ETIMEDOUT`, a diagnosis rather than a mystery.

## Verification

Both directions confirmed against the **live** endpoint: `action.yml` at a real SHA reads `true`,
`nope.yml` reads `false` — a value, not a thrown error. Every other case is driven against an
injected runner, including the two that cannot be produced on demand against the live API: a 429 and
a killed process.

Red-proofed one at a time: treating a 404 as an error fails exactly the negative-answer case,
removing the rate-limit retry fails exactly two, restoring the former exit message fails exactly one.

`pnpm harness:scan` — 126 passed, 3 skipped.

**Not caused by this change**, recorded so the next reader does not re-derive it: five hook tests
(`hook-command-parsing`, `branch-guard-aliases`) time out while the local connection is dropping.
Measured with this change stashed, on `develop` alone: the same tests fail the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMHqgeKoa9GqqXyqLbH2YG
