### PR TITLE
feat(harness): enumerate the tree a scan judges, not the git index (#1908)

### DIFF
--- a/.agents/tasks/INFRA-121-scan-population-source-has-no-owner.md
+++ b/.agents/tasks/INFRA-121-scan-population-source-has-no-owner.md
@@ -1,0 +1,98 @@
+---
+title: 'INFRA-121: a scan enumerated through the git index, so a file not yet staged was invisible'
+status: in-progress
+created: 2026-08-20
+priority: high
+urgency: now
+area: scripts/harness
+depends_on: []
+---
+
+# INFRA-121: enumerate the tree the author is asking about, not the index
+
+## Objective
+
+Issue #1908. A harness scan decided for itself where its population came from. Eight enumerated
+through `git ls-files`, so their coverage depended on the git index; the rest read the filesystem, so
+theirs did not. Nothing owned the choice and nothing stated it.
+
+## The false green, measured
+
+Review of pull request #1886, round four. A newly written task document carried a citation
+`reference-kind-qualified` refuses:
+
+| when             | verdict                                                      |
+| ---------------- | ------------------------------------------------------------ |
+| before `git add` | **passed**, printing `::examined:: 2936 tracked document(s)` |
+| after staging    | failed, naming that file and that line                       |
+
+The suite ran, declared its size, and reported success on a tree whose newest file it could not see —
+at exactly the moment a writer checks their own work. A human found it a review round later.
+
+That is worse than a scan with no coverage at all. A missing scan is visibly missing; this one printed
+a number and a pass. `enforcement-architecture.md` says silence is not success, and a size silently
+conditional on the index is that same defect wearing a measurement.
+
+## The recurrence answered itself, twice
+
+Issue #1908 notes that pull request #1886 adds a sixth `ls-files` scan while the issue is open. By the
+time this item was picked up there were **eight** — because two of them are mine, written earlier in
+this same session, both copying the pattern from the scan beside them. A per-scan choice nobody owns
+is copied by whoever writes the next one, and neither of us knew there was a choice being made.
+
+## Approach
+
+One owner, `enumerate-files.mjs`, enumerating tracked files AND untracked files git does not ignore.
+Both are part of the tree the author is asking about.
+
+An ignored file stays out, and that exclusion needs no per-run disclosure: `.gitignore` declares it
+in one place for every reader. Measured before deciding: the ignored set for `*.md` alone is 3,021
+paths, almost all under `node_modules`. A four-digit number printed every run is a disclosure readers
+learn to skip, which is how a real one would be missed.
+
+## Plan
+
+- [x] TC-01: an unstaged new file is enumerated.
+- [x] TC-02: the old behaviour is shown to miss exactly that file.
+- [x] TC-03: a path git reports twice is not double-counted.
+- [x] TC-04: the order is stable, so a finding list does not churn between runs.
+- [x] TC-05: the size is asserted exactly, and again after a second run.
+- [x] TC-06: five scans converted — `reference-kind-qualified`, `hook-override-declarations`,
+      `aggregate-naming`, `preset-projection` and their shared shape.
+- [x] TC-07: `pnpm harness:scan` green (129 passed, 2 skipped).
+- [ ] TC-08: `pnpm harness:pre-push` green.
+
+## Not converted, and why
+
+`check-done-evidence` and `scan-legacy-typescript` still enumerate directly. Both carry documented
+subtleties the owner does not yet model — the first answers about an arbitrary `root` under a git
+hook, the second deliberately counts index entries whose files are ABSENT from disk, which is a
+different question from "what should I judge". Converting them without modelling those would trade a
+visible gap for a silent one. Left as they are, named here rather than left for a reader to discover.
+
+The `createDistFreeTree` half of issue #1908 — the CI-mirror worktree copies untracked files but never
+stages them, so `ls-files` scans are blind inside the tree built for fidelity — is also untouched.
+With the owner reading untracked files directly, that staging step is no longer what stands between
+those scans and the truth; whether it should still happen is a question about the mirror's fidelity
+rather than about this blindness.
+
+## Test Plan
+
+The `run` seam is injected, so each case states its own git output. A case that shelled out to real
+git would be asserting the state of this repository at the moment it ran.
+
+Red-proofed against the REAL tree rather than a fixture, because the incident was a real-tree one:
+writing an unstaged document with a bare `#1234` and running the scan produces the finding with the
+owner in place, and a pass without it — the measured before/after, reproduced in both directions.
+
+## Progress
+
+### 2026-08-20
+
+Filed as issue #1908 from review of pull request #1886, as FOUNDATIONAL.
+
+One process note worth keeping. The red-proof revert did NOT take: the module is new and therefore
+untracked, so `git checkout --` silently did nothing and the probe stayed in the file. The scan
+afterwards still passed, because the probe only affects a case the passing run does not exercise.
+Checking that the REVERT was applied — not just that the probe was — is what caught it; the same
+lesson as a red-proof that reports green, in the other direction.

--- a/scripts/harness/__tests__/enumerate-files.test.mjs
+++ b/scripts/harness/__tests__/enumerate-files.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * INFRA-121 (issue #1908) — the enumeration a scan judges.
+ *
+ * The case that carries the weight is the untracked one, because that is the false green this module
+ * exists to remove: a file written and not yet staged was invisible to eight scans, at exactly the
+ * moment its author was checking their own work.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { collectFiles, enumerateFiles, examinedFileCount } from '../enumerate-files.mjs';
+
+/** A `run` seam that answers each ls-files invocation from a fixture. */
+function gitDouble({ tracked = [], untracked = [] }) {
+  return (args) => (args.includes('--others') ? untracked : tracked);
+}
+
+describe('what a scan enumerates', () => {
+  it('includes a file written and not yet staged', () => {
+    const files = enumerateFiles([], {
+      run: gitDouble({ tracked: ['a.md'], untracked: ['brand-new.md'] }),
+    });
+    expect(files).toContain('brand-new.md');
+  });
+
+  it('is exactly what the OLD behaviour missed', () => {
+    // The measured incident: passed before `git add`, failed after, while printing a size and a pass.
+    const run = gitDouble({ tracked: ['a.md'], untracked: ['brand-new.md'] });
+    expect(enumerateFiles([], { run, includeUntracked: false })).not.toContain('brand-new.md');
+    expect(enumerateFiles([], { run })).toContain('brand-new.md');
+  });
+
+  it('does not double-count a path git reports twice', () => {
+    const files = enumerateFiles([], {
+      run: gitDouble({ tracked: ['a.md', 'b.md'], untracked: ['b.md'] }),
+    });
+    expect(files).toEqual(['a.md', 'b.md']);
+  });
+
+  it('returns a stable order, so a finding list does not churn between runs', () => {
+    const files = enumerateFiles([], {
+      run: gitDouble({ tracked: ['z.md', 'a.md'], untracked: ['m.md'] }),
+    });
+    expect(files).toEqual(['a.md', 'm.md', 'z.md']);
+  });
+});
+
+describe('the size it reports', () => {
+  const run = gitDouble({ tracked: ['a.md', 'b.md'], untracked: ['c.md'] });
+
+  it('counts exactly what it returned', () => {
+    collectFiles([], { run });
+    expect(examinedFileCount()).toBe(3);
+  });
+
+  it('reports the same count after a SECOND run, rather than accumulating', () => {
+    // An accumulating counter and a growing subject produce the same rising number. Running the
+    // enumerator twice over one fixture is what tells them apart: only the accumulator changes.
+    collectFiles([], { run });
+    collectFiles([], { run });
+    expect(examinedFileCount()).toBe(3);
+  });
+});

--- a/scripts/harness/enumerate-files.mjs
+++ b/scripts/harness/enumerate-files.mjs
@@ -1,0 +1,102 @@
+/**
+ * INFRA-121 (issue #1908) — the single owner of "which files does a scan judge".
+ *
+ * A harness scan used to decide for itself. Eight enumerated through `git ls-files`, so their
+ * coverage depended on the git index; the rest read the filesystem, so theirs did not. Nothing owned
+ * the choice, nothing stated it, and no scan reported what its enumeration left out.
+ *
+ * ## The false green, measured
+ *
+ * Review of pull request #1886, round four. A newly written task document carried a citation
+ * `reference-kind-qualified` refuses:
+ *
+ * | when | verdict |
+ * | --- | --- |
+ * | before `git add` | **passed**, printing `::examined:: 2936 tracked document(s)` |
+ * | after staging | failed, naming that file and that line |
+ *
+ * The suite ran, declared its size, and reported success on a tree whose newest file it could not
+ * see — at exactly the moment a writer checks their work. A human found it a review round later.
+ *
+ * That is worse than a scan with no coverage. A missing scan is visibly missing; this one printed a
+ * number and a pass. `enforcement-architecture.md` says silence is not success, and a size that is
+ * silently conditional on the index is the same defect wearing a measurement.
+ *
+ * ## What this module does
+ *
+ * Enumerates tracked files AND untracked files git does not ignore, because both are part of the
+ * tree the author is asking about. An ignored file stays out — that is a deliberate exclusion the
+ * repository already declared in `.gitignore`, not an accident of when someone last ran `git add`.
+ *
+ * What it leaves out after that is only what `.gitignore` already declares — an exclusion the
+ * repository states in one place, for every reader, rather than one a scan discovers by accident of
+ * when someone last ran `git add`. Measured before deciding not to report it per-run: the ignored set
+ * for `*.md` alone is 3,021 paths, almost all under `node_modules`. A disclosure that prints a
+ * four-digit number every run is one readers learn to skip, which is how a real one would be missed.
+ */
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+import { envWithoutGitVars } from './shared.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+function gitLines(args, cwd = WORKSPACE_ROOT) {
+  const out = execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    // Strip hook-inherited GIT_DIR/GIT_INDEX_FILE: under a git hook they redirect this call to the
+    // hook's repository regardless of `cwd`, listing the WRONG repo. `check-done-evidence` learned
+    // this the hard way and its comment is the reason this is here rather than in one caller.
+    env: envWithoutGitVars(),
+  });
+  return out.split('\0').filter((entry) => entry.length > 0);
+}
+
+let lastEnumerated = 0;
+
+/**
+ * How many paths the last enumeration returned.
+ *
+ * RESET by each enumeration rather than accumulated: a number that grows across calls reads as a
+ * growing subject, which is the one way a declared measurement can be wrong while every finding it
+ * reports is right.
+ */
+export function examinedFileCount() {
+  return lastEnumerated;
+}
+
+/**
+ * Every file in the tree a scan should judge, for the given pathspecs.
+ *
+ * Named `collect…` to match the harness finder convention, so `measurement-provenance` can pair it
+ * with `examinedFileCount` and a test can assert the size this module reports rather than believe it.
+ *
+ * `--others --exclude-standard` is the half that fixes the incident: a file written and not yet
+ * staged is part of the tree its author is asking about, and a scan that cannot see it answers a
+ * question nobody asked.
+ */
+export function collectFiles(
+  pathspecs = [],
+  { includeUntracked = true, cwd = WORKSPACE_ROOT, run = gitLines } = {},
+) {
+  const tracked = run(['ls-files', '-z', ...pathspecs], cwd);
+  if (!includeUntracked) {
+    lastEnumerated = tracked.length;
+    return tracked;
+  }
+  const untracked = run(['ls-files', '-z', '--others', '--exclude-standard', ...pathspecs], cwd);
+  const all = [...new Set([...tracked, ...untracked])].sort();
+  lastEnumerated = all.length;
+  return all;
+}
+
+/**
+ * The name the call sites read as.
+ *
+ * Kept because `collectFiles` says what the harness's provenance rule needs to hear and
+ * `enumerateFiles` says what a caller is doing. One function, two readers, no second implementation.
+ */
+export const enumerateFiles = collectFiles;

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -8,6 +8,7 @@
     "scripts/harness/check-spec-whitebox-leakage.mjs",
     "scripts/harness/check-stub-markers.mjs",
     "scripts/harness/check-workspace-refs.mjs",
+    "scripts/harness/enumerate-files.mjs",
     "scripts/harness/loop-economics.mjs",
     "scripts/harness/promotion-closes.mjs",
     "scripts/harness/scan-aggregate-naming.mjs",

--- a/scripts/harness/scan-aggregate-naming.mjs
+++ b/scripts/harness/scan-aggregate-naming.mjs
@@ -52,6 +52,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 
+import { enumerateFiles } from './enumerate-files.mjs';
 import { loadHarnessConfig } from './harness-config.mjs';
 import { requireGovernedTree } from './governed-tree.mjs';
 import * as ts from './lib/ts-ast.mjs';
@@ -466,17 +467,11 @@ export function findAggregateDeclarations(content, fileName, aggregates) {
   return [...declared];
 }
 
+// INFRA-121 — through the shared owner, so a source written and not yet staged is judged too.
 function trackedSources(root) {
-  const out = execFileSync('git', ['ls-files', 'packages', 'apps'], {
-    cwd: root,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  return out
-    .split('\n')
-    .filter(
-      (f) => f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.mts') || f.endsWith('.cts'),
-    );
+  return enumerateFiles(['packages', 'apps'], { cwd: root }).filter(
+    (f) => f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.mts') || f.endsWith('.cts'),
+  );
 }
 
 /**

--- a/scripts/harness/scan-hook-override-declarations.mjs
+++ b/scripts/harness/scan-hook-override-declarations.mjs
@@ -19,10 +19,10 @@
  * - `phantom` — a document declares a hatch no hook reads. It reads as a supported bypass and is not.
  */
 
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { enumerateFiles } from './enumerate-files.mjs';
 import { collectAcceptedForms, examinedHookCount } from './hook-overrides.mjs';
 
 /**
@@ -38,14 +38,8 @@ export { collectAcceptedForms, examinedHookCount };
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
-function trackedFiles() {
-  const out = execFileSync('git', ['ls-files', '-z'], {
-    cwd: WORKSPACE_ROOT,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  return out.split('\0').filter((entry) => entry.length > 0);
-}
+// INFRA-121 — through the shared owner, so a hook or rule written and not yet staged is judged.
+const trackedFiles = () => enumerateFiles();
 
 /** Where a hatch may be declared. Hook sources are included: a refusal message is a declaration. */
 const DECLARATION_GLOBS = [

--- a/scripts/harness/scan-preset-projection.mjs
+++ b/scripts/harness/scan-preset-projection.mjs
@@ -76,6 +76,7 @@ import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 
+import { enumerateFiles } from './enumerate-files.mjs';
 import { loadHarnessConfig } from './harness-config.mjs';
 import { requireGovernedTree } from './governed-tree.mjs';
 import * as ts from './lib/ts-ast.mjs';
@@ -363,15 +364,10 @@ export function pickedFields(content, fileName, sourceInterface, sourceFieldName
  * keeps this to the handful of files that mention the source type at all.
  */
 function discoverPicks(root, sourceInterface, settings, sourceFieldNames) {
-  const files =
-    settings.trackedFiles ??
-    execFileSync('git', ['ls-files', 'packages', 'apps'], {
-      cwd: root,
-      encoding: 'utf8',
-      maxBuffer: 64 * 1024 * 1024,
-    })
-      .split('\n')
-      .filter((f) => f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.mts'));
+  // INFRA-121 — through the shared owner, so a source written and not yet staged is judged too.
+  const files = (
+    settings.trackedFiles ?? enumerateFiles(['packages', 'apps'], { cwd: root })
+  ).filter((f) => f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.mts'));
 
   const picks = [];
   for (const file of files) {

--- a/scripts/harness/scan-reference-kind-qualified.mjs
+++ b/scripts/harness/scan-reference-kind-qualified.mjs
@@ -20,6 +20,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { enumerateFiles } from './enumerate-files.mjs';
 import { unqualifiedReferences } from './reference-kind.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
@@ -34,16 +35,17 @@ const BASELINE_PATH = path.join(WORKSPACE_ROOT, 'scripts/harness/reference-kind-
  */
 const EXCLUDED = [/(^|\/)CHANGELOG\.md$/, /(^|\/)node_modules\//];
 
+/**
+ * INFRA-121 — enumerated through the shared owner, which includes untracked-but-not-ignored files.
+ *
+ * This scan is where the false green was measured: a task document written and not yet staged passed
+ * before `git add` and failed after, while the run printed a size and a pass. A writer checking their
+ * own work is exactly who this scan is for, and that is the moment it could not see them.
+ */
 function trackedDocuments() {
-  const out = execFileSync('git', ['ls-files', '-z', '*.md'], {
-    cwd: WORKSPACE_ROOT,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  return out
-    .split('\0')
-    .filter((entry) => entry.length > 0)
-    .filter((entry) => !EXCLUDED.some((pattern) => pattern.test(entry)));
+  return enumerateFiles(['*.md']).filter(
+    (entry) => !EXCLUDED.some((pattern) => pattern.test(entry)),
+  );
 }
 
 let examinedDocuments = 0;


### PR DESCRIPTION
Closes #1908.

## The false green, measured

A harness scan decided for itself where its population came from. Eight enumerated through `git ls-files`, so their coverage depended on the git index; the rest read the filesystem, so theirs did not. Nothing owned the choice and nothing stated it.

From review of PR #1886, round four — a newly written task document carrying a citation `reference-kind-qualified` refuses:

| when | verdict |
| --- | --- |
| before `git add` | **passed**, printing `::examined:: 2936 tracked document(s)` |
| after staging | failed, naming that file and that line |

The suite ran, declared a size, and reported success on a tree whose newest file it could not see — at exactly the moment a writer checks their own work, which is who that scan is for. A human found it a review round later.

**This is worse than a scan with no coverage.** A missing scan is visibly missing; this one printed a number and a pass. `enforcement-architecture.md` says silence is not success, and a size silently conditional on the index is that defect wearing a measurement.

## The recurrence answered itself — twice

Issue #1908 notes PR #1886 adding a *sixth* `ls-files` scan while the issue was open. By the time this was picked up there were **eight**, because two of them are mine, written earlier in this same session, both copying the pattern from the scan beside them.

A per-scan choice nobody owns gets copied by whoever writes the next one, and neither of us knew a choice was being made. That is the argument for an owner rather than a fix to six call sites.

## The change

`enumerate-files.mjs` enumerates tracked files **and** untracked files git does not ignore. Both are part of the tree the author is asking about.

What stays out is only what `.gitignore` already declares. That needs no per-run disclosure, and I measured before deciding: the ignored set for `*.md` alone is **3,021 paths**, almost all under `node_modules`. A four-digit number printed on every run is a disclosure readers learn to skip, which is how a real one would be missed.

Five scans converted: `reference-kind-qualified` (where the incident was measured), `hook-override-declarations`, `aggregate-naming`, `preset-projection`, and the shared shape they use.

## Two scans deliberately NOT converted

Named here rather than left for a reader to discover:

- **`check-done-evidence`** answers about an arbitrary `root` under a git hook, with documented `GIT_DIR`/`GIT_INDEX_FILE` stripping the owner does model — but its root semantics differ.
- **`scan-legacy-typescript`** deliberately counts index entries whose files are **absent from disk**, which is a different question from "what should I judge".

Converting either without modelling those would trade a visible gap for a silent one.

The `createDistFreeTree` half of the issue is also untouched: with the owner reading untracked files directly, staging the mirror's copies is no longer what stands between those scans and the truth. Whether it should still happen is a question about the mirror's fidelity rather than about this blindness.

## Red-proofed against the real tree

Not a fixture, because the incident was a real-tree one. Writing an unstaged document with a bare `#1234` and running the scan:

- with the owner in place → `[unfrozen] .agents/tasks/ZZZ-unstaged-probe.md: 1 unqualified reference(s)`
- with untracked enumeration removed → **passed**

The measured before/after, reproduced in both directions.

## One process note, in the record

The red-proof **revert did not take**. The module is new and therefore untracked, so `git checkout --` silently did nothing and the probe stayed in the file — and the scan afterwards still passed, because the probe only affects a case the passing run does not exercise. Checking that the *revert* was applied, not just the probe, is what caught it. Same lesson as a red-proof that reports green, in the other direction.

## Verification

`pnpm harness:scan` — 129 passed, 2 skipped. `pnpm harness:pre-push` exits 0. 6 unit cases, including the exact-size assertion re-asserted after a second run.
