### PR TITLE
docs(tasks): complete INFRA-120, whose work merged as PR #1921

### DIFF
--- a/.agents/tasks/completed/INFRA-120-red-proof-blind-to-an-added-file.md
+++ b/.agents/tasks/completed/INFRA-120-red-proof-blind-to-an-added-file.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-120: the accidental-green gate cannot reach a verdict for a file added in its own range'
-status: in-progress
+status: done
 created: 2026-08-20
+completed: 2026-08-20
 priority: high
 urgency: now
 area: scripts/harness
@@ -67,7 +68,11 @@ that exists.
 - [x] TC-05: the orchestrator reverses to the creating commit rather than the base.
 - [x] TC-06: `NO_EARLIER_STATE` is reported, and the gate does NOT reverse to the file's absence.
 - [x] TC-07: the existing 60 cases still pass.
-- [ ] TC-08: `pnpm harness:pre-push` green.
+- [x] TC-08: `pnpm harness:pre-push` green, and CI clean on PR #1921.
+- [x] TC-09: the summary verdict carries `no-earlier-state` — review caught the first cut skipping
+      the `worst` update and omitting the `rank` entry, so a range whose only pair had no earlier
+      state returned the initial `red-proof-ok`. That is this item's own defect reproduced one level
+      up, which is why it is recorded as a plan item rather than a note.
 
 ## Test Plan
 


### PR DESCRIPTION
Lifecycle only: one frontmatter change and one `git mv` into `completed/`.

## Why a plan item was ADDED, not just ticked

`TC-08` asked for a green pre-push, and PR #1921 is merged with CI clean — that one is a straightforward tick.

`TC-09` is new. Review of that pull request found the first cut skipping the summary `worst` update and omitting the `rank` entry, so a range whose only pair had no earlier state returned the initial `red-proof-ok`. That is **the item's own defect reproduced one level up** — an unverifiable state read as a verdict — and it was fixed in the same pull request.

A record that ticked TC-08 and said nothing would read as if the change had always covered both halves. The plan is the place a reader looks to see what was actually established, so the second half is written down as its own item rather than absorbed into the first.

## Verification

`pnpm harness:scan` — 128 passed, 3 skipped.