### PR TITLE
fix(ci): turn develop green — the scan suite's token, and three bare references

### DIFF
--- a/.agents/tasks/completed/ARCH-035-tool-surface-has-no-defaults-aggregator-leaf.md
+++ b/.agents/tasks/completed/ARCH-035-tool-surface-has-no-defaults-aggregator-leaf.md
@@ -271,7 +271,7 @@ would catch a broken tier.
 
 The **agent axis** is the same shape and still unguarded: `child-process-subagent-runner.ts:208`
 resolves `?? getBuiltInAgent(agentType)` from `agent-framework`'s barrel, and `getBuiltInAgent` is
-absent from `FORBIDDEN_IMPORTS` (`scan-subagent-runner-composition.mjs:48`). It belongs to #1854.
+absent from `FORBIDDEN_IMPORTS` (`scan-subagent-runner-composition.mjs:48`). It belongs to issue #1854.
 
 Three further defects surfaced while testing premises and are filed separately rather than absorbed.
 Rule 8's edge regex (`check-dependency-direction.mjs:363`) cannot distinguish `import type … from`,
@@ -702,7 +702,7 @@ The guard also ran S-2, which I had not, and confirmed the shipped tool surface 
 names.
 
 **Not closed here.** The agent axis (`?? getBuiltInAgent`, absent from the composition scan's
-`FORBIDDEN_IMPORTS`) is the same shape and belongs to #1854, as does the question of whether a
+`FORBIDDEN_IMPORTS`) is the same shape and belongs to issue #1854, as does the question of whether a
 defaults aggregator should be published at all. `DEFAULT_TOOL_DESCRIPTIONS` stayed in `agent-framework`
 beside its only consumer, and this change knowingly widened the coupling between that inventory and the
 tools it describes from in-file to cross-package — recorded as widened rather than left unsaid.

--- a/.agents/tasks/completed/HARNESS-109-scan-suite-results-are-not-reusable.md
+++ b/.agents/tasks/completed/HARNESS-109-scan-suite-results-are-not-reusable.md
@@ -82,7 +82,7 @@ reopen that trade-off.
 
 ## Result
 
-Delivered in two commits. The ignore rule landed first (#1873) because it was measurable on its own;
+Delivered in two commits. The ignore rule landed first (PR #1873) because it was measurable on its own;
 this record closes with the mechanism.
 
 **The measurement that started it.** `isCleanTree()` was false in this clone for one reason — an

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,7 +490,14 @@ jobs:
       # `dist` is a LOCAL pre-CI freshness check (a fresh checkout has no dist to measure — skip printed,
       # never silent); `build-contracts` (INFRA-037) is dist-dependent and runs in the `quality` job after
       # dist restore, so it is skipped here rather than silently no-op'ing on a source/build-change PR.
+      # PR #1891 moved `action-references` onto the authenticated API, where an unverifiable
+      # reference is a FAILURE and not a skip — deliberately, because "could not determine, exit 0"
+      # is the defect that guard exists to catch. This job had no token, so every one of the 80
+      # references was unverifiable and the whole suite went red on arrival. `github.token` is the
+      # same credential the promotion check above already uses.
       - name: Harness scan suite (dist-independent)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: pnpm harness:scan -- --skip dist --skip build-contracts
 
   dependency-audit:


### PR DESCRIPTION
`develop` is red on **two** independent scans, and neither pull request could fix it alone — each
one's own CI fails on the defect the other carries. So they are ordered here together.

## 1. The `scans` job has no token

PR #1891 moved `action-references` onto the authenticated API, where an unverifiable reference is a
**failure and not a skip** — deliberately, because "could not determine, exit 0" is the defect that
guard exists to catch. The job was never given a token, so all 80 references were unverifiable and the
suite went red on arrival:

```
- ci.yml:121: `actions/checkout@v7` could not be verified: … set the GH_TOKEN environment variable …
  Unreachable is a failure, not a skip
```

`github.token` is the same credential the promotion check in this workflow already uses — this grants
nothing new.

## 2. Three bare `#N` references

`scan-reference-kind-qualified` (PR #1890) went red the moment two records landed with references it
had never seen. Three edits, one word each: `#1854` → `issue #1854` (twice), `#1873` → `PR #1873`.
Each is exactly the issue/pull-request distinction a reader cannot make from the number alone.

One of them had already been qualified on its own branch — PR #1888 merged the **pre-rebase** head, so
the fix was not in what landed. Worth recording: a rebased branch merged from an older head silently
drops what the rebase fixed.

## Why one pull request

PR #1892 carried the reference half. Its `scans` check fails on the token defect; this branch's
`scans` check failed on the reference defect. Neither is mergeable alone, so #1892 is closed in favour
of this one, which carries both.

## Verification

`pnpm harness:scan -- --skip dist --skip build-contracts` — **125 passed / 2 skipped** locally. The
token half can only be proven by this pull request's own `scans` run, which is the first one to have
the credential.
