### PR TITLE
fix(agent-command): stop writing the budget through a path someone else can redirect

### DIFF
--- a/packages/agent-command/src/session/__tests__/session-command-module.test.ts
+++ b/packages/agent-command/src/session/__tests__/session-command-module.test.ts
@@ -1,3 +1,15 @@
+import {
+  constants,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 import type { ICommandHostContext, ICommandSessionRuntime } from '@robota-sdk/agent-framework';
 import { InteractiveSession, SystemCommandExecutor } from '@robota-sdk/agent-framework';
@@ -388,6 +400,63 @@ describe('createSessionCommandModule', () => {
     expect(result?.success).toBe(true);
     expect(result?.message).toContain('$5.00');
   });
+
+  it('clearing a budget writes an empty document without checking first (CodeQL js/file-system-race)', async () => {
+    // The `existsSync` this replaced was a check-then-use window: swapping the path for a symlink
+    // between the check and the write made the write land on the symlink's target. There is no
+    // window now because there is no check — and no check is safe to remove here precisely because
+    // `readBudget` reads an absent file and an empty document identically.
+    const executor = new SystemCommandExecutor([
+      ...(createSessionCommandModule().systemCommands ?? []),
+    ]);
+    const cwd = mkdtempSync(join(tmpdir(), 'robota-budget-clear-'));
+    try {
+      const context = { ...createCommandContext(), getCwd: () => cwd };
+
+      // clearing a project that never had the file must succeed, not throw on the missing path
+      const first = await executor.execute('cost', context, 'budget clear');
+      expect(first?.success).toBe(true);
+      expect(readFileSync(join(cwd, '.robota/budget.json'), 'utf-8')).toBe('{}');
+
+      await executor.execute('cost', context, 'budget 5.00');
+      const second = await executor.execute('cost', context, 'budget clear');
+      expect(second?.success).toBe(true);
+      expect(readFileSync(join(cwd, '.robota/budget.json'), 'utf-8')).toBe('{}');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(constants.O_NOFOLLOW === undefined)(
+    'refuses to write the budget through a symbolic link, naming why',
+    async () => {
+      // Removing the race is not the same as removing the redirection: a symlink planted BEFORE the
+      // call is still followed by a plain write. This is the case that pins the second half — and it
+      // is skipped rather than silently weakened on a platform with no O_NOFOLLOW, because a test
+      // that passes by not testing is worse than one that says it did not run.
+      const executor = new SystemCommandExecutor([
+        ...(createSessionCommandModule().systemCommands ?? []),
+      ]);
+      const cwd = mkdtempSync(join(tmpdir(), 'robota-budget-symlink-'));
+      try {
+        const outside = join(cwd, 'outside.txt');
+        writeFileSync(outside, 'ORIGINAL');
+        mkdirSync(join(cwd, '.robota'), { recursive: true });
+        symlinkSync(outside, join(cwd, '.robota/budget.json'));
+        const context = { ...createCommandContext(), getCwd: () => cwd };
+
+        for (const args of ['budget clear', 'budget 5.00']) {
+          const result = await executor.execute('cost', context, args);
+          expect(result?.success).toBe(false);
+          expect(result?.message).toContain('symbolic link');
+          // the point of the whole change: the target is untouched
+          expect(readFileSync(outside, 'utf-8')).toBe('ORIGINAL');
+        }
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('rejects invalid budget amount', async () => {
     const executor = new SystemCommandExecutor([

--- a/packages/agent-command/src/session/session-command.ts
+++ b/packages/agent-command/src/session/session-command.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { closeSync, constants, mkdirSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import { confirmAction, isConfirmed } from '@robota-sdk/agent-core';
 import {
@@ -77,13 +77,14 @@ interface IBudgetConfig {
 }
 
 function readBudget(cwd: string): IBudgetConfig | undefined {
-  const file = join(cwd, BUDGET_FILE);
-  if (!existsSync(file)) return undefined;
   let raw: string;
   try {
-    raw = readFileSync(file, 'utf-8');
+    // No `existsSync` first: the catch already answers the question it asked, and asking twice is
+    // the check-then-use shape CodeQL flags — here it was merely redundant, in `clearBudget` it was
+    // exploitable.
+    raw = readFileSync(join(cwd, BUDGET_FILE), 'utf-8');
   } catch {
-    // allow-fallback: budget file read failure disables feature gracefully
+    // allow-fallback: an absent or unreadable budget file disables the feature gracefully
     return undefined;
   }
   try {
@@ -94,17 +95,78 @@ function readBudget(cwd: string): IBudgetConfig | undefined {
   }
 }
 
-function writeBudget(cwd: string, config: IBudgetConfig): void {
-  const dir = join(cwd, '.robota');
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(cwd, BUDGET_FILE), JSON.stringify(config, null, 2));
+/**
+ * Write the budget document, refusing to follow a symlink at that path.
+ *
+ * Two separate problems were reachable here, and only one of them was the reported race:
+ *
+ * 1. `clearBudget` checked `existsSync` and then wrote — CodeQL `js/file-system-race`, high. Swapping
+ *    the path for a symlink inside that window made the write land on the target instead. Removing
+ *    the check closes the window, because there is no longer a moment between asking and acting.
+ * 2. That alone is not enough. A symlink planted BEFORE the call is still followed, so removing the
+ *    check fixes the race and leaves the redirection. Demonstrated both ways before and after.
+ *
+ * `O_NOFOLLOW` closes the second: the open itself fails with `ELOOP` when the final path component is
+ * a symlink, so the decision is made by the kernel at open time rather than by a check that can go
+ * stale. Windows has no such flag — `O_NOFOLLOW` is undefined there — so the write falls back to the
+ * plain one rather than silently claiming a protection the platform cannot give.
+ */
+function writeBudgetFile(cwd: string, contents: string): void {
+  mkdirSync(join(cwd, dirname(BUDGET_FILE)), { recursive: true });
+  const file = join(cwd, BUDGET_FILE);
+  const noFollow = constants.O_NOFOLLOW;
+  if (noFollow === undefined) {
+    writeFileSync(file, contents);
+    return;
+  }
+  const handle = openSync(
+    file,
+    constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow,
+  );
+  try {
+    writeFileSync(handle, contents);
+  } finally {
+    closeSync(handle);
+  }
 }
 
+function writeBudget(cwd: string, config: IBudgetConfig): void {
+  writeBudgetFile(cwd, JSON.stringify(config, null, 2));
+}
+
+/**
+ * Clear the budget by writing an empty document.
+ *
+ * The `existsSync` that used to guard this write was a check-then-use race — CodeQL
+ * `js/file-system-race`, high severity. Demonstrated rather than assumed: replacing the path with a
+ * symlink between the check and the write makes the write follow it and overwrite the target, so the
+ * guard let a caller reach a file outside the session directory entirely.
+ *
+ * The guard also bought nothing. `readBudget` reads an absent file, an empty document and malformed
+ * JSON all as "no budget set", so writing unconditionally says exactly what the check was protecting.
+ * The only visible change is that clearing on a project that never had the file now creates one
+ * holding `{}` — the same meaning, written down.
+ */
 function clearBudget(cwd: string): void {
-  const file = join(cwd, BUDGET_FILE);
-  if (existsSync(file)) {
-    writeFileSync(file, '{}');
+  writeBudgetFile(cwd, '{}');
+}
+
+/**
+ * What to tell the operator when the budget write was refused.
+ *
+ * `ELOOP` is the guard firing, not a bug: the path is a symlink and the open declined to follow it.
+ * Naming that specifically matters — "could not write the budget" would send someone looking at
+ * permissions, when the thing to look at is what the budget file points to.
+ */
+function describeBudgetWriteFailure(error: unknown): string {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ELOOP') {
+    return (
+      `Refused: ${BUDGET_FILE} is a symbolic link, and the budget is never written through one. ` +
+      'Replace it with a regular file, or remove it.'
+    );
   }
+  return `Could not write the budget: ${error instanceof Error ? error.message : String(error)}`;
 }
 
 function buildCostOutput(context: ICommandHostSessionAccess & ICommandHostWorkspace): {
@@ -166,7 +228,11 @@ export function executeCostCommand(
     const budgetArg = trimmed.slice('budget'.length).trim();
 
     if (budgetArg === 'clear') {
-      clearBudget(context.getCwd());
+      try {
+        clearBudget(context.getCwd());
+      } catch (error) {
+        return { success: false, message: describeBudgetWriteFailure(error) };
+      }
       return { success: true, message: 'Monthly budget cleared.' };
     }
 
@@ -188,7 +254,11 @@ export function executeCostCommand(
         message: 'Usage: /cost budget <amount>  (e.g. /cost budget 5.00)',
       };
     }
-    writeBudget(context.getCwd(), { monthly: amount });
+    try {
+      writeBudget(context.getCwd(), { monthly: amount });
+    } catch (error) {
+      return { success: false, message: describeBudgetWriteFailure(error) };
+    }
     return { success: true, message: `Monthly budget set to ${formatUsd(amount)}.` };
   }
 

--- a/scripts/harness/product-identity-baseline.json
+++ b/scripts/harness/product-identity-baseline.json
@@ -3,6 +3,6 @@
   "packages/agent-tools": 0,
   "packages/agent-session": 30,
   "packages/agent-preset": 3,
-  "packages/agent-command": 8,
+  "packages/agent-command": 7,
   "packages/agent-framework": 52
 }


### PR DESCRIPTION
## Reproducing it found a second defect the report did not name

CodeQL flagged a high-severity `js/file-system-race` at `packages/agent-command/src/session/session-command.ts:106`. Reproducing rather than patching turned up **two** problems, and fixing only the reported one would have left the more useful half of the attack working.

### 1 — the reported race

```ts
function clearBudget(cwd: string): void {
  const file = join(cwd, BUDGET_FILE);
  if (existsSync(file)) {      // check
    writeFileSync(file, '{}'); // …use, line 106
  }
}
```

Swapping the path for a symlink between those two lines makes the write land on the symlink's target. Demonstrated, with a file outside the project overwritten by `{}`.

Removing the check closes the window. And the check was protecting nothing: `readBudget` reads an absent file, an empty document and malformed JSON all as "no budget set", so writing unconditionally says exactly what the check was guarding. The only visible change is that clearing on a project that never had the file now creates one holding `{}` — the same meaning, written down.

### 2 — what removing the check does *not* fix

A symlink planted **before** the call is still followed by a plain write. Re-running the same attack against the check-free version overwrote the target again.

So the race and the redirection are separate defects, and only one was reported. Stopping at the CodeQL finding would have produced a green alert and a live vulnerability.

`O_NOFOLLOW` closes the second: the open fails `ELOOP` when the final path component is a symlink, so the kernel decides at open time rather than a check that can go stale between asking and acting.

| | before | check removed | + `O_NOFOLLOW` |
| --- | --- | --- | --- |
| symlink swapped mid-window | target overwritten | n/a — no window | n/a |
| symlink planted beforehand | target overwritten | **target overwritten** | `ELOOP`, target intact |

## Decisions worth flagging

- **Both writers, one helper.** `writeBudget` had the same exposure. Fixing only the line CodeQL named would have left its sibling open.
- **Windows.** `O_NOFOLLOW` is undefined there, so the write falls back to the plain one rather than claiming a protection the platform cannot give. The test for it **skips** on such a platform rather than passing without testing — a test that passes by not testing is worse than one that says it did not run.
- **A refused write is a result, not a throw.** `success: false` naming the symlink, instead of an `ELOOP` escaping a synchronous command. "Could not write the budget" would send someone to look at permissions; the thing to look at is what the budget file points to.
- **`readBudget`'s own `existsSync` is gone too.** Same check-then-use shape, harmless there because the catch already handled it — which is exactly why it was redundant.

## Red-proof, separately for each half

One fix must not stand in for the other, so each was reverted alone:

| reverted | what went red |
| --- | --- |
| restore `existsSync` in `clearBudget` | exactly the clear-path test |
| drop `O_NOFOLLOW` | exactly the symlink test |

Nineteen of twenty stayed green in each case. The `clear` path had **no test at all** before this.

## Incidentally

`product-identity` for this package fell 8 → 7: the new code takes its directory from `BUDGET_FILE` rather than repeating the literal. Re-frozen in the same change, as that scan asks. Every row of that baseline diff moves down.

## Verification

126 of 129 scans pass (3 skipped). 265 tests pass in `agent-command`. Typecheck clean.

Closes #1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPig8uCgp1ryvt9BVeTz91
