### PR TITLE
docs(tasks): renumber two more records whose IDs an issue claimed first

### DIFF
--- a/.agents/tasks/completed/INFRA-118-dependency-review-omits-win32.md
+++ b/.agents/tasks/completed/INFRA-118-dependency-review-omits-win32.md
@@ -1,14 +1,25 @@
 ---
-title: 'INFRA-115: dependency-review blocks every lockfile-touching pull request on a coverage hole'
-status: in-progress
+title: 'INFRA-118: dependency-review blocks every lockfile-touching pull request on a coverage hole'
+status: done
 created: 2026-08-20
+completed: 2026-08-20
 priority: high
 urgency: now
 area: .github/workflows
 depends_on: []
 ---
 
-# INFRA-115: the sharp allow-list covers four platforms and there are five
+# INFRA-118: the sharp allow-list covers four platforms and there are five
+
+## Renumbered from INFRA-115
+
+Issue #1912 claimed `INFRA-115` on 2026-08-19T16:52:03Z, before this record was written. The earlier
+claim wins, so this one moved. PR #1914 and its commits still say INFRA-115 and cannot be rewritten;
+this paragraph is the bridge for a reader who follows the old number out of one.
+
+Re-derived at the moment of writing: issues hold INFRA-103 and INFRA-109 through INFRA-116, the tree
+holds INFRA-100 and INFRA-102 through INFRA-107, and INFRA-117 is taken by an open pull request. 118
+is the first free one.
 
 ## Objective
 
@@ -77,7 +88,9 @@ which is the mechanism working rather than failing.
 - [x] TC-04: `@img/sharp-libvips-win32-*` was checked for existence AND for presence in the lockfile;
       it exists and is absent, so it is deliberately not listed.
 - [x] TC-05: the workflow still parses as YAML and the job name is unchanged.
-- [ ] TC-06: `Dependency review` is green on a pull request that touches `pnpm-lock.yaml`.
+- [x] TC-06: `Dependency review` is green on a pull request that touches `pnpm-lock.yaml` —
+      PR #1909 merged 2026-08-19T18:00:18Z, an hour after the fix, and its `Dependency review` reports
+      SUCCESS. That is the gate itself, not a re-reading of the workflow file.
 
 ## Test Plan
 
@@ -97,7 +110,9 @@ passed.
 - Steps: open it against `develop` and read the `Dependency review` check.
 - Expected: green. Before this change it reported the three `@img/sharp-win32-*` names on any such
   pull request.
-- Evidence: _to be filled once a lockfile-touching pull request has run_
+- Evidence: PR #1909 touched `pnpm-lock.yaml` and merged 2026-08-19T18:00:18Z with
+  `Dependency review: SUCCESS`. Before this change the same file produced three `@img/sharp-win32-*`
+  findings on any such pull request.
 
 ## Progress
 

--- a/.agents/tasks/completed/INFRA-119-scenario-verifier-not-typechecked.md
+++ b/.agents/tasks/completed/INFRA-119-scenario-verifier-not-typechecked.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-116: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
+title: 'INFRA-119: a breaking signature change reached develop because packages/*/examples is typechecked by nobody'
 status: done
 created: 2026-08-20
 completed: 2026-08-20
@@ -9,7 +9,7 @@ area: packages/agent-command
 depends_on: []
 ---
 
-# INFRA-116: the scenario verifier awaits `createSession`, and the gap that let it break
+# INFRA-119: the scenario verifier awaits `createSession`, and the gap that let it break
 
 ## Objective
 
@@ -82,7 +82,7 @@ The first is the exact failure this item started from, which is what establishes
 second shows the call sites are load-bearing too, and that they fail with a DIFFERENT message —
 worth recording, because the two shapes look unrelated and lead a reader to two different places.
 
-## Renumbered from INFRA-108
+## Renumbered from INFRA-108, then from INFRA-116
 
 Issue #1898 claimed `INFRA-108` on 2026-08-19, several hours before this record was written, for an
 unrelated item (flag attribution having two implementations). Two work items under one ID breaks
@@ -92,7 +92,7 @@ The commits and the pull request that delivered this work (PR #1901) still say I
 cannot be rewritten. This paragraph is the bridge: a reader who follows `INFRA-108` from a commit
 message lands on issue #1898's item and needs to be told where the other one went.
 
-The number is INFRA-116, and getting there took two tries. The first pass read the issue titles once
+The number is INFRA-119, and getting there took THREE tries. The first pass read the issue titles once
 and chose 114 from that reading; between the reading and the choice, five of those issues were
 retitled one number higher, so 114 had become issue #1908's. Review caught it.
 


### PR DESCRIPTION
## Two more IDs claimed by an issue first

| record | collided with | filed |
| --- | --- | --- |
| `INFRA-115` (dependency-review win32) | issue #1912, 2026-08-19T16:52:03Z | → `INFRA-118` |
| `INFRA-116` (scenario verifier) | issue #1913, 2026-08-19T16:54:51Z | → `INFRA-119` |

Both issues predate the records under those numbers. The earlier claim wins.

## Why this keeps happening, which matters more than the rename

This is the third and fourth collision of the session, and **the third happened while fixing the second**. In PR #1911 I re-derived the claimed IDs, chose a free one, and by the time the rename was written that number had been taken by an issue opened minutes earlier.

The repository already carries the lesson as `claims-not-rederived-after-facts-moved` — a claim true when written is not one re-derived after the facts moved — and I applied it. It was not enough. Re-deriving at the moment of use narrows the window; it cannot close it, because **there is no allocation, only observation**. Two sessions reading the same list and each taking "the next free number" will collide however carefully both read first.

Filed as issue #1916 with three candidate mechanisms and what each costs. This pull request is the cleanup that issue names as immediate, not the fix.

Each record carries a forwarding paragraph: the commits and pull requests that delivered the work say the old numbers and cannot be rewritten, so a reader following one out of a commit message needs to be told where it went. `INFRA-119` now records all three of its numbers, because it has had three.

## INFRA-118 also closes

Its `TC-06` asked for `Dependency review` **green on a pull request that actually touches `pnpm-lock.yaml`** — deliberately left open in PR #1914, because re-reading a workflow file is not the same claim as a gate that passed.

PR #1909 touched the lockfile and merged 2026-08-19T18:00:18Z, an hour after the fix, with `Dependency review: SUCCESS`. That is the gate itself, so the item is ticked against the run rather than against the diff, and the record moves to `completed/`.

## Verification

`pnpm harness:scan` — 127 passed, 3 skipped. The suite caught a real slip on the way: the first rename left the index pointing at the old path, so `reference-kind-qualified` died on `ENOENT` for a file that no longer existed. Staging the rename fixed it — and a scan that crashes rather than reporting is worth noticing, since a crash is not a pass.
