### PR TITLE
fix(docs): qualify three bare issue references that turned develop red

### DIFF
--- a/.agents/tasks/completed/ARCH-035-tool-surface-has-no-defaults-aggregator-leaf.md
+++ b/.agents/tasks/completed/ARCH-035-tool-surface-has-no-defaults-aggregator-leaf.md
@@ -271,7 +271,7 @@ would catch a broken tier.
 
 The **agent axis** is the same shape and still unguarded: `child-process-subagent-runner.ts:208`
 resolves `?? getBuiltInAgent(agentType)` from `agent-framework`'s barrel, and `getBuiltInAgent` is
-absent from `FORBIDDEN_IMPORTS` (`scan-subagent-runner-composition.mjs:48`). It belongs to #1854.
+absent from `FORBIDDEN_IMPORTS` (`scan-subagent-runner-composition.mjs:48`). It belongs to issue #1854.
 
 Three further defects surfaced while testing premises and are filed separately rather than absorbed.
 Rule 8's edge regex (`check-dependency-direction.mjs:363`) cannot distinguish `import type … from`,
@@ -702,7 +702,7 @@ The guard also ran S-2, which I had not, and confirmed the shipped tool surface 
 names.
 
 **Not closed here.** The agent axis (`?? getBuiltInAgent`, absent from the composition scan's
-`FORBIDDEN_IMPORTS`) is the same shape and belongs to #1854, as does the question of whether a
+`FORBIDDEN_IMPORTS`) is the same shape and belongs to issue #1854, as does the question of whether a
 defaults aggregator should be published at all. `DEFAULT_TOOL_DESCRIPTIONS` stayed in `agent-framework`
 beside its only consumer, and this change knowingly widened the coupling between that inventory and the
 tools it describes from in-file to cross-package — recorded as widened rather than left unsaid.

--- a/.agents/tasks/completed/HARNESS-109-scan-suite-results-are-not-reusable.md
+++ b/.agents/tasks/completed/HARNESS-109-scan-suite-results-are-not-reusable.md
@@ -82,7 +82,7 @@ reopen that trade-off.
 
 ## Result
 
-Delivered in two commits. The ignore rule landed first (#1873) because it was measurable on its own;
+Delivered in two commits. The ignore rule landed first (PR #1873) because it was measurable on its own;
 this record closes with the mechanism.
 
 **The measurement that started it.** `isCleanTree()` was false in this clone for one reason — an


### PR DESCRIPTION
`develop` is red. `scan-reference-kind-qualified` (PR #1890) went red the moment two records landed
carrying bare `#N` references it had never seen:

```
- [unfrozen] .agents/tasks/completed/ARCH-035-…md: 2 unqualified reference(s)
- [unfrozen] .agents/tasks/completed/HARNESS-109-…md: 1 unqualified reference(s)
exit=1
```

Three edits, one word each — `#1854` → `issue #1854` (twice), `#1873` → `PR #1873`. Each is exactly
the issue/pull-request distinction a reader cannot make from the number alone, which is what the scan
exists to prevent, so the corrections are the ones the rule asks for rather than a way to quiet it.

## Why one of them escaped

The HARNESS-109 reference had already been qualified on its own branch. PR #1888 merged the
**pre-rebase** head, so the fix was not in what landed. Recorded because the same thing will happen to
the next branch that is rebased and then merged from an older head.

## Verification

- `node scripts/harness/scan-reference-kind-qualified.mjs` — exit **1** before, exit **0** after
- `pnpm harness:scan -- --skip dist --skip build-contracts` — 124 passed / 3 skipped
