### PR TITLE
feat(harness): a build-output scan re-runs instead of blocking every reuse (HARNESS-110)

### DIFF
--- a/.agents/tasks/completed/HARNESS-110-build-output-scans-blocked-every-reuse.md
+++ b/.agents/tasks/completed/HARNESS-110-build-output-scans-blocked-every-reuse.md
@@ -1,0 +1,64 @@
+---
+title: 'HARNESS-110: declaring the build-output scans ineligible made a plain scan run unreusable'
+status: done
+created: 2026-08-19
+completed: 2026-08-19
+priority: medium
+urgency: soon
+area: scripts/harness
+depends_on: []
+---
+
+# HARNESS-110: the receipt could not serve the command the item was filed about
+
+## The gap
+
+HARNESS-109 gave the scan suite a receipt, and declared `dist` and `build-contracts` ineligible in
+BOTH directions — a set containing either neither reused a receipt nor wrote one — because `dist/` is
+ignored and a tree hash cannot speak for it.
+
+That reasoning is right about what a receipt may ASSERT and wrong about what a run may DO. A plain
+`pnpm harness:scan` includes both scans, so it was permanently unreusable — and a plain
+`pnpm harness:scan` run twice on one tree is the exact waste HARNESS-109 was filed about. The
+mechanism served `pre-push` and not the hand-run that caused it.
+
+Owner's framing, 2026-08-19, and it is the correct one: **`dist/` is ignored output. It is not branch
+content**, so a receipt keyed on branch content owes it nothing.
+
+## Measured
+
+The two scans stat files; they do not build anything.
+
+| Run                                 | Before           | After                   |
+| ----------------------------------- | ---------------- | ----------------------- |
+| `pnpm harness:scan`, first          | full suite, 22s  | full suite, 22s         |
+| `pnpm harness:scan`, unchanged tree | full suite again | **1s** — 2 scans re-run |
+
+## Direction
+
+- Exclude the two from the receipt's IDENTITY, and re-run them on every invocation.
+- Side effect worth having: a full local run and CI's `--skip dist --skip build-contracts` then
+  produce the same identity and share one receipt, because what the receipt asserts is the result of
+  the scans a tree hash can speak for, and that set is identical in both.
+- Do not judge the adoption ratchet over the re-run handful: it binds over the set that ran, and that
+  set is two scans by construction.
+
+## Done when
+
+- [x] A plain `pnpm harness:scan` is reusable — measured 22s then 1s on an unchanged tree.
+- [x] The build-output scans still report on a reused run — `✓ build-contracts`, `✓ dist` in the
+      1s run, so a stale build is still surfaced.
+- [x] Both call sites share one receipt — the full set and the CI mirror both report
+      `127 scans not re-run: identical tree scanned at …` from the same receipt.
+- [x] A set that is NOTHING but build-output scans claims no saving —
+      `scripts/harness/__tests__/scan-receipt.test.mjs`, "does not claim a saving when the set is
+      nothing but those scans".
+
+## Result
+
+Delivered. `TREE_EXTERNAL_SCANS` keeps its name and its list; what changed is its meaning — from
+"makes the run ineligible" to "is never asserted by a receipt, and always runs". 17 tests, with the
+refusing branches still outnumbering the reusing ones.
+
+What did NOT change: a receipt still asserts only the scans a tree hash can speak for, a dirty tree
+still refuses in both directions, and `--write-adoption-baseline` still forces an observed pass.

--- a/scripts/harness/__tests__/scan-receipt.test.mjs
+++ b/scripts/harness/__tests__/scan-receipt.test.mjs
@@ -16,8 +16,9 @@ import {
   TREE_EXTERNAL_SCANS,
   createScanReceipt,
   decideScanReuse,
+  receiptCoveredScans,
   scanReceiptMatches,
-  scanSetIsEligible,
+  scansThatAlwaysRun,
 } from '../scan-receipt.mjs';
 
 const IDENTITY = {
@@ -116,25 +117,40 @@ describe('scans whose inputs are not in the tree', () => {
     expect([...TREE_EXTERNAL_SCANS].sort()).toEqual(['build-contracts', 'dist']);
   });
 
-  it('makes a set containing one ineligible in both directions', () => {
-    expect(scanSetIsEligible(['consistency', 'dist'])).toBe(false);
-    expect(scanSetIsEligible(['consistency', 'file-size'])).toBe(true);
-
-    const decision = decide({ scanNames: ['consistency', 'dist'] });
-    expect(decision.reuse).toBe(false);
-    expect(decision.eligible).toBe(false);
-    expect(decision.reason).toContain('dist');
+  it('keeps them out of what a receipt asserts, so one receipt serves both call sites', () => {
+    // A full local run and CI's `--skip dist --skip build-contracts` differ only by these two, and
+    // the receipt never spoke for them — so both must produce the SAME identity, or the command the
+    // item was filed about (a plain `pnpm harness:scan`) can never be reused.
+    expect(receiptCoveredScans(['consistency', 'dist', 'build-contracts'])).toEqual([
+      'consistency',
+    ]);
+    expect(receiptCoveredScans(['consistency'])).toEqual(['consistency']);
   });
 
-  it('refuses the ineligible set even when everything else matches perfectly', () => {
-    // The dangerous case: identity, receipt and cleanliness all agree, and reuse must STILL not
-    // happen, because `dist/` can differ under one tree hash.
-    const scans = ['build-contracts', 'consistency'];
-    const identity = { ...IDENTITY, scans };
-    expect(
-      decideScanReuse({ scanNames: scans, identity, receipt: receiptFor(identity), clean: true })
-        .reuse,
-    ).toBe(false);
+  it('re-runs them on a hit instead of blocking the hit', () => {
+    const scans = ['consistency', 'file-size', 'dist'];
+    const identity = { ...IDENTITY, scans: receiptCoveredScans(scans) };
+    const decision = decideScanReuse({
+      scanNames: scans,
+      identity,
+      receipt: receiptFor(identity),
+      clean: true,
+    });
+
+    expect(decision.reuse).toBe(true);
+    expect(scansThatAlwaysRun(scans)).toEqual(['dist']);
+  });
+
+  it('does not claim a saving when the set is nothing but those scans', () => {
+    const scans = ['dist', 'build-contracts'];
+    const decision = decideScanReuse({
+      scanNames: scans,
+      identity: null,
+      receipt: null,
+      clean: true,
+    });
+    expect(decision.reuse).toBe(false);
+    expect(decision.reason).toMatch(/no scan in this set is covered/);
   });
 });
 

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -17,7 +17,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { planScanReuse, writeScanReceipt } from './scan-receipt.mjs';
+import { planScanReuse, scansThatAlwaysRun, writeScanReceipt } from './scan-receipt.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
@@ -975,11 +975,26 @@ export async function main() {
   const scanNames = scans.map((scan) => scan.name);
   const reuse = planScanReuse({ scanNames, root: WORKSPACE_ROOT, writeAdoption });
   if (reuse.reuse) {
+    // A receipt speaks for the scans a tree hash can speak for. The rest — the ones reading build
+    // output — are RE-RUN, not skipped: they cost milliseconds, and a run that quietly stopped
+    // reporting dist staleness would be buying speed with the operator's information.
+    const alwaysRun = new Set(scansThatAlwaysRun(scanNames));
+    const rerun = scans.filter((scan) => alwaysRun.has(scan.name));
     process.stdout.write(
-      `${scanNames.length} scans not re-run: ${reuse.reason}.\n` +
+      `${scanNames.length - rerun.length} scans not re-run: ${reuse.reason}.\n` +
         'Change any tracked file, or delete the receipt, to force a full run.\n',
     );
-    process.exitCode = 0;
+    if (rerun.length === 0) {
+      process.exitCode = 0;
+      return;
+    }
+    process.stdout.write(
+      `re-running ${rerun.length} scan(s) that read outside the tree: ${[...alwaysRun].join(', ')}\n`,
+    );
+    // The adoption ratchet is deliberately NOT judged over this handful: it binds over the set that
+    // ran, and this set is two scans by construction, which would read as every other scan going
+    // missing. The ratchet was judged on the run that wrote the receipt.
+    process.exitCode = await runScans(rerun, undefined, undefined, { checkAdoption: false });
     return;
   }
   process.stdout.write(`▶ scan receipt not reused: ${reuse.reason}\n`);

--- a/scripts/harness/scan-receipt.mjs
+++ b/scripts/harness/scan-receipt.mjs
@@ -18,9 +18,13 @@
  *
  * What a tree hash cannot cover is a scan that reads build OUTPUT. `dist` and `build-contracts`
  * compare `dist/` against `src/`, and `dist/` is ignored: two runs with one tree hash can legitimately
- * disagree. Those scans are therefore declared here, and a run that includes one is not eligible in
- * EITHER direction — it neither reuses a receipt nor writes one. The set CI runs
- * (`--skip dist --skip build-contracts`) is eligible, which is the set `pre-push` repeats.
+ * disagree. Those scans are declared here and are simply ALWAYS RE-RUN — they cost milliseconds,
+ * because they stat files. Making the whole run ineligible instead (HARNESS-109's first shape) meant
+ * a plain `pnpm harness:scan` could never be reused, which is the command the item was filed about.
+ *
+ * They are also excluded from the receipt's identity, so a full local run and CI's
+ * `--skip dist --skip build-contracts` share one receipt: what the receipt asserts is the result of
+ * the scans a tree hash CAN speak for, and that set is the same in both.
  *
  * ## The direction this fails in
  *
@@ -42,7 +46,7 @@ const RECEIPT_FILE = 'robota-verification/harness-scan.json';
 /**
  * Scans whose inputs are NOT in the tree, so a tree hash cannot speak for them. Named, not inferred:
  * a scan added later that reads build output must be added here in the same change, and the test
- * fixture asserting ineligibility is what makes that visible.
+ * asserting they are re-run on a hit is what makes that visible.
  */
 export const TREE_EXTERNAL_SCANS = new Set(['dist', 'build-contracts']);
 
@@ -64,15 +68,20 @@ function hashFile(root, relativePath) {
   }
 }
 
-/** True when every requested scan can be spoken for by a tree hash. */
-export function scanSetIsEligible(scanNames) {
-  return !scanNames.some((name) => TREE_EXTERNAL_SCANS.has(name));
+/** The requested scans a tree hash CAN speak for — the only ones a receipt ever asserts. */
+export function receiptCoveredScans(scanNames) {
+  return [...scanNames].filter((name) => !TREE_EXTERNAL_SCANS.has(name)).sort();
+}
+
+/** The requested scans that must run on every invocation, receipt or not. */
+export function scansThatAlwaysRun(scanNames) {
+  return [...scanNames].filter((name) => TREE_EXTERNAL_SCANS.has(name)).sort();
 }
 
 export function computeScanIdentity({ scanNames, root }) {
   return {
     headTree: run('git', ['rev-parse', 'HEAD^{tree}'], root),
-    scans: [...scanNames].sort(),
+    scans: receiptCoveredScans(scanNames),
     nodeVersion: process.version,
     pnpmVersion: run('pnpm', ['--version'], root),
     lockfileHash: hashFile(root, 'pnpm-lock.yaml'),
@@ -137,13 +146,9 @@ export function decideScanReuse({
       reason: '--write-adoption-baseline re-freezes from an observed pass',
     };
   }
-  if (!scanSetIsEligible(scanNames)) {
-    const external = scanNames.filter((name) => TREE_EXTERNAL_SCANS.has(name)).sort();
-    return {
-      reuse: false,
-      eligible: false,
-      reason: `${external.join(', ')} read build output, which a tree hash cannot speak for`,
-    };
+  if (receiptCoveredScans(scanNames).length === 0) {
+    // Nothing a receipt could assert. Reusing here would report a saving over an empty set.
+    return { reuse: false, eligible: false, reason: 'no scan in this set is covered by a receipt' };
   }
   if (!clean) {
     return { reuse: false, eligible: false, reason: `working tree is not clean: ${dirtyReason}` };
@@ -168,8 +173,8 @@ export function createScanReceipt(identity, scannedAt) {
 }
 
 export function writeScanReceipt({ scanNames, root, scannedAt = new Date().toISOString() }) {
-  if (!scanSetIsEligible(scanNames)) {
-    return { written: false, reason: 'the set includes a scan that reads build output' };
+  if (receiptCoveredScans(scanNames).length === 0) {
+    return { written: false, reason: 'no scan in this set is covered by a receipt' };
   }
   const dirty = realDirtyLines(root);
   if (dirty.length > 0) {
@@ -186,7 +191,7 @@ export function writeScanReceipt({ scanNames, root, scannedAt = new Date().toISO
 
 /** The read half, wired for a real repository: identity + receipt + cleanliness in one call. */
 export function planScanReuse({ scanNames, root, writeAdoption = false }) {
-  if (writeAdoption || !scanSetIsEligible(scanNames)) {
+  if (writeAdoption) {
     return decideScanReuse({
       scanNames,
       identity: null,


### PR DESCRIPTION
Follow-up to HARNESS-109 (PR #1888), on the owner's framing: **`dist/` is ignored output — it is not
branch content**, so a receipt keyed on branch content owes it nothing.

## What was wrong

HARNESS-109 declared `dist` and `build-contracts` ineligible in **both** directions: a set containing
either neither reused a receipt nor wrote one. That is right about what a receipt may ASSERT and wrong
about what a run may DO — a plain `pnpm harness:scan` includes both, so it was permanently unreusable.

And a plain `pnpm harness:scan` run twice on one tree is the exact waste HARNESS-109 was filed about.
The mechanism served `pre-push` and not the hand-run that caused it.

## What this does

The two scans are excluded from the receipt's **identity** and re-run on **every** invocation. They
stat files; they cost milliseconds. Skipping them would buy speed with the operator's information
about a stale build.

```
$ pnpm harness:scan                      # first, clean tree
126 scans passed, 3 skipped
scan receipt written: an unchanged tree will not be re-scanned.          22s

$ pnpm harness:scan                      # unchanged tree
127 scans not re-run: identical tree scanned at 13:46:49.
re-running 2 scan(s) that read outside the tree: build-contracts, dist
✓ build-contracts
✓ dist                                                                    1s
```

## One receipt now serves both call sites

Because the identity no longer lists them, a full local run and CI's
`--skip dist --skip build-contracts` produce the **same** identity:

```
$ pnpm harness:scan -- --skip dist --skip build-contracts
127 scans not re-run: identical tree scanned at 2026-08-19T13:46:49.192Z.

$ pnpm harness:scan
127 scans not re-run: identical tree scanned at 2026-08-19T13:46:49.192Z.
re-running 2 scan(s) that read outside the tree: build-contracts, dist
```

What the receipt asserts is the result of the scans a tree hash can speak for, and that set is
identical in both.

## What did not change

A receipt still asserts only tree-covered scans. A dirty tree still refuses in both directions.
`--write-adoption-baseline` still forces an observed pass. The adoption ratchet is deliberately **not**
judged over the two-scan re-run — it binds over the set that ran, and that set is two scans by
construction, which would read as every other scan going missing; it was judged on the run that wrote
the receipt.

`TREE_EXTERNAL_SCANS` keeps its name and its list. What changed is its meaning.

## Verification

17 tests (the refusing branches still outnumber the reusing ones, including a set that is nothing but
build-output scans claiming no saving). `pnpm harness:scan` — 126 passed / 3 skipped.
