### PR TITLE
fix(harness): four gaps the bulk-edit guard still had after it landed

### DIFF
--- a/.agents/rules/operational.md
+++ b/.agents/rules/operational.md
@@ -144,14 +144,31 @@ Four spellings follow symlinks, and each has a sibling that does not:
 | python `glob.glob` / `glob.iglob` | `pathlib.Path(...).rglob`        |
 
 Shell `**` under `globstar`, zsh `**`, and Node's `fs.globSync` do not traverse symlinked
-directories and are unrestricted. `bulk-edit-guard.sh` refuses the four at the command,
-`scan-symlink-following-enumeration` refuses them in a committed script, and both refuse a write
-whose path resolves inside the store. The declared exception is `BULK_EDIT_ACK=1` inline, after
-checking by hand where the enumeration reaches.
+directories and are unrestricted. `bulk-edit-guard.sh` refuses the four at the command and
+`scan-symlink-following-enumeration` refuses them in a committed script. Only the hook resolves a
+path, and only for a file-writing tool's own target: a redirect and an in-place editor are judged on
+how the path is SPELLED, and the scan resolves nothing.
+
+The declared exception is `BULK_EDIT_ACK=1`, after checking by hand where the enumeration reaches —
+INLINE in the same command, or EXPORTED, which is the only form a file-writing tool can carry
+because such a tool runs no command to put an assignment in front of. They differ in LIFETIME as well
+as spelling: the inline form is scoped to the one command that carries it, and the exported one holds
+for the rest of the session and covers the file-writing tools too. Prefer the inline form. Neither
+reaches above the guard's payload refusals: an ack says a write was checked, not that an unreadable
+payload was.
 
 Enforced by: `bulk-edit-guard` (the command) and `symlink-following-enumeration` (the committed
-script). Neither reaches a python program passed through a heredoc, nor a two-step edit that
-enumerates in one call and writes in the next; those are the reader's obligation.
+script). The HOOK does not reach a python program passed through a heredoc — the body is masked as
+quoted content, which is the blindness every guard in that directory has. The SCAN does reach one,
+because in a committed file a heredoc body is ordinary file text. Neither reaches a two-step edit
+that enumerates in one call and writes in the next. The scan reads a file whose extension says it is
+a script, or — having no extension — whose shebang names an interpreter, so a script in a language
+outside that list is unread.
+
+> **Contained — [INFRA-115](../tasks/INFRA-115-is-this-file-a-script-and-in-what-language.md).**
+> Three of those interpreter names have no matching extension, so the same script is judged under one
+> filename and clean under another. The two filters are hand-written constants and the invariant that
+> they describe one population is held only in prose. Those are the reader's obligation.
 
 The measurements behind the table, and the exposure they corrected, are in
 [INFRA-105](../tasks/INFRA-105-bulk-edits-reach-the-dependency-store.md).

--- a/.agents/tasks/INFRA-109-flag-attribution-has-two-implementations.md
+++ b/.agents/tasks/INFRA-109-flag-attribution-has-two-implementations.md
@@ -1,0 +1,103 @@
+---
+title: 'INFRA-109: flag attribution has two implementations, and the two enforcers disagree'
+status: todo
+created: 2026-08-19
+priority: high
+urgency: next
+area: scripts/harness
+issue: 'https://github.com/woojubb/robota/issues/1898'
+depends_on: []
+---
+
+# INFRA-109: one flag-attribution predicate, two implementations, opposite verdicts
+
+## Objective
+
+`bulk-edit-guard.sh` and `scan-symlink-following-enumeration.mjs` are the two halves of one rule —
+the hook judges a command as it is about to run, the scan judges the same spelling once it has become
+a committed file. Both must answer one question: **is this hazardous flag being passed to THIS
+command, in THIS shell statement?**
+
+They answer it with two independent implementations, and only the hook's was ever corrected.
+
+## The measurement
+
+Driving the scan's exported `findingsIn` and the hook's real stdin protocol over the same commands:
+
+| command                                                | hook    | scan                   |
+| ------------------------------------------------------ | ------- | ---------------------- |
+| `rg -l foo packages \| xargs grep -L bar`              | permits | flags as `rg --follow` |
+| `find packages -L`                                     | refuses | clean                  |
+| `find packages -name '*.ts' -L`                        | refuses | clean                  |
+| `/usr/bin/find -L packages -name x`                    | permits | flags as `find -L`     |
+| `sed -i … node_modules/…` vs `sed --in-place …` (hook) | refuses | permits                |
+| two statements on two lines vs joined by `&&` (hook)   | refuses | permits                |
+
+Six probed shapes, six disagreements. The last three were added by a later round, and are the reason
+this item's scope is wider than the four enumerators it was first written against.
+
+## Why it is here and not fixed in place
+
+The hook has a tokenizer: `segments()` splits a command at `|`, `;`, `&&`, `||`, and `cmd_flag()`
+attributes a flag to a command whose word stands earlier in the same segment. That machinery exists
+because this exact conflation was reported twice in review of pull request #1886 — a wrapper's flag
+argument taking the command-name slot, and an in-place-editor rule reading a conjunction out of a
+coincidence.
+
+The scan has no tokenizer and no notion of a separator. Each of its four `RULES` entries hand-rolls
+its own bound on what may stand between a command and its flag, and the three that have one are all
+different: `find` uses `(?:-[^\s-][^\s]*\s+)*`, `grep` uses `(?:-[a-z][a-z]*\s+)*`, `rg` uses
+`(?:[^\s]+\s+)*?`. The last is lazy and unbounded, so it crosses `|`, `;` and `&&` alike.
+
+Correcting the `rg` bound alone leaves `find`'s two false negatives standing and guarantees a fifth
+ad-hoc bound the next time a spelling is added. The repository has already priced this shape once:
+`scripts/harness/cited-paths.mjs` consolidated five copies of one rule under HARNESS-062, and states
+the reason — a rule with three implementations is three rules.
+
+## What a later round corrected in this item
+
+The first version of this item assumed the hook's `segments()` was the good half, to be promoted to
+both enforcers. It is not, and promoting it would carry three more defects into the scan:
+
+- **A newline does not separate.** `hook_statement_all_words` emits `&&`, `|` and `;` as words and
+  drops the line break, so two statements on two lines merge into one segment. Adding `"\n"` to
+  `is_sep` is inert — the token never arrives. The library's `hook_statement_ranges` already splits
+  it correctly; that is the reader `segments()` should have been built on.
+- **The command word is compared exactly.** `/usr/bin/find -L packages …` is unattributed, and five
+  sites are wrong at once. `invokesWith` in `scan-shell-portability.mjs` already answers this with
+  `w.endsWith('/' + command)` — a third implementation of the same predicate.
+- **The in-place-editor rule hand-rolls a second attribution inside the hook**, rather than using
+  `cmd_flag`, and recognises only the short flag: `sed --in-place` into the store is permitted.
+
+So the owner to consume is not a new one. `.claude/hooks/lib/command-scan.sh` owns statement
+splitting (the INFRA-079 window), and `scan-shell-portability.mjs` owns walked long-form options and
+the qualified-invocation test — and its header records that three successive review rounds of the
+regex shape this scan's `RULES` still use each found another spelling it missed.
+
+## Direction (not yet decided)
+
+The shape of the fix is one attribution predicate both halves consume — statement splitting from
+`command-scan.sh`, option walking and the qualified-invocation test from the portability scan's
+proven form. Whether that owner is a small module the scan imports and the hook shells out to, or a
+single judgement process both call, is the design question this item exists to answer.
+
+## Completion criteria
+
+- [ ] TC-1: one implementation of flag attribution, consumed by both the hook and the scan — and by
+      the hook's in-place-editor rule, which currently has its own.
+- [ ] TC-2: every row of the table above receives the same verdict from both halves.
+- [ ] TC-3: a statement separated by a newline separates, judged through `hook_statement_ranges`
+      rather than a private word walk.
+- [ ] TC-4: a path-qualified invocation is attributed (`/usr/bin/find -L` reads as `find -L`).
+- [ ] TC-5: a long-form option is recognised wherever its short form is (`sed --in-place`,
+      `grep --dereference-recursive`, `rg --follow`), by walking options rather than by pattern.
+- [ ] TC-6: a test asserts hook/scan agreement over a shared case table, so the next added spelling
+      cannot land in one half only.
+- [ ] TC-7: adding a fifth hazardous spelling requires no new intermediate-token bound.
+
+## Contained by
+
+The follow-up to pull request #1886 labels the disagreement at the hook's `segments()`
+(`Contained — INFRA-109.`), under [finding-depth.md](../rules/finding-depth.md). Pull request #1886
+itself merged before the label was written, so the integration branch carries the defect unlabelled
+until that follow-up lands.

--- a/.agents/tasks/INFRA-110-hand-rolled-path-canonicalization-in-the-bulk-edit-guard.md
+++ b/.agents/tasks/INFRA-110-hand-rolled-path-canonicalization-in-the-bulk-edit-guard.md
@@ -1,0 +1,85 @@
+---
+title: 'INFRA-110: the bulk-edit guard hand-rolls path canonicalization, and it fails open'
+status: todo
+created: 2026-08-19
+priority: high
+urgency: next
+area: .claude/hooks
+issue: 'https://github.com/woojubb/robota/issues/1899'
+depends_on: []
+---
+
+# INFRA-110: canonicalize a write path with a canonicalizer, not with a dirname climb
+
+## Objective
+
+`bulk-edit-guard.sh` must answer one question about a write: **where does this path actually land?**
+It answers it with `resolved_through_existing_ancestor`, twelve lines of bash that climb with
+`dirname` to the deepest existing directory, resolve that with `cd` + `pwd -P`, and re-attach the
+segments that do not exist yet.
+
+The function has no stated domain, so its correctness is defined by whichever input shapes a reviewer
+happened to try. Three review rounds of pull request #1886 have each found a new shape.
+
+## The measurement
+
+In a sandbox where `app/vendored -> ../node_modules/pkg` and
+`app/filelink.ts -> ../node_modules/pkg/src/index.ts`:
+
+| write target                            | exit | should be |
+| --------------------------------------- | ---- | --------- |
+| `app/vendored/src/new.ts`               | 2    | 2         |
+| `app/filelink.ts`                       | 0    | 2         |
+| `app/nonexistent/../vendored/src/x.ts`  | 0    | 2         |
+| `app/../app/vendored/src/x.ts`          | 2    | 2         |
+| `app/vendored/src/new.ts`, `CDPATH` set | 0    | 2         |
+
+Three holes, each an input class a canonicalizer handles without being told:
+
+- **`CDPATH` is honoured by `cd`**, so an exported `CDPATH` makes the resolution silently select a
+  different directory — and `cd` then prints the selected path to stdout, so `RESOLVED` comes back as
+  two newline-separated paths. This is a fail-OPEN, against the refuse direction the file declares in
+  its own header.
+- **A `..` after a missing segment is re-attached verbatim** and never normalised, so the write walks
+  back out of the missing directory and into the store unseen.
+- **The final component is never resolved**, only its ancestors, so a symlinked FILE into the store
+  is permitted while the sibling symlinked directory is refused.
+
+## Why it is here and not fixed in place
+
+Each hole is a one-line patch, and patching all three produces a hand-rolled `realpath` with four
+special cases and still no stated domain — the next class (`~`, a trailing slash, a `.` segment, a
+relative path resolved against a cwd that is not the project directory) found by the next reviewer
+rather than by the code. The three rounds already spent are the evidence that this converges slowly
+or not at all:
+
+- round 1: `-e "$FILE_PATH"` is false for the file being created.
+- round 2: the parent may not exist either — add the ancestor climb.
+- round 3: `CDPATH` fails open, `..` is not normalised, the leaf is not resolved.
+
+`scripts/harness/scan-shell-portability.mjs` already names the portable replacement for the
+GNU-only `readlink -f` that this file correctly avoided, and `node` is already invoked from this hook
+directory by `pre-push-check.sh` and `task-tracking.sh` — so the dependency is one this directory
+already carries.
+
+## Direction (not yet decided)
+
+Replace the climb with a canonicalizer that has a stated domain and handles a non-existent tail. The
+open question is cost: this hook runs `PreToolUse` on every `Write`/`Edit`, and a node invocation per
+write is a latency the hook currently does not pay. Whether that is acceptable, or whether the
+resolution should be reached another way, is what this item decides.
+
+## Completion criteria
+
+- [ ] TC-1: every row of the table above returns its "should be" exit code.
+- [ ] TC-2: the resolution has a stated domain, and the input classes outside it are named in the
+      file header's `STATED LIMIT`.
+- [ ] TC-3: a case per row, red-proofed one at a time.
+- [ ] TC-4: the measured `PreToolUse` latency of a write is recorded, so the cost of the choice is a
+      number rather than an assumption.
+
+## Contained by
+
+The follow-up to pull request #1886 labels the three holes at the resolution site
+(`Contained — INFRA-110.`), under [finding-depth.md](../rules/finding-depth.md). Pull request #1886
+itself merged before the label was written.

--- a/.agents/tasks/INFRA-111-redirect-target-has-no-owner.md
+++ b/.agents/tasks/INFRA-111-redirect-target-has-no-owner.md
@@ -1,0 +1,80 @@
+---
+title: 'INFRA-111: "what does this redirect write to" has no owner, so each guard hand-rolls it'
+status: todo
+created: 2026-08-20
+priority: high
+urgency: next
+area: .claude/hooks
+issue: 'https://github.com/woojubb/robota/issues/1903'
+depends_on: []
+---
+
+# INFRA-111: two hooks hand-roll a redirection grammar the library already encodes
+
+## Objective
+
+Two guards ask the same question — **does this command redirect output into a path I protect?** —
+and each answers it with its own regex over redirection spellings. Neither consumes
+`.claude/hooks/lib/command-scan.sh`, which already encodes the redirection grammar and exposes none
+of it.
+
+## The measurement
+
+`bulk-edit-guard.sh`, driven over its real payload protocol:
+
+| command                     | exit  |
+| --------------------------- | ----- |
+| `echo x > node_modules/y`   | 2     |
+| `echo x >> node_modules/y`  | 2     |
+| `echo x >\| node_modules/y` | 2     |
+| `echo x &> node_modules/y`  | 2     |
+| `echo x 2> node_modules/y`  | 2     |
+| `echo x >& node_modules/y`  | **0** |
+| `echo x >&node_modules/y`   | **0** |
+| `echo x 2>& node_modules/y` | **0** |
+| `echo x >&"node_modules/y"` | **0** |
+| `echo x >>& node_modules/y` | **0** |
+
+`branch-guard.sh:1149` asks the same question of `.husky/` with a different regex, and its holes are
+a DIFFERENT set:
+
+| command                      | branch-guard |
+| ---------------------------- | ------------ |
+| `echo x > .husky/pre-push`   | matches      |
+| `echo x &> .husky/pre-push`  | matches      |
+| `echo x >& .husky/pre-push`  | **misses**   |
+| `echo x >\| .husky/pre-push` | **misses**   |
+
+That second row is a live walk-through of a gate whose own refusal says "Zero exceptions".
+
+## Why it is here and not fixed in place
+
+This is the third cut of one regex. The first shipped it; the second added `>|` and its commit
+claimed that was "the only miss across eight probed spellings"; the third measures five more. A
+hand-enumeration that certifies its own exhaustiveness and is wrong the following round is the
+evidence that enumeration is the wrong shape.
+
+The grammar is already written. `command-scan.sh` (INFRA-085) parses redirections, and its own
+comment records the identical tuition:
+
+> `2>&1` and `>&2` put the ampersand AFTER the arrow; `&>` and `&>>` put it BEFORE. Reading only the
+> character in front caught the first pair and missed the second.
+
+So the library has already paid for the exact `>&`/`&>` asymmetry that cost this hook a round — and
+kept the lesson private.
+
+This is NOT [INFRA-109](INFRA-109-flag-attribution-has-two-implementations.md): that item's subject
+is which command received a FLAG, and landing it in full leaves `>& node_modules/x` permitted.
+
+## Completion criteria
+
+- [ ] TC-1: `command-scan.sh` exposes a redirect-target reader — the targets a command writes to.
+- [ ] TC-2: `bulk-edit-guard.sh` and `branch-guard.sh` both consume it; neither keeps a private regex.
+- [ ] TC-3: every row of both tables above receives the correct verdict.
+- [ ] TC-4: a shared case table, so a spelling added to the grammar reaches both consumers at once.
+
+## Contained by
+
+The follow-up to pull request #1886 labels the `>&` family at the redirect rule
+(`Contained — INFRA-111.`), under [finding-depth.md](../rules/finding-depth.md). `branch-guard.sh`'s
+half is pre-existing on the integration branch and is not touched by either change.

--- a/.agents/tasks/INFRA-115-is-this-file-a-script-and-in-what-language.md
+++ b/.agents/tasks/INFRA-115-is-this-file-a-script-and-in-what-language.md
@@ -1,0 +1,59 @@
+---
+title: 'INFRA-115: "is this committed file a script, and in what language" has no owner'
+status: todo
+created: 2026-08-20
+priority: high
+urgency: next
+area: scripts/harness
+issue: 'https://github.com/woojubb/robota/issues/1912'
+depends_on: []
+---
+
+# INFRA-115: one population, two hand-written constants, an invariant held only in prose
+
+## Objective
+
+A scan that judges committed scripts has to answer two halves of one question: **which files are
+scripts**, and **in what language**. Each scan answers it with two independent hand-written
+constants — an extension pattern and a shebang alternation — and nothing checks that the two halves
+describe the same population.
+
+## The measurement
+
+`scan-symlink-following-enumeration.mjs` admits `dash`, `ksh` and `ash` by shebang while
+`SCANNED_EXTENSIONS` has no matching entry. The same file, same content:
+
+| written as          | verdict   |
+| ------------------- | --------- |
+| `scripts/sweep`     | reported  |
+| `scripts/sweep.ksh` | **clean** |
+
+Same for `dash` and `ash`. The file's own comment claims the interpreters are "exactly the ones
+`SCANNED_EXTENSIONS` also admits, and no more", and the commit that wrote that sentence shipped the
+counter-example.
+
+## Why it is a cause and not a typo
+
+The three names were copied verbatim out of `scan-shell-portability.mjs`, which carries the identical
+asymmetry — `EXTENSIONS = /\.(sh|bash|zsh)$/` against
+`SHEBANG = /^#!.*\b(sh|bash|zsh|dash|ksh|ash)\b/` — into the file whose comment cites that scan as
+the lesson to follow. The lesson copied; the defect copied with it.
+
+Aligning three names in one file leaves the first copy self-disagreeing, leaves the invariant held in
+prose in both, and leaves the next scan that needs this predicate to hand-write a third pair. A test
+can pin one out-of-set example, which is what the current one does; it cannot pin the invariant while
+the invariant is a sentence.
+
+## Completion criteria
+
+- [ ] TC-1: one table maps a language to its extensions AND its interpreter names.
+- [ ] TC-2: both filters in each consuming scan are derived from it, not hand-written beside it.
+- [ ] TC-3: a test asserts the agreement over the WHOLE table — every interpreter's language has at
+      least one admitted extension — rather than over one chosen example.
+- [ ] TC-4: `scan-shell-portability.mjs` consumes the same owner, so the copy that started this is
+      not left behind.
+
+## Contained by
+
+The follow-up to pull request #1886 ships the alternation with the asymmetry labelled at the site
+(`Contained — INFRA-115.`), under [finding-depth.md](../rules/finding-depth.md).

--- a/.agents/tasks/INFRA-123-nothing-can-name-the-language-of-an-embedded-payload.md
+++ b/.agents/tasks/INFRA-123-nothing-can-name-the-language-of-an-embedded-payload.md
@@ -1,0 +1,59 @@
+---
+title: 'INFRA-123: nothing can name the language of an embedded payload, so a language-scoped rule has no reachable subject'
+status: todo
+created: 2026-08-20
+priority: medium
+urgency: next
+area: scripts/harness
+issue: 'https://github.com/woojubb/robota/issues/1919'
+depends_on: []
+---
+
+# INFRA-123: the unit that has a language is the payload, and neither enforcer can name one
+
+## Objective
+
+`from glob import glob; glob(…)` and `import glob as g; g.glob(…)` are the symlink-following
+enumerator wearing an import the call site does not spell. Reading that import requires knowing
+**whose language a line is written in**, and neither half of this rule can answer it for the place
+python actually lives here — inside a payload.
+
+## Why the two available subjects both miss
+
+- **The hook cannot attribute to an interpreter.** Every reader it has EXPANDS an interpreter
+  payload, so once `python3 -c "…"` is expanded the payload's own `;`, `|` and `&` are
+  indistinguishable from the shell's. `hook_statement_ranges` splits inside a payload for the same
+  reason. Three cuts were measured and each refused a correct command: a whole-command conjunction, a
+  nearest-interpreter walk with a hand-written reset list, and a separator reset.
+- **The scan can only attribute to a FILE.** Scoped to a file that IS python, the rule judges an
+  empty population here — measured on this tree: **zero** tracked `.py` files and **zero**
+  python-shebang files, against **14** files containing `python3 -c`, every one of them `.sh`,
+  `.mjs`, `.md` or `.yml` (counted on this change's own head; the figure moves as files are added,
+  the two zeroes are the load-bearing halves). The rule would enforce nothing while the rule table said it did.
+  Unscoped, it reports `import glob from 'glob'` — a package this repository depends on that does not
+  follow — which is refusing the safe sibling.
+
+The unit with a language is neither the command nor the file: it is the **payload** — a `-c`
+argument, a heredoc body, a workflow `run:` block. Nothing in either enforcer can name one.
+
+## What was done instead
+
+The import widening was withdrawn rather than shipped unenforced. The follow-up to pull request #1886
+keeps the call spelling, which needs no subject, and its rule table says so.
+
+## Completion criteria
+
+- [ ] TC-1: a reader can name the language of an embedded payload — its interpreter and its extent —
+      without that extent being destroyed by expansion.
+- [ ] TC-2: the import spelling is judged inside a `python -c` payload and a heredoc body, in a file
+      of any type.
+- [ ] TC-3: `import glob from 'glob'` in JavaScript, at the command and in a committed file, is not
+      reported.
+- [ ] TC-4: the hook and the scan agree on every case in the table above.
+
+## Notes
+
+Filed from the fifth review round of the follow-up to pull request #1886, where four of five commits
+re-answered "whose language is this?" and each answer was measured wrong in a different direction.
+Related: [INFRA-109](INFRA-109-flag-attribution-has-two-implementations.md), which owns the
+command-side half of the same missing reader.

--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -60,7 +60,9 @@ refuse_path() {
   echo "[bulk-edit-guard] edit and git can see it — or content HARD-LINKED into the shared store," >&2
   echo "[bulk-edit-guard] where a write silently changes every project on this machine and survives" >&2
   echo "[bulk-edit-guard] pnpm install." >&2
-  echo "[bulk-edit-guard] Deliberate exception: BULK_EDIT_ACK=1 inline in the same command." >&2
+  echo "[bulk-edit-guard] Deliberate exception: BULK_EDIT_ACK=1 — inline in the same command, or" >&2
+  echo "[bulk-edit-guard] exported, which is the only form a tool write can carry because it runs no" >&2
+  echo "[bulk-edit-guard] command to put an assignment in front of. Exported stays armed until unset." >&2
   exit 2
 }
 
@@ -72,6 +74,21 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Mult
     exit 2
   fi
   [[ -n "$FILE_PATH" ]] || exit 0
+
+  # The env-form ack, read HERE: below this branch's own decode refusal, above its judgement.
+  #
+  # It has to exist at all because the refusal advertises `BULK_EDIT_ACK=1` and a `Write` carrying it
+  # exported was refused anyway — the tool branch exits before the check the Bash branch uses, so the
+  # escape named in the message could not be taken by the tool that most needs it. A write carries no
+  # command, so the exported form is the only one it can spell.
+  #
+  # It has to sit HERE rather than at the top of the file, which was the first cut and was measured
+  # wrong: above the decode refusals an ack turned an UNREADABLE payload into a permitted one, on a
+  # guard whose header declares it fails toward refusal. Every sibling in this directory already
+  # reads its ack below its own decode refusal — `check-forbidden-patterns.sh`, `no-foreground-wait`,
+  # `merge-gate` — and the ack means "I checked this write by hand", which is not a claim anyone can
+  # make about a payload nothing could read.
+  if [[ "${BULK_EDIT_ACK:-0}" == "1" ]]; then exit 0; fi
 
   if printf '%s' "$FILE_PATH" | grep -qE "$STORE_SEGMENT_RE"; then
     refuse_path "$FILE_PATH"
@@ -99,6 +116,13 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Mult
   # `cd` + `pwd -P` rather than `readlink -f`: the `-f` form is GNU-only and fails unhelpfully on
   # BSD/macOS, which `shell-portability` refuses (see "Host Platform Is Read, Never Assumed"). `pwd
   # -P` is POSIX and resolves the DIRECTORY chain, which is the level pnpm's symlinks live at.
+  # Contained — INFRA-110. The climb below is hand-rolled canonicalization with no stated domain, and
+  # three measured input classes get past it: an exported `CDPATH` makes `cd` select a different
+  # directory and print it to stdout (a fail-OPEN, against this file's declared refuse direction); a
+  # `..` after a missing segment is re-attached verbatim and never normalised; and the FINAL
+  # component is never resolved, so a symlinked FILE into the store is permitted while the sibling
+  # symlinked DIRECTORY is refused. Each is a one-line patch and all three together are a realpath
+  # with four special cases and still no domain, which is the item rather than this function.
   ANCESTOR=$(dirname -- "$FILE_PATH")
   TAIL=$(basename -- "$FILE_PATH")
   while [[ ! -d "$ANCESTOR" && "$ANCESTOR" != "/" && "$ANCESTOR" != "." ]]; do
@@ -128,7 +152,9 @@ fi
 # trip the guard that reads them.
 MASK=$(hook_verb_scan "$COMMAND" 2>/dev/null || printf '%s' "$COMMAND")
 
+# The same env-form ack, below this branch's decode refusal for the same reason.
 if [[ "${BULK_EDIT_ACK:-0}" == "1" ]]; then exit 0; fi
+
 if printf '%s' "$MASK" |
   grep -qE '(^|[;&|]|&&)[[:space:]]*([[:alnum:]_]+=[^[:space:]]+[[:space:]]+)*BULK_EDIT_ACK=1[[:space:]]'; then
   exit 0
@@ -155,6 +181,14 @@ WORDS=$(hook_statement_all_words "$COMMAND" 2>/dev/null || printf '%s' "$COMMAND
 # inherits the first one's attribution. `find … -exec grep -L {} \;` is read as `find` carrying `-L`
 # and is refused. That is a false positive, and it is the trade taken deliberately — a pipeline is
 # the common shape and is still separated, `-exec grep -L` is not, and the ack is one word away.
+# Contained — INFRA-109. This file answers "which command received this flag" privately, and
+# `scan-symlink-following-enumeration.mjs` answers it again with four regexes of its own, so the two
+# halves of one rule disagree. Measured: a NEWLINE does not separate here (the reader drops the token
+# before `is_sep` can see it), so two statements on two lines share a segment, while the library's
+# `hook_statement_ranges` splits them correctly; and `segment_has_editor_and_store_path` below
+# hand-rolls a SECOND attribution rather than using `cmd_flag`, recognising only a short flag. The
+# readers to consume already exist — `command-scan.sh` for statement splitting, and the portability
+# scan for walked long-form options.
 segments() {
   printf '%s\n' "$WORDS" | awk '
     function is_sep(w) { return w == "|" || w == ";" || w == "&" || w == "&&" || w == "||" || w == "(" || w == ")" }
@@ -224,7 +258,13 @@ segment_has_editor_and_store_path() {
 # tools. Without that, `my_node_modules_old/` — a directory that merely contains the letters — was
 # refused here while the write path permitted it, so one guard contradicted the other on the case both
 # had a test for. Reported in review of this change.
-if printf '%s' "$MASK" | grep -qE '>>?[[:space:]]*([^[:space:]|;&]*/)?(node_modules|\.pnpm)/'; then
+if printf '%s' "$MASK" | grep -qE '>>?\|?[[:space:]]*([^[:space:]|;&]*/)?(node_modules|\.pnpm)/'; then
+  # Contained — INFRA-111. The `>&` family walks through this rule — `>& node_modules/y`, `>&x`,
+  # `2>&`, `>&"x"` and `>>&` are all permitted while `>`, `>>`, `>|`, `&>` and `2>` are refused.
+  # Adding the character would be the fourth cut of one regex; the third certified its own
+  # exhaustiveness and was wrong by five. `branch-guard.sh` hand-rolls the same question for
+  # `.husky/` with a DIFFERENT hole set, and `command-scan.sh` already parses redirections privately,
+  # its own comment recording the identical `>&` versus `&>` miss.
   refuse_path "the command redirects output into node_modules or .pnpm"
 fi
 

--- a/scripts/harness/__tests__/bulk-edit-guard.test.mjs
+++ b/scripts/harness/__tests__/bulk-edit-guard.test.mjs
@@ -39,6 +39,16 @@ function run(payload) {
 }
 
 const bash = (command) => run({ tool_name: 'Bash', tool_input: { command } });
+
+/** The same call with the ack EXPORTED rather than inline — the only form a tool write can take. */
+function runAcked(payload) {
+  const result = spawnSync('bash', [HOOK], {
+    input: typeof payload === 'string' ? payload : JSON.stringify(payload),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: WORKSPACE_ROOT, BULK_EDIT_ACK: '1' },
+  });
+  return { status: result.status, stderr: result.stderr ?? '' };
+}
 const write = (filePath) => run({ tool_name: 'Write', tool_input: { file_path: filePath } });
 
 describe('a file-writing tool naming the dependency store', () => {
@@ -234,6 +244,13 @@ describe('a content write whose target names the store', () => {
     expect(bash('echo broken > node_modules/.pnpm/pkg/index.js').status).toBe(2);
   });
 
+  it("refuses the noclobber-override redirect, which is the same rule's own subject", () => {
+    // `>|` is bash's "write even under noclobber". The rule read `>>?` and then a target, so the
+    // `|` fell into the excluded prefix class and the whole spelling walked through.
+    expect(bash('echo x >| node_modules/y').status).toBe(2);
+    expect(bash('echo x >| /tmp/y').status).toBe(0);
+  });
+
   it('permits the reinstall idioms', () => {
     // `rm -rf node_modules && pnpm install` is what every contributor runs. Refusing it would be a
     // correct command blocked, which is how a guard's ack starts being pasted without being read.
@@ -263,6 +280,35 @@ describe('reading the payload', () => {
 });
 
 describe('the documented escape', () => {
+  it('honours the EXPORTED ack on a tool write, which is the only form one can carry', () => {
+    // The refusal advertises `BULK_EDIT_ACK=1`, and the tool branch used to exit above the check
+    // that reads it — so the escape named in the message could not be taken. A Write carries no
+    // command, so there is nowhere to put an inline assignment; the env form is the whole mechanism.
+    expect(
+      runAcked({ tool_name: 'Write', tool_input: { file_path: 'node_modules/x.js' } }).status,
+    ).toBe(0);
+    expect(write('node_modules/x.js').status).toBe(2);
+  });
+
+  it('refuses an unreadable payload EVEN under the ack, which is the ordering the header asserts', () => {
+    // The ack short-circuits the decode refusals inside the tool branch deliberately: it means "I
+    // have checked this by hand". It must NOT reach above these two, because neither says WHAT was
+    // acked, and a malformed payload would then be the way past the guard.
+    expect(runAcked('').status).toBe(2);
+    expect(runAcked({ tool_input: { command: 'echo hi' } }).status).toBe(2);
+    // THE case the ordering fix actually moved, and the one this file did not have. Both refusals
+    // above already stood above the ack in the version being corrected, so they were green either
+    // way — a late invariant both versions satisfy. A payload naming a tool whose OWN field cannot
+    // be decoded is refused on the integration branch and was permitted by the first cut, which
+    // read the ack at the top of the file.
+    expect(runAcked({ tool_name: 'Bash', tool_input: {} }).status).toBe(2);
+  });
+
+  it("permits Node's fs.glob, which was measured NOT to follow", () => {
+    // The widening that looks obvious — matching a bare `glob(` — refuses this.
+    expect(bash('node -e "console.log(fs.globSync(1))"').status).toBe(0);
+  });
+
   it('permits an inline BULK_EDIT_ACK=1', () => {
     expect(bash('BULK_EDIT_ACK=1 find -L packages -name "*.ts"').status).toBe(0);
   });

--- a/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
+++ b/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
@@ -21,26 +21,59 @@ import {
 const SCRIPT = 'scripts/tools/rewrite.sh';
 
 describe('the four measured spellings', () => {
+  // Each row carries the FILE it is written in. No rule is language-scoped — an earlier cut added
+  // one and withdrew it (INFRA-117) — so the column is documentation: it says what a row is meant to
+  // represent, not something the code branches on.
+  const PY = 'scripts/tools/sweep.py';
   const cases = [
-    ['find -L', 'find -L packages -name "*.ts" -print0', 'find packages -name "*.ts" -print0'],
-    ['grep -R', 'grep -Rl createSession packages/', 'grep -rl createSession packages/'],
-    ['rg --follow', 'rg --follow -l createSession packages', 'rg -l createSession packages'],
+    [
+      'find -L',
+      'find -L packages -name "*.ts" -print0',
+      'find packages -name "*.ts" -print0',
+      SCRIPT,
+    ],
+    ['grep -R', 'grep -Rl createSession packages/', 'grep -rl createSession packages/', SCRIPT],
+    [
+      'rg --follow',
+      'rg --follow -l createSession packages',
+      'rg -l createSession packages',
+      SCRIPT,
+    ],
     [
       'python glob.glob',
-      'python3 -c "import glob; print(glob.glob(\'packages/**/*.ts\', recursive=True))"',
-      "python3 -c \"from pathlib import Path; print(list(Path('packages').rglob('*.ts')))\"",
+      "print(glob.glob('packages/**/*.ts', recursive=True))",
+      "print(list(Path('packages').rglob('*.ts')))",
+      PY,
     ],
   ];
 
-  it.each(cases)('reports %s', (id, hazardous) => {
-    const findings = findingsIn(SCRIPT, hazardous);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].id).toBe(id);
-    expect(findings[0].remedy).toBeTruthy();
+  // The expected SET, not `toHaveLength(1)`. The length form couples "which rule is under test" to
+  // "how many rules the subject trips", and a subject that trips two is not a reason to rewrite the
+  // subject into one nobody writes. The set keeps the "and nothing else fired" half as well.
+  it.each(cases)('reports %s', (id, hazardous, _safe, file) => {
+    const findings = findingsIn(file, hazardous);
+    expect(new Set(findings.map((f) => f.id))).toEqual(new Set([id]));
+    expect(findings.every((f) => f.remedy)).toBe(true);
   });
 
-  it.each(cases)('does not report the safe sibling of %s', (_id, _hazardous, safe) => {
-    expect(findingsIn(SCRIPT, safe)).toEqual([]);
+  it.each(cases)('does not report the safe sibling of %s', (_id, _hazardous, safe, file) => {
+    expect(findingsIn(file, safe)).toEqual([]);
+  });
+
+  it('judges a python CALL wherever it is written, including a non-python file', () => {
+    // The call rule carries no language on purpose. A `.mjs` harness script spawning `python3 -c`
+    // holds a python payload, a shell heredoc holds one too, and a first cut that scoped this rule
+    // by file language stopped judging both — while the rule text still claimed the committed-file
+    // side was covered.
+    expect(
+      findingsIn('scripts/tools/build.mjs', 'execSync(\'python3 -c "print(glob.glob(1))"\')'),
+    ).toMatchObject([{ id: 'python glob.glob' }]);
+    expect(findingsIn('scripts/tools/rewrite.sh', 'glob.glob("**")')).toMatchObject([
+      { id: 'python glob.glob' },
+    ]);
+    expect(
+      findingsIn('.github/workflows/ci.yml', '    run: python3 -c "glob.glob(1)"'),
+    ).toMatchObject([{ id: 'python glob.glob' }]);
   });
 
   it.each([
@@ -147,5 +180,91 @@ describe('the size it declares', () => {
   it('opens only the extensions it claims, so the size and the coverage are the same number', () => {
     expect(scanTrackedFiles(paths, read)).toEqual([]);
     expect(examinedScriptCount()).toBe(3);
+  });
+
+  /**
+   * A reader honouring the two-mode contract: it refuses a strict read it cannot serve, and answers
+   * `null` only when the caller said the read was optional.
+   */
+  function twoModeReader(table, unreadable) {
+    return (file, optional = false) => {
+      if (!unreadable.has(file)) return table[file];
+      if (optional) return null;
+      throw new Error(`strict read of ${file} must not be served`);
+    };
+  }
+
+  it('does not count a file it describes-but-does-not-judge', () => {
+    // The allowlisted files are the guard, its tests and the record. They were opened, counted, and
+    // then returned empty, so the declared size exceeded the judged population by exactly their
+    // number. The fixture had no such row, which is why nothing caught it.
+    const withAllowed = { ...FIXTURE, '.claude/hooks/bulk-edit-guard.sh': 'find -L packages' };
+    expect(scanTrackedFiles(Object.keys(withAllowed), (file) => withAllowed[file])).toEqual([]);
+    expect(examinedScriptCount()).toBe(3);
+  });
+
+  it('judges an extensionless file that says it is a shell script', () => {
+    // A property of the file beats a list of places the property is assumed to hold. This
+    // repository's own git hooks carry no extension and were invisible to the first cut.
+    const withHook = { ...FIXTURE, '.husky/pre-push': '#!/usr/bin/env sh\nfind -L packages\n' };
+    const findings = scanTrackedFiles(Object.keys(withHook), (file) => withHook[file]);
+    expect(findings.map((f) => f.file)).toEqual(['.husky/pre-push']);
+    expect(examinedScriptCount()).toBe(4);
+  });
+
+  it('judges an extensionless script in any language its rules are written against', () => {
+    const withPython = {
+      ...FIXTURE,
+      'scripts/tools/sweep': '#!/usr/bin/env python3\nimport glob\nglob.glob("**")\n',
+    };
+    const findings = scanTrackedFiles(Object.keys(withPython), (file) => withPython[file]);
+    // The assertion is on WHICH file was judged. Deduplicated because a fixture may trip a rule on
+    // more than one line, and the property under test is the population, not the line count.
+    expect([...new Set(findings.map((f) => f.file))]).toEqual(['scripts/tools/sweep']);
+    expect(examinedScriptCount()).toBe(4);
+  });
+
+  it('does not admit ruby, whose extension the population excludes', () => {
+    // The two filters have to agree about one population. A cut listing `ruby` in the shebang
+    // alternation while `SCANNED_EXTENSIONS` had no `.rb` judged the SAME script when written
+    // without an extension and ignored it as `sweep.rb` — one file disagreeing with itself.
+    //
+    // This pins the `ruby` case ONLY, and deliberately does not claim the general invariant: three
+    // interpreters still in the alternation have no matching extension, which is the defect the
+    // `Contained — INFRA-115.` label on `SHEBANG` records. A green case under a general title would
+    // read as proof of something the source says is untrue.
+    const body = '#!/usr/bin/env ruby\nsystem("find -L packages")\n';
+    const extensionless = { ...FIXTURE, 'scripts/tools/sweep': body };
+    expect(scanTrackedFiles(Object.keys(extensionless), (f) => extensionless[f])).toEqual([]);
+    const extensioned = { ...FIXTURE, 'scripts/tools/sweep.rb': body };
+    expect(scanTrackedFiles(Object.keys(extensioned), (f) => extensioned[f])).toEqual([]);
+  });
+
+  it('does not judge an extensionless file that is not a script, and does not count it', () => {
+    const withData = { ...FIXTURE, 'docs/CODEOWNERS': '* @someone\n' };
+    expect(scanTrackedFiles(Object.keys(withData), (file) => withData[file])).toEqual([]);
+    expect(examinedScriptCount()).toBe(3);
+  });
+
+  it('treats an unreadable EXTENSIONLESS path as not-a-script rather than as a failure', () => {
+    // `git ls-files` lists a tracked symlink to a directory, and reading it as text throws. That is
+    // an answer to "is this a script", not an error — and the read is the optional one.
+    const read2 = twoModeReader(FIXTURE, new Set(['link']));
+    expect(scanTrackedFiles([...paths, 'link'], read2)).toEqual([]);
+    expect(examinedScriptCount()).toBe(3);
+  });
+
+  it('asks optionally ONLY for a path the extension list did not admit', () => {
+    // `twoModeReader` throws when a read it was told is STRICT cannot be served. A `.sh` file is in
+    // the population by its extension, so asking for it optionally would let a reader answer
+    // "nothing here" for a file that must be judged.
+    const read2 = twoModeReader(FIXTURE, new Set(['scripts/tools/rewrite.sh']));
+    expect(() => scanTrackedFiles(paths, read2)).toThrow(/strict read/);
+  });
+
+  it('refuses a strict read that came back empty, rather than skipping it', () => {
+    // A reader that returns nothing for an in-population file must not be silently obeyed.
+    const read2 = (file) => (file === 'scripts/tools/rewrite.sh' ? null : FIXTURE[file]);
+    expect(() => scanTrackedFiles(paths, read2)).toThrow(/A strict read must refuse, not skip/);
   });
 });

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -22,9 +22,10 @@
  * Exit 0 = clean, 1 = findings.
  */
 
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+
+import { enumerateFiles } from './enumerate-files.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 
@@ -86,13 +87,22 @@ const ALLOWED_FILES = new Set([
   '.claude/hooks/bulk-edit-guard.sh',
 ]);
 
+/**
+ * The population, delegated to `enumerate-files` — the single owner of "which files does a scan
+ * judge" (INFRA-121).
+ *
+ * This scan used to call `git ls-files` itself. That was one of eight such copies, and the cost was
+ * measured on this very change: a task document passed `reference-kind-qualified` before it was
+ * staged and failed after, because an unstaged file is outside an index-read population. The owner
+ * now includes `--others --exclude-standard`, so a file written and not yet staged is part of the
+ * tree its author is asking about.
+ *
+ * The index remains the right SOURCE here for the reason the header gives — `git ls-files` cannot
+ * return a `node_modules` path, and that is the property the whole rule rests on. What changed is
+ * that the choice has an owner and reports what it enumerated, instead of being made privately here.
+ */
 function trackedFiles() {
-  const out = execFileSync('git', ['ls-files', '-z'], {
-    cwd: WORKSPACE_ROOT,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  return out.split('\0').filter((entry) => entry.length > 0);
+  return enumerateFiles();
 }
 
 /**
@@ -123,9 +133,47 @@ function isCommentary(line) {
   );
 }
 
+/**
+ * An extensionless file is a script if it SAYS SO.
+ *
+ * Gating the population on the extension list alone made this repository's own `.husky/pre-commit`,
+ * `pre-push` and `commit-msg` — three of the fifty tracked extensionless files, and the only three
+ * that are scripts — invisible to a rule whose text claims committed scripts unqualified.
+ * `scan-shell-portability.mjs` had already replaced a list of directories with this same property in
+ * review of #1590, and states the reason: a property of the file beats a list of places the property
+ * is assumed to hold, because the list is what goes stale.
+ *
+ * The interpreters listed are exactly the ones `SCANNED_EXTENSIONS` also admits, and no more. A cut
+ * that added `ruby` and `perl` — which have no matching extension — judged the same script when
+ * written without one and ignored it when written as `sweep.rb`: two filters inside one file
+ * disagreeing about one population. Adding a language means adding both.
+ *
+ * `path.extname` returns '' for a leading-dot name, so `.bashrc` is shebang-tested rather than
+ * classified as carrying a `.bashrc` extension and then matching neither branch.
+ */
+/*
+ * Contained — INFRA-115. `dash`, `ksh` and `ash` are here with no matching entry in
+ * `SCANNED_EXTENSIONS`, so the paragraph above overstates: measured, `#!/bin/ksh` carrying a
+ * hazardous spelling is reported when the file is named `sweep` and clean when it is named
+ * `sweep.ksh` — the same file disagreeing with itself, which is the failure that paragraph names.
+ *
+ * The three names were copied verbatim out of `scan-shell-portability.mjs`, which carries the
+ * identical asymmetry, into the file whose comment cites that scan as the lesson. Aligning three
+ * names here would leave the first copy self-disagreeing, leave the invariant held in prose in both,
+ * and leave the next scan to hand-write a third pair. The predicate — is this committed file a
+ * script, and in what language — needs an owner, which is the item.
+ */
+const SHEBANG = /^#!.*\b(sh|bash|zsh|dash|ksh|ash|python[0-9.]*|node)\b/;
+
+function isScannedScript(relativePath, content) {
+  const extension = path.extname(relativePath);
+  if (SCANNED_EXTENSIONS.has(extension)) return true;
+  return extension === '' && SHEBANG.test(content);
+}
+
 export function findingsIn(relativePath, content) {
   if (ALLOWED_FILES.has(relativePath)) return [];
-  if (!SCANNED_EXTENSIONS.has(path.extname(relativePath))) return [];
+  if (!isScannedScript(relativePath, content)) return [];
 
   const findings = [];
   const lines = content.split('\n');
@@ -160,25 +208,57 @@ export function examinedScriptCount() {
  * The counter is RESET here rather than incremented from wherever it stood. A size that accumulates
  * across runs reads as a growing subject, which is the one way a declared measurement can be wrong
  * while every finding it reports is right.
+ *
+ * THE READER TAKES TWO ARGUMENTS: `(file, optional)`. An optional read is one this scan makes only
+ * to find out whether an extensionless file is a script at all, and the reader may answer `null` —
+ * a tracked symlink to a directory is one of the things that answers no. A read that is NOT optional
+ * is for a file the extension list already admitted, and the reader must refuse it rather than come
+ * back empty-handed; this function throws if one does, because skipping there is the invisibility
+ * the whole rule is about. A caller writing a reader reads this, not the loop below.
  */
 export function scanTrackedFiles(trackedPaths, readFile) {
   examinedScripts = 0;
   const findings = [];
   for (const file of trackedPaths) {
-    if (!SCANNED_EXTENSIONS.has(path.extname(file))) continue;
+    // The allowlist is applied HERE, before the counter, not only inside `findingsIn`. It used to be
+    // inside alone, so the files that describe the spellings were opened, counted, and then returned
+    // empty — the declared size and the judged population differing by a constant, which is what
+    // `measurement-provenance.md` clause 1 is about and what this file's own case asserts.
+    if (ALLOWED_FILES.has(file)) continue;
+    const extension = path.extname(file);
+    if (!SCANNED_EXTENSIONS.has(extension) && extension !== '') continue;
+    // Strictness is decided HERE, where the extension is already known, rather than left to whatever
+    // reader is injected. An extensionless file has to be READ to be classified, so only those fifty
+    // are opened at all, and that read is the optional one: a tracked extensionless path that cannot
+    // be read as text is one of the things "is this a script" answers no to (twelve symlinks to
+    // directories under `.claude/skills/` are tracked, so it is routine rather than an exception).
+    const optional = !SCANNED_EXTENSIONS.has(extension);
+    const content = readFile(file, optional);
+    if (content === null || content === undefined) {
+      if (!optional) {
+        throw new Error(
+          `symlink-following-enumeration: ${file} is in the population by its extension, but the ` +
+            `reader returned no content for it. A strict read must refuse, not skip.`,
+        );
+      }
+      continue;
+    }
+    if (!isScannedScript(file, content)) continue;
     examinedScripts += 1;
-    findings.push(...findingsIn(file, readFile(file)));
+    findings.push(...findingsIn(file, content));
   }
   return findings;
 }
 
 function main() {
-  const read = (file) => {
+  const read = (file, optional = false) => {
     try {
       return readFileSync(path.join(WORKSPACE_ROOT, file), 'utf8');
     } catch {
       // A tracked path that cannot be read is reported, not skipped: silence here would be the same
-      // invisibility the whole rule is about.
+      // invisibility the whole rule is about. `optional` is the one exception, and it is a
+      // CLASSIFICATION rather than a skip — see the contract on `scanTrackedFiles`.
+      if (optional) return null;
       console.error(`symlink-following-enumeration: could not read tracked file ${file}`);
       process.exit(1);
     }


### PR DESCRIPTION
Follow-up to #1886, which landed the bulk-edit guard. Four gaps survived that merge; each is measured against the code on `develop` and red-proofed alone.

## What this fixes

| behaviour | `develop` | here |
| --- | --- | --- |
| `echo x >\| node_modules/y` | permitted | refused |
| `Write` into the store with `BULK_EDIT_ACK=1` **exported** | refused — the escape the refusal advertises cannot be taken | permitted |
| scan sees `.husky/pre-commit`, `pre-push`, `commit-msg` | invisible | judged |
| `::examined::` versus the judged population | over by 4 | equal |

- **The noclobber redirect.** `>|` was the only miss across eight probed spellings.
- **The acknowledgement a file-writing tool can take.** A tool write runs no command, so the exported form is the only one it can carry, and the check sat below that branch's `exit 0`. It now sits in each branch *below that branch's own decode refusal* — above them, an unreadable payload became a permitted one, which is the direction the file's header declares against. The message names both forms and says the exported one stays armed until unset.
- **The scan's population.** Gating on an extension list made this repository's own git hooks invisible to a rule whose text claimed committed scripts without qualification. A shebang now decides, listing exactly the interpreters the extension set also admits so the two filters cannot disagree about one population.
- **The declared size, and the reader contract.** The allowlist is applied before the counter, so the size and the judged population are the same number. The injected reader's two-argument contract moved onto `scanTrackedFiles`, and a strict read that comes back empty now refuses instead of being skipped.

The population also **delegates to `enumerate-files`** rather than calling the index itself — one of the copies that owner exists to replace. It picks up untracked files as a result (3195 → 3207), which closes the incident behind INFRA-121: a file written and not yet staged is now part of the tree its author is asking about.

## What it deliberately does not fix

Five causes are filed and labelled at their sites rather than patched, under [finding-depth.md](.agents/rules/finding-depth.md). Two reach past this change into `develop`:

- **INFRA-109** (#1898) — flag attribution has two implementations; the hook and the scan disagree on six probed shapes.
- **INFRA-110** (#1899) — the write-path resolution hand-rolls canonicalization: `CDPATH` fails open, `..` past a missing segment is unnormalised, a symlinked *file* into the store is permitted.
- **INFRA-111** (#1903) — no owner for "what does this redirect write to": the `>&` family walks through, and `branch-guard.sh` hand-rolls the same question with a *different* hole set.
- **INFRA-115** (#1912) — `dash`/`ksh`/`ash` are admitted by shebang with no matching extension, so one script is judged under one filename and clean under another.
- **INFRA-123** (#1919) — records a **withdrawal**, not a defect. Reading python's import spelling at the command needs to know whose language a line is in; every reader this hook has expands an interpreter payload, so the payload's own separators become the shell's. Three cuts were tried and each refused a correct command, so the widening was withdrawn rather than shipped unenforced. This repository has zero tracked `.py` files, so a file-scoped rule would have judged an empty population while the rule table claimed it was enforced.

Four further causes this work filed are **absent here**: they were picked up and finished on `develop` while this change was in review — two of them (`enumerate-files.mjs`, `scan-hook-override-declarations.mjs`) citing these issue numbers in their own headers. Their records live there, and the duplicates are withdrawn.

## Verification

Six local review rounds; findings per round 4, 4, 5, 4, 2, 2 → 0. Every fix red-proofed individually — reverting its own line fails exactly its own case, and no more.

`pnpm harness:scan` — 127 passed, 2 skipped. Harness tier green.

Four rounds found a defect the previous round's fix had introduced (a permissive path, a silent coverage loss, a payload separator ending attribution, then the same bug on three other characters). Each is recorded in the commit that corrected it.
