### PR TITLE
docs(tasks): qualify three references so the promotion's release gate can pass

### DIFF
--- a/.agents/tasks/completed/ARCH-035-tool-surface-has-no-defaults-aggregator-leaf.md
+++ b/.agents/tasks/completed/ARCH-035-tool-surface-has-no-defaults-aggregator-leaf.md
@@ -271,7 +271,7 @@ would catch a broken tier.
 
 The **agent axis** is the same shape and still unguarded: `child-process-subagent-runner.ts:208`
 resolves `?? getBuiltInAgent(agentType)` from `agent-framework`'s barrel, and `getBuiltInAgent` is
-absent from `FORBIDDEN_IMPORTS` (`scan-subagent-runner-composition.mjs:48`). It belongs to #1854.
+absent from `FORBIDDEN_IMPORTS` (`scan-subagent-runner-composition.mjs:48`). It belongs to issue #1854.
 
 Three further defects surfaced while testing premises and are filed separately rather than absorbed.
 Rule 8's edge regex (`check-dependency-direction.mjs:363`) cannot distinguish `import type … from`,
@@ -702,7 +702,7 @@ The guard also ran S-2, which I had not, and confirmed the shipped tool surface 
 names.
 
 **Not closed here.** The agent axis (`?? getBuiltInAgent`, absent from the composition scan's
-`FORBIDDEN_IMPORTS`) is the same shape and belongs to #1854, as does the question of whether a
+`FORBIDDEN_IMPORTS`) is the same shape and belongs to issue #1854, as does the question of whether a
 defaults aggregator should be published at all. `DEFAULT_TOOL_DESCRIPTIONS` stayed in `agent-framework`
 beside its only consumer, and this change knowingly widened the coupling between that inventory and the
 tools it describes from in-file to cross-package — recorded as widened rather than left unsaid.

--- a/.agents/tasks/completed/HARNESS-109-scan-suite-results-are-not-reusable.md
+++ b/.agents/tasks/completed/HARNESS-109-scan-suite-results-are-not-reusable.md
@@ -82,7 +82,7 @@ reopen that trade-off.
 
 ## Result
 
-Delivered in two commits. The ignore rule landed first (#1873) because it was measurable on its own;
+Delivered in two commits. The ignore rule landed first (PR #1873) because it was measurable on its own;
 this record closes with the mechanism.
 
 **The measurement that started it.** `isCleanTree()` was false in this clone for one reason — an


### PR DESCRIPTION
Found while checking whether `main` is safe to promote to. It is — but `develop` was not.

## The breakage

`scan-reference-kind-qualified` (INFRA-106) was **RED on `develop`**:

```
$ node scripts/harness/scan-reference-kind-qualified.mjs
::examined:: 2929 tracked document(s)
- [unfrozen] .agents/tasks/completed/ARCH-035-…md: 2 unqualified reference(s) …
- [unfrozen] .agents/tasks/completed/HARNESS-109-…md: 1 unqualified reference(s) …
```

That scan runs inside `pnpm harness:verify:release`, which is the **`release-grade verification`
required context on `protect-main`**. So this was not a local-only annoyance: it would have failed the
develop→main promotion at a required check, on documents unrelated to the promotion.

Both files are `[unfrozen]` — they entered the tree after the ratchet's baseline was taken, so they are
held to zero rather than to a frozen count.

## The fix

Prose only, three sites. **The kind of each reference was read from the API, not inferred from
context:**

| Site | Number | Kind (measured) | Change |
| --- | --- | --- | --- |
| `ARCH-035-…md:274` | 1854 | ISSUE | `belongs to #1854` → `belongs to issue #1854` |
| `ARCH-035-…md:705` | 1854 | ISSUE | `belongs to #1854` → `belongs to issue #1854` |
| `HARNESS-109-…md:85` | 1873 | PULL REQUEST | `landed first (#1873)` → `landed first (PR #1873)` |

```
$ gh api repos/woojubb/robota/issues/1854 --jq 'if has("pull_request") then "PR" else "ISSUE" end'
ISSUE
$ gh api repos/woojubb/robota/issues/1873 --jq 'if has("pull_request") then "PR" else "ISSUE" end'
PULL REQUEST
```

That distinction is the entire point of the rule: the same six characters name different objects, and
this repository puts an issue and the pull request that closed it side by side in one paragraph.

The ratchet baseline is **untouched** — an unfrozen file's target is zero, and zero is what these now
are.

## Verification

`pnpm harness:verify:release` — **exit 0**, all six stages (`build:deps`, `harness:scan`,
`harness:test`, `test`, `typecheck`, `lint`), lint reporting 0 errors. Before this change the same
command exited 1 at `harness:scan` with `1 of 129 scans failed`.

## Context

This clears the last blocker to promoting `develop` → `main`. `main` itself is healthy: every workflow
run on it is `success`, and its own tree passes all 116 scans — it is simply 66 commits behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtPyjdqCDpbb54XQ8HoP3m
