### PR TITLE
feat(agent-cli): carry a peer message between two local sessions (#1863)

### DIFF
--- a/.agents/tasks/PEER-005-a-local-channel-between-two-sessions.md
+++ b/.agents/tasks/PEER-005-a-local-channel-between-two-sessions.md
@@ -1,0 +1,100 @@
+---
+title: 'PEER-005: nothing carried a message between two local sessions'
+status: in-progress
+created: 2026-08-19
+priority: high
+urgency: now
+area: packages/agent-cli
+depends_on: []
+---
+
+# PEER-005: the carrier, and only the carrier
+
+## Objective
+
+Stage 2 of issue #1863's remaining scope. Everything above a carrier was already built and waiting
+for one:
+
+| Piece                              | Package                                  | State before this            |
+| ---------------------------------- | ---------------------------------------- | ---------------------------- |
+| Message + ack contracts            | `agent-interface-transport`              | built                        |
+| Ordering, duplicates, ack issuance | `agent-transport-protocol` (the ledger)  | built                        |
+| Session-side ingress               | `agent-framework` (`PeerMessageIngress`) | built, and called by nothing |
+| Bytes between two processes        | —                                        | **absent**                   |
+
+So the message could be shaped, judged and delivered into a session, and there was no way for one to
+reach another. That is what this adds, and it adds nothing else.
+
+## The decisions
+
+**A unix socket inside the guarded directory.** The claim `same-user-same-host` rests on that
+directory's ownership and mode, exactly as it does for the rendezvous. A socket inside a 0700
+directory owned by this uid can be connected to only by that uid — or by root, which already controls
+the process. Admission is established once, at bind time, by `admitLocalPeerSocket`, and never
+re-derived per connection from something a peer chooses.
+
+**The absent guarantee is stated, not implied.** Node's `net` exposes no `SO_PEERCRED`, so there is
+no per-connection credential to read. The guarantee is the directory's. A comment claiming
+per-connection verification would assert a property the code does not have — which is the defect
+class this repository has spent the most review rounds on.
+
+**One message per connection.** Connect, write one JSON line, read one line, close. A persistent
+multiplexed stream needs framing, backpressure and a reconnect policy — three places to be wrong —
+to carry a control message that is sent when a person types. Ordering across messages is the
+ledger's `sequence`, never the socket's.
+
+**The carrier forms no verdict.** `duplicate`, `refused` and `delivered` all come from the ledger and
+are carried back untouched. A carrier that re-decided delivery states would give the sender a second
+opinion about rules that must have exactly one owner.
+
+**An unreadable message is answered with a `refused` ack, not dropped.** The sender is waiting, and
+silence is indistinguishable from a peer that died mid-send — the exact distinction the delivery
+states exist to make.
+
+**A stale socket file is removed before binding.** A crashed session leaves the file with no listener
+and `listen()` then fails with `EADDRINUSE`. Removing it is safe precisely BECAUSE the directory is
+ours: nothing else could have put it there.
+
+## Plan
+
+- [x] TC-01: a message written by one side arrives at the other with its text and origin intact, and
+      the receiver's ack comes back.
+- [x] TC-02: `duplicate` and `refused` verdicts are carried through unchanged.
+- [x] TC-03: two sessions on one directory exchange in both directions.
+- [x] TC-04: binding is refused in a directory that is not 0700.
+- [x] TC-05: sending to a path outside the guarded directory is refused BEFORE connecting.
+- [x] TC-06: sending where nothing listens fails rather than hanging.
+- [x] TC-07: an unreadable message is answered with a refusal.
+- [x] TC-08: a socket file left by a crashed session is taken over.
+- [x] TC-09: `pnpm harness:scan` green.
+- [ ] TC-10: wired to `/peers send` and to `PeerMessageIngress` — the next stage, and what
+      issue #1863's definition of done needs.
+
+## Test Plan
+
+REAL sockets in a scratch directory. A stubbed transport would prove the code calls the functions it
+calls; what has to be established is that bytes written on one side arrive on the other, which is the
+property the whole peer stack was waiting on and the one a stub cannot show.
+
+Ordering, duplicates and ack issuance are deliberately NOT re-asserted here — they belong to the
+ledger, and a second set of cases over them would create a second opinion about rules with one owner.
+
+## Progress
+
+### 2026-08-19
+
+Red-proofed one defect at a time: removing the stale-socket cleanup fails exactly the crash-recovery
+case, removing the receiver's admission check fails exactly the 0700 case, moving the sender's
+admission after the connect fails exactly the containment case, and replacing the refusal ack with a
+silent destroy fails exactly the unreadable-message case.
+
+**One of these caught a case of mine that proved nothing.** The first crash-recovery test tried to
+simulate a crash by closing a server and asserting around it, and passed whatever the code did — an
+in-process server cannot be made to leak its socket path, because closing it unlinks. Writing the
+stale FILE directly reproduces the state a crash leaves, which is more faithful than reproducing the
+crash, and it fails the moment the cleanup is removed.
+
+A second red-proof attempt reported a false all-green because the injected edit had not matched the
+source. Re-running it with the substitution verified showed the case failing at the 10s read timeout,
+as designed. Worth recording: a red-proof that reports green must be checked for having been APPLIED
+before it is read as evidence about the test.

--- a/packages/agent-cli/src/remote-control/__tests__/local-peer-channel.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/local-peer-channel.test.ts
@@ -1,0 +1,232 @@
+/**
+ * PEER-005 (issue #1863, stage 3) — bytes between two local sessions, and nothing more.
+ *
+ * These cases run REAL sockets in a scratch directory. A stubbed transport would prove the code
+ * calls the functions it calls; what has to be established here is that a message written by one
+ * process shape arrives at another and that the ack comes back — the property the whole peer stack
+ * has been waiting on, and the one a stub cannot show.
+ *
+ * What is deliberately NOT re-asserted: ordering, duplicates and ack issuance. Those belong to the
+ * ledger in `agent-transport-protocol` and re-testing them here would create a second opinion about
+ * rules that must have exactly one.
+ */
+
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  listenForPeerMessages,
+  peerSocketPath,
+  sendPeerMessage,
+  type IPeerListener,
+} from '../local-peer-channel.js';
+
+import type { IPeerMessage, IPeerMessageAck } from '@robota-sdk/agent-interface-transport';
+
+const scratch: string[] = [];
+const listeners: IPeerListener[] = [];
+
+afterEach(async () => {
+  while (listeners.length > 0) await listeners.pop()?.close();
+  while (scratch.length > 0) rmSync(scratch.pop() as string, { recursive: true, force: true });
+});
+
+/** A directory shaped the way the rendezvous leaf leaves one: ours, and 0700. */
+function guardedDirectory(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'peer-channel-'));
+  chmodSync(dir, 0o700);
+  scratch.push(dir);
+  return dir;
+}
+
+function message(overrides: Partial<IPeerMessage> = {}): IPeerMessage {
+  return {
+    id: 'msg-1',
+    sequence: 1,
+    origin: { sessionId: 'session-sender' },
+    text: 'hello from the other session',
+    sentAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+const ACCEPT = (received: IPeerMessage): IPeerMessageAck => ({
+  id: received.id,
+  sequence: received.sequence,
+  state: 'delivered',
+});
+
+async function listen(dir: string, sessionId: string, onMessage = ACCEPT): Promise<IPeerListener> {
+  const listener = await listenForPeerMessages({ guardedDirectory: dir, sessionId, onMessage });
+  listeners.push(listener);
+  return listener;
+}
+
+describe('a message reaches the other session', () => {
+  it('delivers the text and returns the ack the receiver issued', async () => {
+    const dir = guardedDirectory();
+    const received: IPeerMessage[] = [];
+    await listen(dir, 'session-receiver', (incoming) => {
+      received.push(incoming);
+      return ACCEPT(incoming);
+    });
+
+    const ack = await sendPeerMessage({
+      guardedDirectory: dir,
+      targetSessionId: 'session-receiver',
+      message: message(),
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.text).toBe('hello from the other session');
+    expect(received[0]?.origin.sessionId).toBe('session-sender');
+    expect(ack).toEqual({ id: 'msg-1', sequence: 1, state: 'delivered' });
+  });
+
+  it('carries back a verdict the carrier did not form', async () => {
+    // The ledger answers a repeated id with the ORIGINAL verdict. This must pass `duplicate` through
+    // untouched — a carrier that re-decided delivery states would give the sender a second opinion
+    // about a rule that has exactly one owner.
+    const dir = guardedDirectory();
+    await listen(dir, 'session-receiver', (incoming) => ({
+      id: incoming.id,
+      sequence: incoming.sequence,
+      state: 'duplicate',
+    }));
+
+    const ack = await sendPeerMessage({
+      guardedDirectory: dir,
+      targetSessionId: 'session-receiver',
+      message: message(),
+    });
+    expect(ack.state).toBe('duplicate');
+  });
+
+  it('carries a refusal and its reason', async () => {
+    const dir = guardedDirectory();
+    await listen(dir, 'session-receiver', (incoming) => ({
+      id: incoming.id,
+      sequence: incoming.sequence,
+      state: 'refused',
+      reason: 'the session is shutting down',
+    }));
+
+    const ack = await sendPeerMessage({
+      guardedDirectory: dir,
+      targetSessionId: 'session-receiver',
+      message: message(),
+    });
+    expect(ack).toMatchObject({ state: 'refused', reason: 'the session is shutting down' });
+  });
+
+  it('both directions on one directory', async () => {
+    // Two sessions each listening and each sending — issue #1863's definition of done in miniature,
+    // minus the shell. One listener answering while the other sends is the case a single-socket test
+    // cannot reach.
+    const dir = guardedDirectory();
+    await listen(dir, 'session-a');
+    await listen(dir, 'session-b');
+
+    const toB = await sendPeerMessage({
+      guardedDirectory: dir,
+      targetSessionId: 'session-b',
+      message: message({ id: 'a-to-b', origin: { sessionId: 'session-a' } }),
+    });
+    const toA = await sendPeerMessage({
+      guardedDirectory: dir,
+      targetSessionId: 'session-a',
+      message: message({ id: 'b-to-a', origin: { sessionId: 'session-b' } }),
+    });
+
+    expect(toB).toMatchObject({ id: 'a-to-b', state: 'delivered' });
+    expect(toA).toMatchObject({ id: 'b-to-a', state: 'delivered' });
+  });
+});
+
+describe('what it refuses', () => {
+  it('refuses to bind in a directory that is not 0700', async () => {
+    // The trust claim IS the directory's mode. Binding in a world-writable directory and calling the
+    // result `same-user-same-host` would be the copyable-credential failure the rendezvous exists to
+    // prevent, wearing a socket.
+    const dir = guardedDirectory();
+    chmodSync(dir, 0o755);
+    await expect(
+      listenForPeerMessages({
+        guardedDirectory: dir,
+        sessionId: 'session-receiver',
+        onMessage: ACCEPT,
+      }),
+    ).rejects.toThrow(/not admitted/);
+  });
+
+  it('refuses to send to a target outside the guarded directory', async () => {
+    // Checked BEFORE connecting. Connecting first would already have handed the text over.
+    const dir = guardedDirectory();
+    await expect(
+      sendPeerMessage({
+        guardedDirectory: dir,
+        targetSessionId: path.join('..', 'escape'),
+        message: message(),
+      }),
+    ).rejects.toThrow(/not admitted|outside/);
+  });
+
+  it('fails rather than hanging when no session is listening there', async () => {
+    const dir = guardedDirectory();
+    await expect(
+      sendPeerMessage({
+        guardedDirectory: dir,
+        targetSessionId: 'session-nobody',
+        message: message(),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('answers an unreadable message with a refusal instead of silence', async () => {
+    // The sender is waiting. Dropping it would be indistinguishable from a peer that died mid-send,
+    // which is exactly the distinction the delivery states exist to make.
+    const dir = guardedDirectory();
+    await listen(dir, 'session-receiver');
+
+    const { createConnection } = await import('node:net');
+    const socketPath = peerSocketPath(dir, 'session-receiver');
+    const reply = await new Promise<string>((resolve, reject) => {
+      const socket = createConnection(socketPath, () => socket.write('not json at all\n'));
+      socket.setEncoding('utf8');
+      socket.on('data', (chunk: string) => resolve(chunk));
+      socket.on('error', reject);
+    });
+    expect(JSON.parse(reply)).toMatchObject({ state: 'refused' });
+  });
+});
+
+describe('rebinding after a crash', () => {
+  it('takes over a socket file a dead session left behind', async () => {
+    // A crashed session leaves its socket FILE with no listener behind it, and `listen()` on an
+    // existing path fails with EADDRINUSE. Removing it is safe precisely BECAUSE the directory is
+    // ours — nothing else could have put it there.
+    //
+    // The stale entry is written directly rather than by killing a server, because an in-process
+    // server cannot be made to leak its path: closing it unlinks. The file IS the state a crash
+    // leaves, so reproducing the state is more faithful than reproducing the crash.
+    const dir = guardedDirectory();
+    writeFileSync(peerSocketPath(dir, 'session-receiver'), '');
+
+    const listener = await listenForPeerMessages({
+      guardedDirectory: dir,
+      sessionId: 'session-receiver',
+      onMessage: ACCEPT,
+    });
+    listeners.push(listener);
+
+    const ack = await sendPeerMessage({
+      guardedDirectory: dir,
+      targetSessionId: 'session-receiver',
+      message: message(),
+    });
+    expect(ack.state).toBe('delivered');
+  });
+});

--- a/packages/agent-cli/src/remote-control/local-peer-channel.ts
+++ b/packages/agent-cli/src/remote-control/local-peer-channel.ts
@@ -1,0 +1,181 @@
+/**
+ * PEER-005 (issue #1863, stage 3) — the carrier that moves one peer message between two local sessions.
+ *
+ * Everything ABOVE this was already built and waiting for a carrier: the message and ack contracts
+ * (`agent-interface-transport`), ordering, duplicates and ack issuance (`agent-transport-protocol`'s
+ * ledger), and the session-side ingress (`agent-framework`). This file adds bytes on a wire and
+ * nothing else. It must not re-decide any of those, and the one easiest to re-decide by accident is
+ * duplicates — the ledger answers a repeated id with the ORIGINAL verdict, and this carries that
+ * back rather than forming its own opinion.
+ *
+ * ## Why a unix socket inside the guarded directory
+ *
+ * The claim `same-user-same-host` rests on the DIRECTORY's ownership and mode, exactly as it does
+ * for the rendezvous. A socket inside a 0700 directory owned by this uid can be connected to only by
+ * that uid — or by root, which already controls the process. So admission is established once, at
+ * bind time, by `admitLocalPeerSocket`; it is never re-derived per connection from anything a peer
+ * chooses.
+ *
+ * Node's `net` exposes no `SO_PEERCRED`, so there is no per-connection credential to read. Saying
+ * that plainly is part of the design: the guarantee is the directory's, and a comment claiming
+ * per-connection verification would assert a property the code does not have.
+ *
+ * ## One message per connection
+ *
+ * Connect, write one JSON line, read one line, close. A persistent multiplexed stream would need
+ * framing, backpressure and a reconnect policy — three places to be wrong — to carry a control
+ * message that is sent when a person types. Ordering across messages is the ledger's `sequence`,
+ * never the socket's.
+ */
+
+import { rmSync } from 'node:fs';
+import { createConnection, createServer, type Server, type Socket } from 'node:net';
+import path from 'node:path';
+
+import { admitLocalPeerSocket } from '@robota-sdk/agent-remote-pairing/local';
+
+import type { IPeerMessage, IPeerMessageAck } from '@robota-sdk/agent-interface-transport';
+
+const LINE_TIMEOUT_MS = 10_000;
+
+/** Where a session listens. Derived from the session id, so a sender needs no second lookup. */
+export function peerSocketPath(guardedDirectory: string, sessionId: string): string {
+  return path.join(guardedDirectory, `${sessionId}.sock`);
+}
+
+/** A refusal carries its reason. There is no admitted-looking result without evidence. */
+function admitOrThrow(socketPath: string, expectedUid: number): void {
+  const admission = admitLocalPeerSocket(socketPath, { expectedUid });
+  if (!admission.admitted) {
+    throw new Error(
+      `local peer channel: ${socketPath} was not admitted, so a message arriving there would prove ` +
+        `nothing about its sender. ${admission.reason ?? 'No reason was given.'}`,
+    );
+  }
+}
+
+/**
+ * Read one newline-terminated JSON line, or reject.
+ *
+ * A peer that closed without sending a line is a FAILURE, not an empty message. Resolving `''` there
+ * would hand the caller a parse error one layer away from the fact that nothing ever arrived.
+ */
+function readLine(socket: Socket, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buffered = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      finish(() => {
+        socket.destroy();
+        reject(new Error(`local peer channel: no line within ${timeoutMs}ms`));
+      });
+    }, timeoutMs);
+    function finish(run: () => void): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      run();
+    }
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk: string) => {
+      buffered += chunk;
+      const at = buffered.indexOf('\n');
+      if (at !== -1) finish(() => resolve(buffered.slice(0, at)));
+    });
+    socket.on('error', (error) => finish(() => reject(error)));
+    socket.on('end', () =>
+      finish(() => reject(new Error('local peer channel: the peer closed before sending a line'))),
+    );
+  });
+}
+
+export interface IPeerListenerOptions {
+  readonly guardedDirectory: string;
+  readonly sessionId: string;
+  /** Handles one message and returns the ack to send back. */
+  readonly onMessage: (message: IPeerMessage) => Promise<IPeerMessageAck> | IPeerMessageAck;
+  readonly expectedUid?: number;
+}
+
+export interface IPeerListener {
+  readonly socketPath: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Listen for peer messages on this session's socket.
+ *
+ * A message that cannot be read is answered with a `refused` ack rather than dropped. The sender is
+ * waiting, and silence would be indistinguishable from a peer that died mid-send — which is the
+ * distinction the delivery states exist to make.
+ */
+export async function listenForPeerMessages(options: IPeerListenerOptions): Promise<IPeerListener> {
+  const socketPath = peerSocketPath(options.guardedDirectory, options.sessionId);
+  admitOrThrow(socketPath, options.expectedUid ?? process.getuid?.() ?? 0);
+  // A socket left by a crashed session blocks the bind. Removing it is safe precisely BECAUSE the
+  // directory is ours: nothing else could have put it there.
+  rmSync(socketPath, { force: true });
+
+  const server: Server = createServer((socket) => {
+    void (async () => {
+      try {
+        const message = JSON.parse(await readLine(socket, LINE_TIMEOUT_MS)) as IPeerMessage;
+        socket.end(`${JSON.stringify(await options.onMessage(message))}\n`);
+      } catch (error) {
+        const refusal: IPeerMessageAck = {
+          id: '',
+          sequence: 0,
+          state: 'refused',
+          reason: error instanceof Error ? error.message : String(error),
+        };
+        socket.end(`${JSON.stringify(refusal)}\n`);
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, resolve);
+  });
+
+  return {
+    socketPath,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => {
+          rmSync(socketPath, { force: true });
+          resolve();
+        });
+      }),
+  };
+}
+
+export interface IPeerSendOptions {
+  readonly guardedDirectory: string;
+  readonly targetSessionId: string;
+  readonly message: IPeerMessage;
+  readonly expectedUid?: number;
+}
+
+/**
+ * Send one message and return the ack the receiver issued.
+ *
+ * The TARGET socket is admitted BEFORE connecting, which is the reason `admitLocalPeerSocket` takes
+ * a path rather than a directory: a path resolving outside the guarded directory carries none of
+ * that directory's guarantees, and connecting first would already have handed the text over.
+ */
+export async function sendPeerMessage(options: IPeerSendOptions): Promise<IPeerMessageAck> {
+  const socketPath = peerSocketPath(options.guardedDirectory, options.targetSessionId);
+  admitOrThrow(socketPath, options.expectedUid ?? process.getuid?.() ?? 0);
+
+  const socket = await new Promise<Socket>((resolve, reject) => {
+    const connection = createConnection(socketPath);
+    connection.once('connect', () => resolve(connection));
+    connection.once('error', reject);
+  });
+
+  socket.write(`${JSON.stringify(options.message)}\n`);
+  const line = await readLine(socket, LINE_TIMEOUT_MS);
+  socket.end();
+  return JSON.parse(line) as IPeerMessageAck;
+}


### PR DESCRIPTION
## What this changes

Stage 3 of issue #1863: the carrier that moves one peer message between two local sessions. Everything above it was already built and waiting — the message and ack contracts (`agent-interface-transport`), ordering/duplicates/ack issuance (`agent-transport-protocol`'s ledger), and the session-side ingress (`agent-framework`). This adds bytes on a wire and nothing else.

`listenForPeerMessages` and `sendPeerMessage`, over a unix socket inside the guarded rendezvous directory from issue #1862.

## The decisions, and what they rest on

**Why a unix socket in the guarded directory.** The `same-user-same-host` claim rests on the *directory's* ownership and mode, exactly as it does for the rendezvous itself: a socket inside a 0700 directory owned by this uid is connectable only by that uid. Admission is established once, at bind time, by `admitLocalPeerSocket` — never re-derived per connection from anything a peer chooses.

Node's `net` exposes no `SO_PEERCRED`, so there is no per-connection credential to read. The module says that plainly rather than carrying a comment that would assert a property the code does not have.

**The sender admits the TARGET path before connecting.** That is why `admitLocalPeerSocket` takes a path rather than a directory: a path resolving outside the guarded directory carries none of its guarantees, and connecting first would already have handed the text over.

**One message per connection.** Connect, write one JSON line, read one line, close. A persistent multiplexed stream would need framing, backpressure and a reconnect policy — three places to be wrong — to carry a control message a person types. Ordering across messages is the ledger's `sequence`, never the socket's.

**A closed connection with no line is a failure, not an empty message.** Resolving `''` there would hand the caller a parse error one layer away from the fact that nothing arrived.

**A message that cannot be read is answered with a `refused` ack, not dropped.** The sender is waiting, and silence is indistinguishable from a peer that died mid-send — which is the distinction the delivery states exist to make.

**Duplicates are not re-decided here.** The ledger answers a repeated id with the ORIGINAL verdict; this carries that back rather than forming its own opinion.

## What this does not do

It is not wired to `/peers send` or to `PeerMessageIngress` yet — that is the next stage and what issue #1863's definition of done needs. The task record tracks it as an open item rather than implying this closes the issue.

## Verification

9 tests, and `pnpm harness:pre-push` exits 0.

One test correction worth naming: the first crash-recovery test proved nothing — an in-process server cannot leak its socket path, because closing it unlinks the file. It now writes the stale socket file directly.
