### PR TITLE
docs(tasks): complete four records whose work is merged on develop

### DIFF
--- a/.agents/tasks/completed/INFRA-106-a-bare-hash-number-does-not-say-issue-or-pull-request.md
+++ b/.agents/tasks/completed/INFRA-106-a-bare-hash-number-does-not-say-issue-or-pull-request.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-106: a bare #N does not say whether it is an issue or a pull request'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-20
 priority: medium
 urgency: next
 area: .agents/rules, scripts/harness, commitlint.config.js

--- a/.agents/tasks/completed/INFRA-107-action-references-is-rate-limited-into-a-red-gate.md
+++ b/.agents/tasks/completed/INFRA-107-action-references-is-rate-limited-into-a-red-gate.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-107: action-references probes an anonymous endpoint, so a shared CI address turns it red'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-20
 priority: high
 urgency: now
 area: scripts/harness

--- a/.agents/tasks/completed/INFRA-108-scenario-verifier-not-typechecked.md
+++ b/.agents/tasks/completed/INFRA-108-scenario-verifier-not-typechecked.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-108: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
-status: in-progress
+status: done
 created: 2026-08-20
+completed: 2026-08-20
 priority: high
 urgency: now
 area: packages/agent-command

--- a/.agents/tasks/completed/PEER-005-a-local-channel-between-two-sessions.md
+++ b/.agents/tasks/completed/PEER-005-a-local-channel-between-two-sessions.md
@@ -1,7 +1,8 @@
 ---
 title: 'PEER-005: nothing carried a message between two local sessions'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-20
 priority: high
 urgency: now
 area: packages/agent-cli
@@ -67,8 +68,16 @@ ours: nothing else could have put it there.
 - [x] TC-07: an unreadable message is answered with a refusal.
 - [x] TC-08: a socket file left by a crashed session is taken over.
 - [x] TC-09: `pnpm harness:scan` green.
-- [ ] TC-10: wired to `/peers send` and to `PeerMessageIngress` — the next stage, and what
-      issue #1863's definition of done needs.
+
+## Follow-on
+
+Wiring this carrier to `/peers send` and to `PeerMessageIngress` is what issue #1863's definition of
+done needs, and it is **not** this item's work — it was written here as an unchecked TC-10, which was
+a mistake: a plan item is what this unit of work delivers, and an item nobody intends to do here
+makes the record unclosable for a reason that is not real. It is stated as a follow-on instead, so
+the fact survives without pretending this item is unfinished.
+
+Tracked by issue #1863's remaining stage.
 
 ## Test Plan
 


### PR DESCRIPTION
## What this changes

Four task records still read `status: in-progress` while their work is merged on develop. `status` is the single source of truth for what is still being worked on, so a stale one misdirects the next reader.

| record | what it delivered | verified present on develop |
| --- | --- | --- |
| INFRA-106 | the reference-kind rule, its tree ratchet and the commitlint rule | `scripts/harness/reference-kind.mjs`, `scan-reference-kind-qualified.mjs` |
| INFRA-107 | the authenticated action-manifest probe | `pathExistsAtCommit` in `scan-action-references.mjs` |
| INFRA-108 | the `await` the scenario verifier was missing | `await createSession` in the scenario helpers |
| PEER-005 | the local peer channel | `packages/agent-cli/src/remote-control/local-peer-channel.ts` |

Each was confirmed by reading the file on develop, not by trusting the PR state — a merged PR and a present deliverable are not the same claim.

## One judgement call, stated rather than buried

PEER-005 carried an unchecked **TC-10: "wired to `/peers send` and to `PeerMessageIngress`"**, whose own line says *"the next stage"*. That was never this item's work, and leaving it as a plan item made the record unclosable for a reason that is not real — the kind of thing that either blocks a correct close forever or gets quietly ticked.

It moves to a `## Follow-on` section with the reasoning written down. A plan item is what this unit of work delivers; work nobody intends to do here belongs where a reader will find it, which is issue #1863's remaining stage.

I did **not** tick it.

## Verification

`pnpm harness:scan` — 126 passed, 3 skipped. `pnpm harness:pre-push` green.
