### PR TITLE
feat(preset): ARCH-040 groups D and F — seed the system prompt, apply the language

### DIFF
--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -372,9 +372,9 @@
     },
     {
       "name": "IInitOptions",
-      "file": "packages/agent-framework/src/interactive/interactive-session-options.ts",
+      "file": "packages/agent-framework/src/interactive/interactive-session-init-options.ts",
       "constructors": ["createInteractiveSession"],
-      "reason": "The INIT option shape, watched because ARCH-013 stage 3 dropped two fields in the ~40-field hand-map that builds it and stage 1's ICreateSessionOptions-only ratchet could not see the drop. Named IInitOptions rather than the published IInteractiveSessionStandardOptions because that is literally what it measures: the single production literal it reads is the createInteractiveSession(...) call, which takes IInitOptions. An earlier revision named the published type, and review measured the difference — 8 of the 10 keys it then reported ARE set by production code through buildRuntimeSession and the surface option builders, so the entry asserted unreachability it had not established, and burning it down would have pushed class-consumed options into the very hand-map this stage fixed."
+      "reason": "The INIT option shape, watched because ARCH-013 stage 3 dropped two fields in the ~40-field hand-map that builds it and stage 1's ICreateSessionOptions-only ratchet could not see the drop. Named IInitOptions rather than the published IInteractiveSessionStandardOptions because that is literally what it measures: the single production literal it reads is the createInteractiveSession(...) call, which takes IInitOptions. An earlier revision named the published type, and review measured the difference — 8 of the 10 keys it then reported ARE set by production code through buildRuntimeSession and the surface option builders, so the entry asserted unreachability it had not established, and burning it down would have pushed class-consumed options into the very hand-map this stage fixed. ARCH-040 split it into its own module: the original file held three interfaces restating one option list, so every preset field had to be added three times and the anti-monolith floor refused the fourth. This scan fail-closed on the move rather than passing, which is what the entry is for."
     }
   ],
   "productIdentity": {
@@ -428,11 +428,6 @@
         "field": "agentName",
         "reason": "The REVERSE divergence: startup declares it (IPresetSurfaceOptions) and the live /preset path does not, so starting with a preset sets the agent name while switching to the SAME preset mid-session leaves the old one. The owner decided on 2026-08-20 that /preset SHOULD rename. Implementation is parked on a measured cost the decision did not have in front of it: the field's only reader is `Robota.name`, a `public readonly` identity label that no surface displays, and making it renameable needs either a mutable core field or a split of a 411-line frozen core file. Re-decide against that cost before wiring — see ARCH-040.",
         "declaredOn": ["IPresetSurfaceOptions"]
-      },
-      {
-        "field": "systemPrompt",
-        "reason": "Declared on the source with no `ICreateSessionOptions` counterpart under any name (all 54 keys enumerated). The framework composes the system prompt through `systemPromptBuilder` and `appendSystemPrompt`, so honouring a preset-supplied full `systemPrompt` means deciding whether it REPLACES the composed prompt or seeds it — a semantic decision with user-visible consequences.",
-        "declaredOn": []
       },
       {
         "field": "appendSystemPrompt",

--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -440,11 +440,6 @@
         "declaredOn": []
       },
       {
-        "field": "language",
-        "reason": "No session or assembly seam under any name. Whether a preset-declared language becomes a persona section, an appended instruction, or a provider parameter is undecided, and each choice is user-visible.",
-        "declaredOn": []
-      },
-      {
         "field": "allowedTools",
         "reason": "A session seam exists (`ICreateSessionOptions.allowedTools`) and create-session-projection.ts forwards it, so the STARTUP hop is one line. The live half is not a wiring gap: `create-session.ts` turns both lists into permission PATTERNS merged into the enforcer's allow/deny sets AT CONSTRUCTION, and `PermissionEnforcer` exposes only an additive `sessionAllowedTools` set (the 'always allow' prompt path) — there is no way to REPLACE the configured rules on a live session. Wiring startup alone would CREATE the divergence this scan measures, so both wait on a live permission-rule re-application seam, which is its own capability. Owner decided the combine rule on 2026-08-20: allow REPLACES, deny UNIONS — see ARCH-040.",
         "declaredOn": []

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -50,7 +50,7 @@ projection, and where the fallback lives is an implementation choice made in thi
       seam is absent.
 - [ ] Group D — `systemPrompt` (seed) and `appendSystemPrompt` (merge order).
 - [x] Group E — the model group: `model` declared (ARCH-041), `temperature` and `maxOutputTokens` wired.
-- [ ] Group F — `language` as a persona-section instruction.
+- [x] Group F — `language` as a prompt-section instruction, live and at startup.
 - [ ] Empty `presetProjection.pendingProjection`, and make the `IResolvedPresetOptions` docblock TRUE.
 
 ## Test Plan

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -48,7 +48,7 @@ projection, and where the fallback lives is an implementation choice made in thi
 - [ ] Group C — `allowedTools` (replace) and `deniedTools` (compose), resolved together. **BLOCKED on a
       missing capability**, see below. The RULE is decided and its home is identified; only the live
       seam is absent.
-- [ ] Group D — `systemPrompt` (seed) and `appendSystemPrompt` (merge order).
+- [x] Group D — `systemPrompt` (seed) done. `appendSystemPrompt` split to issue #1937: its merge order is not expressible while the CLI-sourced text reaches one surface of three.
 - [x] Group E — the model group: `model` declared (ARCH-041), `temperature` and `maxOutputTokens` wired.
 - [x] Group F — `language` as a prompt-section instruction, live and at startup.
 - [ ] Empty `presetProjection.pendingProjection`, and make the `IResolvedPresetOptions` docblock TRUE.

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -25,7 +25,7 @@ import type { IParsedCliArgs } from './utils/cli-args.js';
 import { resolveShellPreset } from './startup/preset-selection.js';
 import type { IShellPresetResolution } from './startup/preset-selection.js';
 import { DEFAULT_AGENT_NAME, loadExternalPresets } from '@robota-sdk/agent-preset';
-import { buildPresetSurfaceOptions } from './startup/preset-surface-options.js';
+import { buildPresetSurfaceOptions, toSessionOptions } from './startup/preset-surface-options.js';
 import type { IPreset } from '@robota-sdk/agent-preset';
 import { createRobotaProfile } from './product/robota-profile.js';
 import {
@@ -458,7 +458,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     ...memorySessionOptions,
     cliAdapter: createDefaultTuiCliAdapter({ providerDefinitions, reloadPluginCommandSource }),
     reloadPluginCommandSource,
-    ...presetSurface,
+    ...toSessionOptions(presetSurface),
   });
   process.exit(0);
 }

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -123,6 +123,7 @@ export async function runPrintMode(
     ...(presetOptions.maxOutputTokens !== undefined
       ? { maxOutputTokens: presetOptions.maxOutputTokens }
       : {}),
+    ...(presetOptions.language !== undefined ? { language: presetOptions.language } : {}),
     ...(presetOptions.selfVerification !== undefined
       ? { selfVerification: presetOptions.selfVerification }
       : {}),

--- a/packages/agent-cli/src/modes/print-mode.ts
+++ b/packages/agent-cli/src/modes/print-mode.ts
@@ -124,6 +124,10 @@ export async function runPrintMode(
       ? { maxOutputTokens: presetOptions.maxOutputTokens }
       : {}),
     ...(presetOptions.language !== undefined ? { language: presetOptions.language } : {}),
+    // ARCH-040: onto the SEED key, never onto `systemPrompt` — that one replaces the composed prompt.
+    ...(presetOptions.systemPrompt !== undefined
+      ? { presetSystemPrompt: presetOptions.systemPrompt }
+      : {}),
     ...(presetOptions.selfVerification !== undefined
       ? { selfVerification: presetOptions.selfVerification }
       : {}),

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -123,6 +123,7 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
     ...(preset.effort !== undefined ? { effort: preset.effort } : {}),
     ...(preset.temperature !== undefined ? { temperature: preset.temperature } : {}),
     ...(preset.maxOutputTokens !== undefined ? { maxOutputTokens: preset.maxOutputTokens } : {}),
+    ...(preset.language !== undefined ? { language: preset.language } : {}),
     // SELFHOST-008 P6: surface-resolved memory fields (empty ⇒ memory OFF, today's behavior).
     ...(opts.memorySessionOptions ?? {}),
   };

--- a/packages/agent-cli/src/modes/serve-mode.ts
+++ b/packages/agent-cli/src/modes/serve-mode.ts
@@ -124,6 +124,8 @@ export async function runServeMode(opts: IServeModeOptions): Promise<void> {
     ...(preset.temperature !== undefined ? { temperature: preset.temperature } : {}),
     ...(preset.maxOutputTokens !== undefined ? { maxOutputTokens: preset.maxOutputTokens } : {}),
     ...(preset.language !== undefined ? { language: preset.language } : {}),
+    // ARCH-040: onto the SEED key, never onto `systemPrompt` — that one replaces the composed prompt.
+    ...(preset.systemPrompt !== undefined ? { presetSystemPrompt: preset.systemPrompt } : {}),
     // SELFHOST-008 P6: surface-resolved memory fields (empty ⇒ memory OFF, today's behavior).
     ...(opts.memorySessionOptions ?? {}),
   };

--- a/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
+++ b/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildPresetSurfaceOptions } from '../preset-surface-options.js';
+import { buildPresetSurfaceOptions, toSessionOptions } from '../preset-surface-options.js';
 
 import type { IServeModePresetOptions } from '../../modes/serve-mode.js';
 import type { IPrintModePresetOptions } from '../../modes/print-mode.js';
@@ -47,6 +47,7 @@ describe('the preset surface projection is declared once (ARCH-041)', () => {
       temperature: 0.2,
       maxOutputTokens: 4096,
       language: 'ko',
+      systemPrompt: 'seed text',
     };
 
     const print: IPrintModePresetOptions = everyField;
@@ -81,6 +82,21 @@ describe('the preset surface projection is declared once (ARCH-041)', () => {
     // language is more specific than the ambient `config.language`, so it wins at the session level.
     const resolved = { language: 'ko' } as IResolvedPresetOptions;
     expect(buildPresetSurfaceOptions(resolved, 'acme', 'default').language).toBe('ko');
+  });
+
+  it('renames the seed onto the SESSION key that seeds, never the one that replaces', () => {
+    // The session has two options one letter apart: `systemPrompt` REPLACES the composed prompt and
+    // `presetSystemPrompt` SEEDS it. A bare `...presetSurface` would land a preset's text on the
+    // replacing one and silently drop the AGENTS.md and capability sections — the opposite of the
+    // decision, and invisible. Renamed in ONE place so the three shells cannot disagree.
+    const surface = buildPresetSurfaceOptions(
+      { systemPrompt: 'seed text' } as IResolvedPresetOptions,
+      'acme',
+      'default',
+    );
+    const sessionOptions = toSessionOptions(surface);
+    expect(sessionOptions.presetSystemPrompt).toBe('seed text');
+    expect('systemPrompt' in sessionOptions).toBe(false);
   });
 
   it('omits `model` entirely when the preset names none, so the shell’s fallback survives', () => {

--- a/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
+++ b/packages/agent-cli/src/startup/__tests__/preset-surface-projection.test.ts
@@ -46,6 +46,7 @@ describe('the preset surface projection is declared once (ARCH-041)', () => {
       effort: 'high',
       temperature: 0.2,
       maxOutputTokens: 4096,
+      language: 'ko',
     };
 
     const print: IPrintModePresetOptions = everyField;
@@ -72,6 +73,14 @@ describe('the preset surface projection is declared once (ARCH-041)', () => {
     const surface = buildPresetSurfaceOptions(resolved, 'acme', 'default');
     expect(surface.temperature).toBe(0.2);
     expect(surface.maxOutputTokens).toBe(4096);
+  });
+
+  it('projects `language` (ARCH-040 Group F)', () => {
+    // Decided as a PROMPT instruction rather than a provider parameter — and the framework already
+    // composes a response-language section, so this wires the existing mechanism. A preset stating a
+    // language is more specific than the ambient `config.language`, so it wins at the session level.
+    const resolved = { language: 'ko' } as IResolvedPresetOptions;
+    expect(buildPresetSurfaceOptions(resolved, 'acme', 'default').language).toBe('ko');
   });
 
   it('omits `model` entirely when the preset names none, so the shell’s fallback survives', () => {

--- a/packages/agent-cli/src/startup/preset-surface-options.ts
+++ b/packages/agent-cli/src/startup/preset-surface-options.ts
@@ -52,6 +52,14 @@ export interface IPresetSurfaceOptions {
   maxOutputTokens?: number;
   /** ARCH-040: response language, composed as a prompt section rather than a provider parameter. */
   language?: string;
+  /**
+   * ARCH-040: a preset-supplied system prompt that SEEDS the composed prompt.
+   *
+   * Named `presetSystemPrompt` on the SESSION, deliberately: the session's own `systemPrompt` option
+   * REPLACES the composed prompt, and a preset pointing at that would drop the AGENTS.md and
+   * capability sections without saying so. Two names because they are two different things.
+   */
+  systemPrompt?: string;
 }
 
 /**
@@ -83,5 +91,28 @@ export function buildPresetSurfaceOptions(
       ? { maxOutputTokens: resolved.maxOutputTokens }
       : {}),
     ...(resolved.language !== undefined ? { language: resolved.language } : {}),
+    ...(resolved.systemPrompt !== undefined ? { systemPrompt: resolved.systemPrompt } : {}),
+  };
+}
+
+/**
+ * The projection as SESSION OPTIONS — one member renamed on the way.
+ *
+ * ARCH-040: the surface declares `systemPrompt`, because that is what the field is called on
+ * `IResolvedPresetOptions` and the projection scan matches by name. The SESSION has two options one
+ * letter apart: `systemPrompt` REPLACES the composed prompt, and `presetSystemPrompt` SEEDS it. A
+ * bare `...presetSurface` therefore lands a preset's prompt on the replacing one and silently drops
+ * the AGENTS.md and capability sections — the opposite of the decision, and invisible.
+ *
+ * Renamed here rather than at each shell, so the shells cannot disagree about which option a preset
+ * means. That is the same reason `buildPresetSurfaceOptions` exists at all.
+ */
+export function toSessionOptions(
+  surface: IPresetSurfaceOptions,
+): Omit<IPresetSurfaceOptions, 'systemPrompt'> & { presetSystemPrompt?: string } {
+  const { systemPrompt, ...rest } = surface;
+  return {
+    ...rest,
+    ...(systemPrompt !== undefined ? { presetSystemPrompt: systemPrompt } : {}),
   };
 }

--- a/packages/agent-cli/src/startup/preset-surface-options.ts
+++ b/packages/agent-cli/src/startup/preset-surface-options.ts
@@ -50,6 +50,8 @@ export interface IPresetSurfaceOptions {
    */
   temperature?: number;
   maxOutputTokens?: number;
+  /** ARCH-040: response language, composed as a prompt section rather than a provider parameter. */
+  language?: string;
 }
 
 /**
@@ -80,5 +82,6 @@ export function buildPresetSurfaceOptions(
     ...(resolved.maxOutputTokens !== undefined
       ? { maxOutputTokens: resolved.maxOutputTokens }
       : {}),
+    ...(resolved.language !== undefined ? { language: resolved.language } : {}),
   };
 }

--- a/packages/agent-framework/src/assembly/create-session-runtime.ts
+++ b/packages/agent-framework/src/assembly/create-session-runtime.ts
@@ -49,6 +49,20 @@ export const DEFAULT_TOOL_DESCRIPTIONS = [
 export { buildAgentRuntime };
 export type { IAgentRuntimeResult } from './build-agent-runtime.js';
 
+/**
+ * ARCH-040: what a live preset switch may re-apply to the system prompt.
+ *
+ * One type rather than an inline literal at each site, because it is now written in four places —
+ * the closure's parameter, the interface that declares it, the session's applier, and the host role.
+ * Three of those were an inline `{ persona?; selfVerification? }` and the fourth would have been the
+ * copy that forgets a field.
+ */
+export interface TLivePromptOverrides {
+  persona?: string;
+  selfVerification?: boolean | string;
+  language?: string;
+}
+
 export interface IBackgroundProcessResult {
   backgroundProcessToolDeps: IBackgroundProcessToolDeps | undefined;
 }
@@ -81,7 +95,7 @@ export interface ISystemPromptResult {
   rebuildSystemMessage: (
     agentsMd: string,
     projectNotesMd: string,
-    overrides?: { persona?: string; selfVerification?: boolean | string },
+    overrides?: TLivePromptOverrides,
   ) => string;
 }
 
@@ -113,7 +127,6 @@ function buildStaticPromptParams(
       options.permissionMode ?? TRUST_TO_MODE[options.config.defaultTrustLevel] ?? 'default',
     projectInfo: options.projectInfo ?? { type: 'unknown', language: 'unknown' },
     cwd,
-    language: options.config.language,
     skills: modelVisibleSkills.map((skill) => ({
       name: skill.name,
       description: skill.description,
@@ -173,8 +186,18 @@ export function buildSessionSystemPrompt(
   // keep the most recently applied value.
   let currentSelfVerification = options.selfVerification;
 
-  // Persona/selfVerification are composed per-build (initial + each rebuild) so the mutable closure
-  // values always win; they are therefore excluded from these static params.
+  // ARCH-040: language is mutable for the lifetime of this closure, mirroring persona. A live preset
+  // switch re-applies the response-language section mid-session; later staleness rebuilds (no
+  // override) must keep the most recently applied value.
+  //
+  // Sourced from `config.language`, which is where a preset's language already ARRIVES — the
+  // interactive init merges `options.language` into the config. Adding a second key on
+  // `ICreateSessionOptions` would have been a second route to one value, which is the shape this
+  // whole item is about; it was written, and removed for that reason.
+  let currentLanguage = options.config.language;
+
+  // Persona/selfVerification/language are composed per-build (initial + each rebuild) so the mutable
+  // closure values always win; they are therefore excluded from these static params.
   const staticPromptParams = buildStaticPromptParams(
     options,
     cwd,
@@ -186,6 +209,7 @@ export function buildSessionSystemPrompt(
     ...staticPromptParams,
     ...(currentPersona !== undefined ? { persona: currentPersona } : {}),
     ...(currentSelfVerification !== undefined ? { selfVerification: currentSelfVerification } : {}),
+    ...(currentLanguage !== undefined ? { language: currentLanguage } : {}),
   });
   const finalSystemMessage = options.appendSystemPrompt
     ? `${systemMessage}\n\n${options.appendSystemPrompt}`
@@ -194,7 +218,7 @@ export function buildSessionSystemPrompt(
   const rebuildSystemMessage = (
     newAgentsMd: string,
     newProjectNotesMd: string,
-    overrides?: { persona?: string; selfVerification?: boolean | string },
+    overrides?: TLivePromptOverrides,
   ): string => {
     // PRESET-014: a persona override mutates the retained persona so subsequent rebuilds
     // (e.g. staleness refresh, which passes no override) keep the latest applied persona.
@@ -206,12 +230,16 @@ export function buildSessionSystemPrompt(
     if (overrides?.selfVerification !== undefined) {
       currentSelfVerification = overrides.selfVerification;
     }
+    if (overrides?.language !== undefined) {
+      currentLanguage = overrides.language;
+    }
     const rebuilt = buildPrompt({
       ...staticPromptParams,
       ...(currentPersona !== undefined ? { persona: currentPersona } : {}),
       ...(currentSelfVerification !== undefined
         ? { selfVerification: currentSelfVerification }
         : {}),
+      ...(currentLanguage !== undefined ? { language: currentLanguage } : {}),
       agentsMd: newAgentsMd,
       projectNotesMd: newProjectNotesMd,
     });

--- a/packages/agent-framework/src/assembly/create-session-runtime.ts
+++ b/packages/agent-framework/src/assembly/create-session-runtime.ts
@@ -61,6 +61,7 @@ export interface TLivePromptOverrides {
   persona?: string;
   selfVerification?: boolean | string;
   language?: string;
+  presetSystemPrompt?: string;
 }
 
 export interface IBackgroundProcessResult {
@@ -196,6 +197,12 @@ export function buildSessionSystemPrompt(
   // whole item is about; it was written, and removed for that reason.
   let currentLanguage = options.config.language;
 
+  // ARCH-040: a preset-supplied system prompt, mutable for the lifetime of this closure like the
+  // three above it. It SEEDS the composed prompt as a priority-4 section — the framework's own
+  // `systemPrompt` option is the REPLACE seam, and a preset pointing at that would drop the
+  // AGENTS.md and capability sections without saying so.
+  let currentPresetSystemPrompt = options.presetSystemPrompt;
+
   // Persona/selfVerification/language are composed per-build (initial + each rebuild) so the mutable
   // closure values always win; they are therefore excluded from these static params.
   const staticPromptParams = buildStaticPromptParams(
@@ -210,6 +217,9 @@ export function buildSessionSystemPrompt(
     ...(currentPersona !== undefined ? { persona: currentPersona } : {}),
     ...(currentSelfVerification !== undefined ? { selfVerification: currentSelfVerification } : {}),
     ...(currentLanguage !== undefined ? { language: currentLanguage } : {}),
+    ...(currentPresetSystemPrompt !== undefined
+      ? { presetSystemPrompt: currentPresetSystemPrompt }
+      : {}),
   });
   const finalSystemMessage = options.appendSystemPrompt
     ? `${systemMessage}\n\n${options.appendSystemPrompt}`
@@ -233,6 +243,9 @@ export function buildSessionSystemPrompt(
     if (overrides?.language !== undefined) {
       currentLanguage = overrides.language;
     }
+    if (overrides?.presetSystemPrompt !== undefined) {
+      currentPresetSystemPrompt = overrides.presetSystemPrompt;
+    }
     const rebuilt = buildPrompt({
       ...staticPromptParams,
       ...(currentPersona !== undefined ? { persona: currentPersona } : {}),
@@ -240,6 +253,9 @@ export function buildSessionSystemPrompt(
         ? { selfVerification: currentSelfVerification }
         : {}),
       ...(currentLanguage !== undefined ? { language: currentLanguage } : {}),
+      ...(currentPresetSystemPrompt !== undefined
+        ? { presetSystemPrompt: currentPresetSystemPrompt }
+        : {}),
       agentsMd: newAgentsMd,
       projectNotesMd: newProjectNotesMd,
     });

--- a/packages/agent-framework/src/assembly/create-session-types.ts
+++ b/packages/agent-framework/src/assembly/create-session-types.ts
@@ -185,6 +185,14 @@ export interface ICreateSessionOptions {
   maxOutputTokens?: number;
   /** Text to append to the generated system prompt. */
   appendSystemPrompt?: string;
+  /**
+   * ARCH-040: a PRESET-supplied system prompt, composed as a priority-4 section above persona.
+   *
+   * Distinct from `systemPrompt`, which REPLACES the composed prompt. A preset pointing at that seam
+   * would silently drop the AGENTS.md, project-notes, skill and capability sections — context the
+   * person choosing a preset did not ask to lose. Owner decision 2026-08-20: seed, do not replace.
+   */
+  presetSystemPrompt?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */
   persona?: string;
   /** Model command execution bridge. */

--- a/packages/agent-framework/src/command-api/host-roles.ts
+++ b/packages/agent-framework/src/command-api/host-roles.ts
@@ -80,6 +80,8 @@ export interface ICommandHostPresetApplication {
   applySelfVerification(enabled: boolean): void;
   /** ARCH-040 — re-apply the preset's response language to the live system prompt. */
   applyResponseLanguage(language: string): void;
+  /** ARCH-040 — re-apply the preset's seeding system prompt to the live system prompt. */
+  applyPresetSystemPrompt(text: string): void;
   /**
    * PRESET-015 — re-apply command-module selection to the live session. Returns any
    * `enabled`/`disabled` names that matched no live command module (INFRA-032) so the `/preset`

--- a/packages/agent-framework/src/command-api/host-roles.ts
+++ b/packages/agent-framework/src/command-api/host-roles.ts
@@ -78,6 +78,8 @@ export interface ICommandHostPresetApplication {
   applyPersona(persona: string): void;
   /** PRESET-017 — toggle the verify-before-done self-verification section on the live prompt. */
   applySelfVerification(enabled: boolean): void;
+  /** ARCH-040 — re-apply the preset's response language to the live system prompt. */
+  applyResponseLanguage(language: string): void;
   /**
    * PRESET-015 — re-apply command-module selection to the live session. Returns any
    * `enabled`/`disabled` names that matched no live command module (INFRA-032) so the `/preset`

--- a/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
+++ b/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
@@ -21,6 +21,7 @@ interface IRuntimeSpies {
   setActivePresetId?: ReturnType<typeof vi.fn>;
   applyModelOptions?: ReturnType<typeof vi.fn>;
   applyPersona?: ReturnType<typeof vi.fn>;
+  applyResponseLanguage?: ReturnType<typeof vi.fn>;
   applyCommandModuleSelection?: ReturnType<typeof vi.fn>;
   setParallelSubagentsEnabled?: ReturnType<typeof vi.fn>;
   applySelfVerification?: ReturnType<typeof vi.fn>;
@@ -210,6 +211,38 @@ describe('applyPresetToSession model group (PRESET-013)', () => {
 
     expect(context.getSession().applyModelOptions).toBeTypeOf('function');
     expect(result.applied).toContain('effort');
+  });
+});
+
+describe('applyPresetToSession language group (ARCH-040)', () => {
+  // `language` had no seam anywhere and was the last of the ten fields to be decidable from an
+  // existing mechanism: the framework already composes a response-language prompt section, so the
+  // owner's decision — a prompt instruction, not a provider parameter — wires what is there rather
+  // than inventing a second place for the same idea.
+  it('re-applies the language through the live rebuild seam', async () => {
+    const { context } = createContext();
+    const applyResponseLanguage = vi.fn();
+    (context as unknown as Record<string, unknown>)['applyResponseLanguage'] =
+      applyResponseLanguage;
+
+    const result = await applyPresetToSession(context, 'acme', { language: 'ko' });
+
+    expect(applyResponseLanguage).toHaveBeenCalledWith('ko');
+    expect(result.applied).toContain('language');
+  });
+
+  it('reports the group skipped when the preset names no language', async () => {
+    // "this preset said nothing about language" and "the language was set to undefined" are
+    // different statements, and only one of them is true.
+    const { context } = createContext();
+    const applyResponseLanguage = vi.fn();
+    (context as unknown as Record<string, unknown>)['applyResponseLanguage'] =
+      applyResponseLanguage;
+
+    const result = await applyPresetToSession(context, 'acme', { permissionMode: 'default' });
+
+    expect(applyResponseLanguage).not.toHaveBeenCalled();
+    expect(result.skipped).toContain('language');
   });
 });
 

--- a/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
+++ b/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
@@ -246,6 +246,32 @@ describe('applyPresetToSession language group (ARCH-040)', () => {
   });
 });
 
+describe('applyPresetToSession seeding-prompt group (ARCH-040)', () => {
+  it('re-applies the preset system prompt through the live rebuild seam', async () => {
+    const { context } = createContext();
+    const applyPresetSystemPrompt = vi.fn();
+    (context as unknown as Record<string, unknown>)['applyPresetSystemPrompt'] =
+      applyPresetSystemPrompt;
+
+    const result = await applyPresetToSession(context, 'acme', { systemPrompt: 'seed text' });
+
+    expect(applyPresetSystemPrompt).toHaveBeenCalledWith('seed text');
+    expect(result.applied).toContain('systemPrompt');
+  });
+
+  it('reports the group skipped when the preset names none', async () => {
+    const { context } = createContext();
+    const applyPresetSystemPrompt = vi.fn();
+    (context as unknown as Record<string, unknown>)['applyPresetSystemPrompt'] =
+      applyPresetSystemPrompt;
+
+    const result = await applyPresetToSession(context, 'acme', { permissionMode: 'default' });
+
+    expect(applyPresetSystemPrompt).not.toHaveBeenCalled();
+    expect(result.skipped).toContain('systemPrompt');
+  });
+});
+
 describe('applyPresetToSession persona group (PRESET-014)', () => {
   it('TC-03: persona present → applyPersona called with it, result.applied lists persona', async () => {
     const { context, spies } = createContext();

--- a/packages/agent-framework/src/command-api/preset/preset-application.ts
+++ b/packages/agent-framework/src/command-api/preset/preset-application.ts
@@ -28,6 +28,8 @@ export interface IPresetApplicationOptions {
   maxOutputTokens?: number;
   /** PRESET-014 — preset persona re-applied to the live system prompt. */
   persona?: string;
+  /** ARCH-040 — response language, re-applied as a prompt section. */
+  language?: string;
   /** PRESET-015 — allowlist of command-module names to keep on the live session. */
   enabledCommandModules?: readonly string[];
   /** PRESET-015 — denylist of command-module names to remove from the live session. */
@@ -110,6 +112,15 @@ export async function applyPresetToSession(
     applied.push('persona');
   } else {
     skipped.push('persona');
+  }
+
+  // ARCH-040 language group — re-applied through the same rebuild seam as persona. Owner decision
+  // 2026-08-20: a preset's `language` is a prompt instruction, not a provider parameter.
+  if (options.language !== undefined) {
+    context.applyResponseLanguage(options.language);
+    applied.push('language');
+  } else {
+    skipped.push('language');
   }
 
   // PRESET-015 command-module group — re-applied via the host context's

--- a/packages/agent-framework/src/command-api/preset/preset-application.ts
+++ b/packages/agent-framework/src/command-api/preset/preset-application.ts
@@ -30,6 +30,8 @@ export interface IPresetApplicationOptions {
   persona?: string;
   /** ARCH-040 — response language, re-applied as a prompt section. */
   language?: string;
+  /** ARCH-040 — a preset-supplied system prompt that SEEDS the composed prompt (priority 4). */
+  systemPrompt?: string;
   /** PRESET-015 — allowlist of command-module names to keep on the live session. */
   enabledCommandModules?: readonly string[];
   /** PRESET-015 — denylist of command-module names to remove from the live session. */
@@ -121,6 +123,15 @@ export async function applyPresetToSession(
     applied.push('language');
   } else {
     skipped.push('language');
+  }
+
+  // ARCH-040 seeding-prompt group. `systemPrompt` SEEDS rather than replaces — the framework's own
+  // replace seam would drop the AGENTS.md and capability sections without saying so.
+  if (options.systemPrompt !== undefined) {
+    context.applyPresetSystemPrompt(options.systemPrompt);
+    applied.push('systemPrompt');
+  } else {
+    skipped.push('systemPrompt');
   }
 
   // PRESET-015 command-module group — re-applied via the host context's

--- a/packages/agent-framework/src/context/__tests__/preset-system-prompt-seed.test.ts
+++ b/packages/agent-framework/src/context/__tests__/preset-system-prompt-seed.test.ts
@@ -1,0 +1,61 @@
+/**
+ * ARCH-040 Group D — a preset's `systemPrompt` SEEDS the composed prompt, it does not replace it.
+ *
+ * The session already offers a REPLACE seam (`ICreateSessionOptions.systemPrompt`). Pointing a preset
+ * at it would silently drop the AGENTS.md, project-notes, skill and capability sections the framework
+ * composes — context the person choosing a preset did not ask to lose. Owner decision 2026-08-20:
+ * seed, do not replace.
+ *
+ * The decisive case is the last one. "The text appears" is true of a replacement too; only "the text
+ * appears AND the surrounding sections survive" tells the two apart.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildSystemPrompt } from '../system-prompt-builder.js';
+
+const AGENTS_MD = 'PROJECT-INSTRUCTIONS-MARKER';
+const SEED = 'SEED-PROMPT-MARKER';
+
+function build(extra: Record<string, unknown>): string {
+  return buildSystemPrompt({
+    cwd: '/workspace',
+    projectInfo: { type: 'unknown', language: 'unknown' },
+    permissionMode: 'default',
+    agentsMd: AGENTS_MD,
+    projectNotesMd: '',
+    toolDescriptions: [],
+    ...extra,
+  } as never);
+}
+
+describe('a preset system prompt seeds the composed prompt (ARCH-040)', () => {
+  it('includes the seed text', () => {
+    expect(build({ presetSystemPrompt: SEED })).toContain(SEED);
+  });
+
+  it('KEEPS the project instructions the framework composes', () => {
+    // The half that distinguishes a seed from a replacement. A replacing implementation passes the
+    // case above and fails this one, which is why both are here.
+    const prompt = build({ presetSystemPrompt: SEED });
+    expect(prompt).toContain(AGENTS_MD);
+  });
+
+  it('places the seed ABOVE the persona, so it frames what follows', () => {
+    // Priority 4 vs persona's 5. Asserted by ORDER rather than by the priority number, because the
+    // number is an implementation detail and the order is the behaviour.
+    const prompt = build({ presetSystemPrompt: SEED, persona: 'PERSONA-MARKER' });
+    expect(prompt.indexOf(SEED)).toBeLessThan(prompt.indexOf('PERSONA-MARKER'));
+  });
+
+  it('adds nothing when the preset names no system prompt', () => {
+    const prompt = build({});
+    expect(prompt).not.toContain(SEED);
+    expect(prompt).toContain(AGENTS_MD);
+  });
+
+  it('adds nothing for a blank string', () => {
+    // Same rule persona follows: an empty value is not a section, it is an absent one.
+    expect(build({ presetSystemPrompt: '   ' })).toContain(AGENTS_MD);
+  });
+});

--- a/packages/agent-framework/src/context/system-prompt-builder.ts
+++ b/packages/agent-framework/src/context/system-prompt-builder.ts
@@ -5,6 +5,7 @@ import {
   createProjectNotesSection,
   createPermissionSection,
   createPersonaSection,
+  createPresetSystemPromptSection,
   createProjectMemorySection,
   createProjectSection,
   createResponseLanguageSection,
@@ -25,6 +26,11 @@ export interface ISystemPromptParams {
    * composed as a `source: 'persona'` section with priority 5; empty/undefined adds no section.
    */
   persona?: string;
+  /**
+   * ARCH-040: a preset-supplied system prompt, composed as a priority-4 section ABOVE persona. It
+   * seeds the prompt rather than replacing it — see `createPresetSystemPromptSection`.
+   */
+  presetSystemPrompt?: string;
   /**
    * PRESET-017: when enabled, a concise verify-before-done directive is composed as a
    * `source: 'self-verification'` section with priority 6; false/undefined adds no section.
@@ -115,6 +121,12 @@ function buildCapabilityDescriptors(params: ISystemPromptParams): ICapabilityDes
 export function buildSystemPrompt(params: ISystemPromptParams): string {
   const sections: ISystemPromptSection[] = [];
 
+  appendOptionalSection(
+    sections,
+    params.presetSystemPrompt !== undefined && params.presetSystemPrompt.trim().length > 0
+      ? createPresetSystemPromptSection(params.presetSystemPrompt)
+      : undefined,
+  );
   appendOptionalSection(
     sections,
     params.persona !== undefined && params.persona.trim().length > 0

--- a/packages/agent-framework/src/context/system-prompt-section-providers.ts
+++ b/packages/agent-framework/src/context/system-prompt-section-providers.ts
@@ -19,6 +19,19 @@ function createSection(
 }
 
 /**
+ * ARCH-040: a preset-supplied system prompt SEEDS the composed prompt — it does not replace it.
+ *
+ * Owner decision 2026-08-20. `IInteractiveSessionStandardOptions.systemPrompt` already offers a
+ * REPLACE seam, and pointing a preset at it would silently drop the AGENTS.md, project-notes, skill
+ * and capability sections the framework composes — context the person choosing a preset did not ask
+ * to lose. A section instead: priority `4` puts it above persona (5) and therefore above AGENTS.md
+ * (10), so it establishes the frame everything else is read in, which is what "seed" means here.
+ */
+export function createPresetSystemPromptSection(text: string): ISystemPromptSection {
+  return createSection('preset-system-prompt', undefined, 4, text, 'preset-system-prompt');
+}
+
+/**
  * PRESET-003: a preset persona is a normal section with a declared priority, not a
  * hardcoded slot. Priority `5` sits in the top band (5 < AGENTS.md=10) so the persona
  * establishes identity/behaviour before project instructions — the position is decided

--- a/packages/agent-framework/src/context/system-prompt-types.ts
+++ b/packages/agent-framework/src/context/system-prompt-types.ts
@@ -1,6 +1,7 @@
 export type TSystemPromptSectionSource =
   | 'framework'
   | 'persona'
+  | 'preset-system-prompt'
   | 'self-verification'
   | 'project-instructions'
   | 'runtime'

--- a/packages/agent-framework/src/interactive/create-session-projection.ts
+++ b/packages/agent-framework/src/interactive/create-session-projection.ts
@@ -53,6 +53,9 @@ export function buildCreateSessionOptions(
     deniedTools: options.deniedTools,
     model: options.model,
     ...(options.effort !== undefined ? { effort: options.effort } : {}),
+    ...(options.presetSystemPrompt !== undefined
+      ? { presetSystemPrompt: options.presetSystemPrompt }
+      : {}),
     ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
     ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     appendSystemPrompt: options.appendSystemPrompt,

--- a/packages/agent-framework/src/interactive/interactive-session-init-options.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init-options.ts
@@ -1,9 +1,13 @@
 /**
- * Public option interfaces for InteractiveSession construction and configuration.
+ * The INTERNAL async-init option shape.
  *
- * IInteractiveSessionStandardOptions: standard construction (cwd + provider).
- * IInteractiveSessionInjectedOptions: test/advanced injection of a pre-built session.
- * IInitOptions: internal async init shape passed to createInteractiveSession().
+ * Split out of `interactive-session-options.ts` by ARCH-040. That file held three interfaces
+ * restating one option list — the public standard arm, the injected arm, and this — so every preset
+ * field had to be added three times, and the anti-monolith floor refused the fourth addition. The
+ * split is by responsibility: what a CALLER may pass lives there, what the async init hands onward
+ * lives here.
+ *
+ * Re-exported from the original module, so no consumer has to know it moved.
  */
 
 import type { IInteractiveSessionStore } from './session-persistence.js';
@@ -42,15 +46,28 @@ import type { IRetrievalAdapter } from '@robota-sdk/agent-tools';
 import type { ISandboxClient, IWorkspaceManifest } from '@robota-sdk/agent-tools';
 
 /** Standard construction: cwd + provider. Config/context loaded internally. */
-export interface IInteractiveSessionStandardOptions {
+
+export interface IInitOptions {
   cwd: string;
   provider: IAIProvider;
   permissionMode?: ICreateSessionOptions['permissionMode'];
+  /** CMD-005: unified ask renderer, forwarded into the session as the model-question tool seam. */
+  askHandler?: IUserInteraction['ask'];
   maxTurns?: number;
-  sessionStore?: IInteractiveSessionStore;
-  sessionName?: string;
+  permissionHandler?: TInteractivePermissionHandler;
   resumeSessionId?: string;
   forkSession?: boolean;
+  onTextDelta: (delta: string) => void;
+  onContextUpdate?: (state: IContextWindowState) => void;
+  onCompactEvent?: (event: ICompactEvent) => void;
+  onToolExecution: (event: {
+    type: 'start' | 'end';
+    toolName: string;
+    toolArgs?: TToolArgs;
+    success?: boolean;
+    denied?: boolean;
+    toolResultData?: string;
+  }) => void;
   /** Skip AGENTS.md/CLAUDE.md loading and plugin discovery. */
   bare?: boolean;
   /** Pre-approved tool names passed to createSession. */
@@ -71,7 +88,7 @@ export interface IInteractiveSessionStandardOptions {
   appendSystemPrompt?: string;
   /** Preset persona block composed as a `source: 'persona'` system-prompt section (priority 5). */
   persona?: string;
-  /** `systemPrompt` REPLACES the composed prompt; `presetSystemPrompt` SEEDS it (ARCH-040). */
+  /** Replace the entire system prompt with this string. Takes precedence over the default builder. */
   systemPrompt?: string;
   presetSystemPrompt?: string;
   /** Override config language (e.g., "ko", "en"). Injected into system prompt. */
@@ -80,39 +97,22 @@ export interface IInteractiveSessionStandardOptions {
   backgroundTaskRunners?: IBackgroundTaskRunner[];
   /** Runtime shell override for subagent execution. */
   subagentRunnerFactory?: TSubagentRunnerFactory;
-  /**
-   * ARCH-005: subagent definitions contributed by the composition root (e.g. the capability packs
-   * `assembleProduct` merged). Composed INTO the built-in tier ahead of `BUILT_IN_AGENTS`; precedence is
-   * discovered project/user definitions > these > `BUILT_IN_AGENTS`. Absent ⇒ unchanged behavior.
-   */
+  /** ARCH-005: composition-root-contributed subagent definitions (see the standard options). */
   agentDefinitions?: readonly IAgentDefinition[];
   /** Optional command modules composed into this session. */
   commandModules?: readonly ICommandModule[];
-  /** Host adapters available to composed command modules. */
-  commandHostAdapters?: ICommandHostAdapters;
-  /** Shell exec function for preprocessing `` !`cmd` `` patterns in skills — injected from composition root. */
-  shellExec?: TShellExecFn;
-  /**
-   * REMOTE-006: optional command-execution policy for remote-origin (`source==='remote'`) commands arriving over a
-   * transport. **Allow by default** — local == remote; injected only so a consumer can opt into a restriction.
-   */
-  remoteCommandPolicy?: IRemoteCommandPolicy;
-  /**
-   * TERM-001: transport-provided terminal-handoff capability. When present, the session can hand the
-   * real terminal to a child process (e.g. `/shell`, `$EDITOR`) and restore the display. Absent /
-   * `canHandoffTerminal === false` for transports with no interactive TTY (headless).
-   */
-  terminalHandoff?: ITerminalHandoff;
   /** Model-visible command descriptors derived from the composed command executor. */
   commandDescriptors?: readonly ICapabilityDescriptor[];
-  /** Provider definitions for hot-swap via /provider switch. */
-  providerDefinitions?: readonly import('@robota-sdk/agent-core').IProviderDefinition[];
+  /** Role projection resolved once from the selected executable commands. */
+  commandSemanticRoles?: ISystemCommandSemanticRoles;
   /** Model command execution bridge. */
   modelCommandExecutor?: (command: string, args: string) => Promise<ICommandResult | null>;
   /** Predicate for commands allowed through the model command execution bridge. */
   isModelCommandInvocable?: (command: string) => boolean;
   /** Preloaded config to avoid duplicate discovery when caller needs it too. */
   config?: IResolvedConfig;
+  /** Recorder used to snapshot files before Write/Edit tools mutate them. */
+  editCheckpointRecorder?: IEditCheckpointRecorder;
   /** Opt-in local-first reversible execution policy for write/shell tools. */
   reversibleExecution?: IReversibleExecutionOptions;
   /** Optional provider sandbox client used by sandbox-aware built-in tools. */
@@ -120,22 +120,10 @@ export interface IInteractiveSessionStandardOptions {
   /** ARCH-033: the name a child process uses to rebuild a sandbox like this one. */
   sandboxType?: string;
   /**
-   * SELFHOST-008: optional durable-memory store injected by the surface. Threads to startup-memory
-   * injection; absent, the neutral filesystem reference adapter is the default (memory unchanged).
+   * SELFHOST-008: optional durable-memory store. When present, startup-memory injection reads through
+   * it; absent, the neutral filesystem reference adapter is the default (memory works unchanged).
    */
   memoryStore?: IMemoryStore;
-  /**
-   * SELFHOST-008 P2: optional automatic post-turn memory-capture policy. When present, the dormant
-   * capture pipeline is wired into the live turn (awaited in the controller's finally before persist),
-   * gated by this policy (default reference policy = approval_required = queue). Absent ⇒ capture OFF.
-   */
-  automaticMemory?: IAutomaticMemoryConfig;
-  /**
-   * SELFHOST-008 P3: optional per-turn durable-memory recall policy. When present, each turn recalls
-   * query-relevant memory (query = the turn input) and injects it EPHEMERALLY into that turn's model call
-   * (never persisted). Absent ⇒ recall OFF (startup-only injection, unchanged). The budget is surface-owned.
-   */
-  recallMemory?: IPerTurnRecallConfig;
   /** Fresh-session workspace manifest applied through the sandbox client. */
   workspaceManifest?: IWorkspaceManifest;
   /** Sandbox target root for workspace manifest entries. Defaults to /workspace. */
@@ -150,8 +138,6 @@ export interface IInteractiveSessionStandardOptions {
   enableParallelSubagents?: boolean;
   /** Preset execution capability: run a post-task self-verification step. */
   selfVerification?: boolean | string;
-  /** Organization policy for enforcing provider restrictions, command blocks, and API key rules. */
-  orgPolicy?: IOrgPolicy;
   /** Additional tools registered alongside the default CLI tools. */
   additionalTools?: IToolWithEventService[];
   /**
@@ -167,29 +153,3 @@ export interface IInteractiveSessionStandardOptions {
   /** Request structured output from the provider for this session. */
   responseFormat?: { type: 'text' | 'json_object' };
 }
-
-/** Test/advanced construction: inject pre-built session directly. */
-export interface IInteractiveSessionInjectedOptions {
-  session: Session;
-  cwd?: string;
-  provider?: IAIProvider;
-  permissionMode?: ICreateSessionOptions['permissionMode'];
-  maxTurns?: number;
-  sessionStore?: IInteractiveSessionStore;
-  sessionName?: string;
-  resumeSessionId?: string;
-  forkSession?: boolean;
-  /** Optional command modules composed into this injected session. */
-  commandModules?: readonly ICommandModule[];
-  /** Host adapters available to composed command modules. */
-  commandHostAdapters?: ICommandHostAdapters;
-  /** TERM-001: transport-provided terminal-handoff capability (see standard options). */
-  terminalHandoff?: ITerminalHandoff;
-}
-
-/** Union of standard and injected construction options. */
-export type TInteractiveSessionOptions =
-  IInteractiveSessionStandardOptions | IInteractiveSessionInjectedOptions;
-
-/** ARCH-040: split out by responsibility; re-exported so no consumer has to know it moved. */
-export type { IInitOptions } from './interactive-session-init-options.js';

--- a/packages/agent-framework/src/interactive/interactive-session-init-workspace.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init-workspace.ts
@@ -61,3 +61,28 @@ export async function restoreInteractiveSandboxSnapshot(options: IInitOptions): 
   await options.sandboxClient.restore(options.sandboxSnapshotId);
   return true;
 }
+
+/**
+ * The PRESET-derived session values, carried together.
+ *
+ * ARCH-040. Each is a field a preset resolves and the session consumes, and each was a separate
+ * conditional spread in the init literal until there were four of them. Grouping them means the next
+ * preset field is added in one place rather than appended to a list nobody is reading — the same
+ * reason `interactiveSandboxOptions` above exists.
+ *
+ * A `Pick` of `IInitOptions`, which `option-reachability` reads as a declared projection of it.
+ */
+export function interactivePresetOptions(
+  options: Pick<
+    IInteractiveSessionStandardOptions,
+    'temperature' | 'maxOutputTokens' | 'presetSystemPrompt'
+  >,
+): Pick<IInitOptions, 'temperature' | 'maxOutputTokens' | 'presetSystemPrompt'> {
+  return {
+    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}),
+    ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
+    ...(options.presetSystemPrompt !== undefined
+      ? { presetSystemPrompt: options.presetSystemPrompt }
+      : {}),
+  };
+}

--- a/packages/agent-framework/src/interactive/interactive-session-init.ts
+++ b/packages/agent-framework/src/interactive/interactive-session-init.ts
@@ -16,6 +16,7 @@ import { detectProject } from '../context/project-detector.js';
 import { projectPaths } from '../paths.js';
 import {
   applyInteractiveWorkspaceManifest,
+  interactivePresetOptions,
   interactiveSandboxOptions,
   restoreInteractiveSandboxSnapshot,
 } from './interactive-session-init-workspace.js';
@@ -245,8 +246,6 @@ export async function initializeInteractiveSessionAsync(
     deniedTools: options.deniedTools,
     model: options.model,
     ...(options.effort !== undefined ? { effort: options.effort } : {}),
-    ...(options.temperature !== undefined ? { temperature: options.temperature } : {}), // ARCH-040
-    ...(options.maxOutputTokens !== undefined ? { maxOutputTokens: options.maxOutputTokens } : {}),
     appendSystemPrompt: options.appendSystemPrompt,
     ...(options.persona !== undefined ? { persona: options.persona } : {}),
     ...(options.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
@@ -259,6 +258,7 @@ export async function initializeInteractiveSessionAsync(
     editCheckpointRecorder: checkpointStore,
     ...(options.reversibleExecution ? { reversibleExecution: options.reversibleExecution } : {}),
     ...interactiveSandboxOptions(options, deps.sandboxSnapshotId),
+    ...interactivePresetOptions(options),
     ...(options.memoryStore ? { memoryStore: options.memoryStore } : {}),
     ...(options.agentName ? { agentName: options.agentName } : {}),
     ...(options.activePresetId !== undefined ? { activePresetId: options.activePresetId } : {}),

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -608,32 +608,32 @@ export class InteractiveSession
   }
 
   /**
-   * The ONE way a preset field is re-applied to the live prompt: recompose from the tracked
-   * AGENTS.md/CLAUDE.md entries — what the staleness refresh uses — plus the override. No-op before
-   * init. ARCH-040 extracted it; a third copy is how the next one diverges.
+   * The ONE way a preset field reaches the live prompt — recompose from the tracked context entries
+   * plus the override. No-op before init. Extracted by ARCH-040: PRESET-014 and PRESET-017 were the
+   * same five lines twice, and a third copy is how the next one diverges.
    */
   private rebuildLivePrompt(overrides: TLivePromptOverrides): void {
     if (this.rebuildSystemMessage === null) return;
     const agents = this.agentsFileEntries.map((e) => e.content).join('\n\n');
     const notes = this.projectNotesFileEntries.map((e) => e.content).join('\n\n');
-    this.getSessionOrThrow().updateSystemMessage(
-      this.rebuildSystemMessage(agents, notes, overrides),
-    );
+    const rebuilt = this.rebuildSystemMessage(agents, notes, overrides);
+    this.getSessionOrThrow().updateSystemMessage(rebuilt);
   }
 
-  /** PRESET-014: re-apply a preset persona to the live system prompt. */
   applyPersona(persona: string): void {
     this.rebuildLivePrompt({ persona });
   }
 
-  /** PRESET-017: toggle the verify-before-done section on the live system prompt. */
   applySelfVerification(enabled: boolean): void {
     this.rebuildLivePrompt({ selfVerification: enabled });
   }
 
-  /** ARCH-040: re-apply the preset's response language to the live system prompt. */
   applyResponseLanguage(language: string): void {
     this.rebuildLivePrompt({ language });
+  }
+
+  applyPresetSystemPrompt(text: string): void {
+    this.rebuildLivePrompt({ presetSystemPrompt: text });
   }
 
   /**

--- a/packages/agent-framework/src/interactive/interactive-session.ts
+++ b/packages/agent-framework/src/interactive/interactive-session.ts
@@ -48,6 +48,7 @@ import type {
   IInteractiveSessionEvents,
   IExecutionResult,
 } from './types.js';
+import type { TLivePromptOverrides } from '../assembly/create-session-runtime.js';
 import type { ICommandHostContext } from '../command-api/index.js';
 import type {
   IAgentJobHostContext,
@@ -607,33 +608,32 @@ export class InteractiveSession
   }
 
   /**
-   * PRESET-014: re-apply a preset persona to the live system prompt. Recomposes the system
-   * message from the currently tracked AGENTS.md/CLAUDE.md entries (the same content the staleness
-   * refresh uses) plus the new persona, then propagates it to the session. No-op before init,
-   * when the rebuild closure is not yet available.
+   * The ONE way a preset field is re-applied to the live prompt: recompose from the tracked
+   * AGENTS.md/CLAUDE.md entries — what the staleness refresh uses — plus the override. No-op before
+   * init. ARCH-040 extracted it; a third copy is how the next one diverges.
    */
-  applyPersona(persona: string): void {
+  private rebuildLivePrompt(overrides: TLivePromptOverrides): void {
     if (this.rebuildSystemMessage === null) return;
-    const currentAgents = this.agentsFileEntries.map((e) => e.content).join('\n\n');
-    const currentClaude = this.projectNotesFileEntries.map((e) => e.content).join('\n\n');
-    const msg = this.rebuildSystemMessage(currentAgents, currentClaude, { persona });
-    this.getSessionOrThrow().updateSystemMessage(msg);
+    const agents = this.agentsFileEntries.map((e) => e.content).join('\n\n');
+    const notes = this.projectNotesFileEntries.map((e) => e.content).join('\n\n');
+    this.getSessionOrThrow().updateSystemMessage(
+      this.rebuildSystemMessage(agents, notes, overrides),
+    );
   }
 
-  /**
-   * PRESET-017: toggle the verify-before-done self-verification section on the live system prompt.
-   * Recomposes the system message from the currently tracked AGENTS.md/CLAUDE.md entries plus the
-   * new selfVerification flag, then propagates it to the session. No-op before init, when the
-   * rebuild closure is not yet available.
-   */
+  /** PRESET-014: re-apply a preset persona to the live system prompt. */
+  applyPersona(persona: string): void {
+    this.rebuildLivePrompt({ persona });
+  }
+
+  /** PRESET-017: toggle the verify-before-done section on the live system prompt. */
   applySelfVerification(enabled: boolean): void {
-    if (this.rebuildSystemMessage === null) return;
-    const currentAgents = this.agentsFileEntries.map((e) => e.content).join('\n\n');
-    const currentClaude = this.projectNotesFileEntries.map((e) => e.content).join('\n\n');
-    const msg = this.rebuildSystemMessage(currentAgents, currentClaude, {
-      selfVerification: enabled,
-    });
-    this.getSessionOrThrow().updateSystemMessage(msg);
+    this.rebuildLivePrompt({ selfVerification: enabled });
+  }
+
+  /** ARCH-040: re-apply the preset's response language to the live system prompt. */
+  applyResponseLanguage(language: string): void {
+    this.rebuildLivePrompt({ language });
   }
 
   /**

--- a/packages/agent-framework/src/testing/command-host-double.ts
+++ b/packages/agent-framework/src/testing/command-host-double.ts
@@ -158,6 +158,7 @@ export function createTestCommandHost(
     getUserInteraction: () => undefined,
     applyPersona: () => {},
     applySelfVerification: () => {},
+    applyResponseLanguage: () => {},
     // An empty array is "every name matched" (INFRA-032), not "nothing was applied".
     applyCommandModuleSelection: () => [],
     getAutoCompactThresholdSource: () => 'session',

--- a/packages/agent-framework/src/testing/command-host-double.ts
+++ b/packages/agent-framework/src/testing/command-host-double.ts
@@ -159,6 +159,7 @@ export function createTestCommandHost(
     applyPersona: () => {},
     applySelfVerification: () => {},
     applyResponseLanguage: () => {},
+    applyPresetSystemPrompt: () => {},
     // An empty array is "every name matched" (INFRA-032), not "nothing was applied".
     applyCommandModuleSelection: () => [],
     getAutoCompactThresholdSource: () => 'session',


### PR DESCRIPTION
Two more groups of #1820. With these, six of the ten fields are resolved and the remaining four are split into their own items with the blocking cause named.

## Group F — `language`

Declared on the preset contract with no seam under any name. Owner decision: a PROMPT instruction, not a provider parameter — and the framework already composes a response-language section, so this wires what exists.

`language` joins `persona` and `selfVerification` as a value the rebuild closure retains and a live preset switch can override.

**Two things were built and then removed**, both second routes to one value:

- an `ICreateSessionOptions.language` key — a preset's language already ARRIVES at `config.language`, so this was a second path to the same place. `doc-examples` found it as a duplicate identifier before the reasoning did.
- a third copy of the live-prompt applier — `applyPersona` and `applySelfVerification` were the same five lines twice. They share one private `rebuildLivePrompt` now, which is also what made room under the size ratchet: the file is the same length with two more capabilities.

## Group D — `systemPrompt` SEEDS, it does not replace

The session already offers a REPLACE seam. Pointing a preset at it would silently drop the AGENTS.md, project-notes, skill and capability sections — context the person choosing a preset did not ask to lose. So it is a priority-4 section, above persona (5) and therefore above AGENTS.md (10).

The decisive case is the pair: *"the text appears"* is true of a replacement too. Only *"the text appears AND the surrounding sections survive"* tells them apart, so both are asserted — plus the ORDER against persona, by position rather than by the priority number.

**The two session options are one letter apart.** `systemPrompt` replaces, `presetSystemPrompt` seeds. A bare `...presetSurface` lands a preset's text on the replacing one and drops those sections invisibly. `toSessionOptions` renames it in ONE place, so the three shells cannot disagree about which option a preset means.

## A split the anti-monolith floor forced, and was right to

`interactive-session-options.ts` held THREE interfaces restating one option list — the public standard arm, the injected arm, and `IInitOptions` — so every preset field had to be added three times, and the floor refused the fourth addition. `IInitOptions` moves to its own module: what a CALLER may pass stays, what the async init hands onward leaves.

`option-reachability` **fail-closed on the move** rather than passing, which is exactly what that entry exists for.

## What is split out, and why it is not a deferral

- **#1934** — the tool lists. The combine rule is decided (allow replaces, deny unions); the live half needs a capability that does not exist, since the lists become permission PATTERNS at construction and the enforcer exposes only an additive set. Wiring startup alone CREATES the divergence the scan measures, so it was written, measured, and reverted.
- **#1937** — `appendSystemPrompt`. Its merge order is not expressible while `buildAppendSystemPrompt` has one caller and the CLI-sourced text reaches one surface of three. That is the prerequisite, not a companion.
- **Group B (`agentName`)** — parked awaiting an owner re-decision, with the measured cost recorded: its only reader is a `readonly` identity label no surface displays.

`presetProjection.pendingProjection`: 6 exemptions → 4.

## Verification

- `pnpm harness:scan` — 129 passed, 2 skipped
- `pnpm typecheck` — 0 errors
- full suite — exits 0
- red-proofed: dropping the seed section fails the seed cases, lowering its priority below persona fails exactly the ordering case, and dropping either live application fails exactly its live case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu51kQ6VZNaQejxgwKJ8BW