### PR TITLE
docs(agent-cli): document /peers, the last thing issue #1863 was waiting on

### DIFF
--- a/.agents/tasks/PEER-004-local-discovery-reaches-the-operator.md
+++ b/.agents/tasks/PEER-004-local-discovery-reaches-the-operator.md
@@ -68,21 +68,33 @@ session is, which is the question the registry keys its entries on.
       throwing or taking the other adapter down with it.
 - [x] TC-07: `pnpm harness:scan` green and the three touched packages' suites green.
 - [x] TC-08 (user-execution): two `agent-cli` sessions on one host, `/peers` in each showing the
-      other. **EXECUTED 2026-08-20** — two real `pnpm cli:dev` sessions driven through PTYs, same host,
-      same user. The first, alone, reported `No other live session is announced. Start a second session
-  on this host, as this user, and it appears here.` Once the second was up, its `/peers` listed both
-      with itself marked:
+      other. Executed 2026-08-20 — evidence below.
 
-      ```
-              Live sessions:
-                b8319b98-bb7b-486c-a499-cf1585b39e61  (this session)
-                97ffafe3-f770-4877-90a4-bd86df6be010
-              ```
+## User Execution Evidence
 
-              TC-05's distinction is what the first output shows: "no other session" reads as its own sentence
-              with a next step, not as an empty list a reader would have to interpret. Full transcripts and the
-              `/peers send` half are recorded in
-              [PEER-006](PEER-006-peers-send-reaches-the-other-session.md).
+**TC-08, executed 2026-08-20.** Two real `pnpm cli:dev` sessions driven through PTYs, same host, same
+user.
+
+The first, alone:
+
+```
+No other live session is announced. Start a second session on this host, as this user, and it
+appears here.
+```
+
+Once the second was up, its `/peers`:
+
+```
+Live sessions:
+  b8319b98-bb7b-486c-a499-cf1585b39e61  (this session)
+  97ffafe3-f770-4877-90a4-bd86df6be010
+```
+
+TC-05's distinction is what the first output shows: "no other session" reads as its own sentence with
+a next step, not as an empty list a reader would have to interpret.
+
+Full transcripts and the `/peers send` half, including both directions, are recorded in
+[PEER-006](PEER-006-peers-send-reaches-the-other-session.md).
 
 ## Test Plan
 

--- a/.agents/tasks/PEER-004-local-discovery-reaches-the-operator.md
+++ b/.agents/tasks/PEER-004-local-discovery-reaches-the-operator.md
@@ -67,8 +67,22 @@ session is, which is the question the registry keys its entries on.
 - [x] TC-06: the assembly wires the adapter, generates the id, and reports a refusal without
       throwing or taking the other adapter down with it.
 - [x] TC-07: `pnpm harness:scan` green and the three touched packages' suites green.
-- [ ] TC-08 (user-execution): two `agent-cli` sessions on one host, `/peers` in each showing the
-      other. Runnable once this ships.
+- [x] TC-08 (user-execution): two `agent-cli` sessions on one host, `/peers` in each showing the
+      other. **EXECUTED 2026-08-20** — two real `pnpm cli:dev` sessions driven through PTYs, same host,
+      same user. The first, alone, reported `No other live session is announced. Start a second session
+  on this host, as this user, and it appears here.` Once the second was up, its `/peers` listed both
+      with itself marked:
+
+      ```
+              Live sessions:
+                b8319b98-bb7b-486c-a499-cf1585b39e61  (this session)
+                97ffafe3-f770-4877-90a4-bd86df6be010
+              ```
+
+              TC-05's distinction is what the first output shows: "no other session" reads as its own sentence
+              with a next step, not as an empty list a reader would have to interpret. Full transcripts and the
+              `/peers send` half are recorded in
+              [PEER-006](PEER-006-peers-send-reaches-the-other-session.md).
 
 ## Test Plan
 

--- a/.agents/tasks/PEER-006-peers-send-reaches-the-other-session.md
+++ b/.agents/tasks/PEER-006-peers-send-reaches-the-other-session.md
@@ -93,13 +93,75 @@ peer-supplied driver id through is a one-character change that no other test wou
 - Terminal A: `/peers send <B's session id> hello back`
 - Expect in B: the same, in the other direction.
 - Cleanup: exit both sessions; `/peers` in a third session shows neither.
-- Evidence: _to be filled after implementation_
+- Evidence: **EXECUTED 2026-08-20** against `feat/peer-origin-rendered` (PEER-007 merged into the same
+  tree), two real `pnpm cli:dev` sessions driven through PTYs on this host as this user.
+
+  A alone:
+
+  ```
+  System:
+    No other live session is announced. Start a second session on this host, as this user, and it appears here.
+  ```
+
+  B, after A was already up:
+
+  ```
+  System:
+    Live sessions:
+      b8319b98-bb7b-486c-a499-cf1585b39e61  (this session)
+      97ffafe3-f770-4877-90a4-bd86df6be010
+    Send to one: /peers send <session-id> <message>
+  ```
+
+  `/peers send 97ffafe3-… hello from B` — what A rendered:
+
+  ```
+  peer:b8319b98-bb7b-486c-a499-cf1585b39e61:
+    hello from B
+  Robota:
+    STUB-ACK: …
+  ```
+
+  The label carries B's session id exactly as `/peers` reported it, and the agent answered the peer's
+  turn. B saw the delivery acknowledged: `97ffafe3-… has the message; it is waiting behind work already
+running there.`
+
+  **The control run is what makes this mean anything.** A separate session where the operator typed the
+  message rendered `You:`. Counted across the two transcripts, the labels are mutually exclusive — the
+  peer-driven transcript contains `peer:<id>:` and zero occurrences of `You:`; the operator transcript
+  contains `You:` and zero occurrences of `peer:`. Without that second run the first only shows that a
+  label appears, not that the two are told apart.
+
+  **Both directions, run separately 2026-08-21.** Issue #1863's definition of done says _both_, and one
+  direction only shows that a label appears — not that it names the right peer. A second pair:
+
+  | direction | label the receiver rendered                 | sender's id from `/peers` |
+  | --------- | ------------------------------------------- | ------------------------- |
+  | B → A     | `peer:620c8924-9ee6-4058-9e65-2d0204b2a103` | B = `620c8924-…`          |
+  | A → B     | `peer:dfad4f56-7bc3-4eb4-b1e2-e86f10960333` | A = `dfad4f56-…`          |
+
+  Each session labelled the OTHER one. A single direction would pass even if the label were wired to
+  the wrong end.
+
+  Provider: no credential was present (probed: no `ANTHROPIC_*`/`OPENAI_*`/`GEMINI_*` in the
+  environment, no `.env` — only `.env.example`, no settings under `~/.robota`, and no Ollama on
+  :11434). A local OpenAI-compatible stub stood in so the sessions could reach a prompt. It serves the
+  model call only; discovery, delivery and attribution are the product's own code and are what this
+  scenario observes.
 
 **Scenario 2 — a target that is not there**
 
 - Terminal A: `/peers send 00000000-0000-0000-0000-000000000000 hello`
 - Expect: a refusal naming the unannounced target, not a socket error and not a hang.
-- Evidence: _to be filled after implementation_
+- Evidence: **EXECUTED 2026-08-20**, same pair of sessions:
+
+  ```
+  System:
+    Not delivered to 00000000-0000-0000-0000-000000000000. no session 00000000-0000-0000-0000-000000000000
+    is announced on this host. Run /peers to see which are.
+  ```
+
+  It names the target, says where to look, and returns immediately — no socket error, no hang.
 
 ## Progress
 

--- a/packages/agent-cli/README.md
+++ b/packages/agent-cli/README.md
@@ -391,6 +391,16 @@ Typing `/` in the TUI opens an autocomplete popup. Arrow keys navigate, Tab inse
 | `/skills [name]`       | List registered skills or activate one by name                       |
 | `/plugin [subcommand]` | Plugin management                                                    |
 
+### Sessions on this host
+
+| Command                              | Description                               |
+| ------------------------------------ | ----------------------------------------- |
+| `/peers`                             | List the other live sessions on this host |
+| `/peers send <session-id> <message>` | Send a message to one of them             |
+
+See [Talking to another session](#talking-to-another-session) for the flow and what happens when the
+other session is busy.
+
 ### Utility
 
 | Command  | Description                                        |
@@ -400,6 +410,95 @@ Typing `/` in the TUI opens an autocomplete popup. Arrow keys navigate, Tab inse
 | `/exit`  | Exit CLI                                           |
 
 Skill commands discovered from `.agents/skills/` and `.claude/commands/` appear alongside built-in commands.
+
+## Talking to another session
+
+Two `robota` sessions running on the same host, as the same user, can see and address each other.
+Nothing crosses a machine boundary and nothing is configured — a session becomes discoverable by
+being alive and stops being discoverable when it exits.
+
+### Seeing who is there
+
+```
+/peers
+```
+
+With nothing else running:
+
+```
+No other live session is announced. Start a second session on this host, as this user,
+and it appears here.
+```
+
+That is a sentence rather than an empty list on purpose: "no one is there" and "discovery is not
+working" are different answers, and an empty list cannot tell you which one you got.
+
+With a second session up:
+
+```
+Live sessions:
+  b8319b98-bb7b-486c-a499-cf1585b39e61  (this session)
+  97ffafe3-f770-4877-90a4-bd86df6be010
+
+Send to one: /peers send <session-id> <message>
+```
+
+### Sending
+
+```
+/peers send 97ffafe3-f770-4877-90a4-bd86df6be010 rerun the failing suite
+```
+
+The message becomes a **turn** in the other session — the agent there answers it as if the operator
+had typed it. The sender is told which of four things happened, as a sentence:
+
+| Outcome                                                                  | What it means                                                                     |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `Delivered to <id>.`                                                     | It arrived and started.                                                           |
+| `<id> has the message; it is waiting behind work already running there.` | It arrived and is queued. Deliberately **not** reported as delivered.             |
+| `<id> had already seen that message.`                                    | A retry that the receiver recognised; it does not run twice.                      |
+| `Not delivered to <id>. <reason>`                                        | Nothing ran. The reason names the target, e.g. that no such session is announced. |
+
+The second row is the one worth knowing. Reporting a queued message as delivered would hide a wait
+the operator can otherwise see and act on.
+
+### What the receiving operator sees
+
+The message is attributed to the sender, not to whoever is sitting at the receiving terminal:
+
+```
+peer:b8319b98-bb7b-486c-a499-cf1585b39e61:
+  rerun the failing suite
+Robota:
+  …
+```
+
+Your own turns still read `You:`. The name in the label is **derived from the peer's session id** —
+it is not a display name the sender chose, because a name the transcript's reader trusts must not be
+picked by the party being named. It is display attribution only: nothing anywhere uses it to decide
+what a turn is allowed to do.
+
+### When the other session is busy
+
+A message arriving mid-turn joins that session's existing pending queue rather than interrupting or
+opening a second one. Three things follow from how that queue works:
+
+- **Consecutive messages from the same sender coalesce**, last one wins. That is right for a person
+  retyping and wrong for a peer saying two separate things. The replaced one is not swallowed: it
+  settles as refused with the reason `coalesced`, so the sender learns it never ran rather than
+  assuming both did. Tracked as `PEER-003`.
+- **Messages from different senders do not coalesce** — they queue in arrival order.
+- **The queue holds 32.** Beyond that a message settles as refused with the reason `dropped`.
+- **A cleared queue** — abort, cancel, or shutdown — settles the waiting entries with `cancelled`.
+
+In every case the submission that never became a turn says so. A message that arrived and was then
+displaced is a different thing from one that ran, and the sender is told which it got.
+
+### Limits
+
+- Same host, same user. There is no network path here.
+- A session that exits removes its own entry; a crashed one is reaped by the next session that looks.
+- Session ids are what you address. There are no aliases.
 
 ## Plugin Management
 


### PR DESCRIPTION
## What was missing

Issue #1863 lists four items. Three shipped — local discovery (PEER-004), the command (PEER-006), and the TUI attribution (PEER-007, issue #1915). The fourth was **"CLI documentation of the message flow and its concurrency behaviour"**, and `/peers` appeared in no README, no SPEC, and no command table. Every other slash command is listed; this one was reachable only by typing `/` and reading the popup.

## What this adds

- A `Sessions on this host` row in the slash-command table.
- A `Talking to another session` section: seeing who is there, sending, what the receiving operator sees, and what happens when that session is busy.

## The concurrency half is the part worth writing down

Because the interesting states are the ones that are **not** "delivered":

| state | what the sender is told |
| --- | --- |
| queued behind a running turn | reported as queued, deliberately **not** as delivered |
| displaced by a later message from the same sender | refused, reason `coalesced` |
| queue at capacity (32) | refused, reason `dropped` |
| queue cleared — abort, cancel, shutdown | refused, reason `cancelled` |

The first row is the one an operator needs: reporting a queued message as delivered would hide a wait they can otherwise see and act on. The rest matter because a submission that never became a turn says so, rather than leaving the sender to assume it ran.

## Read out of the code, not out of the issue

That distinction earned its keep. Issue #1863 says the sender learns "via a `coalesced` ack" — but `TPeerDeliveryState` has no `coalesced` member. The actual mechanism is `peer-message-ingress.ts` settling `refused` with reason `coalesced`. Documenting the issue's phrasing would have described a field that does not exist.

Sources for each claim:

- `describeSend` in `packages/agent-command/src/peers/peers-command.ts` — the four send outcomes and their exact wording;
- the enqueue path in `packages/agent-framework/src/interactive/interactive-session-pending-queue.ts` — the tail-coalesce rule and the depth of 32;
- the header of `packages/agent-framework/src/interactive/peer-message-ingress.ts` — how each queue outcome becomes a delivery state the sender sees.

Every string quoted in the new section was checked against the source it came from.

## Also: the user-execution evidence for PEER-004 and PEER-006

Recorded on both task records, including a **second run for both directions**. Issue #1863's definition of done says *both*, and one direction only shows that a label appears — not that it names the right peer:

| direction | label the receiver rendered | sender's id from `/peers` |
| --- | --- | --- |
| B → A | `peer:620c8924-9ee6-4058-9e65-2d0204b2a103` | B = `620c8924-…` |
| A → B | `peer:dfad4f56-7bc3-4eb4-b1e2-e86f10960333` | A = `dfad4f56-…` |

Each session labelled the other one. A single direction would have passed even with the label wired to the wrong end.

Both runs were real `pnpm cli:dev` sessions driven through PTYs on one host as one user, with a local OpenAI-compatible stub standing in for the model call only — no credential was present, and discovery, delivery and attribution are the product's own code.

## Verification

129 of 129 scans pass. Documentation and task records only; no source change.

Closes #1863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPig8uCgp1ryvt9BVeTz91
