### PR TITLE
feat(preset)!: rename the agent when a preset switch says so (ARCH-040 Group B)

### DIFF
--- a/.agents/harness.config.json
+++ b/.agents/harness.config.json
@@ -425,11 +425,6 @@
     "$pendingComment": "The burn-down. Each entry is a field this floor HAS measured as undeclared or one-sidedly declared, whose fix needs a decision this scan cannot make — recorded as a NAMED, EXPIRING exemption rather than an opaque count, because an exemption that is unnamed or non-expiring is indistinguishable from no floor. `declaredOn` records the surfaces the field was measured on when the entry was written; if the live state differs in EITHER direction the entry is reported (`preset-pending-state-changed`), so an exemption expires when the work is DONE and not only when the field is deleted. Review measured the earlier version failing exactly that: fixing a pending field printed green, which made the list a baseline with extra words. This list may shrink and must never grow without a reviewed reason. Tracked as GitHub issue #1820.",
     "pendingProjection": [
       {
-        "field": "agentName",
-        "reason": "The REVERSE divergence: startup declares it (IPresetSurfaceOptions) and the live /preset path does not, so starting with a preset sets the agent name while switching to the SAME preset mid-session leaves the old one. The owner decided on 2026-08-20 that /preset SHOULD rename. Implementation is parked on a measured cost the decision did not have in front of it: the field's only reader is `Robota.name`, a `public readonly` identity label that no surface displays, and making it renameable needs either a mutable core field or a split of a 411-line frozen core file. Re-decide against that cost before wiring — see ARCH-040.",
-        "declaredOn": ["IPresetSurfaceOptions"]
-      },
-      {
         "field": "appendSystemPrompt",
         "reason": "A session seam DOES exist (`ICreateSessionOptions.appendSystemPrompt`, projected by create-session-projection.ts), so the last hop is ready. The first hop is missing, and wiring it requires deciding the merge order against the CLI-sourced append text that `buildAppendSystemPrompt` produces — today that helper is called only from print-mode.ts, so `--task-file`/`--json-schema`/`--append-system-prompt` are themselves dropped in TUI and serve mode.",
         "declaredOn": []

--- a/.agents/tasks/ARCH-040-preset-projection-decisions.md
+++ b/.agents/tasks/ARCH-040-preset-projection-decisions.md
@@ -43,8 +43,8 @@ projection, and where the fallback lives is an implementation choice made in thi
 ## Plan
 
 - [x] Group A — remove `defaultTrustLevel` from `IResolvedPresetOptions` and its validator.
-- [ ] Group B — `agentName` on the live `/preset` path. **PARKED on a measured cost the decision did
-      not have in front of it** (see below); every other group is independent of it.
+- [x] Group B — `agentName` on the live `/preset` path. The parked cost turned out to have a third
+      option the first analysis missed — see below.
 - [ ] Group C — `allowedTools` (replace) and `deniedTools` (compose), resolved together. **BLOCKED on a
       missing capability**, see below. The RULE is decided and its home is identified; only the live
       seam is absent.
@@ -69,7 +69,7 @@ session/assembly seam"_. It is false today for `systemPrompt`, `language`, `temp
 `maxOutputTokens` and `defaultTrustLevel`. Changing the words without changing the fact is the
 defect, not the fix; this item makes it true.
 
-## Group B is parked, and why
+## Group B: parked, then unparked — the first analysis was too narrow
 
 The owner decided `/preset` should rename the agent. Implementing it turned up a cost the decision
 was not made against, so it is recorded here rather than paid silently.
@@ -155,3 +155,25 @@ Checked after C, so the next reader does not discover it one group at a time:
 | F — `language`  | present, once it is a persona section                | present                         | feasible                |
 
 Groups B and C are the two that need a capability. D, E and F are wiring on seams that already exist.
+
+### How it was actually done
+
+The parked analysis offered two options — a mutable field on a core class, or splitting a 411-line
+frozen file — and called them the only two. There was a third, and missing it is what parked the
+group for a day:
+
+`Robota` declares `protected override config`, which means the BASE already declares `config`. So
+`name` could become a getter reading `this.config.name`, placed on `RobotaBase` — where `config`
+lives — and both the field declaration and its constructor assignment could leave `robota.ts`
+entirely. That file got three lines SMALLER, and its ratchet was re-frozen at the gain.
+
+The rename itself is then `updateConfiguration({ name })`, the agent's existing config seam, extended
+to accept `name` beside `tools`. Because `name` reads through `config`, writing the config IS the
+rename — there is no second copy on the instance to leave stale, which is exactly what the original
+"mutable field" sketch would have created.
+
+One more guard had to be satisfied honestly rather than dodged: `product-identity` refused the single
+new call because `agent-session`'s agent field was named `robota` — the consumer's product name in a
+neutral library, frozen at 30 occurrences with no exemption mechanism. Renaming the field to `agent`
+took the count to 3 (the remainder is the real `~/.robota` directory). Re-spelling the call to avoid
+the marker was the alternative, and it is the failure this repository has scans about.

--- a/packages/agent-core/src/core/__tests__/agent-rename.test.ts
+++ b/packages/agent-core/src/core/__tests__/agent-rename.test.ts
@@ -1,0 +1,66 @@
+/**
+ * ARCH-040 (issue #1820) — an agent can be renamed while it is live.
+ *
+ * A preset carries `agentName`, and it reached the agent only at construction: starting with a
+ * preset set the name while switching to the SAME preset mid-session left the old one. One preset,
+ * two answers, decided by WHEN it was chosen.
+ *
+ * `name` reads THROUGH `config` now, so `updateConfiguration({ name })` is the whole rename. These
+ * assert that every reader agrees afterwards — a rename that moved one and not the others would be
+ * the divergence with extra steps, which is exactly what a copied field on the instance produced.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { Robota } from '../robota.js';
+
+import type { IAgentConfig } from '../../interfaces/agent.js';
+
+function agent(): Robota {
+  return new Robota({
+    name: 'before',
+    aiProviders: [
+      { name: 'mock', version: '1', chat: async () => ({}), supportsTools: () => true },
+    ],
+    defaultModel: { provider: 'mock', model: 'mock-model' },
+    systemMessage: 'test',
+  } as unknown as IAgentConfig);
+}
+
+describe('renaming a live agent (ARCH-040)', () => {
+  it('changes what `name` reports', async () => {
+    const robota = agent();
+    expect(robota.name).toBe('before');
+
+    await robota.updateConfiguration({ name: 'after' });
+
+    expect(robota.name).toBe('after');
+  });
+
+  it('keeps `getConfig()` in step with `name`', async () => {
+    // The half a copied field breaks: before ARCH-040 the instance held its own `name`, so a config
+    // write moved one reader and not the other. Asserting both is what rules that out.
+    const robota = agent();
+    await robota.updateConfiguration({ name: 'after' });
+
+    expect(robota.getConfig().name).toBe('after');
+    expect(robota.getConfig().name).toBe(robota.name);
+  });
+
+  it('leaves the rest of the config alone', async () => {
+    const robota = agent();
+    await robota.updateConfiguration({ name: 'after' });
+
+    expect(robota.getConfig().systemMessage).toBe('test');
+    expect(robota.getConfig().defaultModel.model).toBe('mock-model');
+  });
+
+  it('still refuses a patch it does not support', async () => {
+    // The seam stays narrow. Accepting `name` must not turn `updateConfiguration` into a general
+    // config setter, which is what the original error was guarding.
+    const robota = agent();
+    await expect(
+      robota.updateConfiguration({ systemMessage: 'nope' } as Partial<IAgentConfig>),
+    ).rejects.toThrow(/only .tools. and .name./);
+  });
+});

--- a/packages/agent-core/src/core/robota-base.ts
+++ b/packages/agent-core/src/core/robota-base.ts
@@ -44,6 +44,27 @@ export abstract class RobotaBase extends AbstractAgent<
 > {
   protected moduleManager!: IModuleManagerProxy;
   protected pluginManager!: IPluginManagerProxy;
+  /**
+   * Narrowed from `AbstractAgent`'s optional `config`: a Robota agent always has one, assigned in the
+   * constructor. Declared HERE so `name` below can read it without a fallback that would lie.
+   */
+  declare protected config: IAgentConfig;
+
+  /**
+   * The agent's identity label, read THROUGH `config` rather than copied at construction.
+   *
+   * ARCH-040 (issue #1820): a preset carries `agentName`, and it reached the agent only when the
+   * agent was built — so starting with a preset set the name while switching to the SAME preset
+   * mid-session left the old one. One preset with two answers, decided by when it was chosen.
+   *
+   * Reading through `config` makes `updateConfiguration({ name })` the rename, so there is one way
+   * to change it and `getConfig()`, `getStats()` and `getName()` cannot disagree about what this
+   * agent is called. It lives on the BASE because `config` does; the subclass keeps no copy to
+   * forget to update.
+   */
+  get name(): string {
+    return this.config.name;
+  }
 
   addPlugin(plugin: TPlugin): void {
     this.pluginManager.addPlugin(plugin);

--- a/packages/agent-core/src/core/robota-config-manager.ts
+++ b/packages/agent-core/src/core/robota-config-manager.ts
@@ -139,12 +139,21 @@ export class RobotaConfigManager {
     return { version };
   }
 
-  /** Update configuration partially. Currently supports tools. */
+  /**
+   * Update configuration partially — `tools` and `name`. ARCH-040 added `name`: `RobotaBase.name`
+   * reads through `config`, so writing it here IS the rename, with no second copy to forget.
+   */
   async updateConfiguration(patch: Partial<IAgentConfig>): Promise<{ version: number }> {
     if (patch.tools) {
       return this.updateTools(patch.tools);
     }
-    throw new ConfigurationError('updateConfiguration: only tools patch is supported at this time');
+    if (patch.name !== undefined) {
+      this.setConfig({ ...this.getConfig(), name: patch.name });
+      const version = this.bumpConfigVersion();
+      this.setConfigUpdatedAt(Date.now());
+      return { version };
+    }
+    throw new ConfigurationError('updateConfiguration: only `tools` and `name` are supported');
   }
 
   /** Read-only configuration overview for UI. */

--- a/packages/agent-core/src/core/robota.ts
+++ b/packages/agent-core/src/core/robota.ts
@@ -57,7 +57,6 @@ export class Robota
   extends RobotaBase
   implements IAgent<IAgentConfig, IRunOptions, TUniversalMessage>
 {
-  public readonly name: string;
   public readonly version: string = '1.0.0';
 
   private aiProviders: AIProviders;
@@ -69,7 +68,6 @@ export class Robota
   private executionService!: ExecutionService;
   private eventService: IEventService;
   private agentEventService: IEventService;
-  protected override config: IAgentConfig;
   private conversationId: string;
   private logger: ILogger;
   private initializationPromise?: Promise<void> | undefined;
@@ -83,7 +81,6 @@ export class Robota
 
   constructor(config: IAgentConfig) {
     super();
-    this.name = config.name;
     this.config = config;
     this.conversationId =
       config.conversationId ||

--- a/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
+++ b/packages/agent-framework/src/command-api/preset/__tests__/preset-application.test.ts
@@ -20,6 +20,7 @@ interface IRuntimeSpies {
   setPermissionMode: ReturnType<typeof vi.fn>;
   setActivePresetId?: ReturnType<typeof vi.fn>;
   applyModelOptions?: ReturnType<typeof vi.fn>;
+  applyAgentName?: ReturnType<typeof vi.fn>;
   applyPersona?: ReturnType<typeof vi.fn>;
   applyResponseLanguage?: ReturnType<typeof vi.fn>;
   applyCommandModuleSelection?: ReturnType<typeof vi.fn>;
@@ -77,6 +78,7 @@ function createContext(
     getAutoCompactThreshold: () => 0.8,
     ...(includeActivePreset && { setActivePresetId: recordSpy('setActivePresetId') }),
     ...(includeApplyModelOptions && { applyModelOptions: recordSpy('applyModelOptions') }),
+    applyAgentName: recordSpy('applyAgentName'),
     ...(includeSetParallelSubagentsEnabled && {
       setParallelSubagentsEnabled: recordSpy('setParallelSubagentsEnabled'),
     }),
@@ -211,6 +213,27 @@ describe('applyPresetToSession model group (PRESET-013)', () => {
 
     expect(context.getSession().applyModelOptions).toBeTypeOf('function');
     expect(result.applied).toContain('effort');
+  });
+});
+
+describe('applyPresetToSession identity group (ARCH-040)', () => {
+  // The REVERSE divergence, and the one nobody had named: startup applied the preset's `agentName`
+  // and the live path did not, so switching to the SAME preset mid-session left the old name. One
+  // preset, two answers, decided by WHEN it was chosen. Owner decision 2026-08-20: `/preset` renames.
+  it('renames the live agent when the preset carries an agentName', async () => {
+    const { context, spies } = createContext();
+    const result = await applyPresetToSession(context, 'acme', { agentName: 'acme-bot' });
+    expect(spies.applyAgentName).toHaveBeenCalledWith('acme-bot');
+    expect(result.applied).toContain('agentName');
+  });
+
+  it('leaves the name alone when the preset carries none, and says so', async () => {
+    // `skipped` is the honest report: "this preset said nothing about the name" is a different
+    // statement from "the name was set to undefined", and only one of them is true.
+    const { context, spies } = createContext();
+    const result = await applyPresetToSession(context, 'acme', { permissionMode: 'default' });
+    expect(spies.applyAgentName).not.toHaveBeenCalled();
+    expect(result.skipped).toContain('agentName');
   });
 });
 

--- a/packages/agent-framework/src/command-api/preset/preset-application.ts
+++ b/packages/agent-framework/src/command-api/preset/preset-application.ts
@@ -28,6 +28,8 @@ export interface IPresetApplicationOptions {
   maxOutputTokens?: number;
   /** PRESET-014 — preset persona re-applied to the live system prompt. */
   persona?: string;
+  /** ARCH-040 — the agent's identity label, re-applied to the live agent. */
+  agentName?: string;
   /** ARCH-040 — response language, re-applied as a prompt section. */
   language?: string;
   /** ARCH-040 — a preset-supplied system prompt that SEEDS the composed prompt (priority 4). */
@@ -132,6 +134,16 @@ export async function applyPresetToSession(
     applied.push('systemPrompt');
   } else {
     skipped.push('systemPrompt');
+  }
+
+  // ARCH-040 identity group — the REVERSE divergence, and the one nobody had named: startup applied
+  // the preset's `agentName` and the live path did not, so switching to the SAME preset mid-session
+  // left the old name. Owner decision 2026-08-20: `/preset` renames.
+  if (options.agentName !== undefined) {
+    await context.getSession().applyAgentName(options.agentName);
+    applied.push('agentName');
+  } else {
+    skipped.push('agentName');
   }
 
   // PRESET-015 command-module group — re-applied via the host context's

--- a/packages/agent-framework/src/command-api/session-roles.ts
+++ b/packages/agent-framework/src/command-api/session-roles.ts
@@ -53,6 +53,13 @@ export interface ICommandSessionModel {
    * configuration, so callers must await the result.
    */
   applyModelOptions(options: IModelReapplyOptions): void | Promise<void>;
+  /**
+   * ARCH-040 — re-apply the preset's `agentName` to the live agent.
+   *
+   * REQUIRED, like every other member of this role port: an optional one would make each consumer
+   * decide what "no rename seam" means, and `/preset` would decide it alone.
+   */
+  applyAgentName(name: string): void | Promise<void>;
 }
 
 /** Live preset state carried by the session. */

--- a/packages/agent-framework/src/testing/command-host-double.ts
+++ b/packages/agent-framework/src/testing/command-host-double.ts
@@ -117,6 +117,7 @@ export function createTestSessionRuntime(
     getSessionTokenUsage: () => undefined,
     getModelId: () => undefined,
     applyModelOptions: () => {},
+    applyAgentName: () => {},
     getActivePresetId: () => 'default',
     setActivePresetId: () => {},
     setParallelSubagentsEnabled: () => {},

--- a/packages/agent-session/src/__tests__/compaction-honours-abort.test.ts
+++ b/packages/agent-session/src/__tests__/compaction-honours-abort.test.ts
@@ -172,7 +172,7 @@ describe('the turn signal reaches compaction through the run context (RUNTIME-00
         shouldAutoCompact: () => true,
         getContextState: () => ({}),
       },
-      robota: { getHistory: () => [] },
+      agent: { getHistory: () => [] },
       aiProvider: {},
       compact: (signal?: AbortSignal) => {
         received = signal;

--- a/packages/agent-session/src/__tests__/selfhost-009-existing-events-regression.test.ts
+++ b/packages/agent-session/src/__tests__/selfhost-009-existing-events-regression.test.ts
@@ -82,7 +82,7 @@ function createProvider(): IAIProvider {
 }
 
 function createContext(
-  robota: Robota,
+  agent: Robota,
   hooks: THooksConfig,
   executor: IHookTypeExecutor,
 ): IRunContext {
@@ -90,7 +90,7 @@ function createContext(
     sessionId: 'test-session',
     cwd: '/tmp/test',
     model: 'test-model',
-    robota,
+    agent,
     aiProvider: createProvider(),
     contextTracker: new ContextWindowTracker('test-model', undefined, false),
     hooks: hooks as unknown as Record<string, unknown>,

--- a/packages/agent-session/src/__tests__/selfhost-009-model-call-hooks.test.ts
+++ b/packages/agent-session/src/__tests__/selfhost-009-model-call-hooks.test.ts
@@ -86,7 +86,7 @@ function createProvider(): IAIProvider {
 }
 
 function createContext(
-  robota: Robota,
+  agent: Robota,
   hooks: THooksConfig,
   hookTypeExecutors: IHookTypeExecutor[],
 ): IRunContext {
@@ -94,7 +94,7 @@ function createContext(
     sessionId: 'test-session',
     cwd: '/tmp/test',
     model: 'test-model',
-    robota,
+    agent,
     aiProvider: createProvider(),
     contextTracker: new ContextWindowTracker('test-model', undefined, false),
     hooks: hooks as unknown as Record<string, unknown>,

--- a/packages/agent-session/src/__tests__/session-run-realtime-context.test.ts
+++ b/packages/agent-session/src/__tests__/session-run-realtime-context.test.ts
@@ -34,7 +34,7 @@ function assistantMessage(id: string, contentLength: number): TUniversalMessage 
  * usedTokens is non-decreasing across emissions.
  */
 function createFakeRobota(rounds: number): {
-  robota: Robota;
+  agent: Robota;
   run: ReturnType<typeof vi.fn>;
 } {
   const messages: TUniversalMessage[] = [];
@@ -73,14 +73,14 @@ function createProvider(): IAIProvider {
 }
 
 function createContext(
-  robota: Robota,
+  agent: Robota,
   onContextUpdate: (state: IContextWindowState) => void,
 ): IRunContext {
   return {
     sessionId: 'test-session',
     cwd: '/tmp/test',
     model: 'test-model',
-    robota,
+    agent,
     aiProvider: createProvider(),
     // autoCompactThreshold=false so executeRun never tries to compact in this test.
     contextTracker: new ContextWindowTracker('test-model', undefined, false),

--- a/packages/agent-session/src/session-base.ts
+++ b/packages/agent-session/src/session-base.ts
@@ -15,7 +15,7 @@ import type {
 } from '@robota-sdk/agent-core';
 
 export abstract class SessionBase {
-  protected abstract readonly robota: Robota;
+  protected abstract readonly agent: Robota;
   protected abstract readonly permissionEnforcer: PermissionEnforcer;
   protected abstract readonly contextTracker: ContextWindowTracker;
   protected abstract permissionMode: TPermissionMode;
@@ -102,7 +102,7 @@ export abstract class SessionBase {
    */
   updateSystemMessage(newMessage: string): void {
     this.systemMessage = newMessage;
-    this.robota.updateSystemPrompt(newMessage);
+    this.agent.updateSystemPrompt(newMessage);
   }
 
   /**
@@ -122,10 +122,10 @@ export abstract class SessionBase {
     // agent initializes lazily on the first `run()`, so a live model change before any message
     // (e.g. `/preset` right after launch) would otherwise hit the "must be fully initialized"
     // guard. Bring the agent to a ready state first — idempotent and side-effect-free.
-    await this.robota.ensureReady();
+    await this.agent.ensureReady();
     const nextModel = options.model ?? this.model;
     // The system prompt is not model config; it is updated independently via updateSystemMessage.
-    this.robota.setModel({
+    this.agent.setModel({
       provider: this.aiProvider.name,
       model: nextModel,
       ...(options.effort !== undefined && { effort: options.effort }),
@@ -133,6 +133,20 @@ export abstract class SessionBase {
       ...(options.maxOutputTokens !== undefined && { maxTokens: options.maxOutputTokens }),
     });
     this.model = nextModel;
+  }
+
+  /**
+   * Re-apply the agent's identity label to a LIVE session.
+   *
+   * ARCH-040 (issue #1820): a preset's `agentName` reached the agent only at construction, so
+   * starting with a preset set the name while switching to the SAME preset mid-session left the old
+   * one — one preset with two answers, decided by when it was chosen.
+   *
+   * Goes through `updateConfiguration`, the agent's own config seam: the agent's `name` reads THROUGH
+   * its config, so writing the config is the whole rename and no copy is left stale.
+   */
+  async applyAgentName(name: string): Promise<void> {
+    await this.agent.updateConfiguration({ name });
   }
 
   getToolSchemas(): IToolSchema[] {
@@ -167,7 +181,7 @@ export abstract class SessionBase {
 
   /** Estimate context usage from current conversation history (used after session restore). */
   syncContextFromHistory(): void {
-    this.contextTracker.updateFromHistory(this.robota.getHistory());
+    this.contextTracker.updateFromHistory(this.agent.getHistory());
   }
 
   getAutoCompactThreshold(): TAutoCompactThreshold {
@@ -179,11 +193,11 @@ export abstract class SessionBase {
   }
 
   getHistory(): TUniversalMessage[] {
-    return this.robota.getHistory();
+    return this.agent.getHistory();
   }
 
   getFullHistory(): IHistoryEntry[] {
-    return this.robota.getFullHistory();
+    return this.agent.getFullHistory();
   }
 
   getSessionTokenUsage(): { inputTokens: number; outputTokens: number } | undefined {
@@ -206,7 +220,7 @@ export abstract class SessionBase {
 
   /** Add an event entry to history (not a chat message) */
   addHistoryEntry(entry: IHistoryEntry): void {
-    this.robota.addHistoryEntry(entry);
+    this.agent.addHistoryEntry(entry);
   }
 
   /** Inject a message into conversation history without execution (used for session restore). */
@@ -215,7 +229,7 @@ export abstract class SessionBase {
     content: string,
     options?: { toolCallId?: string; name?: string },
   ): void {
-    this.robota.injectMessage(role, content, options);
+    this.agent.injectMessage(role, content, options);
   }
 
   /**
@@ -223,11 +237,11 @@ export abstract class SessionBase {
    * Used during session restore to correctly reconstruct tool_use+tool_result pairs.
    */
   injectRawMessage(msg: TUniversalMessage): void {
-    this.robota.injectRawMessage(msg);
+    this.agent.injectRawMessage(msg);
   }
 
   clearHistory(): void {
-    this.robota.clearHistory();
+    this.agent.clearHistory();
     this.contextTracker.reset();
   }
 }

--- a/packages/agent-session/src/session-history-ops.ts
+++ b/packages/agent-session/src/session-history-ops.ts
@@ -31,7 +31,7 @@ export interface ICompactContext {
   sessionId: string;
   cwd: string;
   systemMessage: string;
-  robota: Robota;
+  agent: Robota;
   aiProvider: IAIProvider;
   compactionOrchestrator: CompactionOrchestrator;
   contextTracker: ContextWindowTracker;
@@ -87,7 +87,7 @@ export async function compact(
   // ("rejects if cancelled AND there was work") for no gain over the one already in force.
   signal?.throwIfAborted();
 
-  const history = ctx.robota.getHistory();
+  const history = ctx.agent.getHistory();
 
   // Exclude system messages from compaction — they are preserved and re-injected after
   const nonSystemHistory = history.filter((msg) => msg.role !== 'system');
@@ -114,12 +114,12 @@ export async function compact(
   // Clear history, re-inject system message, then inject summary.
   // System message must persist across compactions — it contains project context
   // (cwd, AGENTS.md, CLAUDE.md) that the AI needs for every response.
-  ctx.robota.clearHistory();
-  ctx.robota.injectMessage('system', ctx.systemMessage);
-  ctx.robota.injectMessage('assistant', `[Context Summary]\n${summary}`);
+  ctx.agent.clearHistory();
+  ctx.agent.injectMessage('system', ctx.systemMessage);
+  ctx.agent.injectMessage('assistant', `[Context Summary]\n${summary}`);
 
   // Reset token tracking based on the new shorter history
-  ctx.contextTracker.updateFromHistory(ctx.robota.getHistory());
+  ctx.contextTracker.updateFromHistory(ctx.agent.getHistory());
 
   // Fire PostCompact hook after history replacement is complete
   const postHookInput: IHookInput = {
@@ -156,7 +156,7 @@ export interface IPersistContext {
   systemPrompt: string;
   toolSchemas: IToolSchema[];
   sessionStore: IInteractiveSessionStore;
-  robota: Robota;
+  agent: Robota;
   getFullHistory: () => Array<{
     id: string;
     timestamp: Date;
@@ -168,7 +168,7 @@ export interface IPersistContext {
 
 /** Persist the current session to the store */
 export function persistSession(ctx: IPersistContext): void {
-  const history = ctx.robota.getHistory();
+  const history = ctx.agent.getHistory();
   const now = new Date().toISOString();
 
   const existing = ctx.sessionStore.load(ctx.sessionId);

--- a/packages/agent-session/src/session-run.ts
+++ b/packages/agent-session/src/session-run.ts
@@ -78,7 +78,7 @@ export interface IRunContext {
   permissionMode?: string;
   /** Absolute path to session transcript file — passed to all hook inputs as transcript_path */
   transcriptPath?: string;
-  robota: Robota;
+  agent: Robota;
   aiProvider: IAIProvider;
   contextTracker: ContextWindowTracker;
   hooks: Record<string, unknown> | undefined;
@@ -113,7 +113,7 @@ export async function executeRun(
 ): Promise<string> {
   // Auto-compact BEFORE processing the new message (not after).
   // This prevents compaction from interfering with the current response stream.
-  ctx.contextTracker.updateFromHistory(ctx.robota.getHistory());
+  ctx.contextTracker.updateFromHistory(ctx.agent.getHistory());
   if (ctx.contextTracker.shouldAutoCompact()) {
     // Providers store onTextDelta as an instance property for their own internal streaming.
     // Compaction calls provider.chat() without passing onTextDelta in options, so the
@@ -160,7 +160,7 @@ export async function executeRun(
   // Clear sessionStart stdout after first injection
   ctx.clearSessionStartStdout();
 
-  const history = ctx.robota.getHistory();
+  const history = ctx.agent.getHistory();
   const historyJson = JSON.stringify(history);
   const providerCapabilities = getProviderCapabilities(ctx.aiProvider);
   ctx.log('pre_run', {
@@ -193,7 +193,7 @@ export async function executeRun(
         }
       : undefined;
 
-    response = await ctx.robota.run(enrichedMessage, {
+    response = await ctx.agent.run(enrichedMessage, {
       signal: abortSignal,
       maxExecutionRounds: ctx.maxTurns ?? 0,
       // Thin pass-through of the per-turn options to agent-core (SELFHOST-008 P3, PEER-007).
@@ -217,7 +217,7 @@ export async function executeRun(
         // fires once per round with the round's usage already committed to history, which is
         // the right cadence — frequent enough to feel live, sparse enough to avoid render flooding.
         if (event === 'assistant_message_committed') {
-          ctx.contextTracker.updateFromHistory(ctx.robota.getHistory());
+          ctx.contextTracker.updateFromHistory(ctx.agent.getHistory());
           ctx.onContextUpdate?.(ctx.contextTracker.getContextState());
         }
       },
@@ -233,7 +233,7 @@ export async function executeRun(
     ctx.log('error', {
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? (error.stack ?? '') : '',
-      historyLength: ctx.robota.getHistory().length,
+      historyLength: ctx.agent.getHistory().length,
     });
     runHooks(
       ctx.hooks as THooksConfig | undefined,
@@ -257,7 +257,7 @@ export async function executeRun(
   }
 
   // Log the response and full history structure
-  const postHistory = ctx.robota.getHistory();
+  const postHistory = ctx.agent.getHistory();
   const historyStructure = postHistory.map((msg) => {
     const hasToolCalls =
       'toolCalls' in msg && Array.isArray(msg.toolCalls) && msg.toolCalls.length > 0;

--- a/packages/agent-session/src/session.ts
+++ b/packages/agent-session/src/session.ts
@@ -59,7 +59,7 @@ const ID_RANDOM_LENGTH = 9;
 
 /** Wraps a Robota agent with project context, permission state, and optional persistence. */
 export class Session extends SessionBase {
-  protected readonly robota: Robota;
+  protected readonly agent: Robota;
   /**
    * SELFHOST-004: session-owned observable event bus. Injected into the agent so tools (incl. the
    * `FunctionTool` span-completion emit) publish here; the interactive turn subscribes to it to
@@ -150,7 +150,7 @@ export class Session extends SessionBase {
     );
     this.contextTracker = contextTracker;
     this.compactionOrchestrator = compactionOrchestrator;
-    this.robota = buildRobota(
+    this.agent = buildRobota(
       options,
       this.permissionEnforcer,
       tools,
@@ -211,7 +211,7 @@ export class Session extends SessionBase {
       systemPrompt: this.systemMessage,
       toolSchemas: this.toolSchemas,
       sessionStore: this.sessionStore,
-      robota: this.robota,
+      agent: this.agent,
       getFullHistory: () => this.getFullHistory(),
     });
   }
@@ -254,14 +254,14 @@ export class Session extends SessionBase {
       // CORE-022 (SPEC § Disposal Chain Contract): shutdown drives agent destruction —
       // plugins are disposed so no timers/listeners survive and the process can exit.
       await step('destroy-agent', async () => {
-        await this.robota.destroy();
+        await this.agent.destroy();
       });
     })();
     return this.shutdownPromise;
   }
 
   swapProvider(newProvider: IAIProvider, model: string): void {
-    this.robota.swapDefaultProvider(newProvider, model);
+    this.agent.swapDefaultProvider(newProvider, model);
     newProvider.configureNativeWebTools?.({ webSearch: true });
     if ('onServerToolUse' in newProvider) {
       (
@@ -292,7 +292,7 @@ export class Session extends SessionBase {
       sessionId: this.sessionId,
       cwd: this.cwd,
       model: this.model,
-      robota: this.robota,
+      agent: this.agent,
       aiProvider: this.aiProvider,
       contextTracker: this.contextTracker,
       hooks: this.hooks,

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -9,7 +9,7 @@
   "packages/agent-core/src/abstracts/abstract-ai-provider.ts": 306,
   "packages/agent-core/src/abstracts/abstract-module.ts": 315,
   "packages/agent-core/src/abstracts/abstract-workflow-converter.ts": 319,
-  "packages/agent-core/src/core/robota.ts": 411,
+  "packages/agent-core/src/core/robota.ts": 408,
   "packages/agent-core/src/index.ts": 313,
   "packages/agent-core/src/managers/agent-factory.ts": 301,
   "packages/agent-core/src/plugins/event-emitter-plugin.ts": 310,

--- a/scripts/harness/product-identity-baseline.json
+++ b/scripts/harness/product-identity-baseline.json
@@ -1,7 +1,7 @@
 {
   "packages/agent-core": 0,
   "packages/agent-tools": 0,
-  "packages/agent-session": 30,
+  "packages/agent-session": 3,
   "packages/agent-preset": 3,
   "packages/agent-command": 8,
   "packages/agent-framework": 52


### PR DESCRIPTION
Closes #1820.

The last of ARCH-040's ten fields that this repository can decide. The two that remain are split into their own items with the blocking cause named — see the end.

## The divergence

Startup applied the preset's `agentName`; the live `/preset` path did not. So starting with a preset set the name, and switching to the SAME preset mid-session left the old one — one preset with two answers, decided by WHEN it was chosen. Owner decision: `/preset` renames.

## This group was parked for a day on an analysis that was too narrow

The parked note offered two options — a mutable field on a core class, or splitting a 411-line frozen file — and called them the only two. **There was a third, and it is better than either.**

`Robota` declares `protected override config`, which means the BASE already declares `config`. So `name` becomes a getter on `RobotaBase` reading `this.config.name`, and both the field declaration and its constructor assignment leave the subclass. `robota.ts` is **three lines smaller**, and its ratchet is re-frozen at the gain.

Because `name` reads THROUGH `config`, `updateConfiguration({ name })` is the whole rename — there is no second copy on the instance to leave stale, which is exactly what the original "mutable field" sketch would have created. The seam stays narrow: a patch that is neither `tools` nor `name` still throws, and a case asserts it.

## One guard was satisfied rather than dodged

`product-identity` refused the single new call: `agent-session`'s agent field was named `robota` — the consumer's product name inside a neutral library — frozen at 30 occurrences with **no exemption mechanism**.

Two ways out: spell the call so it avoids the `.robota` marker, or fix what the marker points at. Re-spelling the thing a guard detects is the failure mode this repository has scans about, so the field is `agent` now and the count fell **30 → 3**. The remainder is the real `~/.robota` session directory, which is a genuine product path.

**BREAKING**: `SessionBase`'s protected `robota` member is `agent`. `getBuiltInAgent`-style external subclasses must rename their property.

## Why #1820 closes here

`presetProjection.pendingProjection`: **10 exemptions → 3**, and each of the three now has an owner:

| field | disposition |
| --- | --- |
| `allowedTools`, `deniedTools` | **#1934** — the combine rule is decided; the live half needs a capability that does not exist (permission patterns are fixed at construction). Written, measured against the projection scan, and **reverted**, because wiring the startup half alone CREATES the divergence that scan exists to measure. |
| `appendSystemPrompt` | **#1937** — its merge order is not expressible while `buildAppendSystemPrompt` has one caller and the CLI text reaches one surface of three. The prerequisite, not a companion. |

Everything ARCH-040 could decide is decided: `defaultTrustLevel` removed, the model group carried to construction, `language` applied as a prompt section, `systemPrompt` seeding rather than replacing, `model` declared, and `agentName` renaming live.

## Verification

- `pnpm harness:scan` — 128 passed, 3 skipped
- `pnpm typecheck` — 0 errors
- full suite — exits 0
- red-proofed: copying the name onto the instance instead of reading through `config` fails two of the four rename cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu51kQ6VZNaQejxgwKJ8BW