### PR TITLE
feat(packages): typecheck the examples directory CI already executes (INFRA-124)

### DIFF
--- a/.agents/tasks/INFRA-124-examples-are-typechecked-by-nobody.md
+++ b/.agents/tasks/INFRA-124-examples-are-typechecked-by-nobody.md
@@ -1,0 +1,91 @@
+---
+title: 'INFRA-124: packages/*/examples was read by no typechecker, so a breaking signature change landed green'
+status: in-progress
+created: 2026-08-20
+priority: high
+urgency: now
+area: packages
+depends_on: []
+---
+
+# INFRA-124: the compiler reads the directory CI executes
+
+## Objective
+
+Issue #1902. `packages/*/examples/` was typechecked by nobody. Nine packages carry such a directory,
+and several hold executable scenario verifiers wired into `scenario:verify`, which `quality` runs as a
+required check. So CI EXECUTED that code while the compiler never read it — the worst of both: it can
+break the gate, and the gate that would have caught it at compile time did not look.
+
+## The measurement the issue asked for, taken properly
+
+Issue #1902 said the blast radius had to be measured against a full declaration build before the shape
+could be chosen, and recorded that my first probe was untrustworthy — it was dominated by `TS7016`
+because an ad-hoc config did not reproduce the workspace's `exports`/type resolution.
+
+Taken again after `pnpm build`, with each package's own `tsconfig.json` extended rather than replaced:
+
+| package                                                                                                  | errors |
+| -------------------------------------------------------------------------------------------------------- | ------ |
+| agent-command                                                                                            | 2      |
+| agent-core                                                                                               | 3      |
+| agent-session                                                                                            | 8      |
+| agent-executor, agent-framework, agent-product, agent-transport, agent-transport-tui, agent-transport-ws | 0 each |
+
+**Thirteen, not hundreds.** The earlier estimate was wrong by orders of magnitude, and wrong in the
+direction that would have justified deferring this.
+
+Two of the thirteen were configuration rather than code: `agent-core` genuinely imports `../src/*.ts`
+by extension because `tsx` runs its source directly, so that package's config enables
+`allowImportingTsExtensions` rather than the examples being rewritten to lie about how they run.
+
+## What the other eleven were
+
+Every one a real defect a reader would have wanted to know about:
+
+- **`TDirectSession` read `.session` off a `Promise`.** ARCH-035 made `createSession` async; INFRA-119
+  awaited the CALL and left this alias one line over, resolving to `never` in silence. The same
+  defect, in the same file, surviving the fix for it — because nothing typechecked the directory.
+- **A command descriptor omitted `userInvocable`**, which `ICapabilityDescriptor` requires.
+- **Five message literals omitted `id` and `state`**, which `IBaseMessage` requires.
+- **Three terminal stubs omitted `writeError`, `prompt` and `select`**, which `ITerminalOutput`
+  requires. The `select` signature was read from the contract rather than guessed — my first stub had
+  a plausible generic shape the interface does not use.
+
+## Approach
+
+Each package gains a `tsconfig.examples.json` extending its own config, and its `typecheck` script
+runs it. Wiring into the EXISTING gate rather than adding a new one: `quality` already runs
+`typecheck` per affected package, so no workflow changes and no second thing to remember.
+
+`rootDir` is the reason a separate config is needed at all — the package config sets it to `src` with
+`declaration: true`, and widening `include` to `examples` conflicts with both.
+
+## Plan
+
+- [x] TC-01: measured all nine packages against a real declaration build — 13 errors, not the
+      untrustworthy earlier figure.
+- [x] TC-02: every error fixed, or its configuration cause named (`allowImportingTsExtensions`).
+- [x] TC-03: all nine packages typecheck their examples at zero.
+- [x] TC-04: `scenario:verify` still passes — the edits are type-level, and the behaviour is unchanged.
+- [x] TC-05: reintroducing the INFRA-119 defect is caught at TYPECHECK time, not scenario runtime —
+      the issue's definition of done, verified by actually reintroducing it.
+- [ ] TC-06: `pnpm harness:pre-push` green.
+
+## Test Plan
+
+The compiler is the test. What needs proving is that it now READS this directory, which a passing
+typecheck cannot show on its own — a config that included nothing would also pass.
+
+So the proof is the red-proof: dropping the `await` that INFRA-119 added produces
+`Property 'session' does not exist on type 'Promise<ICreateSessionResult>'` from `pnpm typecheck`,
+where before this change it produced nothing until the scenario ran and threw two frames away.
+
+## Progress
+
+### 2026-08-20
+
+Filed as issue #1902 from INFRA-119, where the gap let a sync-to-async signature change land green.
+The count came in an order of magnitude under the earlier estimate, which is worth recording: the
+first probe's noise was an artefact of how it was taken, and had it been believed this would have been
+deferred as a nine-package migration rather than done as a thirteen-error fix.

--- a/packages/agent-command/examples/semantic-command-role-scenario-helpers.ts
+++ b/packages/agent-command/examples/semantic-command-role-scenario-helpers.ts
@@ -13,7 +13,10 @@ import {
   type ISystemCommandSemanticRoles,
 } from '@robota-sdk/agent-framework';
 
-export type TDirectSession = ReturnType<typeof createSession>['session'];
+// ARCH-035 made `createSession` async, so its ReturnType is a Promise. INFRA-119 awaited the CALL and
+// left this alias reading `.session` off the promise — a `never`, silently, because nothing typechecked
+// this directory. It is the same defect one line over, and the reason issue #1902 exists.
+export type TDirectSession = Awaited<ReturnType<typeof createSession>>['session'];
 export type TSubagentSession = ReturnType<typeof createSubagentSession>;
 
 export const config: IResolvedConfig = {
@@ -69,6 +72,7 @@ export async function readSystemMessage(
         name: commandName,
         kind: 'builtin-command',
         description: 'Activate a skill',
+        userInvocable: true,
         modelInvocable: true,
       },
     ],

--- a/packages/agent-command/package.json
+++ b/packages/agent-command/package.json
@@ -27,7 +27,7 @@
     "build": "tsdown",
     "build:js": "tsdown --no-dts",
     "build:types": "tsdown --dts",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "scenario:verify": "pnpm scenario:verify:semantic-command-roles",

--- a/packages/agent-command/tsconfig.examples.json
+++ b/packages/agent-command/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-core/examples/verify-offline.ts
+++ b/packages/agent-core/examples/verify-offline.ts
@@ -25,9 +25,13 @@ class MockAIProvider extends AbstractAIProvider {
     options?.onTextDelta?.(content);
 
     return {
+      // `IBaseMessage` requires `id` and `state`; this literal predates both and only compiled
+      // because nothing typechecked this directory (issue #1902).
+      id: `offline-${Date.now()}`,
       role: 'assistant',
       content: `offline:${content}`,
       timestamp: new Date(),
+      state: 'complete',
     };
   }
 }

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -71,7 +71,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src --ext .ts,.tsx",
-    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "typecheck": "tsgo -p tsconfig.json --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "scenario:verify": "pnpm exec tsx examples/verify-offline.ts",
     "scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-core --output examples/scenarios/offline-verify.record.json -- pnpm scenario:verify",

--- a/packages/agent-core/tsconfig.examples.json
+++ b/packages/agent-core/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-executor/package.json
+++ b/packages/agent-executor/package.json
@@ -44,7 +44,7 @@
     "scenario:verify": "pnpm exec tsx --conditions=source examples/verify-shell-resolution-contract.ts",
     "scenario:verify:windows-shell": "pnpm exec tsx --conditions=source examples/verify-windows-shell-runners.ts",
     "scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-executor --output examples/scenarios/shell-resolution-contract.record.json -- pnpm scenario:verify",
-    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "typecheck": "tsgo -p tsconfig.json --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "lint": "eslint src --ext .ts",
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"
   },

--- a/packages/agent-executor/tsconfig.examples.json
+++ b/packages/agent-executor/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-framework/package.json
+++ b/packages/agent-framework/package.json
@@ -53,7 +53,7 @@
     "scenario:verify:runtime-session-store": "pnpm exec tsx --conditions=source examples/verify-agent-runtime-session-store.ts",
     "scenario:verify:prompt-resolution": "pnpm exec tsx --conditions=source examples/verify-prompt-request-resolution.ts",
     "scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-framework --output examples/scenarios/framework-offline-scenarios.record.json -- pnpm scenario:verify",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "lint": "eslint src/ --ext .ts",
     "clean": "rimraf dist",
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh",

--- a/packages/agent-framework/tsconfig.examples.json
+++ b/packages/agent-framework/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-product/package.json
+++ b/packages/agent-product/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robota-sdk/agent-product",
   "version": "3.0.0-beta.79",
-  "description": "The product-assembly kernel for the Robota SDK: assembleProduct — a pure, IO-free fold over IProductProfile that delegates runtime construction to agent-framework",
+  "description": "The product-assembly kernel for the Robota SDK: assembleProduct \u2014 a pure, IO-free fold over IProductProfile that delegates runtime construction to agent-framework",
   "type": "module",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",
@@ -39,7 +39,7 @@
     "scenario:verify": "pnpm scenario:verify:composition-contract",
     "scenario:verify:composition-contract": "pnpm exec tsx --conditions=source examples/verify-composition-contract.ts",
     "scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-product --output examples/scenarios/composition-contract.record.json -- pnpm scenario:verify",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "lint": "eslint src/ --ext .ts",
     "clean": "rimraf dist",
     "prepublishOnly": "bash ../../scripts/check-pnpm-publish.sh"

--- a/packages/agent-product/tsconfig.examples.json
+++ b/packages/agent-product/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-session/examples/verify-compaction-contract.ts
+++ b/packages/agent-session/examples/verify-compaction-contract.ts
@@ -41,9 +41,11 @@ class OfflineCompactionProvider extends AbstractAIProvider {
     _options?: IChatOptions,
   ): Promise<TUniversalMessage> {
     return {
+      id: `example-${Date.now()}-1`,
       role: 'assistant',
       content: 'deterministic compact summary',
       timestamp: new Date('2026-08-15T00:00:00.000Z'),
+      state: 'complete',
     };
   }
 
@@ -56,6 +58,15 @@ class OfflineCompactionProvider extends AbstractAIProvider {
 }
 
 const silentTerminal: ITerminalOutput = {
+  writeError(_text: string): void {},
+  async prompt(): Promise<string> {
+    // A silent example terminal answers nothing rather than blocking; `ITerminalOutput` requires the
+    // member, and a stub that omitted it only compiled because nothing typechecked this directory.
+    return '';
+  },
+  async select(_options: string[], initialIndex = 0): Promise<number> {
+    return initialIndex;
+  },
   write(): void {},
   writeLine(): void {},
   writeMarkdown(): void {},

--- a/packages/agent-session/examples/verify-offline.ts
+++ b/packages/agent-session/examples/verify-offline.ts
@@ -15,9 +15,11 @@ class MockAIProvider extends AbstractAIProvider {
     const content = typeof last?.content === 'string' ? last.content : '';
 
     return {
+      id: `example-${Date.now()}-2`,
       role: 'assistant',
       content: `session:${content}`,
       timestamp: new Date(),
+      state: 'complete',
     };
   }
 
@@ -26,14 +28,25 @@ class MockAIProvider extends AbstractAIProvider {
     _options?: IChatOptions,
   ): AsyncIterable<TUniversalMessage> {
     yield {
+      id: `example-${Date.now()}-3`,
       role: 'assistant',
       content: 'session-stream',
       timestamp: new Date(),
+      state: 'complete',
     };
   }
 }
 
 const silentTerminal: ITerminalOutput = {
+  writeError(_text: string): void {},
+  async prompt(): Promise<string> {
+    // A silent example terminal answers nothing rather than blocking; `ITerminalOutput` requires the
+    // member, and a stub that omitted it only compiled because nothing typechecked this directory.
+    return '';
+  },
+  async select(_options: string[], initialIndex = 0): Promise<number> {
+    return initialIndex;
+  },
   write(_text: string): void {},
   writeLine(_text: string): void {},
   writeMarkdown(_md: string): void {},

--- a/packages/agent-session/examples/verify-session-record-field-preservation.ts
+++ b/packages/agent-session/examples/verify-session-record-field-preservation.ts
@@ -43,9 +43,11 @@ class OfflineProvider extends AbstractAIProvider {
   ): Promise<TUniversalMessage> {
     const content = messages.at(-1)?.content;
     return {
+      id: `example-${Date.now()}-4`,
       role: 'assistant',
       content: `arch-015:${typeof content === 'string' ? content : ''}`,
       timestamp: new Date(),
+      state: 'complete',
     };
   }
 
@@ -58,6 +60,15 @@ class OfflineProvider extends AbstractAIProvider {
 }
 
 const silentTerminal: ITerminalOutput = {
+  writeError(_text: string): void {},
+  async prompt(): Promise<string> {
+    // A silent example terminal answers nothing rather than blocking; `ITerminalOutput` requires the
+    // member, and a stub that omitted it only compiled because nothing typechecked this directory.
+    return '';
+  },
+  async select(_options: string[], initialIndex = 0): Promise<number> {
+    return initialIndex;
+  },
   write(): void {},
   writeLine(): void {},
   writeMarkdown(): void {},
@@ -96,7 +107,15 @@ function createExistingRecord(): IInteractiveSessionRecord {
     cwd: '/stale/session',
     createdAt: CREATED_AT,
     updatedAt: STALE_UPDATED_AT,
-    messages: [{ role: 'user', content: 'stale message' }],
+    messages: [
+      {
+        id: `example-${Date.now()}-5`,
+        role: 'user',
+        content: 'stale message',
+        timestamp: new Date(STALE_UPDATED_AT),
+        state: 'complete',
+      },
+    ],
     history: [
       {
         id: 'stale-history',

--- a/packages/agent-session/package.json
+++ b/packages/agent-session/package.json
@@ -44,7 +44,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src --ext .ts,.tsx",
-    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "typecheck": "tsgo -p tsconfig.json --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "scenario:verify": "pnpm exec tsx --conditions=source examples/verify-offline.ts && pnpm exec tsx --conditions=source examples/verify-session-record-field-preservation.ts && pnpm exec tsx --conditions=source examples/verify-compaction-contract.ts",
     "scenario:record": "node ../../scripts/harness/record-owner-scenario.mjs --scope packages/agent-session --output examples/scenarios/offline-verify.record.json -- pnpm scenario:verify",

--- a/packages/agent-session/tsconfig.examples.json
+++ b/packages/agent-session/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-transport-tui/package.json
+++ b/packages/agent-transport-tui/package.json
@@ -38,7 +38,7 @@
     "build": "tsdown",
     "build:js": "tsdown --no-dts",
     "build:types": "tsdown --dts",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "scenario:verify": "pnpm exec tsx --conditions=source examples/verify-session-event-rendering.ts",

--- a/packages/agent-transport-tui/tsconfig.examples.json
+++ b/packages/agent-transport-tui/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-transport-ws/package.json
+++ b/packages/agent-transport-ws/package.json
@@ -38,7 +38,7 @@
     "build": "tsdown",
     "build:js": "tsdown --no-dts",
     "build:types": "tsdown --dts",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "clean": "rimraf dist",

--- a/packages/agent-transport-ws/tsconfig.examples.json
+++ b/packages/agent-transport-ws/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}

--- a/packages/agent-transport/package.json
+++ b/packages/agent-transport/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robota-sdk/agent-transport",
   "version": "3.0.0-beta.79",
-  "description": "Core transport package for Robota SDK — headless adapter, scripted-provider testing fixtures, and the transport registry",
+  "description": "Core transport package for Robota SDK \u2014 headless adapter, scripted-provider testing fixtures, and the transport registry",
   "type": "module",
   "main": "dist/node/index.js",
   "types": "dist/node/index.d.ts",
@@ -74,7 +74,7 @@
     "build": "tsdown",
     "build:js": "tsdown --no-dts",
     "build:types": "tsdown --dts",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo -p tsconfig.examples.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage --passWithNoTests",
     "scenario:verify": "pnpm exec tsx --conditions=source examples/verify-session-event-delivery.ts",

--- a/packages/agent-transport/tsconfig.examples.json
+++ b/packages/agent-transport/tsconfig.examples.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "typeRoots": ["./node_modules/@types", "../../node_modules/@types"]
+  },
+  "include": ["examples/**/*", "src/**/*"]
+}


### PR DESCRIPTION
## The defect

`packages/*/examples/` was read by no typechecker. Nine packages carry such a directory, and several hold executable scenario verifiers wired into `scenario:verify`, which `quality` runs as a **required** check.

So CI executed that code while the compiler never looked at it — the worst of both. It could break the gate, and the gate that would have caught it at compile time did not read it.

## The measurement that decided the shape

Issue #1902 said the blast radius had to be measured against a full declaration build before the shape could be chosen, and recorded that my first probe was untrustworthy. Taken again after a real build, extending each package's own config rather than replacing it: **thirteen errors, not the hundreds the noisy probe implied.**

Wrong by orders of magnitude, and wrong in the direction that would have justified deferring this as a nine-package migration. That is why the issue asked for the second measurement.

Two of the thirteen were configuration rather than code: `agent-core` genuinely imports `../src/*.ts` by extension because tsx runs its source directly, so that package enables `allowImportingTsExtensions` rather than its examples being rewritten to lie about how they run.

## Red-proof

Injecting a type error into `packages/agent-session/examples/verify-offline.ts`:

```
examples/verify-offline.ts(79,7): error TS2322: Type 'string' is not assignable to type 'number'.
```

Before this change that file compiled against nothing. The probe was reverted and the revert verified by re-reading the file and re-running the typecheck, not assumed — a revert in this repo has silently failed before.

## Verification

Workspace typecheck clean across all packages, on a tree rebased onto current `develop`.

Closes #1902

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPig8uCgp1ryvt9BVeTz91
