### PR TITLE
fix(harness): reverse an added source to the state that has it, not to its absence (#1905)

### DIFF
--- a/.agents/tasks/INFRA-120-red-proof-blind-to-an-added-file.md
+++ b/.agents/tasks/INFRA-120-red-proof-blind-to-an-added-file.md
@@ -1,0 +1,90 @@
+---
+title: 'INFRA-120: the accidental-green gate cannot reach a verdict for a file added in its own range'
+status: in-progress
+created: 2026-08-20
+priority: high
+urgency: now
+area: scripts/harness
+depends_on: []
+---
+
+# INFRA-120: reverse to the state that HAS the file, not to its absence
+
+## Objective
+
+Issue #1905. `check-regression-red-proof` is the declared mechanism against accidental-green tests,
+and its CI job is named "enforcing: accidental-green only". For a source file **added within the range
+it examines**, that verdict is structurally unreachable.
+
+## The mechanism, traced
+
+`defaultReverseApply(base, srcPaths)` reverse-applies `merge-base(origin/develop, HEAD)..HEAD`. For a
+file added in that range:
+
+1. reversing the diff DELETES the file;
+2. every case importing it throws, so the run is a transform/import error;
+3. `classifyVitestOutcome` reports `run-error`, never `all-pass` or `added-cases-pass`;
+4. `decidePairVerdict` returns `ACCIDENTAL_GREEN` only on those two — so it returns `INCONCLUSIVE`.
+
+The `addedCases` machinery built for exactly this granularity (INFRA-072) is defeated by the
+whole-range reversal that runs before it.
+
+## Measured
+
+Pull request #1886 added a scan and its test in the same range across three review rounds. A case
+added in round two was green three ways: on the current module, on the current module with the line it
+guards deleted, and on the round-two predecessor that had no such support at all. The pull request's
+red-proof job emitted exactly one verdict, for a different file, and none for that pair. **A human
+found it.**
+
+This is the gate's SECOND structural blind spot, and the file's own header records the first:
+"Measured over PRs #1525–PR #1530: twelve CI runs, zero verdicts, nine of them `no same-package pair` —
+while human review caught four accidental-green tests in that same window, all of them under
+`scripts/harness/__tests__/` (INFRA-071)." Same gate, same directory, found the same way.
+
+## Approach
+
+The reversal base becomes a per-source question rather than one range-wide constant.
+
+- **Existed at base** → reverse to `base`. Unchanged; this is the case the gate was designed for.
+- **Added in the range, revised later** → reverse to the commit that CREATED it. Later rounds'
+  revisions are undone, the file still exists, its tests run, and a verdict becomes reachable. This is
+  exactly the pull request #1886 shape: a case added in round two against a round-two predecessor.
+- **Added and never revised** → there is genuinely no earlier state. `reversalBaseFor` returns `null`
+  and the gate reports `NO_EARLIER_STATE` rather than reversing to the file's absence and reading the
+  resulting throws as a verdict.
+
+`NO_EARLIER_STATE` is a named verdict rather than folded into `INCONCLUSIVE` because the two have
+different remedies: inconclusive asks for a better pair, this asks for a red proof against a state
+that exists.
+
+## Plan
+
+- [x] TC-01: a file added and later revised reverses to its creating commit.
+- [x] TC-02: a file that existed at base still reverses to base.
+- [x] TC-03: a file added and never revised returns `null`.
+- [x] TC-04: a file the range never touched returns base.
+- [x] TC-05: the orchestrator reverses to the creating commit rather than the base.
+- [x] TC-06: `NO_EARLIER_STATE` is reported, and the gate does NOT reverse to the file's absence.
+- [x] TC-07: the existing 60 cases still pass.
+- [ ] TC-08: `pnpm harness:pre-push` green.
+
+## Test Plan
+
+Injected seams, as the rest of this file's orchestration fixtures already use: a case that shelled out
+to `git log` for a path existing only in a fixture would couple the test to a repository state.
+
+Adding the seam exposed that `baseIo` had to supply it too — six existing orchestration fixtures
+began shelling out to real git the moment the default became live. That is worth recording rather
+than quietly fixing: a new default in an injected-seam design reaches every existing caller of the
+helper, and the failure it produces looks like a broken test rather than a missing injection.
+
+Red-proofed: restoring the whole-range reversal fails exactly the two added-file cases and leaves the
+other 64 green.
+
+## Progress
+
+### 2026-08-20
+
+Filed as issue #1905 from review of pull request #1886, as FOUNDATIONAL. The specific accidental-green
+case was corrected in that pull request; this item is why it was not caught mechanically.

--- a/.agents/tasks/completed/INFRA-117-override-forms-have-no-owner.md
+++ b/.agents/tasks/completed/INFRA-117-override-forms-have-no-owner.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-117: a hook escape hatch is declared in five places and compared against none'
-status: in-progress
+status: done
 created: 2026-08-20
+completed: 2026-08-20
 priority: high
 urgency: now
 area: .claude/hooks, scripts/harness
@@ -71,7 +72,7 @@ itself that it is not the authority: the hook source is.
 - [x] TC-07: the four live findings are fixed and the scan passes.
 - [x] TC-08: the counter is asserted exactly, and again after a second run of the finder.
 - [x] TC-09: `pnpm harness:scan` green (128 passed, 3 skipped).
-- [ ] TC-10: `pnpm harness:pre-push` green.
+- [x] TC-10: `pnpm harness:pre-push` green, and CI clean on PR #1917.
 
 ## Test Plan
 

--- a/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof-execution-witness.test.mjs
@@ -64,6 +64,9 @@ function witnessIo(overrides = {}) {
     readText: (p) => files[p] ?? '',
     fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
     isDirty: () => false,
+    // INFRA-120 — injected like every other git-touching seam. Without it these fixtures shell out
+    // to `git log` for a path that exists only here.
+    reversalBase: () => 'BASE',
     reverseApply: () => {},
     restore: () => {},
     addedTestCaseDiff: () => "+    it('the new regression case', () => {",

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -1089,6 +1089,42 @@ describe('INFRA-120 (issue #1905): a source ADDED in the range', () => {
     expect(reversedFrom).toEqual(['CREATED']);
   });
 
+  it('the TOP-LEVEL verdict carries it, not just the per-pair decision', async () => {
+    // Review finding on the pull request: the `continue` skipped the `worst` update and `rank` had no
+    // entry, so a range whose only pair had no earlier state returned the initial `red-proof-ok` —
+    // a summary reporting a proof that was never attempted. The same swallowing this change exists
+    // to stop, one level up.
+    const { verdict, decisions } = await runRegressionRedProof(
+      baseIo({ reversalBase: () => null }),
+    );
+    expect(verdict).toBe(VERDICT.NO_EARLIER_STATE);
+    expect(decisions[0].verdict).toBe(VERDICT.NO_EARLIER_STATE);
+  });
+
+  it('does not let it outrank a real accidental-green elsewhere in the range', async () => {
+    // It sits beside INCONCLUSIVE: both say no verdict was reached. A defect that WAS found must
+    // still be what the summary reports.
+    const source = 'packages/x/src/target.ts';
+    const test = 'packages/x/src/a.test.ts';
+    const files = {
+      [abs(test)]: `import { t } from './target.js';`,
+      [abs(source)]: 'export const t = 1;',
+    };
+    const { verdict } = await runRegressionRedProof(
+      baseIo({
+        changedFiles: [source, test],
+        readText: (p) => files[p] ?? '',
+        fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+        runVitest: () => ({
+          testResults: [
+            { name: abs(test), assertionResults: [{ title: 'a case', status: 'passed' }] },
+          ],
+        }),
+      }),
+    );
+    expect(verdict).toBe(VERDICT.ACCIDENTAL_GREEN);
+  });
+
   it('through the orchestrator: no earlier state is REPORTED, not silently inconclusive', async () => {
     let reversed = false;
     const { decisions } = await runRegressionRedProof(

--- a/scripts/harness/__tests__/check-regression-red-proof.test.mjs
+++ b/scripts/harness/__tests__/check-regression-red-proof.test.mjs
@@ -30,6 +30,7 @@ import {
   reachableRelativeGraph,
   relativeSpecifiers,
   resolveRelativeImport,
+  reversalBaseFor,
   runRegressionRedProof,
   testExecutesHook,
 } from '../check-regression-red-proof.mjs';
@@ -690,6 +691,10 @@ function baseIo(overrides = {}) {
     readText: (p) => files[p] ?? '',
     fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
     isDirty: () => false,
+    // INFRA-120 — injected like every other git-touching seam. Without it these fixtures would shell
+    // out to `git log` for a path that exists only in the fixture, which is the coupling the rest of
+    // this helper exists to avoid.
+    reversalBase: () => 'BASE',
     reverseApply: () => {},
     restore: () => {},
     runVitest: () => ({ testResults: [] }),
@@ -1038,5 +1043,64 @@ describe('what blocks a merge once the gate is enforcing (INFRA-046)', () => {
     const job = ci.slice(ci.indexOf('  regression-red-proof:'), ci.indexOf('  patch-coverage:'));
 
     expect(job).toMatch(/REGRESSION_RED_PROOF_ENFORCE:\s*'1'/);
+  });
+});
+
+describe('INFRA-120 (issue #1905): a source ADDED in the range', () => {
+  it('reverses to the commit that CREATED the file, not to its absence', () => {
+    // Reversing to the base deletes the file, so every case importing it throws — and an all-throwing
+    // run produces neither `all-pass` nor `added-cases-pass`, the only two outcomes that become
+    // ACCIDENTAL_GREEN. The gate cannot report the defect it exists for on anything the range added.
+    const log = (args) => {
+      if (args[0] === 'cat-file') throw new Error('does not exist at base');
+      return 'CREATED\nREVISED\n';
+    };
+    expect(reversalBaseFor('packages/x/src/new.ts', 'BASE', log)).toBe('CREATED');
+  });
+
+  it('returns the base for a file that already existed there', () => {
+    const log = (args) => (args[0] === 'cat-file' ? '' : 'ONE\nTWO\n');
+    expect(reversalBaseFor('packages/x/src/old.ts', 'BASE', log)).toBe('BASE');
+  });
+
+  it('returns null when the range added the file and never revised it', () => {
+    // There is genuinely no earlier state. Saying so is the honest answer; reversing to nothing and
+    // reading the wreckage would not be.
+    const log = (args) => {
+      if (args[0] === 'cat-file') throw new Error('does not exist at base');
+      return 'CREATED\n';
+    };
+    expect(reversalBaseFor('packages/x/src/new.ts', 'BASE', log)).toBeNull();
+  });
+
+  it('returns the base for a file the range never touched', () => {
+    expect(reversalBaseFor('packages/x/src/untouched.ts', 'BASE', () => '')).toBe('BASE');
+  });
+
+  it('through the orchestrator: reverses to the creating commit rather than the base', async () => {
+    const reversedFrom = [];
+    await runRegressionRedProof(
+      baseIo({
+        reversalBase: () => 'CREATED',
+        reverseApply: (paths, from) => reversedFrom.push(from),
+        runVitest: () => ({ testResults: [] }),
+      }),
+    );
+    expect(reversedFrom).toEqual(['CREATED']);
+  });
+
+  it('through the orchestrator: no earlier state is REPORTED, not silently inconclusive', async () => {
+    let reversed = false;
+    const { decisions } = await runRegressionRedProof(
+      baseIo({
+        reversalBase: () => null,
+        reverseApply: () => {
+          reversed = true;
+        },
+      }),
+    );
+    expect(decisions[0].verdict).toBe(VERDICT.NO_EARLIER_STATE);
+    // The point of the branch: it must not reverse to the base and read the resulting throws.
+    expect(reversed, 'reversing to the absence of the file is what this avoids').toBe(false);
   });
 });

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -57,6 +57,11 @@ export const VERDICT = Object.freeze({
   SKIPPED_NOT_FIX: 'skipped-not-fix', // range has no fix: commit
   SKIPPED_NO_PAIR: 'skipped-no-pair', // no same-package source+test pair
   SKIPPED_OPT_OUT: 'skipped-opt-out', // allow-green-at-base: <reason>
+  // INFRA-120: the range ADDED this source and never revised it, so there is no earlier state of it
+  // to reverse to. Reversing to `base` deletes it and every case throws, which reads as a verdict and
+  // is not one. Named rather than folded into INCONCLUSIVE: the two have different remedies —
+  // inconclusive asks for a better pair, this asks for a red proof against a state that exists.
+  NO_EARLIER_STATE: 'no-earlier-state',
 });
 
 // ── Pure: file classification ─────────────────────────────────────────────────────────────────────
@@ -582,6 +587,47 @@ export function defaultReverseApply(base, srcPaths, readDiff = gitRaw, exec = ex
   exec('git', ['apply', '-R'], { cwd: WORKSPACE_ROOT, input: patch });
 }
 
+/**
+ * INFRA-120 (issue #1905) — the base to reverse a source file TO.
+ *
+ * For a file that existed at `base` this is `base`, and the whole-range reversal is the right
+ * mutation. For a file the range ADDED it is not: reversing to `base` DELETES the file, every case
+ * importing it throws, and `classifyVitestOutcome` can then produce neither `all-pass` nor
+ * `added-cases-pass` — the only two outcomes `decidePairVerdict` turns into `ACCIDENTAL_GREEN`. The
+ * gate that exists to catch accidental green is structurally unable to report it for anything the
+ * range introduced.
+ *
+ * Measured on pull request #1886, which added a scan and its test across three review rounds. A case
+ * added in round two passed on the current module, on the current module with the line it guards
+ * deleted, AND on the round-two predecessor that had no such support. The job emitted one verdict,
+ * for a different file, and none for that pair. A human found it.
+ *
+ * The answer is the file's state at the commit that CREATED it: later rounds' revisions are reversed,
+ * the file still exists, and its tests can run and be judged. When the range added the file and never
+ * revised it there is genuinely no earlier state — `null` says so, and the caller reports that rather
+ * than reversing to nothing and reading the wreckage as a verdict.
+ */
+export function reversalBaseFor(source, base, readLog = git) {
+  const touching = readLog(['log', '--format=%H', '--reverse', `${base}..HEAD`, '--', source])
+    .split('\n')
+    .filter(Boolean);
+  if (touching.length === 0) return base;
+
+  const existedAtBase = (() => {
+    try {
+      readLog(['cat-file', '-e', `${base}:${source}`]);
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  if (existedAtBase) return base;
+
+  // Added in the range. Its creating commit is the earliest state that HAS the file; anything before
+  // it is the file's absence, which is what makes the reversal unreadable.
+  return touching.length > 1 ? touching[0] : null;
+}
+
 function mergeBase(ref = 'origin/develop') {
   try {
     return git(['merge-base', ref, 'HEAD']);
@@ -649,7 +695,9 @@ export async function runRegressionRedProof(io = {}) {
   const fileExists = io.fileExists ?? existsSync;
   const isDirty =
     io.isDirty ?? ((paths) => git(['status', '--porcelain', '--', ...paths]).length > 0);
-  const reverseApply = io.reverseApply ?? ((srcPaths) => defaultReverseApply(base, srcPaths));
+  const reverseApply =
+    io.reverseApply ?? ((srcPaths, from = base) => defaultReverseApply(from, srcPaths));
+  const reversalBase = io.reversalBase ?? ((source) => reversalBaseFor(source, base));
   const restore = io.restore ?? ((srcPaths) => git(['checkout', '--', ...srcPaths]));
   const runVitest = io.runVitest ?? defaultRunVitest;
   const addedTestCaseDiff =
@@ -741,10 +789,30 @@ export async function runRegressionRedProof(io = {}) {
       let outcome = null;
       let witness = WITNESS.UNKNOWN;
       let runtimeMutation = true;
+      // INFRA-120 — reverse to the earliest state that HAS this file, not to its absence.
+      const from = exercised ? reversalBase(source) : base;
+      if (exercised && from === null) {
+        decisions.push({
+          pkg: pair.pkg,
+          source,
+          verdict: VERDICT.NO_EARLIER_STATE,
+          outcome: null,
+          witness,
+          importsReversedFile: true,
+          relation: 'executed',
+          runtimeMutation: true,
+        });
+        log(
+          `⚠︎ ${source} — the range added this file and never revised it, so there is no earlier ` +
+            'state to reverse to. Reversing to the base would delete it and every case would throw, ' +
+            'which is not a verdict.',
+        );
+        continue;
+      }
       if (exercised) {
         let deciders = [];
         const fixedText = readText(path.resolve(WORKSPACE_ROOT, source));
-        reverseApply([source]);
+        reverseApply([source], from);
         try {
           const sourceAbs = path.resolve(WORKSPACE_ROOT, source);
           const reversedText = fileExists(sourceAbs) ? readText(sourceAbs) : null;

--- a/scripts/harness/check-regression-red-proof.mjs
+++ b/scripts/harness/check-regression-red-proof.mjs
@@ -716,6 +716,12 @@ export async function runRegressionRedProof(io = {}) {
     // was offered, where INCONCLUSIVE is the absence of one. Below ACCIDENTAL_GREEN: a case that at
     // least fails is not yet shown to guard nothing.
     [VERDICT.PROOF_UNREACHED]: 3,
+    // Beside INCONCLUSIVE rather than above it: both say the gate reached no verdict, and neither is
+    // a defect in the change. It must not be BELOW `RED_PROOF_OK`, which is the omission review
+    // caught — a range whose only pair has no earlier state would otherwise return the initial
+    // `red-proof-ok`, and the summary would report a proof that was never attempted. That is the same
+    // swallowing this change exists to stop, one level up.
+    [VERDICT.NO_EARLIER_STATE]: 2,
     [VERDICT.INCONCLUSIVE]: 2,
     [VERDICT.RED_PROOF_OK]: 1,
   };
@@ -807,6 +813,10 @@ export async function runRegressionRedProof(io = {}) {
             'state to reverse to. Reversing to the base would delete it and every case would throw, ' +
             'which is not a verdict.',
         );
+        // The summary must carry it too. Skipping this line is what let the top-level verdict stay at
+        // its initial `red-proof-ok` for a range whose only pair could not be judged.
+        if ((rank[VERDICT.NO_EARLIER_STATE] ?? 0) > (rank[worst] ?? 0))
+          worst = VERDICT.NO_EARLIER_STATE;
         continue;
       }
       if (exercised) {


### PR DESCRIPTION
Closes #1905.

## The gate could not reach the verdict it exists for

`check-regression-red-proof` is the declared mechanism against accidental-green tests, and its CI job is named "enforcing: accidental-green only". For a source file **added within the range it examines**, that verdict was structurally unreachable. Traced end to end:

1. `defaultReverseApply` reverse-applies the whole range, which **deletes** a file the range added;
2. every case importing it throws, so the run is a transform/import error;
3. `classifyVitestOutcome` reports `run-error`;
4. `decidePairVerdict` returns `ACCIDENTAL_GREEN` only on `all-pass` or `added-cases-pass` — so it returns `INCONCLUSIVE`.

The per-case machinery built for exactly this granularity (INFRA-072) is defeated by the whole-range reversal that runs *before* it.

## Measured, and found by a human

PR #1886 added a scan and its test across three review rounds. A case added in round two was green **three ways**: on the current module, on the current module with the line it guards deleted, and on the round-two predecessor that had no such support at all. That pull request's red-proof job emitted exactly one verdict — for a different file — and none for that pair.

This is the gate's **second** structural blind spot, and its own header records the first: twelve CI runs over PRs #1525–PR #1530, zero verdicts, while human review caught four accidental-green tests in that same window, all under `scripts/harness/__tests__/`. Same gate, same directory, found the same way.

## The change

The reversal base becomes a **per-source** question rather than one range-wide constant:

| case | reverses to |
| --- | --- |
| existed at base | `base` — unchanged, the case the gate was designed for |
| added in range, revised later | **the commit that created it** — later rounds are undone, the file still exists, its tests run, a verdict is reachable |
| added and never revised | nothing. `reversalBaseFor` returns `null` |

The third gets a named verdict, `no-earlier-state`, rather than being folded into `INCONCLUSIVE`. The two have different remedies: inconclusive asks for a better pair; this asks for a red proof against a state that exists. And critically the gate does **not** reverse to the file's absence and read the resulting throws — a test asserts that it does not.

The middle row is exactly the PR #1886 shape: a case added in round two, judged against the round-two predecessor.

## Red-proofed

Restoring the whole-range reversal fails **exactly** the two added-file cases and leaves the other 64 green.

## One thing worth recording

Adding the seam meant six existing orchestration fixtures began shelling out to real `git log` for paths that exist only in a fixture — and then a *second* test file did the same, after the first fix looked like the whole of it.

A new default in an injected-seam design reaches **every** existing caller of the helper, and the failure it produces reads as a broken test rather than a missing injection. Both files now inject it, and the task record says why.

## Verification

`pnpm harness:pre-push` exits 0. 103 cases across the two red-proof suites.
