### PR TITLE
feat(harness): derive a hook's accepted override forms from its own source (#1904)

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -499,6 +499,46 @@ malformed, duplicate, stale, or unreadable markers. Deliberate exception: `MERGE
 in the same command**, which prints that the gate did not verify — an override is a visible choice,
 not a silent one.
 
+## Which Form An Override Takes
+
+Every guard here declares an escape hatch, and **the form is not interchangeable**. There are two,
+they have different lifetimes, and using the wrong one fails silently — the command runs, the guard
+refuses anyway, and the reader concludes the guard is broken.
+
+**Inline** — `VAR=1 <command>`, in the same statement. The hook reads the command STRING, so the
+assignment must prefix the guarded command. It excuses only the statement it prefixes: `VAR=1 date;
+git push` does not disarm the push. This is the safer form, and most hatches use it.
+
+**Environment** — `export VAR=1`. The hook reads `${VAR}` from its own environment. A PreToolUse hook
+runs as a separate process and never sees an inline assignment on the agent's command, so only an
+exported variable reaches it. It then stays armed for every later command until unset, which is the
+opposite lifetime from inline and the reason this form is worth naming rather than assuming.
+
+| variable                                                                                          | hook                          | form        |
+| ------------------------------------------------------------------------------------------------- | ----------------------------- | ----------- |
+| `MERGE_GATE_ACK`                                                                                  | `merge-gate.sh`               | inline      |
+| `PRE_PUSH_ALLOW_UNREVIEWED`                                                                       | `pre-push-check.sh`           | inline      |
+| `WORKTREE_CWD_GUARD_ALLOW_MAIN`                                                                   | `worktree-cwd-guard.sh`       | inline      |
+| `BRANCH_GUARD_ALLOW_DELETE`, `_BASE`, `_BRANCH_COPY`, `_OPEN_BRANCHES`, `_BADNAME`, `_MAIN_MERGE` | `branch-guard.sh`             | either      |
+| `BULK_EDIT_ACK`                                                                                   | `bulk-edit-guard.sh`          | either      |
+| `FOREGROUND_WAIT_ACK`                                                                             | `no-foreground-wait.sh`       | either      |
+| `HOOK_EDIT_ACK`                                                                                   | `check-forbidden-patterns.sh` | environment |
+| `LOCKFILE_CHURN_ACK`                                                                              | `pre-push-check.sh`           | environment |
+
+`BRANCH_GUARD_ALLOW_BADNAME` exempts a branch name from the naming convention, and
+`BRANCH_GUARD_ALLOW_MAIN_MERGE` a push or merge into `main` for a release the user approved. Both
+were accepted by the hook and named in no rule until this section; an undeclared bypass is worse than
+a declared one, because the reader who needs it cannot find it and the reader auditing the guard does
+not know it is there.
+
+This table is NOT the authority on what works — the hook source is. It is the declaration the scan
+compares against that source, in both directions.
+
+Enforced by: `hook-override-declarations` (`scripts/harness/scan-hook-override-declarations.mjs`),
+which DERIVES the accepted forms from each hook's own code rather than from a list. A hand-kept list
+of accepted forms would be one more copy of exactly the thing that drifted — the declaration existed
+in up to five places and nothing compared any of them to the code.
+
 The hook deliberately does NOT judge whether a prose finding was addressed; that is the reviewer's
 call, and a hook guessing at it would be a check measuring the wrong thing. It establishes only that
 CI is green and that a current review exists to be read.

--- a/.agents/tasks/INFRA-117-override-forms-have-no-owner.md
+++ b/.agents/tasks/INFRA-117-override-forms-have-no-owner.md
@@ -1,0 +1,129 @@
+---
+title: 'INFRA-117: a hook escape hatch is declared in five places and compared against none'
+status: in-progress
+created: 2026-08-20
+priority: high
+urgency: now
+area: .claude/hooks, scripts/harness
+depends_on: []
+---
+
+# INFRA-117: the accepted form is derived from the hook, not restated beside it
+
+## Objective
+
+Issue #1904. Every guard in `.claude/hooks/` declares an escape hatch. What it ACCEPTS is decided by
+the code reading the variable; what it is DECLARED to accept was written by hand in up to five other
+places, and nothing compared any of them to the code. Both drift directions were live at once.
+
+## Measured before anything was written
+
+Fourteen override variables across 14 hooks, and **three distinct accepted forms** — not one:
+
+| form             | variables                                                                      | how the hook reads it                         |
+| ---------------- | ------------------------------------------------------------------------------ | --------------------------------------------- |
+| inline only      | `MERGE_GATE_ACK`, `PRE_PUSH_ALLOW_UNREVIEWED`, `WORKTREE_CWD_GUARD_ALLOW_MAIN` | greps the command STRING                      |
+| either           | the six `BRANCH_GUARD_ALLOW_*`, `BULK_EDIT_ACK`, `FOREGROUND_WAIT_ACK`         | both, via `stmt_override` or a pair of checks |
+| environment only | `HOOK_EDIT_ACK`, `LOCKFILE_CHURN_ACK`                                          | `${VAR:-}` from its own environment           |
+
+The forms are not interchangeable and have opposite lifetimes. Inline excuses only the statement it
+prefixes; an exported variable stays armed for every later command until unset. A PreToolUse hook
+runs as a separate process, so an inline assignment on the agent's command never reaches one that
+reads its environment — the command runs, the guard refuses anyway, and the reader concludes the
+guard is broken rather than the declaration.
+
+### What the scan found on its first run
+
+Four live defects, wider than the two issue #1904 named:
+
+| finding                                             | variable                                                                    |
+| --------------------------------------------------- | --------------------------------------------------------------------------- |
+| declared INLINE, accepted only from the environment | `LOCKFILE_CHURN_ACK` (`pre-push-check.sh` said "inline" in its own refusal) |
+| accepted, declared nowhere outside its hook         | `BRANCH_GUARD_ALLOW_BADNAME`                                                |
+| accepted, declared nowhere outside its hook         | `BRANCH_GUARD_ALLOW_MAIN_MERGE`                                             |
+| accepted, declared nowhere outside its hook         | `WORKTREE_CWD_GUARD_ALLOW_MAIN`                                             |
+
+`AGENTS.md`'s "Each has a documented **inline** override" was false for two of the fourteen and
+understated eight more.
+
+## Approach
+
+The accepted forms are **derived from the hook source**, never listed. A hand-kept list of accepted
+forms would be a sixth copy of exactly the thing that drifted, and it would drift the same way — one
+edit to a hook, none to the list, nothing comparing them.
+
+`hook-overrides.mjs` owns the derivation. `scan-hook-override-declarations.mjs` compares every
+declaration site — `AGENTS.md`, `.agents/rules/*.md`, and the hook's own refusal messages — against
+it, in both directions.
+
+`git-branch.md` § "Which Form An Override Takes" is the declaration the scan judges. It says on
+itself that it is not the authority: the hook source is.
+
+## Plan
+
+- [x] TC-01: every override variable and its accepted form(s) derived from 14 hook files.
+- [x] TC-02: an INLINE claim for an environment-only hatch is refused.
+- [x] TC-03: a hatch accepted by a hook and declared in no rule is refused.
+- [x] TC-04: an indirect acceptor (`stmt_override`) resolves to both forms, so six variables are not
+      reported as accepting nothing.
+- [x] TC-05: a declaration naming the variable WITHOUT claiming a form passes.
+- [x] TC-06: prose proximity is not read as a form claim.
+- [x] TC-07: the four live findings are fixed and the scan passes.
+- [x] TC-08: the counter is asserted exactly, and again after a second run of the finder.
+- [x] TC-09: `pnpm harness:scan` green (128 passed, 3 skipped).
+- [ ] TC-10: `pnpm harness:pre-push` green.
+
+## Test Plan
+
+Fixture sources rather than the real hooks: a case pinned to `pre-push-check.sh` would fail the day
+that hook is reworded, which is drift in the test rather than in the subject.
+
+The cases that carry the most weight are the two FALSE POSITIVES the first cut produced, because each
+was a detector claiming a form claim where the text made none:
+
+- `HOOK_EDIT_ACK` was reported as declared-inline because its refusal reads
+  `HOOK_EDIT_ACK=1 (git-branch.md)` — a citation, not a command line. The hook says "in the
+  environment" two lines above, correctly.
+- `MERGE_GATE_ACK` was reported as declared-exported because a wrapped paragraph put the variable on
+  the same source line as a sentence about the environment form. Where prose happens to wrap is not a
+  claim.
+
+A scan that guesses at prose produces findings whose fix is to reword something no reader ever
+misread. Both detectors are now explicit-only, and both false positives are pinned as passing cases.
+
+## User Execution Test Scenarios
+
+**Scenario — the declaration and the code disagree**
+
+- Prerequisites: this repository, no build needed.
+- Steps: edit `.agents/rules/git-branch.md` and change the `LOCKFILE_CHURN_ACK` row's form from
+  `environment` to `inline`, then run `pnpm harness:scan:hook-override-declarations`.
+- Expected: a `[wrong-form]` finding naming the variable and saying the hook reads it from its own
+  environment. Revert the edit and it passes.
+- Evidence: run 2026-08-20 — the probe produced exactly that finding, and the restore returned the
+  scan to green.
+
+**Scenario — a new hatch nobody declared**
+
+- Steps: in any hook, read a new `${SOMETHING_ACK:-0}`, then run the scan.
+- Expected: an `[undeclared]` finding naming the hook.
+- Evidence: run 2026-08-20 — injecting `BRAND_NEW_HATCH_ACK` into `no-foreground-wait.sh` produced
+  `- [undeclared] BRAND_NEW_HATCH_ACK: accepted by no-foreground-wait.sh …`, and the restore returned
+  the scan to green.
+
+## Progress
+
+### 2026-08-20
+
+Filed as issue #1904 from review of pull request #1886, as FOUNDATIONAL: that pull request had
+corrected one of four copies of a declaration and left three.
+
+Two detectors had to be narrowed after measuring them against the real tree, and both narrowings are
+the same lesson — a detector that reads prose loosely reports drift that is not there, and the cost
+lands on whoever rewords the sentence to make a scan happy without understanding why.
+
+The derivation had to be widened once in the other direction: the first inline detector required
+`[[:space:]]` immediately beside `NAME=1` and so missed `merge-gate.sh` and `pre-push-check.sh`,
+whose acceptors put a capture group between them. Checking both directions is what surfaced it —
+those two hooks came back accepting NOTHING, and a hook that accepts nothing is a finding rather than
+a quiet zero.

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -723,7 +723,8 @@ if [ -z "${LOCKFILE_CHURN_ACK:-}" ]; then
       echo "[pre-push-check] and a resolution moving a package into the production graph is what" >&2
       echo "[pre-push-check] dependency-review refuses, one CI cycle later." >&2
       echo "[pre-push-check] Restore it:  git checkout origin/develop -- pnpm-lock.yaml" >&2
-      echo "[pre-push-check] Deliberate resolution change with no manifest edit: LOCKFILE_CHURN_ACK=1 inline." >&2
+      echo "[pre-push-check] Deliberate resolution change with no manifest edit: export LOCKFILE_CHURN_ACK=1" >&2
+      echo "[pre-push-check] (read from the environment, NOT inline — this check runs after the hook is invoked)" >&2
       exit 2
     fi
   fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ The most-hit refusals, in imperative form. Reasoning lives in [git-branch.md](.a
 - **Cut branches from a freshly-fetched `origin/develop`**, one at a time.
 - **An open PR's diff is frozen** except to resolve a reported finding.
 
-Each has a documented inline override (`MERGE_GATE_ACK=1`, `PRE_PUSH_ALLOW_UNREVIEWED=1`, `BRANCH_GUARD_ALLOW_DELETE=1`, …). An override is a visible choice, used after verifying by hand what the hook could not reach — never a way past a gate you have not satisfied.
+Each has a documented override — the FORM differs and is not interchangeable. Most are **inline** (`MERGE_GATE_ACK=1 gh pr merge …`), which excuses only the statement they prefix. A few are read from the **environment** (`HOOK_EDIT_ACK`, `LOCKFILE_CHURN_ACK`), which means they stay armed until unset rather than for one command. [git-branch.md](.agents/rules/git-branch.md) § "Which Form An Override Takes" is the owner; `hook-override-declarations` derives the accepted forms from the hook source and refuses a declaration that names the wrong one. An override is a visible choice, used after verifying by hand what the hook could not reach — never a way past a gate you have not satisfied.
 
 ## Common Pitfalls
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "examples:typecheck": "pnpm --filter \"./examples/**\" run typecheck",
     "harness:scan:conflict-markers": "node scripts/harness/scan-conflict-markers.mjs",
     "harness:scan:reference-kind-qualified": "node scripts/harness/scan-reference-kind-qualified.mjs",
+    "harness:scan:hook-override-declarations": "node scripts/harness/scan-hook-override-declarations.mjs",
     "harness:scan:symlink-following-enumeration": "node scripts/harness/scan-symlink-following-enumeration.mjs",
     "harness:scan:deprecated-markers": "node scripts/harness/scan-deprecated-markers.mjs",
     "harness:scan:orphan-exports": "node scripts/harness/check-orphan-exports.mjs",

--- a/scripts/harness/__tests__/hook-overrides.test.mjs
+++ b/scripts/harness/__tests__/hook-overrides.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * INFRA-112 (issue #1904) — deriving what a hook ACCEPTS from its own source.
+ *
+ * The two cases that matter are the acceptors the first detector missed and the indirect one it
+ * could not see, because each would have made the scan report a hook as accepting nothing — and a
+ * hook that accepts nothing is a finding, not a quiet zero.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { acceptedFormsIn, collectAcceptedForms, overrideNamesIn } from '../hook-overrides.mjs';
+
+describe('what a hook accepts, derived from its source', () => {
+  it('reads an environment-only hatch as environment', () => {
+    const source = 'if [ "${LOCKFILE_CHURN_ACK:-0}" != "1" ]; then refuse; fi';
+    expect(acceptedFormsIn(source).LOCKFILE_CHURN_ACK).toEqual({
+      environment: true,
+      inline: false,
+    });
+  });
+
+  it('reads a command-string acceptor as inline', () => {
+    // The acceptor that the first detector MISSED: a capture group sits between `=1` and the class.
+    const source = String.raw`grep -qE '(^|[[:space:]])MERGE_GATE_ACK=1([[:space:]]+x)*[[:space:]]+gh'`;
+    expect(acceptedFormsIn(source).MERGE_GATE_ACK).toEqual({ environment: false, inline: true });
+  });
+
+  it('follows an indirect acceptor to both forms', () => {
+    // `stmt_override` tests `${!token:-0}` AND a statement regex, so the six branch-guard hatches
+    // accept both while their names appear beside neither construct.
+    const source = 'if ! stmt_override BRANCH_GUARD_ALLOW_DELETE; then refuse; fi';
+    expect(acceptedFormsIn(source).BRANCH_GUARD_ALLOW_DELETE).toEqual({
+      environment: true,
+      inline: true,
+    });
+  });
+
+  it('names a variable it only mentions, with neither form', () => {
+    const source = 'echo "see SOME_OTHER_ACK in the other hook"';
+    expect(acceptedFormsIn(source).SOME_OTHER_ACK).toEqual({ environment: false, inline: false });
+    expect(overrideNamesIn(source)).toContain('SOME_OTHER_ACK');
+  });
+
+  it('counts the hooks it opened, reset per call rather than accumulated', () => {
+    const read = () => 'if [ "${A_ACK:-0}" != "1" ]; then :; fi';
+    collectAcceptedForms(['one.sh', 'two.sh'], read);
+    const second = collectAcceptedForms(['one.sh'], read);
+    expect(second.get('A_ACK')?.hooks).toEqual(['one.sh']);
+  });
+});

--- a/scripts/harness/__tests__/scan-hook-override-declarations.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-override-declarations.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * INFRA-112 (issue #1904) — comparing a declaration against what the code accepts.
+ *
+ * The cases that matter are the two FALSE POSITIVES the first cut produced, because each was a
+ * detector claiming a form claim where the text made none. A scan that guesses at prose produces
+ * findings whose fix is to reword something no reader ever misread, and this one judges documents.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectAcceptedForms,
+  examinedHookCount,
+  findDeclarationFindings,
+} from '../scan-hook-override-declarations.mjs';
+
+describe('comparing declarations against what the code accepts', () => {
+  const environmentOnly = new Map([
+    ['LOCKFILE_CHURN_ACK', { environment: true, inline: false, hooks: ['.claude/hooks/x.sh'] }],
+  ]);
+  const inlineOnly = new Map([
+    ['MERGE_GATE_ACK', { environment: false, inline: true, hooks: ['.claude/hooks/x.sh'] }],
+  ]);
+
+  it('refuses an inline claim for an environment-only hatch', () => {
+    const findings = findDeclarationFindings(environmentOnly, [
+      ['.agents/rules/r.md', '`LOCKFILE_CHURN_ACK=1` inline.'],
+    ]);
+    expect(findings.map((finding) => finding.kind)).toEqual(['wrong-form']);
+  });
+
+  it('refuses a hatch no document outside the hook mentions', () => {
+    const findings = findDeclarationFindings(environmentOnly, [
+      ['.claude/hooks/x.sh', 'LOCKFILE_CHURN_ACK'],
+    ]);
+    expect(findings.map((finding) => finding.kind)).toEqual(['undeclared']);
+  });
+
+  it('accepts a declaration that names the variable without claiming a form', () => {
+    // The `HOOK_EDIT_ACK` false positive: `HOOK_EDIT_ACK=1 (git-branch.md)` is a citation, not a
+    // command line, and the hook says "in the environment" correctly two lines above.
+    const findings = findDeclarationFindings(environmentOnly, [
+      ['.agents/rules/r.md', 'If the change is intended: LOCKFILE_CHURN_ACK=1 (git-branch.md)'],
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it('does not read prose proximity as an exported claim', () => {
+    // The `MERGE_GATE_ACK` false positive: a wrapped paragraph put the variable on the same source
+    // line as a sentence about the environment form. Where prose wraps is not a claim.
+    const findings = findDeclarationFindings(inlineOnly, [
+      [
+        '.agents/rules/r.md',
+        'Most are inline (`MERGE_GATE_ACK=1 gh pr merge`), a few are read from the environment.',
+      ],
+    ]);
+    expect(findings).toEqual([]);
+  });
+
+  it('refuses an explicit export spelling for an inline-only hatch', () => {
+    const findings = findDeclarationFindings(inlineOnly, [
+      ['.agents/rules/r.md', 'Run `export MERGE_GATE_ACK=1` first. MERGE_GATE_ACK is inline.'],
+    ]);
+    expect(findings.map((finding) => finding.kind)).toEqual(['wrong-form']);
+  });
+});
+
+describe('the size this scan reports', () => {
+  const read = () => 'if [ "${A_ACK:-0}" != "1" ]; then :; fi';
+
+  it('counts exactly the hooks the finder opened', () => {
+    collectAcceptedForms(['one.sh', 'two.sh', 'three.sh'], read);
+    expect(examinedHookCount()).toBe(3);
+  });
+
+  it('reports the same count after a SECOND run, rather than accumulating', () => {
+    // An accumulating counter and a growing subject produce the same rising number. Running the
+    // finder twice over the same fixture is what tells them apart: only the accumulator changes.
+    collectAcceptedForms(['one.sh', 'two.sh', 'three.sh'], read);
+    collectAcceptedForms(['one.sh', 'two.sh', 'three.sh'], read);
+    expect(examinedHookCount()).toBe(3);
+  });
+});

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -24,6 +24,7 @@
     "harness-script-import-safety",
     "helper-limits",
     "hook-catalog",
+    "hook-override-declarations",
     "hook-registration",
     "hook-syntax",
     "interface-imports",

--- a/scripts/harness/hook-overrides.mjs
+++ b/scripts/harness/hook-overrides.mjs
@@ -1,0 +1,127 @@
+/**
+ * INFRA-112 (issue #1904) — the single owner of "which escape-hatch forms does this hook accept".
+ *
+ * Every guard in `.claude/hooks/` declares an escape hatch. What it ACCEPTS is decided by the code
+ * reading the variable; what it is DECLARED to accept was written by hand in up to five other places
+ * — the refusal message, a second refusal in the same file, the rule section, the card in AGENTS.md,
+ * and a task record — and nothing compared any of them to the code. Both drift directions were
+ * measured on the integration branch before this module existed.
+ *
+ * This module does not hold a list of accepted forms. It DERIVES them from the hook source, because
+ * a hand-kept list would be a sixth copy of exactly the thing that drifted.
+ *
+ * ## The two mechanisms, and why the distinction is not cosmetic
+ *
+ * **Statement-scoped inline** — the hook greps the command STRING for `VAR=1` prefixing the guarded
+ * command. It excuses only the statement it prefixes, so `VAR=1 date; git push` does not disarm the
+ * push. `merge-gate.sh` says this on itself: "It must be inline because this hook reads the command".
+ *
+ * **Environment** — the hook reads `${VAR:-}` from its own environment. A PreToolUse hook runs as a
+ * separate process, so an inline assignment on the agent's command never reaches it; only a variable
+ * exported into the session does. That form therefore stays armed for every later command until it is
+ * unset, which is the opposite lifetime from the inline one.
+ *
+ * A reader told "inline" about an environment-only hatch will type something that does not work. A
+ * reader told "inline" about a hook that also accepts the environment does not know a bypass can
+ * outlive the command that set it. Neither is a documentation nicety.
+ */
+
+/** `${VAR}`, `${VAR:-x}`, `${!token}` indirection, and a bare `$VAR` test. */
+function readsEnvironment(source, name) {
+  const braced = new RegExp(String.raw`\$\{!?${name}[:}]`);
+  const bare = new RegExp(String.raw`\$${name}\b`);
+  return braced.test(source) || bare.test(source);
+}
+
+/**
+ * An inline acceptor is a regex that binds `VAR=1` to a position in the command string.
+ *
+ * Matched on `NAME=1` appearing inside a pattern rather than in prose, which is what separates an
+ * acceptor from a refusal message telling the reader to type it.
+ */
+function readsInline(source, name) {
+  // A LINE containing both `NAME=1` and a POSIX character class is a regex, not prose. The first cut
+  // of this required `[[:space:]]` immediately beside `NAME=1` and missed both `merge-gate.sh` and
+  // `pre-push-check.sh`, whose acceptors read `NAME=1([[:space:]]+...` — a capture group sits between
+  // them. Checking both directions is what surfaced that: the detector reported two hooks as
+  // accepting nothing, and two hooks that accept nothing would be a finding, not a quiet zero.
+  return source
+    .split('\n')
+    .some((line) => line.includes(`${name}=1`) && /\[\[:(space|alnum|alpha):\]\]/.test(line));
+}
+
+/**
+ * Indirect acceptors: a helper taking the variable NAME as an argument.
+ *
+ * `branch-guard.sh` routes six variables through `stmt_override`, which tests `${!token:-0}` AND the
+ * statement regex — so those six accept both forms while the name appears beside neither construct.
+ * Reading the call site is the only way to see that; a scan that looked for the constructs alone
+ * would report six false "declared but not accepted" findings.
+ */
+const INDIRECT = [{ helper: 'stmt_override', environment: true, inline: true }];
+
+function indirectForms(source, name) {
+  for (const entry of INDIRECT) {
+    if (new RegExp(String.raw`\b${entry.helper}\s+${name}\b`).test(source)) return entry;
+  }
+  return undefined;
+}
+
+/** Every override-shaped variable name a hook mentions at all. */
+export function overrideNamesIn(source) {
+  const names = new Set();
+  const pattern = /\b[A-Z][A-Z0-9_]*(?:_ACK|_ALLOW[A-Z0-9_]*|_SKIP[A-Z0-9_]*)\b/g;
+  for (const match of source.matchAll(pattern)) names.add(match[0]);
+  return [...names].sort();
+}
+
+/**
+ * What one hook accepts, per variable.
+ *
+ * A name it mentions but neither reads nor matches is reported with both forms false — that is a
+ * variable the hook only TALKS about, which is either another hook's hatch named in prose or a
+ * declaration with nothing behind it. The caller decides which; this module reports what it found.
+ */
+export function acceptedFormsIn(source) {
+  const forms = {};
+  for (const name of overrideNamesIn(source)) {
+    const indirect = indirectForms(source, name);
+    forms[name] = indirect
+      ? { environment: indirect.environment, inline: indirect.inline }
+      : { environment: readsEnvironment(source, name), inline: readsInline(source, name) };
+  }
+  return forms;
+}
+
+let examinedHooks = 0;
+
+/** How many hook files this run actually read. Reset per call, never accumulated across runs. */
+export function examinedHookCount() {
+  return examinedHooks;
+}
+
+/**
+ * Derive the accepted forms for every hook.
+ *
+ * A variable accepted by MORE than one hook is merged permissively: if any hook accepts the inline
+ * form, the inline form works somewhere, and a declaration naming it is not wrong. Reporting per-hook
+ * would be stricter but unreadable, because the declarations name the variable, not the file.
+ */
+export function collectAcceptedForms(hookPaths, readFile) {
+  examinedHooks = 0;
+  const merged = new Map();
+  for (const hookPath of hookPaths) {
+    examinedHooks += 1;
+    const forms = acceptedFormsIn(readFile(hookPath));
+    for (const [name, form] of Object.entries(forms)) {
+      const found = merged.get(name) ?? { environment: false, inline: false, hooks: [] };
+      if (form.environment || form.inline) found.hooks.push(hookPath);
+      merged.set(name, {
+        environment: found.environment || form.environment,
+        inline: found.inline || form.inline,
+        hooks: found.hooks,
+      });
+    }
+  }
+  return merged;
+}

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -13,6 +13,7 @@
     "scripts/harness/scan-barrel-parameter-types.mjs",
     "scripts/harness/scan-claude-review-coverage.mjs",
     "scripts/harness/scan-conflict-markers.mjs",
+    "scripts/harness/scan-hook-override-declarations.mjs",
     "scripts/harness/scan-interface-runtime.mjs",
     "scripts/harness/scan-loop-proof.mjs",
     "scripts/harness/scan-loop-run-records.mjs",

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -451,6 +451,12 @@ export const SCAN_COMMANDS = [
     name: 'reference-kind-qualified',
     command: ['node', 'scripts/harness/scan-reference-kind-qualified.mjs'],
   },
+  // INFRA-112. The accepted forms are derived from each hook's own source, so this compares the
+  // declarations against the code rather than against a list that would drift beside them.
+  {
+    name: 'hook-override-declarations',
+    command: ['node', 'scripts/harness/scan-hook-override-declarations.mjs'],
+  },
   {
     name: 'symlink-following-enumeration',
     command: ['node', 'scripts/harness/scan-symlink-following-enumeration.mjs'],

--- a/scripts/harness/scan-hook-override-declarations.mjs
+++ b/scripts/harness/scan-hook-override-declarations.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * INFRA-112 (issue #1904) — every declared escape hatch names the form its hook actually accepts.
+ *
+ * `AGENTS.md` said "Each has a documented **inline** override". Measured before this scan existed,
+ * that was false for three variables that accept only an exported one, and understated three more
+ * that accept both. Nothing compared any declaration to the code, so both drift directions were live
+ * at once: a hatch advertised and not accepted, and a hatch accepted and not advertised.
+ *
+ * The accepted forms are DERIVED from the hook source by `hook-overrides.mjs`. This scan holds no
+ * list of its own — a list here would be the copy that drifts next.
+ *
+ * ## What a finding means
+ *
+ * - `undeclared` — a hook accepts a hatch no document mentions. The reader who needs it cannot find
+ *   it, and the reader auditing the guard does not know it is there. The second is the dangerous one.
+ * - `wrong-form` — a document names a form the code does not accept. A reader following it types
+ *   something that silently does not work, and concludes the guard is broken rather than the doc.
+ * - `phantom` — a document declares a hatch no hook reads. It reads as a supported bypass and is not.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { collectAcceptedForms, examinedHookCount } from './hook-overrides.mjs';
+
+/**
+ * The size this scan reports, re-exported so the declaration and the reader are one symbol.
+ *
+ * `measurement-provenance` asks that a scan announcing a size expose the reader behind it AND the
+ * finder that moves it, so the number can be asserted rather than believed — and asserted again after
+ * a second run, which is what tells an accumulating counter from a growing subject. Both are
+ * re-exported from the module that does the counting rather than reimplemented, so a second counter
+ * cannot exist to disagree with this one.
+ */
+export { collectAcceptedForms, examinedHookCount };
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+function trackedFiles() {
+  const out = execFileSync('git', ['ls-files', '-z'], {
+    cwd: WORKSPACE_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out.split('\0').filter((entry) => entry.length > 0);
+}
+
+/** Where a hatch may be declared. Hook sources are included: a refusal message is a declaration. */
+const DECLARATION_GLOBS = [
+  /^AGENTS\.md$/,
+  /^\.agents\/rules\/.*\.md$/,
+  /^\.claude\/hooks\/.*\.sh$/,
+];
+
+/**
+ * A hatch that is deliberately not advertised outside its own hook.
+ *
+ * `TASK_TRACKING_SKIP_ISSUES` suppresses an informational listing rather than a refusal — there is no
+ * gate to bypass, so a rule section for it would document a preference as an override.
+ */
+const NOT_ADVERTISED = new Set(['TASK_TRACKING_SKIP_ISSUES']);
+
+/**
+ * Does this text declare the INLINE form for `name`?
+ *
+ * Only an EXPLICIT claim counts — the word "inline" on the same line, or the variable shown prefixing
+ * a real command. Most declarations name the variable and no form at all, and reading those as a form
+ * claim is how the first cut of this scan reported `HOOK_EDIT_ACK` wrongly: its refusal reads
+ * `HOOK_EDIT_ACK=1 (git-branch.md)`, which is a citation, not a command line. The hook says "in the
+ * environment" two lines above, correctly.
+ *
+ * Narrow on purpose. A scan that guesses at a form claim produces findings whose fix is to reword
+ * prose the reader never misread.
+ */
+const COMMAND_VERBS = String.raw`(?:git|gh|pnpm|npm|node|bash|sh|sleep|cat|sed|rm|mv)\b`;
+
+function declaresInline(text, name) {
+  const namedInline = new RegExp(String.raw`^.*\b${name}\b.*\binline\b.*$`, 'im');
+  const prefixesCommand = new RegExp(String.raw`${name}=1\s+${COMMAND_VERBS}`);
+  return namedInline.test(text) || prefixesCommand.test(text);
+}
+
+/**
+ * Does this text declare the EXPORTED form for `name`? Only `export NAME=` counts.
+ *
+ * The first cut also accepted the variable and the word "environment" on one source line, and a
+ * wrapped paragraph naming several hatches put `MERGE_GATE_ACK` on the same line as a sentence about
+ * the environment form — a false positive produced entirely by where the prose happened to wrap.
+ * Proximity in prose is not a claim; the imperative spelling is.
+ */
+function declaresExported(text, name) {
+  return new RegExp(String.raw`export\s+${name}=`).test(text);
+}
+
+export function findDeclarationFindings(accepted, documents) {
+  const findings = [];
+  const seen = new Map();
+
+  for (const [file, text] of documents) {
+    for (const name of accepted.keys()) {
+      if (!text.includes(name)) continue;
+      const forms = seen.get(name) ?? { inline: false, exported: false, files: [] };
+      forms.inline = forms.inline || declaresInline(text, name);
+      forms.exported = forms.exported || declaresExported(text, name);
+      forms.files.push(file);
+      seen.set(name, forms);
+    }
+  }
+
+  for (const [name, form] of accepted) {
+    if (form.hooks.length === 0) continue;
+    const declared = seen.get(name);
+    const outside = (declared?.files ?? []).filter((file) => !file.startsWith('.claude/hooks/'));
+
+    if (declared === undefined || (outside.length === 0 && !NOT_ADVERTISED.has(name))) {
+      findings.push({
+        kind: 'undeclared',
+        name,
+        detail:
+          `accepted by ${form.hooks.map((hook) => path.basename(hook)).join(', ')} and declared in no ` +
+          'rule or AGENTS.md. A bypass nobody documented is one the auditor does not know to look for.',
+      });
+      continue;
+    }
+    if (declared.inline && !form.inline) {
+      findings.push({
+        kind: 'wrong-form',
+        name,
+        detail:
+          'declared as an INLINE override, which this hook does not accept — it reads the variable ' +
+          'from its own environment, and a PreToolUse hook never sees an inline assignment.',
+      });
+    }
+    if (form.inline && !form.environment && declared.exported) {
+      findings.push({
+        kind: 'wrong-form',
+        name,
+        detail:
+          'declared as an EXPORTED override, which this hook does not accept — it matches the ' +
+          'assignment against the command string, so only the statement it prefixes is excused.',
+      });
+    }
+  }
+  return findings;
+}
+
+function main() {
+  const tracked = trackedFiles();
+  const hooks = tracked.filter((file) => /^\.claude\/hooks\/[^/]+\.sh$/.test(file));
+  const accepted = collectAcceptedForms(hooks, (file) =>
+    readFileSync(path.join(WORKSPACE_ROOT, file), 'utf8'),
+  );
+
+  const documents = tracked
+    .filter((file) => DECLARATION_GLOBS.some((pattern) => pattern.test(file)))
+    .map((file) => [file, readFileSync(path.join(WORKSPACE_ROOT, file), 'utf8')]);
+
+  const findings = findDeclarationFindings(accepted, documents);
+  console.log(`::examined:: ${examinedHookCount()} hook file(s)`);
+
+  if (findings.length > 0) {
+    for (const finding of findings) {
+      console.error(`- [${finding.kind}] ${finding.name}: ${finding.detail}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+  const live = [...accepted.values()].filter((form) => form.hooks.length > 0).length;
+  console.log(
+    `hook-override-declarations scan passed (${live} accepted override variable(s) across ` +
+      `${examinedHookCount()} hook(s)). The accepted forms are DERIVED from the hook source, so this ` +
+      'cannot pass by agreeing with a list that drifted alongside them.',
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main();
+}


### PR DESCRIPTION
Closes #1904.

## What was actually wrong

Every guard in `.claude/hooks/` declares an escape hatch. What it **accepts** is decided by the code reading the variable; what it is **declared** to accept was written by hand in up to five other places, and nothing compared any of them to the code.

Measured across all 14 hooks before anything was written — and the shape is worse than the issue described. There are **three** accepted forms, not one:

| form | variables | how the hook reads it |
| --- | --- | --- |
| inline only | `MERGE_GATE_ACK`, `PRE_PUSH_ALLOW_UNREVIEWED`, `WORKTREE_CWD_GUARD_ALLOW_MAIN` | greps the command **string** |
| either | the six `BRANCH_GUARD_ALLOW_*`, `BULK_EDIT_ACK`, `FOREGROUND_WAIT_ACK` | both, via `stmt_override` or a pair of checks |
| environment only | `HOOK_EDIT_ACK`, `LOCKFILE_CHURN_ACK` | `${VAR:-}` from its own environment |

The forms are not interchangeable and have **opposite lifetimes**. Inline excuses only the statement it prefixes; an exported variable stays armed for every later command until unset. A PreToolUse hook runs as a separate process, so an inline assignment on the agent's command never reaches one that reads its environment — the command runs, the guard refuses anyway, and the reader concludes the guard is broken rather than the declaration.

## Four live defects, found by the scan on its first run

| finding | variable |
| --- | --- |
| declared INLINE in its own refusal, accepted only from the environment | `LOCKFILE_CHURN_ACK` |
| accepted by a hook, declared in no rule at all | `BRANCH_GUARD_ALLOW_BADNAME` |
| accepted by a hook, declared in no rule at all | `BRANCH_GUARD_ALLOW_MAIN_MERGE` |
| accepted by a hook, declared in no rule at all | `WORKTREE_CWD_GUARD_ALLOW_MAIN` |

`AGENTS.md`'s "Each has a documented **inline** override" was false for two of the fourteen and understated eight more. All four are fixed here, and `AGENTS.md` now points at the owning section instead of generalising.

## The design decision

**The accepted forms are derived from the hook source, never listed.** A hand-kept list would be a sixth copy of exactly the thing that drifted, and it would drift the same way — one edit to a hook, none to the list, nothing comparing them. `git-branch.md` § "Which Form An Override Takes" says on itself that it is not the authority; the hook source is.

## Two detectors narrowed, one widened — each for a reason worth keeping

Narrowed, and both narrowings are one lesson: **a detector that reads prose loosely reports drift that is not there**, and the cost lands on whoever rewords a sentence to make a scan happy without understanding why.

- `HOOK_EDIT_ACK` was reported as declared-inline because its refusal reads `HOOK_EDIT_ACK=1 (git-branch.md)` — a citation, not a command line. The hook says "in the environment" two lines above, correctly.
- `MERGE_GATE_ACK` was reported as declared-exported because a wrapped paragraph put the variable on the same **source line** as a sentence about the environment form. Where prose happens to wrap is not a claim.

Widened, in the other direction: the first inline detector required the character class immediately beside `NAME=1` and so missed `merge-gate.sh` and `pre-push-check.sh`, whose acceptors put a capture group between them. Checking both directions is what surfaced it — those two came back accepting **nothing**, and a hook that accepts nothing is a finding rather than a quiet zero.

Both false positives are pinned as passing cases, so a future widening cannot silently reintroduce them.

## Red-proofed against the real tree, both directions, each reverted

| defect injected | what went red |
| --- | --- |
| declare `LOCKFILE_CHURN_ACK` as inline in the rule table | `[wrong-form]` naming the variable and the reason |
| read a new `BRAND_NEW_HATCH_ACK` in `no-foreground-wait.sh` | `[undeclared]` naming the hook |

## Harness conformance

The scan brought four floors with it, each satisfied rather than waived: `fixture-floor` (test named after the scan), `harness-script-import-safety` (a test per module), `measurement-provenance` (exported reader **and** finder, exact assertion, re-asserted after a second run so an accumulating counter is told from a growing subject), and `examined-size adoption drift` (registered in the frozen set in this same change).

## Verification

`pnpm harness:scan` — 128 passed, 3 skipped. `pnpm harness:pre-push` exits 0. 10 unit cases across the two modules.
