### PR TITLE
docs(tasks): complete INFRA-121, whose work merged as PR #1923

### DIFF
--- a/.agents/tasks/completed/INFRA-121-scan-population-source-has-no-owner.md
+++ b/.agents/tasks/completed/INFRA-121-scan-population-source-has-no-owner.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-121: a scan enumerated through the git index, so a file not yet staged was invisible'
-status: in-progress
+status: done
 created: 2026-08-20
+completed: 2026-08-20
 priority: high
 urgency: now
 area: scripts/harness
@@ -60,7 +61,7 @@ learn to skip, which is how a real one would be missed.
 - [x] TC-06: five scans converted — `reference-kind-qualified`, `hook-override-declarations`,
       `aggregate-naming`, `preset-projection` and their shared shape.
 - [x] TC-07: `pnpm harness:scan` green (129 passed, 2 skipped).
-- [ ] TC-08: `pnpm harness:pre-push` green.
+- [x] TC-08: `pnpm harness:pre-push` green, and CI clean on PR #1923.
 
 ## Not converted, and why
 


### PR DESCRIPTION
Lifecycle only: one frontmatter change and one `git mv` into `completed/`.

`TC-08` asked for a green pre-push; PR #1923 is merged with CI clean, so the item is ticked against the run rather than the intent.

## What stays in the record

The two scans INFRA-121 deliberately did **not** convert — `check-done-evidence` and `scan-legacy-typescript`, each with its reason — remain in the completed file. That is the part a future reader needs: a completed item that looks total invites the next person to assume the whole class is handled, and here it is not.

The `createDistFreeTree` half of issue #1908 is recorded the same way, for the same reason.

## Verification

`pnpm harness:scan` — 128 passed, 3 skipped.