### PR TITLE
refactor(preset): ARCH-040 groups A and E, one projection declaration (ARCH-041), and issue #1929

### DIFF
--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -425,11 +425,6 @@
     "$pendingComment": "The burn-down. Each entry is a field this floor HAS measured as undeclared or one-sidedly declared, whose fix needs a decision this scan cannot make — recorded as a NAMED, EXPIRING exemption rather than an opaque count, because an exemption that is unnamed or non-expiring is indistinguishable from no floor. `declaredOn` records the surfaces the field was measured on when the entry was written; if the live state differs in EITHER direction the entry is reported (`preset-pending-state-changed`), so an exemption expires when the work is DONE and not only when the field is deleted. Review measured the earlier version failing exactly that: fixing a pending field printed green, which made the list a baseline with extra words. This list may shrink and must never grow without a reviewed reason. Tracked as GitHub issue #1820.",
     "pendingProjection": [
       {
-        "field": "model",
-        "reason": "NOT dropped — hand-mapped. `cli.ts:262` computes `resolvedPreset.model ?? providerSettings.model` and threads the result into all three construction sites, so the value reaches the session; what is missing is the DECLARED projection. Resolving it means moving the field onto IPresetSurfaceOptions, which requires deciding where the `?? providerSettings.model` fallback lives, because the surface is built after the model id is first needed (cli.ts:330 vs :262).",
-        "declaredOn": ["IPresetApplicationOptions"]
-      },
-      {
         "field": "temperature",
         "reason": "Applied by the live /preset path via `applyModelOptions` (preset-application.ts), and by nothing at startup. Unlike `model` there is no `ICreateSessionOptions` seam at all — the value would have to reach the provider config, so this is a new seam rather than a re-declaration. Same class as `effort` before stage 1.",
         "declaredOn": ["IPresetApplicationOptions"]

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -460,11 +460,6 @@
         "declaredOn": []
       },
       {
-        "field": "defaultTrustLevel",
-        "reason": "Measured fully dead by the ARCH-013 audit: validated by preset-validation and then read by nothing, with no seam anywhere. Removing an unconsumed public contract is a product decision rather than a grep result, so it stays declared and exempted until its owner decides between wiring it to the permission/trust axis and dropping it.",
-        "declaredOn": []
-      },
-      {
         "field": "allowedTools",
         "reason": "A session seam exists (`ICreateSessionOptions.allowedTools`) and create-session-projection.ts already forwards it from IInitOptions, so only the preset→surface hop is missing. Wiring it requires deciding how a preset allowlist composes with the session-level and pack-level tool sets rather than replacing them.",
         "declaredOn": []

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -441,7 +441,7 @@
       },
       {
         "field": "agentName",
-        "reason": "The REVERSE divergence, and the one nobody had named: startup declares it (IPresetSurfaceOptions) and the live /preset path does not, so starting with a preset sets the agent name while switching to the same preset mid-session leaves the old one. Resolving it needs a product decision — whether `/preset` should rename the agent mid-session — not just a seam.",
+        "reason": "The REVERSE divergence: startup declares it (IPresetSurfaceOptions) and the live /preset path does not, so starting with a preset sets the agent name while switching to the SAME preset mid-session leaves the old one. The owner decided on 2026-08-20 that /preset SHOULD rename. Implementation is parked on a measured cost the decision did not have in front of it: the field's only reader is `Robota.name`, a `public readonly` identity label that no surface displays, and making it renameable needs either a mutable core field or a split of a 411-line frozen core file. Re-decide against that cost before wiring — see ARCH-040.",
         "declaredOn": ["IPresetSurfaceOptions"]
       },
       {

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -456,12 +456,12 @@
       },
       {
         "field": "allowedTools",
-        "reason": "A session seam exists (`ICreateSessionOptions.allowedTools`) and create-session-projection.ts already forwards it from IInitOptions, so only the preset→surface hop is missing. Wiring it requires deciding how a preset allowlist composes with the session-level and pack-level tool sets rather than replacing them.",
+        "reason": "A session seam exists (`ICreateSessionOptions.allowedTools`) and create-session-projection.ts forwards it, so the STARTUP hop is one line. The live half is not a wiring gap: `create-session.ts` turns both lists into permission PATTERNS merged into the enforcer's allow/deny sets AT CONSTRUCTION, and `PermissionEnforcer` exposes only an additive `sessionAllowedTools` set (the 'always allow' prompt path) — there is no way to REPLACE the configured rules on a live session. Wiring startup alone would CREATE the divergence this scan measures, so both wait on a live permission-rule re-application seam, which is its own capability. Owner decided the combine rule on 2026-08-20: allow REPLACES, deny UNIONS — see ARCH-040.",
         "declaredOn": []
       },
       {
         "field": "deniedTools",
-        "reason": "The denylist half of the same decision as `allowedTools`, and it must be resolved with it: an allowlist that composes and a denylist that replaces would contradict each other.",
+        "reason": "The denylist half of the same decision as `allowedTools`, blocked on the same missing capability, and it must ship with it: an allowlist that replaces and a denylist that unions is one rule, and half of it is a contradiction. The union belongs in `resolvePreset`'s `mergeDefined` rather than at a surface, because precedence is the resolver's job — a union applied by one of three shells is a rule the other two disagree with.",
         "declaredOn": []
       }
     ]

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -425,16 +425,6 @@
     "$pendingComment": "The burn-down. Each entry is a field this floor HAS measured as undeclared or one-sidedly declared, whose fix needs a decision this scan cannot make — recorded as a NAMED, EXPIRING exemption rather than an opaque count, because an exemption that is unnamed or non-expiring is indistinguishable from no floor. `declaredOn` records the surfaces the field was measured on when the entry was written; if the live state differs in EITHER direction the entry is reported (`preset-pending-state-changed`), so an exemption expires when the work is DONE and not only when the field is deleted. Review measured the earlier version failing exactly that: fixing a pending field printed green, which made the list a baseline with extra words. This list may shrink and must never grow without a reviewed reason. Tracked as GitHub issue #1820.",
     "pendingProjection": [
       {
-        "field": "temperature",
-        "reason": "Applied by the live /preset path via `applyModelOptions` (preset-application.ts), and by nothing at startup. Unlike `model` there is no `ICreateSessionOptions` seam at all — the value would have to reach the provider config, so this is a new seam rather than a re-declaration. Same class as `effort` before stage 1.",
-        "declaredOn": ["IPresetApplicationOptions"]
-      },
-      {
-        "field": "maxOutputTokens",
-        "reason": "Identical to `temperature`: live-only via `applyModelOptions`, no session-construction seam, needs a provider-config route. The two travel together in the model group and should be resolved together.",
-        "declaredOn": ["IPresetApplicationOptions"]
-      },
-      {
         "field": "agentName",
         "reason": "The REVERSE divergence: startup declares it (IPresetSurfaceOptions) and the live /preset path does not, so starting with a preset sets the agent name while switching to the SAME preset mid-session leaves the old one. The owner decided on 2026-08-20 that /preset SHOULD rename. Implementation is parked on a measured cost the decision did not have in front of it: the field's only reader is `Robota.name`, a `public readonly` identity label that no surface displays, and making it renameable needs either a mutable core field or a split of a 411-line frozen core file. Re-decide against that cost before wiring — see ARCH-040.",
         "declaredOn": ["IPresetSurfaceOptions"]

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -43,7 +43,8 @@ projection, and where the fallback lives is an implementation choice made in thi
 ## Plan
 
 - [x] Group A — remove `defaultTrustLevel` from `IResolvedPresetOptions` and its validator.
-- [ ] Group B — `agentName` on the live `/preset` path.
+- [ ] Group B — `agentName` on the live `/preset` path. **PARKED on a measured cost the decision did
+      not have in front of it** (see below); every other group is independent of it.
 - [ ] Group C — `allowedTools` (replace) and `deniedTools` (compose), resolved together.
 - [ ] Group D — `systemPrompt` (seed) and `appendSystemPrompt` (merge order).
 - [ ] Group E — the model group: `model` declared, `temperature` and `maxOutputTokens` wired.
@@ -65,3 +66,28 @@ asserted in BOTH directions, since a rule about combination can fail either way.
 session/assembly seam"_. It is false today for `systemPrompt`, `language`, `temperature`,
 `maxOutputTokens` and `defaultTrustLevel`. Changing the words without changing the fact is the
 defect, not the fix; this item makes it true.
+
+## Group B is parked, and why
+
+The owner decided `/preset` should rename the agent. Implementing it turned up a cost the decision
+was not made against, so it is recorded here rather than paid silently.
+
+**What `agentName` actually reaches.** Its only reader is `Robota.name` — a `public readonly`
+identity label. No surface displays it: the TUI's `agentName` option is forwarded straight into
+session construction and rendered nowhere, and `Robota.name` is read by the module-manager
+construction and by `getConfig()`/`getStats()`. So a mid-session rename changes a label almost
+nothing observes.
+
+**What it costs.** `Robota.name` is assigned once in the constructor and declared `readonly`.
+`updateConfiguration` is not a general seam — it throws for any patch that is not `tools`. Making the
+name renameable therefore means either a mutable field on a core class or a split of
+`packages/agent-core/src/core/robota.ts`, which the file-size ratchet freezes at 411 lines. A
+first cut measured +25 lines; compressed to the minimum it is still +8, and offsetting that by
+trimming unrelated code in the same file is the "regenerate the baseline" move ARCH-038 argued
+against three days earlier.
+
+**The question to re-decide:** is a renameable identity label worth a mutable field on
+`Robota`, or is the honest resolution of the divergence the other direction — `agentName` is
+construction-time identity, and the STARTUP surface should stop implying otherwise?
+
+Nothing about this blocks Groups C–F, which touch neither the field nor the file.

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -49,7 +49,7 @@ projection, and where the fallback lives is an implementation choice made in thi
       missing capability**, see below. The RULE is decided and its home is identified; only the live
       seam is absent.
 - [ ] Group D — `systemPrompt` (seed) and `appendSystemPrompt` (merge order).
-- [ ] Group E — the model group: `model` declared, `temperature` and `maxOutputTokens` wired.
+- [x] Group E — the model group: `model` declared (ARCH-041), `temperature` and `maxOutputTokens` wired.
 - [ ] Group F — `language` as a persona-section instruction.
 - [ ] Empty `presetProjection.pendingProjection`, and make the `IResolvedPresetOptions` docblock TRUE.
 

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -91,3 +91,32 @@ against three days earlier.
 construction-time identity, and the STARTUP surface should stop implying otherwise?
 
 Nothing about this blocks Groups C–F, which touch neither the field nor the file.
+
+## Found while starting Group C: the projection is still written THREE times
+
+`IPresetSurfaceOptions` says of itself that "adding a field here now reaches every surface at once,
+which is the only property that makes this worth extracting." That property does not hold. Two of the
+three shell surfaces declare their OWN copy of the projection:
+
+| interface                 | file                                                       | carries `model`? |
+| ------------------------- | ---------------------------------------------------------- | ---------------- |
+| `IPresetSurfaceOptions`   | `packages/agent-cli/src/startup/preset-surface-options.ts` | no               |
+| `IPrintModePresetOptions` | `packages/agent-cli/src/modes/print-mode.ts`               | **yes**          |
+| `IServeModePresetOptions` | `packages/agent-cli/src/modes/serve-mode.ts`               | no               |
+
+They have already drifted — `model` reached print mode and neither of the others, which is the exact
+shape ARCH-013 was filed about, surviving the extraction meant to end it.
+
+**The measurement has the same blind spot.** `presetProjection.surfaces` in
+`.agents/harness.config.json` lists two interfaces, and neither of the two mode copies is one of
+them, so the divergence rule cannot see the surfaces that actually diverged.
+
+**Why it blocks the remaining groups rather than being an aside.** Every one of C, D, E and F adds a
+field to the projection. With three copies, each field must be added in three places and the scan
+checks two of them — so the work would install exactly the defect this item exists to remove, three
+times over.
+
+**Disposition.** This is a separate cause, one level under ARCH-040, and it should be filed as its own
+item rather than folded in — the repository's own rule. It could not be filed as a GitHub issue in
+this session because GitHub was unreachable (both `git push` and `api.github.com` time out); FILE IT
+before Groups C–F resume.

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -45,7 +45,9 @@ projection, and where the fallback lives is an implementation choice made in thi
 - [x] Group A — remove `defaultTrustLevel` from `IResolvedPresetOptions` and its validator.
 - [ ] Group B — `agentName` on the live `/preset` path. **PARKED on a measured cost the decision did
       not have in front of it** (see below); every other group is independent of it.
-- [ ] Group C — `allowedTools` (replace) and `deniedTools` (compose), resolved together.
+- [ ] Group C — `allowedTools` (replace) and `deniedTools` (compose), resolved together. **BLOCKED on a
+      missing capability**, see below. The RULE is decided and its home is identified; only the live
+      seam is absent.
 - [ ] Group D — `systemPrompt` (seed) and `appendSystemPrompt` (merge order).
 - [ ] Group E — the model group: `model` declared, `temperature` and `maxOutputTokens` wired.
 - [ ] Group F — `language` as a persona-section instruction.
@@ -120,3 +122,36 @@ times over.
 item rather than folded in — the repository's own rule. It could not be filed as a GitHub issue in
 this session because GitHub was unreachable (both `git push` and `api.github.com` time out); FILE IT
 before Groups C–F resume.
+
+## Group C is blocked on a capability, not on a decision
+
+The combine rule is settled — allow REPLACES, deny UNIONS — and its home is
+`resolvePreset`'s `mergeDefined`, not a surface: precedence is the resolver's job, and a union
+applied by one of three shells is a rule the other two disagree with.
+
+**What is missing is a live seam.** `create-session.ts` turns both lists into permission PATTERNS and
+merges them into the enforcer's allow/deny sets **at construction**. `PermissionEnforcer` exposes only
+an additive `sessionAllowedTools` set — the "always allow" prompt path — so there is no way to REPLACE
+the configured rules on a running session.
+
+Wiring the startup half alone would have been worse than leaving both: it CREATES the divergence this
+scan exists to measure, with startup applying a preset's tool lists and `/preset` silently not. The
+implementation was written, measured against the scan, and reverted for that reason rather than
+landed half-applied.
+
+**What it needs:** live permission-rule re-application on `PermissionEnforcer` — a real capability
+with its own consequences (what happens to a tool mid-call, whether a denial can be added to a session
+that already allowed it), and therefore its own item.
+
+## The shape the remaining groups actually have
+
+Checked after C, so the next reader does not discover it one group at a time:
+
+| group           | live seam                                            | startup seam                    | verdict                 |
+| --------------- | ---------------------------------------------------- | ------------------------------- | ----------------------- |
+| C — tools       | **absent** (patterns fixed at construction)          | present                         | blocked on a capability |
+| D — prompts     | present (`applyPersona` rebuilds the system message) | present                         | feasible                |
+| E — model group | present (`applyModelOptions` already applies both)   | absent (session `defaultModel`) | feasible                |
+| F — `language`  | present, once it is a persona section                | present                         | feasible                |
+
+Groups B and C are the two that need a capability. D, E and F are wiring on seams that already exist.

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -1,0 +1,67 @@
+---
+title: 'ARCH-040: ten resolved-preset fields need a projection DECISION, not just a seam'
+status: in-progress
+created: 2026-08-20
+priority: medium
+urgency: soon
+area: packages/agent-preset, packages/agent-framework, packages/agent-cli
+depends_on: [ARCH-013]
+issue: https://github.com/woojubb/robota/issues/1820
+---
+
+# ARCH-040: the ten fields ARCH-013 stage 2 measured but could not decide
+
+## Problem
+
+ARCH-013 stage 2 landed the MEASUREMENT: `scripts/harness/scan-preset-projection.mjs` checks that
+every `IResolvedPresetOptions` field appears in a **declared** projection — a surface interface
+member or a `Pick` of the source — and that the two projection surfaces do not diverge.
+
+Ten fields could not be resolved in that change, because each needs a decision with **user-visible
+consequences** that a scan cannot make. They were recorded as named, expiring exemptions in
+`.agents/harness.config.json` → `presetProjection.pendingProjection`, each carrying its own reason,
+so the list is visible in review and a stale entry is reported as `preset-exemption-unused`.
+
+Filed as issue #1820. This item executes the decisions.
+
+## The decisions, and who made them
+
+The owner decided all four groups on 2026-08-20. Recorded here rather than in a commit message,
+because a decision is the thing a later reader needs and a commit message is not where they look.
+
+| Group                                                             | Decision                                                                                                                                                                                                                                                                           |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agentName`                                                       | `/preset` **renames** the agent mid-session. Startup already applies it; the divergence meant the same preset gave two different results depending on when it was chosen.                                                                                                          |
+| `allowedTools` / `deniedTools`                                    | An allowlist **REPLACES** — it is a statement of the complete permitted set. A denylist **COMPOSES** (union) — a denial is never weakened by a preset.                                                                                                                             |
+| `systemPrompt` / `appendSystemPrompt`                             | `systemPrompt` **SEEDS** the framework's composed prompt rather than replacing it; a full replacement would silently drop the AGENTS.md and skill context the framework composes. `appendSystemPrompt` appends **after** the CLI-sourced text.                                     |
+| `temperature`, `maxOutputTokens`, `language`, `defaultTrustLevel` | Wire the first two through a provider-config seam (the live `/preset` path already applies them, so startup is the asymmetry). `language` becomes a persona-section instruction. `defaultTrustLevel` is **removed from the contract** — the ARCH-013 audit measured it fully dead. |
+
+`model` needs no owner decision: the value already reaches the session by hand
+(`cli.ts` computes `resolvedPreset.model ?? providerSettings.model`). What is missing is the DECLARED
+projection, and where the fallback lives is an implementation choice made in this item.
+
+## Plan
+
+- [x] Group A — remove `defaultTrustLevel` from `IResolvedPresetOptions` and its validator.
+- [ ] Group B — `agentName` on the live `/preset` path.
+- [ ] Group C — `allowedTools` (replace) and `deniedTools` (compose), resolved together.
+- [ ] Group D — `systemPrompt` (seed) and `appendSystemPrompt` (merge order).
+- [ ] Group E — the model group: `model` declared, `temperature` and `maxOutputTokens` wired.
+- [ ] Group F — `language` as a persona-section instruction.
+- [ ] Empty `presetProjection.pendingProjection`, and make the `IResolvedPresetOptions` docblock TRUE.
+
+## Test Plan
+
+Red-first per group: each decision is asserted through the shipped path, and each is red-proofed —
+the mutation that undoes it fails the named case and nothing else. The composing/replacing pair is
+asserted in BOTH directions, since a rule about combination can fail either way.
+
+`pnpm harness:verify-like-ci` green, and `scan-preset-projection` passing with an EMPTY
+`pendingProjection` — which is the measurement this item exists to satisfy.
+
+## The claim that must become true
+
+`IResolvedPresetOptions`' docblock says _"Every field maps to an existing `agent-framework`
+session/assembly seam"_. It is false today for `systemPrompt`, `language`, `temperature`,
+`maxOutputTokens` and `defaultTrustLevel`. Changing the words without changing the fact is the
+defect, not the fix; this item makes it true.

--- a/.agents/tasks/completed/ARCH-041-one-preset-projection.md
+++ b/.agents/tasks/completed/ARCH-041-one-preset-projection.md
@@ -1,0 +1,91 @@
+---
+title: 'ARCH-041: the preset→surface projection is written three times, and has already drifted'
+status: done
+completed: 2026-08-20
+created: 2026-08-20
+priority: high
+urgency: now
+area: packages/agent-cli, scripts/harness
+depends_on: []
+blocks: [ARCH-040]
+---
+
+# ARCH-041: three copies of one projection, and a measurement that sees two of them
+
+## Problem
+
+`packages/agent-cli/src/startup/preset-surface-options.ts` says of itself:
+
+> Adding a field here now reaches every surface at once, which is the only property that makes this
+> worth extracting.
+
+The property does not hold. Two of the three shell surfaces declare their OWN copy:
+
+| interface                 | file                                | carries `model`? |
+| ------------------------- | ----------------------------------- | ---------------- |
+| `IPresetSurfaceOptions`   | `startup/preset-surface-options.ts` | no               |
+| `IPrintModePresetOptions` | `modes/print-mode.ts`               | **yes**          |
+| `IServeModePresetOptions` | `modes/serve-mode.ts`               | no               |
+
+They have already drifted: `model` reached print mode and neither of the others. That is the exact
+shape ARCH-013 was filed about — "a field added to the resolved preset arrives at whichever surfaces
+someone remembered, and is silently absent from the rest" — surviving the extraction meant to end it.
+
+**The measurement shares the blind spot.** `presetProjection.surfaces` in `.agents/harness.config.json`
+lists two interfaces, and neither mode copy is one of them, so the divergence rule cannot see the
+surfaces that actually diverged. A guard whose subject excludes the drifting case is a guard that
+cannot fire.
+
+## Why it is filed rather than absorbed into ARCH-040
+
+Found while starting ARCH-040's Group C. Every remaining ARCH-040 group (tools, prompts, model
+group, language) adds a field to this projection, so with three copies each field lands in three
+places while the scan checks two — installing the defect ARCH-040 exists to remove, three times over.
+It is a cause one level under that item and blocks it.
+
+It ships on ARCH-040's branch because ARCH-040 cannot proceed without it and GitHub was unreachable
+for the whole session, so a separate PR was not openable. The record is separate because the CAUSE is.
+
+## What
+
+One declaration. The mode surfaces take `Partial<IPresetSurfaceOptions>` rather than re-declaring it,
+so a field added to the shared type reaches all three by construction — the property the docblock
+already claims. `model` moves onto the shared type, which is also the declared projection ARCH-040's
+`model` entry was waiting for.
+
+## Test Plan
+
+Red-first: a field added to `IPresetSurfaceOptions` and projected must be visible to all three
+surfaces without any per-surface edit, asserted by a case that fails if a surface re-declares its own
+shape. Then: `scan-preset-projection` passes with `model` removed from `pendingProjection`, and the
+existing print/serve mode tests stay green.
+
+## Result
+
+One declaration. `IPrintModePresetOptions` and `IServeModePresetOptions` are now
+`Partial<IPresetSurfaceOptions>`, so a field added to the shared type reaches all three surfaces by
+construction — the property the docblock already claimed.
+
+`model` moved onto the shared type and is projected from `resolved.model`. The shell's
+`?? providerSettings.model` fallback stays where it is: the two cannot disagree, because whenever the
+key is present it holds the value the shell computed, and whenever the preset names no model the key
+is ABSENT rather than explicitly `undefined`, so the shell's own key survives the spread. Threading
+the fallback in as well would have been a second answer to a question that already has one — and it
+also cost `cli.ts` six lines it had no budget for, which is how the simpler design got found.
+
+`presetProjection.pendingProjection`: 9 exemptions to 8.
+
+### Where the enforcement is, and where it is not
+
+The single-declaration property is enforced by the TYPECHECK. Measured: re-declaring
+`IPrintModePresetOptions` as its own interface produces 12 `tsgo` errors and 3 GREEN vitest cases,
+because vitest does not typecheck. The first draft of the test file called its assignment case "the
+enforcement", which would have been a case that cannot fail on the condition it names — the defect
+this repository has a scan family about. The file now says plainly that the assignment case
+documents a compile-time contract and that `pnpm typecheck`, a stage of `harness:verify-like-ci`, is
+the gate. The two `model` cases are ordinary runtime assertions and are red-proofed.
+
+## Unblocks
+
+ARCH-040 Groups C–F can now add a field in ONE place. Group B remains parked on its own re-decision,
+which is independent of this.

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -1,4 +1,5 @@
 import type { IAIProvider, IToolWithEventService, TPermissionMode } from '@robota-sdk/agent-core';
+import type { IPresetSurfaceOptions } from '../startup/preset-surface-options.js';
 import type {
   IAgentDefinition,
   ICommandHostAdapters,
@@ -32,28 +33,15 @@ export interface IPrintModeSessionResolution {
 }
 
 /** Preset-resolved identity/persona the thin-shell CLI forwards into the headless session. */
-export interface IPrintModePresetOptions {
-  /**
-   * CLI-076: the resolved model id (the same value the CLI header displays — `resolvedPreset.model ??
-   * providerSettings.model`). Forwarded to the headless session so an explicit `--model` override reaches
-   * the provider chat call rather than being silently replaced by the session's default model.
-   */
-  model?: string;
-  /** Resolved agent name (preset value, else agent-preset DEFAULT_AGENT_NAME). */
-  agentName?: string;
-  /** Active preset id selected at startup (PRESET-011 runtime state). Defaults to 'default'. */
-  activePresetId?: string;
-  /** Resolved preset persona block composed as a `source: 'persona'` system-prompt section. */
-  persona?: string;
-  /** Resolved preset permission mode (overridden by an explicit CLI --permission-mode flag). */
-  permissionMode?: TPermissionMode;
-  /** Preset execution capability: activate agent runtime + subagent/background dispatch. */
-  enableParallelSubagents?: boolean;
-  /** Preset execution capability: run a post-task self-verification step. */
-  selfVerification?: boolean;
-  /** ARCH-013: resolved preset effort, forwarded to the session's `effort` seam. */
-  effort?: ICreateSessionOptions['effort'];
-}
+/**
+ * ARCH-041: ONE declaration. This used to be a hand-written copy of `IPresetSurfaceOptions`, and the
+ * two had already drifted — `model` was declared here and on neither of the other two surfaces,
+ * which is the shape ARCH-013 was filed about surviving the extraction meant to end it.
+ *
+ * `Partial` because a caller may supply none of it; the shared type states which fields exist, this
+ * states only that they are all optional here.
+ */
+export type IPrintModePresetOptions = Partial<IPresetSurfaceOptions>;
 
 export async function runPrintMode(
   cwd: string,

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -119,6 +119,10 @@ export async function runPrintMode(
       ? { enableParallelSubagents: presetOptions.enableParallelSubagents }
       : {}),
     ...(presetOptions.effort !== undefined ? { effort: presetOptions.effort } : {}),
+    ...(presetOptions.temperature !== undefined ? { temperature: presetOptions.temperature } : {}),
+    ...(presetOptions.maxOutputTokens !== undefined
+      ? { maxOutputTokens: presetOptions.maxOutputTokens }
+      : {}),
     ...(presetOptions.selfVerification !== undefined
       ? { selfVerification: presetOptions.selfVerification }
       : {}),

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -16,6 +16,7 @@ import {
 } from './serve-monitor-ui.js';
 import { settleOnServeTransportFailure } from './serve-transport-failure.js';
 import { startRuntimeHost } from '@robota-sdk/agent-framework';
+import type { IPresetSurfaceOptions } from '../startup/preset-surface-options.js';
 import type { ICreateSessionOptions } from '@robota-sdk/agent-framework';
 
 import type { IParsedCliArgs } from '../utils/cli-args.js';
@@ -37,16 +38,10 @@ import type {
 } from '@robota-sdk/agent-interface-transport';
 
 /** Preset-resolved identity/posture the thin-shell CLI forwards into the headless runtime session. */
-export interface IServeModePresetOptions {
-  agentName?: string;
-  activePresetId?: string;
-  persona?: string;
-  permissionMode?: TInteractiveSessionOptions['permissionMode'];
-  enableParallelSubagents?: boolean;
-  selfVerification?: boolean;
-  /** ARCH-013: resolved preset effort, forwarded to the session's `effort` seam. */
-  effort?: ICreateSessionOptions['effort'];
-}
+/**
+ * ARCH-041: ONE declaration — see the note on `IPrintModePresetOptions`. This was the third copy.
+ */
+export type IServeModePresetOptions = Partial<IPresetSurfaceOptions>;
 
 export interface IServeModeOptions {
   cwd: string;

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -121,6 +121,8 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
       : {}),
     ...(preset.selfVerification !== undefined ? { selfVerification: preset.selfVerification } : {}),
     ...(preset.effort !== undefined ? { effort: preset.effort } : {}),
+    ...(preset.temperature !== undefined ? { temperature: preset.temperature } : {}),
+    ...(preset.maxOutputTokens !== undefined ? { maxOutputTokens: preset.maxOutputTokens } : {}),
     // SELFHOST-008 P6: surface-resolved memory fields (empty ⇒ memory OFF, today's behavior).
     ...(opts.memorySessionOptions ?? {}),
   };

--- a/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
+++ b/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
@@ -44,6 +44,8 @@ describe('the preset surface projection is declared once (ARCH-041)', () => {
       enableParallelSubagents: true,
       selfVerification: true,
       effort: 'high',
+      temperature: 0.2,
+      maxOutputTokens: 4096,
     };
 
     const print: IPrintModePresetOptions = everyField;
@@ -58,6 +60,18 @@ describe('the preset surface projection is declared once (ARCH-041)', () => {
     // three surfaces rather than at the one someone remembered.
     const resolved = { model: 'preset-model', agentName: 'acme-bot' } as IResolvedPresetOptions;
     expect(buildPresetSurfaceOptions(resolved, 'acme', 'default').model).toBe('preset-model');
+  });
+
+  it('projects the model group’s other two dials (ARCH-040 Group E)', () => {
+    // `temperature` and `maxOutputTokens` were applied by the live `/preset` path through
+    // `applyModelOptions` and by NOTHING at startup — one session holding two answers for the same
+    // preset depending on when it was chosen, which is exactly what `effort` did before ARCH-013
+    // stage 1. They reach the session's agent config at construction now, on the same two channels
+    // `applyModelOptions` writes, so the two answers are one answer.
+    const resolved = { temperature: 0.2, maxOutputTokens: 4096 } as IResolvedPresetOptions;
+    const surface = buildPresetSurfaceOptions(resolved, 'acme', 'default');
+    expect(surface.temperature).toBe(0.2);
+    expect(surface.maxOutputTokens).toBe(4096);
   });
 
   it('omits `model` entirely when the preset names none, so the shell’s fallback survives', () => {

--- a/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
+++ b/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPresetSurfaceOptions } from '../preset-surface-options.js';
+
+import type { IServeModePresetOptions } from '../../modes/serve-mode.js';
+import type { IPrintModePresetOptions } from '../../modes/print-mode.js';
+import type { IPresetSurfaceOptions } from '../preset-surface-options.js';
+import type { IResolvedPresetOptions } from '@robota-sdk/agent-preset';
+
+/**
+ * ARCH-041 — the projection is declared ONCE.
+ *
+ * `IPresetSurfaceOptions` claimed that "adding a field here now reaches every surface at once, which
+ * is the only property that makes this worth extracting". It did not hold: `print-mode.ts` and
+ * `serve-mode.ts` each declared their own copy, and the three had already drifted — `model` was on
+ * print mode's copy and on neither of the others. That is the shape ARCH-013 was filed about,
+ * surviving the extraction meant to end it.
+ *
+ * WHERE THE ENFORCEMENT ACTUALLY IS, stated because the first draft of this file implied otherwise:
+ * the single-declaration property is enforced by the TYPECHECK, not by this runner. Vitest does not
+ * typecheck, so the assignment case below passes whether or not a mode re-declares its own copy —
+ * measured, not assumed: re-declaring `IPrintModePresetOptions` produces 12 `tsgo` errors and 3
+ * green vitest cases.
+ *
+ * `pnpm typecheck` is a stage of `harness:verify-like-ci`, so the gate is real; it is simply not this
+ * file. The assignment case is kept because it FAILS THE BUILD at the point a copy reappears, and
+ * because it names the property in the place someone editing these types will look — but it is
+ * documentation of a compile-time contract, not a runtime assertion, and calling it the latter would
+ * be the "case that cannot fail on the condition it names" defect this repository scans for.
+ *
+ * The two `model` cases below are ordinary runtime assertions and do fail on their condition:
+ * dropping the projection turns the first red.
+ */
+describe('the preset surface projection is declared once (ARCH-041)', () => {
+  it('both mode surfaces accept every field of the shared projection', () => {
+    // If either mode re-declares its own shape, a field the shared type has and the copy lacks makes
+    // these assignments stop compiling — which is the failure this case exists to cause.
+    const everyField: Required<IPresetSurfaceOptions> = {
+      model: 'some-model',
+      agentName: 'acme-bot',
+      activePresetId: 'acme',
+      persona: 'be brief',
+      permissionMode: 'default',
+      enableParallelSubagents: true,
+      selfVerification: true,
+      effort: 'high',
+    };
+
+    const print: IPrintModePresetOptions = everyField;
+    const serve: IServeModePresetOptions = everyField;
+
+    expect(print.model).toBe('some-model');
+    expect(serve.model).toBe('some-model');
+  });
+
+  it('projects `model` from the resolved preset (ARCH-040 / ARCH-041)', () => {
+    // The field that measured the drift. It reaches the shared projection now, so it arrives at all
+    // three surfaces rather than at the one someone remembered.
+    const resolved = { model: 'preset-model', agentName: 'acme-bot' } as IResolvedPresetOptions;
+    expect(buildPresetSurfaceOptions(resolved, 'acme', 'default').model).toBe('preset-model');
+  });
+
+  it('omits `model` entirely when the preset names none, so the shell’s fallback survives', () => {
+    // The shell computes `resolvedPreset.model ?? providerSettings.model` and spreads this object
+    // over its own key. An explicitly-undefined `model` would clobber that fallback; an ABSENT key
+    // cannot. The two answers can never disagree, which is why the fallback stays where it is.
+    const surface = buildPresetSurfaceOptions({} as IResolvedPresetOptions, 'acme', 'default');
+    expect('model' in surface).toBe(false);
+  });
+});

--- a/packages/agent-cli/src/startup/preset-surface-options.ts
+++ b/packages/agent-cli/src/startup/preset-surface-options.ts
@@ -43,6 +43,13 @@ export interface IPresetSurfaceOptions {
   enableParallelSubagents?: boolean;
   selfVerification?: boolean;
   effort?: ICreateSessionOptions['effort'];
+  /**
+   * ARCH-040: the model group's other two dials. The live `/preset` path has always applied both
+   * through `applyModelOptions`; startup applied neither, so one session held two answers for the
+   * same preset depending on when it was chosen — what `effort` did before ARCH-013 stage 1.
+   */
+  temperature?: number;
+  maxOutputTokens?: number;
 }
 
 /**
@@ -69,5 +76,9 @@ export function buildPresetSurfaceOptions(
       ? { selfVerification: resolved.selfVerification }
       : {}),
     ...(resolved.effort !== undefined ? { effort: resolved.effort } : {}),
+    ...(resolved.temperature !== undefined ? { temperature: resolved.temperature } : {}),
+    ...(resolved.maxOutputTokens !== undefined
+      ? { maxOutputTokens: resolved.maxOutputTokens }
+      : {}),
   };
 }

--- a/packages/agent-cli/src/startup/preset-surface-options.ts
+++ b/packages/agent-cli/src/startup/preset-surface-options.ts
@@ -14,10 +14,28 @@ import type { IResolvedPresetOptions } from '@robota-sdk/agent-preset';
  * the three surfaces while `/preset` applied it mid-session.
  *
  * Adding a field here now reaches every surface at once, which is the only property that makes this
- * worth extracting. `scan-option-reachability` covers the hop below this one — from these options
+ * worth extracting — and ARCH-041 made that true. Until then `print-mode.ts` and `serve-mode.ts` each
+ * re-declared their own copy, the three had already drifted on `model`, and the projection scan's
+ * configured surfaces saw two of the three. The mode surfaces take `Partial<IPresetSurfaceOptions>`
+ * now, so there is one declaration and nothing to keep in step. `scan-option-reachability` covers the hop below this one — from these options
  * into `createSession` — so the two together span the chain.
  */
 export interface IPresetSurfaceOptions {
+  /**
+   * CLI-076 / ARCH-040: the resolved model id — the same value the CLI header displays. Forwarded so
+   * an explicit `--model` reaches the provider chat call rather than being silently replaced by the
+   * session's default.
+   *
+   * ARCH-041 moved it HERE from `IPrintModePresetOptions`, where it was the measured drift: it
+   * reached print mode and neither of the other two surfaces.
+   *
+   * Projected from `resolved.model`, and the shell's `?? providerSettings.model` fallback is left
+   * where it is. The two cannot disagree: the shell computes `resolvedPreset.model ??
+   * providerSettings.model`, so whenever this key is present it holds the same value, and whenever
+   * it is absent the shell's own key is the one that survives the spread. Threading the fallback in
+   * here as well would be a second answer to a question that already has one.
+   */
+  model?: string;
   agentName: string;
   activePresetId: string;
   persona: string | undefined;
@@ -39,6 +57,7 @@ export function buildPresetSurfaceOptions(
   permissionMode: ICreateSessionOptions['permissionMode'] | undefined,
 ): IPresetSurfaceOptions {
   return {
+    ...(resolved.model !== undefined ? { model: resolved.model } : {}),
     agentName: resolved.agentName ?? DEFAULT_AGENT_NAME,
     activePresetId: presetId,
     persona: resolved.persona,

--- a/packages/agent-framework/src/assembly/create-session-types.ts
+++ b/packages/agent-framework/src/assembly/create-session-types.ts
@@ -176,6 +176,13 @@ export interface ICreateSessionOptions {
    * parameter; providers without native effort ignore it as a documented no-op.
    */
   effort?: TModelEffort;
+  /**
+   * ARCH-040: sampling temperature and output cap. Same shape as `effort` one line up, and the same
+   * cause — the live `/preset` path applied both through `applyModelOptions` and startup applied
+   * neither, so one session held two answers for the same preset depending on when it was chosen.
+   */
+  temperature?: number;
+  maxOutputTokens?: number;
   /** Text to append to the generated system prompt. */
   appendSystemPrompt?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */

--- a/packages/agent-framework/src/assembly/create-session.ts
+++ b/packages/agent-framework/src/assembly/create-session.ts
@@ -284,6 +284,8 @@ export async function createSession(options: ICreateSessionOptions): Promise<ICr
     ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),
     ...(options.responseFormat ? { responseFormat: options.responseFormat } : {}),
     ...(options.effort !== undefined ? { effort: options.effort } : {}),
+    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+    ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
   });
   wireSessionDeps(session, agentToolDeps, backgroundProcessToolDeps, backgroundTaskManager);
 

--- a/packages/agent-framework/src/command-api/provider/__tests__/env-default-provider.test.ts
+++ b/packages/agent-framework/src/command-api/provider/__tests__/env-default-provider.test.ts
@@ -56,6 +56,23 @@ const DEEPSEEK = definition({
 });
 const DEFINITIONS = [ANTHROPIC, OPENAI_NO_MODEL, GEMINI, GEMMA_LITERAL_KEY, DEEPSEEK];
 
+/**
+ * The settings files a TEST means when it says "this project's".
+ *
+ * Issue #1929: the production default also reads `~/.robota/settings.json` and `~/.claude/settings.json`,
+ * which no `cwd` isolates. A case whose premise is "no settings anywhere" was therefore true only on a
+ * machine whose developer had never configured the CLI — and read that developer's real profile
+ * otherwise. Stating the list makes the premise true by construction.
+ */
+function projectSettingsPaths(root: string): string[] {
+  return [
+    join(root, '.robota', 'settings.json'),
+    join(root, '.robota', 'settings.local.json'),
+    join(root, '.claude', 'settings.json'),
+    join(root, '.claude', 'settings.local.json'),
+  ];
+}
+
 describe('resolveEnvDefaultProvider (CLI-066)', () => {
   it('TC-01: synthesizes the anthropic config from definition defaults when its env key is set', () => {
     const config = resolveEnvDefaultProvider(DEFINITIONS, { ANTHROPIC_API_KEY: 'sk-test' });
@@ -130,6 +147,9 @@ describe('readProviderSettings env-default integration (CLI-066)', () => {
     const config = readProviderSettings(cwd, {
       providerDefinitions: DEFINITIONS,
       env: { ANTHROPIC_API_KEY: 'sk-test' },
+      // Issue #1929: the default list reaches the developer's real `~/.robota/settings.json`, which
+      // no `cwd` isolates — "no settings anywhere" has to be stated, not hoped for.
+      settingsPaths: projectSettingsPaths(cwd),
     });
 
     expect(config.name).toBe('anthropic');
@@ -165,7 +185,11 @@ describe('readProviderSettings env-default integration (CLI-066)', () => {
     cwd = mkdtempSync(join(tmpdir(), 'robota-env-default-'));
 
     expect(() =>
-      readProviderSettings(cwd as string, { providerDefinitions: DEFINITIONS, env: {} }),
+      readProviderSettings(cwd as string, {
+        providerDefinitions: DEFINITIONS,
+        env: {},
+        settingsPaths: projectSettingsPaths(cwd as string),
+      }),
     ).toThrow(ProviderConfigError);
   });
 });

--- a/packages/agent-framework/src/command-api/provider/__tests__/provider-factory.test.ts
+++ b/packages/agent-framework/src/command-api/provider/__tests__/provider-factory.test.ts
@@ -24,7 +24,18 @@ describe('readProviderSettings error typing (CLI-064)', () => {
   it('TC-04: throws ProviderConfigError when no provider configuration exists', () => {
     cwd = mkdtempSync(join(tmpdir(), 'robota-provider-factory-'));
     try {
-      readProviderSettings(cwd);
+      // Issue #1929: `cwd` isolates the PROJECT settings and nothing else — the default list also
+      // reads the developer's real `~/.robota/settings.json`, so "no configuration exists" has to be
+      // stated rather than assumed of the host. `env: {}` closes the other environment-shaped input.
+      readProviderSettings(cwd, {
+        env: {},
+        settingsPaths: [
+          join(cwd, '.robota', 'settings.json'),
+          join(cwd, '.robota', 'settings.local.json'),
+          join(cwd, '.claude', 'settings.json'),
+          join(cwd, '.claude', 'settings.local.json'),
+        ],
+      });
       expect.unreachable('readProviderSettings must throw without configuration');
     } catch (error) {
       expect(error).toBeInstanceOf(ProviderConfigError);

--- a/packages/agent-framework/src/command-api/provider/provider-factory.ts
+++ b/packages/agent-framework/src/command-api/provider/provider-factory.ts
@@ -16,6 +16,20 @@ export interface IReadProviderSettingsOptions {
   providerDefinitions?: readonly IProviderDefinition[];
   /** Environment map for env-default synthesis (test seam, default: process.env). */
   env?: Record<string, string | undefined>;
+  /**
+   * Settings files to merge, in precedence order (test seam, default:
+   * {@link getProviderSettingsPaths} over `cwd`).
+   *
+   * Issue #1929. The default list includes the USER-level settings file under the operator's home
+   * directory, which no `cwd` can isolate — so a case whose premise is "no settings anywhere" was
+   * true only on a machine whose developer had never configured the CLI, and read that developer's
+   * real profile otherwise. The failure direction was the harmless one; the other is a case going
+   * green because the host's profile happened to match what it expected.
+   *
+   * The same shape as `env` directly above, and for the same reason: an input the environment
+   * supplies has to be injectable, or the result stops depending on the code under test.
+   */
+  settingsPaths?: readonly string[];
 }
 
 /**
@@ -72,7 +86,10 @@ export function readProviderSettings(
   cwd: string,
   options: IReadProviderSettingsOptions = {},
 ): IProviderDefinitionConfig {
-  const merged = readMergedProviderSettings(cwd);
+  const merged =
+    options.settingsPaths === undefined
+      ? readMergedProviderSettings(cwd)
+      : readMergedProviderSettingsFromPaths(options.settingsPaths);
   const providerConfig = resolveActiveProvider(
     merged,
     options.providerOverride,

--- a/packages/agent-framework/src/interactive/create-session-projection.ts
+++ b/packages/agent-framework/src/interactive/create-session-projection.ts
@@ -53,6 +53,8 @@ export function buildCreateSessionOptions(
     deniedTools: options.deniedTools,
     model: options.model,
     ...(options.effort !== undefined ? { effort: options.effort } : {}),
+    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+    ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     appendSystemPrompt: options.appendSystemPrompt,
     ...(options.persona !== undefined ? { persona: options.persona } : {}),
     ...(options.systemPrompt ? { systemPromptBuilder: () => options.systemPrompt! } : {}),

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -245,6 +245,8 @@ export async function initializeInteractiveSessionAsync(
     deniedTools: options.deniedTools,
     model: options.model,
     ...(options.effort !== undefined ? { effort: options.effort } : {}),
+    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}), // ARCH-040
+    ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     appendSystemPrompt: options.appendSystemPrompt,
     ...(options.persona !== undefined ? { persona: options.persona } : {}),
     ...(options.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),

--- a/packages/agent-framework/src/interactive/interactive-session-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-options.ts
@@ -65,6 +65,9 @@ export interface IInteractiveSessionStandardOptions {
    * Typed FROM the seam, not re-declared beside it — that is how the two drift apart again.
    */
   effort?: ICreateSessionOptions['effort'];
+  /** ARCH-040: see {@link ICreateSessionOptions.temperature} — same cause as `effort`. */
+  temperature?: number;
+  maxOutputTokens?: number;
   /** Text to append to the system prompt. */
   appendSystemPrompt?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */
@@ -224,6 +227,8 @@ export interface IInitOptions {
    * Typed FROM the seam, not re-declared beside it — that is how the two drift apart again.
    */
   effort?: ICreateSessionOptions['effort'];
+  temperature?: number;
+  maxOutputTokens?: number;
   /** Text to append to the system prompt. */
   appendSystemPrompt?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */

--- a/packages/agent-preset/docs/SPEC.md
+++ b/packages/agent-preset/docs/SPEC.md
@@ -51,7 +51,6 @@ Types owned by this package (SSOT):
 | `IResolvedPresetOptions`    | `preset-types.ts`          | Framework-facing option subset a preset resolves into                     |
 | `TPresetEffort`             | `preset-types.ts`          | Effort dial: `'low' \| 'medium' \| 'high' \| 'xhigh' \| 'max'`            |
 | `TPresetAutonomy`           | `preset-types.ts`          | Behaviour posture: `'ask-first' \| 'balanced' \| 'act-first'`             |
-| `TPresetTrustLevel`         | `preset-types.ts`          | Trust profile: `'safe' \| 'moderate' \| 'full'`                           |
 | `TPresetPermissionMode`     | `preset-types.ts`          | Reused from `ICreateSessionOptions['permissionMode']` (framework SSOT)    |
 | `IPresetSummary`            | `resolve-preset.ts`        | `{ id, title, description }` discovery view of a preset                   |
 | `IResolvePresetContext`     | `resolve-preset.ts`        | `{ cliOverrides?, explicit? }` override layers for `resolvePreset`        |
@@ -71,7 +70,6 @@ indexed access rather than redefining the permission-mode union.
 | `IResolvedPresetOptions`     | Interface | Resolved framework-option subset                                                                                                                                                                                        |
 | `TPresetEffort`              | Type      | Effort dial union                                                                                                                                                                                                       |
 | `TPresetAutonomy`            | Type      | Autonomy posture union                                                                                                                                                                                                  |
-| `TPresetTrustLevel`          | Type      | Trust-level union                                                                                                                                                                                                       |
 | `TPresetPermissionMode`      | Type      | Permission-mode union (reused from framework)                                                                                                                                                                           |
 | `IPresetSummary`             | Interface | `{ id, title, description }` summary                                                                                                                                                                                    |
 | `IResolvePresetContext`      | Interface | Override layers for resolution                                                                                                                                                                                          |
@@ -144,6 +142,17 @@ caller builds a `createPresetRegistry(...)` over them and owns it. Policy:
 - **A load registers nothing** (ARCH-009). There is no module-global registry to clear, and no
   teardown to forget: a second load in the same process cannot see the first one's presets, and two
   products in one process each read only their own.
+
+### Removed: `defaultTrustLevel` (ARCH-040)
+
+The preset contract carried a `defaultTrustLevel` that nothing read. It was removed by owner decision
+rather than wired, and the reason is stronger than "unconsumed": a preset already states its posture
+three ways — `permissionMode`, `defaultPermissionMode` and `autonomy` — and `resolvePreset` PROMOTES
+the last two into the first. A fourth spelling would be a second answer to one question, which is what
+the projection scan calls `derivationOnly`.
+
+The trust axis itself is untouched: `config.defaultTrustLevel` still reaches the session and still
+maps to a permission mode. What is gone is the preset's own copy of it.
 
 ## Error Taxonomy
 

--- a/packages/agent-preset/src/__tests__/load-external-presets.test.ts
+++ b/packages/agent-preset/src/__tests__/load-external-presets.test.ts
@@ -179,6 +179,26 @@ describe('validateExternalPreset', () => {
     }
   });
 
+  it('drops `defaultTrustLevel`, which the preset contract no longer carries (ARCH-040)', () => {
+    // Removed by owner decision, and the reason is stronger than "nothing read it": a preset already
+    // states its posture three ways — `permissionMode`, `defaultPermissionMode` and `autonomy`, the
+    // last two of which `resolvePreset` PROMOTES into the first. A fourth spelling would be a second
+    // answer to one question, which is exactly what the projection scan calls `derivationOnly`.
+    //
+    // The trust axis itself is untouched: `config.defaultTrustLevel` still reaches the session and
+    // still maps to a permission mode. What is gone is the preset's own copy of it.
+    const result = validateExternalPreset({
+      id: 'x',
+      title: 'X',
+      description: 'd',
+      defaultTrustLevel: 'full',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect('defaultTrustLevel' in result.preset).toBe(false);
+    }
+  });
+
   it('drops unrecognised keys from the built preset', () => {
     const result = validateExternalPreset({
       id: 'x',

--- a/packages/agent-preset/src/index.ts
+++ b/packages/agent-preset/src/index.ts
@@ -11,7 +11,6 @@
 export type {
   TPresetEffort,
   TPresetAutonomy,
-  TPresetTrustLevel,
   TPresetPermissionMode,
   IResolvedPresetOptions,
   IPreset,

--- a/packages/agent-preset/src/preset-types.ts
+++ b/packages/agent-preset/src/preset-types.ts
@@ -11,13 +11,10 @@ import type { ICreateSessionOptions } from '@robota-sdk/agent-framework';
 export type TPresetEffort = NonNullable<ICreateSessionOptions['effort']>;
 
 /**
- * Behavioural autonomy posture. Drives the permission posture
- * (`permissionMode` / `defaultTrustLevel`) — it is a mechanism mapping, not a display label.
+ * Behavioural autonomy posture. Drives the permission posture (`permissionMode`) — it is a mechanism
+ * mapping, not a display label.
  */
 export type TPresetAutonomy = 'ask-first' | 'balanced' | 'act-first';
-
-/** Default trust level applied when the preset opts into a coarse permission posture. */
-export type TPresetTrustLevel = 'safe' | 'moderate' | 'full';
 
 /**
  * Permission mode reused from the framework option SSOT (`ICreateSessionOptions`).
@@ -61,7 +58,6 @@ export interface IResolvedPresetOptions {
    * `permissionMode`), {@link resolvePreset} promotes it to `permissionMode`.
    */
   defaultPermissionMode?: TPresetPermissionMode;
-  defaultTrustLevel?: TPresetTrustLevel;
   allowedTools?: readonly string[];
   deniedTools?: readonly string[];
 

--- a/packages/agent-preset/src/preset-validation.ts
+++ b/packages/agent-preset/src/preset-validation.ts
@@ -3,7 +3,6 @@ import type {
   TPresetAutonomy,
   TPresetEffort,
   TPresetPermissionMode,
-  TPresetTrustLevel,
   IResolvedPresetOptions,
 } from './preset-types.js';
 
@@ -23,9 +22,6 @@ const PERMISSION_MODE_VALUES: readonly TPresetPermissionMode[] = [
   'acceptEdits',
   'bypassPermissions',
 ];
-
-/** Runtime membership list for {@link TPresetTrustLevel}. */
-const TRUST_LEVEL_VALUES: readonly TPresetTrustLevel[] = ['safe', 'moderate', 'full'];
 
 /** Narrowing guard: `value` is a non-null, non-array object. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -138,12 +134,6 @@ function validateEnumFields(
     assign(raw as TPresetPermissionMode);
   }
 
-  if (value.defaultTrustLevel !== undefined) {
-    if (!TRUST_LEVEL_VALUES.includes(value.defaultTrustLevel as TPresetTrustLevel)) {
-      return `defaultTrustLevel: expected one of ${TRUST_LEVEL_VALUES.join(', ')}`;
-    }
-    options.defaultTrustLevel = value.defaultTrustLevel as TPresetTrustLevel;
-  }
   return undefined;
 }
 

--- a/packages/agent-session/src/__tests__/model-dials-at-construction.test.ts
+++ b/packages/agent-session/src/__tests__/model-dials-at-construction.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ARCH-040 Group E — the model group reaches the agent at CONSTRUCTION, not only mid-session.
+ *
+ * `applyModelOptions` has always propagated `temperature` and `maxOutputTokens` to the agent on a
+ * live session (see `apply-model-options.test.ts`). Startup propagated NEITHER, so one session held
+ * two answers for the same preset depending on WHEN it was chosen — exactly what `effort` did before
+ * ARCH-013 stage 1 fixed it.
+ *
+ * These assert on the agent CONFIG the session builds, because that is the hop that was missing. A
+ * check on the session options would pass while the value stopped at the boundary.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { Session } from '../session.js';
+
+const constructorSpy = vi.fn();
+
+vi.mock('@robota-sdk/agent-core', async () => {
+  const actual = await vi.importActual('@robota-sdk/agent-core');
+  return {
+    ...actual,
+    Robota: vi.fn().mockImplementation((config: unknown) => {
+      constructorSpy(config);
+      return {
+        run: vi.fn().mockResolvedValue('mock response'),
+        getHistory: vi.fn().mockReturnValue([]),
+        clearHistory: vi.fn(),
+        injectMessage: vi.fn(),
+        getFullHistory: vi.fn().mockReturnValue([]),
+        addHistoryEntry: vi.fn(),
+        ensureReady: vi.fn().mockResolvedValue(undefined),
+        setModel: vi.fn(),
+      };
+    }),
+  };
+});
+
+const MOCK_PROVIDER = {
+  name: 'mock-provider',
+  version: '1.0.0',
+  chat: vi.fn(),
+  supportsTools: () => true,
+  validateConfig: () => true,
+};
+
+const MOCK_TERMINAL = {
+  write: vi.fn(),
+  writeLine: vi.fn(),
+  writeMarkdown: vi.fn(),
+  writeError: vi.fn(),
+  prompt: vi.fn(),
+  select: vi.fn(),
+  spinner: () => ({ stop: vi.fn(), update: vi.fn() }),
+};
+
+function defaultModelOf(extra: Record<string, unknown>): Record<string, unknown> {
+  constructorSpy.mockClear();
+  new Session({
+    cwd: process.cwd(),
+    tools: [],
+    provider: MOCK_PROVIDER as never,
+    systemMessage: 'test',
+    terminal: MOCK_TERMINAL as never,
+    model: 'base-model',
+    ...extra,
+  } as never);
+  const config = constructorSpy.mock.calls[0]?.[0] as { defaultModel: Record<string, unknown> };
+  return config.defaultModel;
+}
+
+describe('the model group reaches the agent config at construction (ARCH-040)', () => {
+  it('carries `temperature` onto the agent’s default model', () => {
+    expect(defaultModelOf({ temperature: 0.2 })).toMatchObject({ temperature: 0.2 });
+  });
+
+  it('maps `maxOutputTokens` onto the agent’s `maxTokens` channel', () => {
+    // The SAME channel `applyModelOptions` writes. Two names for one dial would put the startup and
+    // mid-session answers on different fields, which is the divergence with extra steps.
+    expect(defaultModelOf({ maxOutputTokens: 4096 })).toMatchObject({ maxTokens: 4096 });
+  });
+
+  it('omits both when the session names neither, rather than sending undefined', () => {
+    // An explicit `undefined` is a value the provider request builder would carry; an absent key is
+    // not. The distinction is why these are conditional spreads and not plain assignments.
+    const defaultModel = defaultModelOf({});
+    expect('temperature' in defaultModel).toBe(false);
+    expect('maxTokens' in defaultModel).toBe(false);
+  });
+});

--- a/packages/agent-session/src/session-components.ts
+++ b/packages/agent-session/src/session-components.ts
@@ -82,6 +82,10 @@ export function buildRobota(
       provider: provider.name,
       model,
       ...(options.effort !== undefined && { effort: options.effort }),
+      // ARCH-040: the same two channels `applyModelOptions` writes on a live session, so the
+      // startup answer and the mid-session answer are the same answer.
+      ...(options.temperature !== undefined && { temperature: options.temperature }),
+      ...(options.maxOutputTokens !== undefined && { maxTokens: options.maxOutputTokens }),
     },
     // Single source of truth for the system prompt (agent-level, not model config).
     systemMessage,

--- a/packages/agent-session/src/session-types.ts
+++ b/packages/agent-session/src/session-types.ts
@@ -157,4 +157,14 @@ export interface ISessionOptions {
    * request builder. When unset, the framework→provider seam defaults it to `'high'`.
    */
   effort?: TModelEffort;
+  /**
+   * ARCH-040: sampling temperature and output cap, threaded to the agent config at CONSTRUCTION.
+   *
+   * The live `/preset` path has always applied both through `applyModelOptions`, and startup applied
+   * neither — so one session held two answers for the same preset depending on WHEN it was chosen,
+   * which is what `effort` did before ARCH-013 stage 1 fixed it. `maxOutputTokens` maps to the
+   * agent's `maxTokens` channel, the same name `applyModelOptions` already writes.
+   */
+  temperature?: number;
+  maxOutputTokens?: number;
 }


### PR DESCRIPTION
Progress on #1820 (ARCH-040), plus the cause found underneath it and one unrelated blocker fixed on the way.

## ARCH-041 — the projection was written THREE times, and had already drifted

`IPresetSurfaceOptions` says of itself that "adding a field here now reaches every surface at once, which is the only property that makes this worth extracting". It did not hold: `print-mode.ts` and `serve-mode.ts` each declared their own copy, and `model` was on print mode's copy and on **neither** of the others — the exact shape ARCH-013 was filed about, surviving the extraction meant to end it. The projection scan's configured surfaces saw two of the three, so nothing reported it.

Both mode types are `Partial<IPresetSurfaceOptions>` now, and `model` moved onto the shared type.

It earned its keep immediately: the very next change (Group E) added two fields to the shared type, and the `Required<>` case caught the fixture instantly. Under three copies, those two fields would have gone silently missing from two surfaces.

## ARCH-040 Group A — `defaultTrustLevel` removed

Owner decision. The reason is stronger than "nothing read it", and worth stating because a removal justified by a grep is one the next person re-adds: a preset already states its posture **three** ways — `permissionMode`, `defaultPermissionMode`, `autonomy` — and `resolvePreset` promotes the last two into the first. A fourth spelling is a second answer to one question, which is what the projection scan calls `derivationOnly` for the other two. The trust axis is untouched: `config.defaultTrustLevel` still reaches the session.

## ARCH-040 Group E — the model group reaches the session at construction

`temperature` and `maxOutputTokens` were applied by the live `/preset` path through `applyModelOptions` and by **nothing** at startup — one session holding two answers for the same preset depending on when it was chosen, exactly what `effort` did before ARCH-013 stage 1. They now travel the chain `effort` travels and land on the same two agent channels `applyModelOptions` writes.

`option-reachability` caught the first cut declaring the keys with nothing assigning them; the init hop was added rather than the declaration removed.

## Issue #1929 — three tests read the developer's real settings

Found by this branch's own pre-push run and **reproduced on `develop` with the branch stashed**, so it predates the work. Three cases whose premise is "no provider configuration exists" isolate the project directory and inject `env`, but the default settings list also reaches the operator's home directory. `readProviderSettings` gains a `settingsPaths` seam — the same shape as the `env` seam directly above it, for the same reason.

The failure direction was the harmless one. The other is a case going GREEN because the host's profile happened to match what it expected.

## What is NOT in here, and why

- **Group B (`agentName`)** — parked. Its only reader is a `readonly` identity label no surface displays; renaming needs a mutable core field or a split of a 411-line frozen file. Reverted rather than paid silently; the measurement is in the task record, awaiting a re-decision.
- **Group C (tools)** — the combine rule is decided (allow replaces, deny unions) but the live half needs a capability that does not exist: the lists become permission PATTERNS at construction and the enforcer exposes only an additive session-allowed set. Written, measured against the scan, and **reverted** — wiring the startup half alone CREATES the divergence the scan exists to measure.
- **Groups D and F** — feasible on existing seams, not yet done.

`presetProjection.pendingProjection`: 10 exemptions → 6.

## Verification

- `pnpm harness:scan` — 129 passed, 2 skipped
- `pnpm typecheck` — 0 errors
- full suite — exits 0 (it did not before the #1929 fix, on this machine)
- every change red-proofed; the parked/reverted ones carry their measurement instead of code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu51kQ6VZNaQejxgwKJ8BW