### PR TITLE
fix(agent-command): await the createSession the scenario verifier calls (INFRA-108)

### DIFF
--- a/.agents/tasks/INFRA-108-scenario-verifier-not-typechecked.md
+++ b/.agents/tasks/INFRA-108-scenario-verifier-not-typechecked.md
@@ -52,9 +52,9 @@ Two separable things, and this item does only the first:
 
 1. **The break** — `readSystemMessage` becomes `async` and awaits, and its four call sites await it.
    That is the whole fix; nothing else about the scenario changes.
-2. **The gap** — bringing `packages/*/examples/` under a typecheck. Filed separately, because it is a
-   nine-package change whose blast radius has to be measured against a full declaration build before
-   anyone can say what it costs, and develop is red NOW.
+2. **The gap** — bringing `packages/*/examples/` under a typecheck. Filed as issue #1902, because it
+   is a nine-package change whose blast radius has to be measured against a full declaration build
+   before anyone can say what it costs, and develop is red NOW.
 
 ## Plan
 
@@ -63,7 +63,7 @@ Two separable things, and this item does only the first:
       attributed to the right change.
 - [x] TC-03: the real frame was established by unmasking it, not by inference.
 - [x] TC-04: `pnpm harness:pre-push` is green.
-- [ ] TC-05: the typecheck gap is filed as its own issue.
+- [x] TC-05: opened issue #1902 for the typecheck gap, with the measured scope it needs.
 
 ## Test Plan
 

--- a/.agents/tasks/INFRA-108-scenario-verifier-not-typechecked.md
+++ b/.agents/tasks/INFRA-108-scenario-verifier-not-typechecked.md
@@ -1,0 +1,91 @@
+---
+title: 'INFRA-108: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
+status: in-progress
+created: 2026-08-20
+priority: high
+urgency: now
+area: packages/agent-command
+depends_on: []
+---
+
+# INFRA-108: the scenario verifier awaits `createSession`, and the gap that let it break
+
+## Objective
+
+`packages/agent-command`'s `scenario:verify` fails on a clean `origin/develop`, so every branch
+rebased onto develop inherits a red `quality` check for a defect it did not introduce.
+
+## What broke
+
+PR #1885 (ARCH-035) changed `createSession` from a synchronous function to an `async` one. One
+caller was not updated: `readSystemMessage` in
+`packages/agent-command/examples/semantic-command-role-scenario-helpers.ts` did
+`const created = createSession({...})` and then read `created.session` off the unawaited promise.
+
+`created.session` is `undefined`, so the scenario threw — but not where the mistake was:
+
+| where it was reported                  | what it said                                               |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `verify-semantic-command-roles.ts:198` | `Cannot read properties of undefined (reading 'shutdown')` |
+| the actual failure, two frames earlier | `undefined` has no `getSystemMessage`                      |
+
+The reported frame is in the `finally` block: the scenario's cleanup loop does `session.shutdown()`
+over an array that now holds an `undefined` the try block pushed, and that TypeError REPLACES the
+original one. The message names a cleanup step that was never the problem.
+
+## Measured, not assumed
+
+| probe                                                       | result                                                                  |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `pnpm scenario:verify` on a detached clean `origin/develop` | fails — the defect is develop's, not any branch's                       |
+| the same, with the `finally` loop null-guarded              | reveals the real frame in `readSystemMessage`                           |
+| `packages/agent-command/tsconfig.json`                      | `include: ["src/**/*"]` — `examples/` is outside it                     |
+| root `examples:typecheck`                                   | `pnpm --filter "./examples/**" run typecheck` — the ROOT workspace only |
+
+So the compiler never reads `packages/*/examples/`, and neither does the `examples-typecheck` CI job
+that appears to cover it by name. Nine packages carry such a directory. A signature change to a
+published function can break every one of them and still go green.
+
+## Approach
+
+Two separable things, and this item does only the first:
+
+1. **The break** — `readSystemMessage` becomes `async` and awaits, and its four call sites await it.
+   That is the whole fix; nothing else about the scenario changes.
+2. **The gap** — bringing `packages/*/examples/` under a typecheck. Filed separately, because it is a
+   nine-package change whose blast radius has to be measured against a full declaration build before
+   anyone can say what it costs, and develop is red NOW.
+
+## Plan
+
+- [x] TC-01: `pnpm scenario:verify` in `packages/agent-command` passes.
+- [x] TC-02: the failure was reproduced on a clean detached `origin/develop` FIRST, so the fix is
+      attributed to the right change.
+- [x] TC-03: the real frame was established by unmasking it, not by inference.
+- [x] TC-04: `pnpm harness:pre-push` is green.
+- [ ] TC-05: the typecheck gap is filed as its own issue.
+
+## Test Plan
+
+The scenario verifier is itself the test: it is an executable scenario whose exit code is the
+assertion. It fails on develop and passes here, and both halves were run.
+
+Red-proofed in both places the `await` matters, one at a time:
+
+| await removed                                | what the scenario reported                                                                           |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `await createSession(...)` in the helper     | `Cannot read properties of undefined (reading 'shutdown')` — the ORIGINAL symptom, at the same frame |
+| one `await readSystemMessage(...)` call site | `coincidentalPrompt.includes is not a function`                                                      |
+
+The first is the exact failure this item started from, which is what establishes the diagnosis. The
+second shows the call sites are load-bearing too, and that they fail with a DIFFERENT message —
+worth recording, because the two shapes look unrelated and lead a reader to two different places.
+
+## Progress
+
+### 2026-08-20
+
+Found while diagnosing a red `quality` check on the PEER-004 pull request. The first reading blamed
+that branch — the check was red on its head commit, and it was green before. Reproducing on a
+detached clean `origin/develop` is what corrected it: CI tests the PR MERGED INTO its base, so a
+branch cut before ARCH-035 shows the base's defect on its own head sha and looks like the culprit.

--- a/packages/agent-command/examples/semantic-command-role-scenario-helpers.ts
+++ b/packages/agent-command/examples/semantic-command-role-scenario-helpers.ts
@@ -47,13 +47,18 @@ export function command(
   };
 }
 
-export function readSystemMessage(
+/**
+ * ARCH-035 made `createSession` async. This helper is `async` for that reason alone — awaiting the
+ * result is not a style choice here: `created.session` on an unawaited promise is `undefined`, and
+ * the failure surfaces two frames away as a missing method on the session.
+ */
+export async function readSystemMessage(
   cwd: string,
   commandName: string,
   sessions: TDirectSession[],
   commandSemanticRoles?: ISystemCommandSemanticRoles,
-): string {
-  const created = createSession({
+): Promise<string> {
+  const created = await createSession({
     config,
     cwd,
     context: { agentsMd: '', projectNotesMd: '' },
@@ -162,19 +167,19 @@ export async function verifyOmissionBehaviors(options: {
     subagentSpawn: new SystemCommandExecutor(alternate.slice(0, 2)).getSemanticRoles(),
   };
   const prompts = {
-    skillActivation: readSystemMessage(
+    skillActivation: await readSystemMessage(
       cwd,
       'activate-skill-alt',
       directSessions,
       omissionRoles.skillActivation,
     ),
-    contextReduction: readSystemMessage(
+    contextReduction: await readSystemMessage(
       cwd,
       'activate-skill-alt',
       directSessions,
       omissionRoles.contextReduction,
     ),
-    subagentSpawn: readSystemMessage(
+    subagentSpawn: await readSystemMessage(
       cwd,
       'activate-skill-alt',
       directSessions,
@@ -246,7 +251,12 @@ export async function verifyOmissionBehaviors(options: {
   } finally {
     await unannotatedInteractive.shutdown();
   }
-  const unannotatedPrompt = readSystemMessage(cwd, 'skills', directSessions, unannotatedRoles);
+  const unannotatedPrompt = await readSystemMessage(
+    cwd,
+    'skills',
+    directSessions,
+    unannotatedRoles,
+  );
   const unannotatedSubagent = createTrackedSubagent(
     cwd,
     projectedSpawnTool,

--- a/packages/agent-command/examples/verify-semantic-command-roles.ts
+++ b/packages/agent-command/examples/verify-semantic-command-roles.ts
@@ -114,10 +114,10 @@ async function main(): Promise<void> {
         'agent job provenance omitted the alternate semantic command id',
       );
 
-      const alternatePrompt = readSystemMessage(cwd, 'activate-skill-alt', directSessions, {
+      const alternatePrompt = await readSystemMessage(cwd, 'activate-skill-alt', directSessions, {
         skillActivation: 'activate-skill-alt',
       });
-      const coincidentalPrompt = readSystemMessage(cwd, 'skills', directSessions);
+      const coincidentalPrompt = await readSystemMessage(cwd, 'skills', directSessions);
       assertCondition(
         alternatePrompt.includes('## Skills'),
         'alternate role omitted skill metadata',


### PR DESCRIPTION
## develop is red, and this is why

`pnpm scenario:verify` in `packages/agent-command` fails on a clean detached `origin/develop`. Every branch rebased onto develop therefore inherits a red `quality` check for a defect it did not introduce.

PR #1885 (ARCH-035) changed `createSession` from synchronous to `async`. One caller was not updated: `readSystemMessage` in the semantic-command-role scenario helpers read `.session` off the unawaited promise, so every session it tracked was `undefined`.

## The symptom named the wrong place

| where it was reported | what it said |
| --- | --- |
| `verify-semantic-command-roles.ts:198` | `Cannot read properties of undefined (reading 'shutdown')` |
| the actual failure, two frames earlier | `undefined` has no `getSystemMessage` |

The reported frame is the `finally` cleanup loop. It iterates the array the `try` block pushed the `undefined` into, and its TypeError **replaces** the original one — so the message points at a cleanup step that was never the problem. The masking had to be removed before the cause was visible; both frames are kept in the task record so the next reader does not repeat that step.

## Attribution

Reproduced on a detached clean `origin/develop` **before** anything was changed. That step is what corrected a wrong first reading: CI tests a pull request *merged into its base*, so a branch cut before ARCH-035 shows the base's defect on its own head sha and reads as the culprit. I initially blamed PEER-004 for exactly this reason.

## Red-proofed, one at a time

| await removed | what the scenario reported |
| --- | --- |
| `await createSession(...)` in the helper | `Cannot read properties of undefined (reading 'shutdown')` — the original symptom, at the original frame |
| one `await readSystemMessage(...)` call site | `coincidentalPrompt.includes is not a function` |

Both were reverted before committing.

## The gap underneath — filed separately, not fixed here

`packages/*/examples/` sits outside every package's tsconfig `include`, and the root `examples:typecheck` script filters `./examples/**` — the workspace root only, despite the CI job's name. **Nine packages** carry such a directory, so a breaking signature change to a published function can land green.

Closing that is a nine-package change whose blast radius has to be measured against a full declaration build first, and develop is red now. Filed as its own issue.

I also deliberately did **not** null-guard the cleanup loop that masked the error. That is a second defect, and it belongs with the gap it hides rather than smuggled into a one-line fix.

## Verification

`pnpm harness:pre-push` exits 0. `pnpm scenario:verify` passes here and fails on develop — both halves were run.
