### PR TITLE
docs(tasks): renumber a record whose ID two work items were using

### DIFF
--- a/.agents/tasks/completed/INFRA-114-scenario-verifier-not-typechecked.md
+++ b/.agents/tasks/completed/INFRA-114-scenario-verifier-not-typechecked.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-108: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
+title: 'INFRA-114: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
 status: done
 created: 2026-08-20
 completed: 2026-08-20
@@ -9,7 +9,7 @@ area: packages/agent-command
 depends_on: []
 ---
 
-# INFRA-108: the scenario verifier awaits `createSession`, and the gap that let it break
+# INFRA-114: the scenario verifier awaits `createSession`, and the gap that let it break
 
 ## Objective
 
@@ -81,6 +81,19 @@ Red-proofed in both places the `await` matters, one at a time:
 The first is the exact failure this item started from, which is what establishes the diagnosis. The
 second shows the call sites are load-bearing too, and that they fail with a DIFFERENT message —
 worth recording, because the two shapes look unrelated and lead a reader to two different places.
+
+## Renumbered from INFRA-108
+
+Issue #1898 claimed `INFRA-108` on 2026-08-19, several hours before this record was written, for an
+unrelated item (flag attribution having two implementations). Two work items under one ID breaks
+every reference to either, and the earlier claim wins — so this one moves to the next free number.
+
+The commits and the pull request that delivered this work (PR #1901) still say INFRA-108, and that
+cannot be rewritten. This paragraph is the bridge: a reader who follows `INFRA-108` from a commit
+message lands on issue #1898's item and needs to be told where the other one went.
+
+Checked before choosing: INFRA-109 through INFRA-113 are claimed by issue #1899, issue #1903,
+issue #1904, issue #1905 and issue #1908.
 
 ## Progress
 

--- a/.agents/tasks/completed/INFRA-116-scenario-verifier-not-typechecked.md
+++ b/.agents/tasks/completed/INFRA-116-scenario-verifier-not-typechecked.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-114: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
+title: 'INFRA-116: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
 status: done
 created: 2026-08-20
 completed: 2026-08-20
@@ -9,7 +9,7 @@ area: packages/agent-command
 depends_on: []
 ---
 
-# INFRA-114: the scenario verifier awaits `createSession`, and the gap that let it break
+# INFRA-116: the scenario verifier awaits `createSession`, and the gap that let it break
 
 ## Objective
 
@@ -92,8 +92,19 @@ The commits and the pull request that delivered this work (PR #1901) still say I
 cannot be rewritten. This paragraph is the bridge: a reader who follows `INFRA-108` from a commit
 message lands on issue #1898's item and needs to be told where the other one went.
 
-Checked before choosing: INFRA-109 through INFRA-113 are claimed by issue #1899, issue #1903,
-issue #1904, issue #1905 and issue #1908.
+The number is INFRA-116, and getting there took two tries. The first pass read the issue titles once
+and chose 114 from that reading; between the reading and the choice, five of those issues were
+retitled one number higher, so 114 had become issue #1908's. Review caught it.
+
+The lesson is the one this repository already wrote down as "a claim true when written, not
+re-derived when the facts moved": an ID survey is a measurement with a shelf life, and the moment of
+USE is when it has to be re-taken. Re-derived at the moment of writing this line:
+
+| ID                     | held by                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------- |
+| INFRA-109 .. INFRA-114 | issues, including issue #1899 (110) and issue #1908 (114)                               |
+| INFRA-115              | `.agents/tasks/INFRA-115-dependency-review-omits-win32.md`, opened in this same session |
+| INFRA-116              | free — taken here                                                                       |
 
 ## Progress
 


### PR DESCRIPTION
## One ID, two work items

Issue #1898 claimed `INFRA-108` on 2026-08-19 for *flag attribution has two implementations, and the two enforcers disagree*. Several hours later I wrote a task record under the same number for *the scenario verifier awaits createSession* (merged as PR #1901).

An ID that names two different work items breaks every reference to either one. The earlier claim wins, so mine moves to **INFRA-114**.

## What was checked before choosing

`INFRA-109` through `INFRA-113` are already held — by issue #1899, issue #1903, issue #1904, issue #1905 and issue #1908 respectively. 114 is the first free number.

## The part that cannot be fixed

The commits and the pull request that delivered the work still say `INFRA-108`, and rewriting merged history is not on the table. So the record carries a `## Renumbered from INFRA-108` paragraph: a reader who follows the old number out of a commit message lands on issue #1898's item and has to be told where the other one went. A rename with no forwarding note would just move the confusion rather than resolve it.

## Verification

`pnpm harness:scan` green.

Worth noting what caught a defect in this very change: `reference-kind-qualified` — the rule landed two days ago — refused my own new sentence, because I wrote "claimed by issues #1899, #1903, #1904, #1905 and #1908" and only the first reference in that list carried a kind. Each one now names itself.
