### PR TITLE
fix(harness): the Node-pin guard could not see the packages that were unpinned (INFRA-102)

### DIFF
--- a/.agents/tasks/completed/INFRA-102-node-version-is-not-single-valued-across-the-workspace.md
+++ b/.agents/tasks/completed/INFRA-102-node-version-is-not-single-valued-across-the-workspace.md
@@ -1,6 +1,7 @@
 ---
 title: 'INFRA-102: the Node version is not single-valued across the workspace, so every package tests on an unpinned runtime'
-status: in-progress
+status: done
+completed: 2026-08-21
 created: 2026-08-17
 priority: high
 urgency: now
@@ -85,3 +86,55 @@ added.
 - Discovered while completing ARCH-031; the seam change is unrelated (it reproduces identically with
   those changes stashed).
 - GitHub issue #1768.
+
+## Progress
+
+### 2026-08-21
+
+Closed — but the item was NOT finished when it was found, and the gap was in the guard rather than in
+the pins.
+
+**What was already there.** `volta.extends` on 67 manifests, `scan-node-version-single-valued`
+registered and passing, and the pin binding correctly in `packages/dag-adapters-sqlite` — the package
+whose ABI mismatch made the problem visible in the first place.
+
+**What the guard could not see.** `listWorkspaceManifests` enumerated `packages/*` and `apps/*` ONE
+level deep. `packages/dag-nodes/*` is a NESTED group declared in `pnpm-workspace.yaml`, so its twenty
+manifests were outside the population entirely. Measured on this tree before the fix:
+
+- 20 of 20 carried no `volta` field.
+- Every one resolved to **Node 24.19.0** against a root declaring **22.14.0**.
+- Each has a `test` script, so `pnpm test` ran them on an undeclared runtime — the exact condition
+  this item exists to remove.
+- The scan reported the workspace single-valued over **67 of its 87** manifests.
+
+Red-proofed rather than argued: with the one-level walk restored AND a nested pin deleted, the scan
+reports **passed**. A guard whose population excludes the failures is a guard that cannot fire, which
+is the same shape as the defect one level up.
+
+**The fix is delegation, not a second glob.** `scripts/harness/workspace-packages.mjs` was written
+for precisely this class — its own header says "several harness scans used a one-level `readdirSync`
+loop and therefore silently skipped NESTED package groups (INFRA-021)" — and this scan was one more
+copy of it. It now calls `listWorkspacePackageDirs`, and the declared size went 67 → 87.
+
+The twenty manifests then got `volta.extends: ../../../package.json`. Written as a TEXT append rather
+than a JSON round-trip: the first pass used `json.dumps` and re-encoded the em-dash in seven
+`description` fields to `\u2014`, changing lines the edit had no business touching.
+
+**Verified by running it**, not by reading the config: `cd packages/dag-nodes/file-read && node -v`
+now reports `v22.14.0` where it reported `v24.19.0`, and that package's suite passes (2 files, 9
+tests) on the declared runtime.
+
+Three cases added, and one of them was wrong first: `resolves a nested package through its
+three-level extends` mutated the manifest PATH instead of the `extends` TARGET, so it compared a
+package with itself and passed either way. Rewritten to build a second fixture whose `extends` is the
+`../../` a copy-paste from a top-level sibling would produce — which resolves to the group directory,
+where there is no manifest.
+
+| mutation                          | fails                             |
+| --------------------------------- | --------------------------------- |
+| the one-level population restored | exactly 3 — every new nested case |
+| one nested pin deleted            | exactly 1, naming that manifest   |
+
+`pnpm harness:scan` — 129 passed, 2 skipped.
+`npx vitest run scripts/harness/__tests__/` — 225 files, 4277 tests, all passed.

--- a/packages/dag-nodes/file-read/package.json
+++ b/packages/dag-nodes/file-read/package.json
@@ -56,5 +56,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/file-write/package.json
+++ b/packages/dag-nodes/file-write/package.json
@@ -56,5 +56,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/gemini-image-edit/package.json
+++ b/packages/dag-nodes/gemini-image-edit/package.json
@@ -60,5 +60,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/http-request/package.json
+++ b/packages/dag-nodes/http-request/package.json
@@ -58,5 +58,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/image-loader/package.json
+++ b/packages/dag-nodes/image-loader/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/image-source/package.json
+++ b/packages/dag-nodes/image-source/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/input/package.json
+++ b/packages/dag-nodes/input/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/instant-node/package.json
+++ b/packages/dag-nodes/instant-node/package.json
@@ -63,5 +63,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/llm-text/package.json
+++ b/packages/dag-nodes/llm-text/package.json
@@ -59,5 +59,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/mcp-tool/package.json
+++ b/packages/dag-nodes/mcp-tool/package.json
@@ -59,5 +59,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/multi-input/package.json
+++ b/packages/dag-nodes/multi-input/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/ok-emitter/package.json
+++ b/packages/dag-nodes/ok-emitter/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/seedance-video/package.json
+++ b/packages/dag-nodes/seedance-video/package.json
@@ -60,5 +60,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/skill/package.json
+++ b/packages/dag-nodes/skill/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/text-output/package.json
+++ b/packages/dag-nodes/text-output/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/text-template/package.json
+++ b/packages/dag-nodes/text-template/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/text-to-image/package.json
+++ b/packages/dag-nodes/text-to-image/package.json
@@ -60,5 +60,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/tool/package.json
+++ b/packages/dag-nodes/tool/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/transform/package.json
+++ b/packages/dag-nodes/transform/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/packages/dag-nodes/utility-text/package.json
+++ b/packages/dag-nodes/utility-text/package.json
@@ -57,5 +57,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "volta": {
+    "extends": "../../../package.json"
   }
 }

--- a/scripts/harness/__tests__/scan-node-version-single-valued.test.mjs
+++ b/scripts/harness/__tests__/scan-node-version-single-valued.test.mjs
@@ -37,6 +37,14 @@ function addPackage(root, name, manifest) {
   return path.posix.join('packages', name, 'package.json');
 }
 
+/** A package in a NESTED group, the shape `pnpm-workspace.yaml` declares as `packages/<g>/*`. */
+function addNestedPackage(root, group, name, manifest) {
+  const dir = path.join(root, 'packages', group, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, ...manifest }));
+  return path.posix.join('packages', group, name, 'package.json');
+}
+
 afterEach(() => {
   while (roots.length) rmSync(roots.pop(), { recursive: true, force: true });
 });
@@ -131,5 +139,63 @@ describe('node-version-single-valued — this repository', () => {
   it('resolves a real workspace manifest through extends to the root literal', () => {
     const [first] = listWorkspaceManifests();
     expect(resolveManifestPin(process.cwd(), first)).toEqual({ ok: true, version: readRootPin() });
+  });
+});
+
+describe('the population includes the packages that were actually broken', () => {
+  /**
+   * The scan enumerated `packages/*` and `apps/*` one level deep, so a NESTED group — declared in
+   * `pnpm-workspace.yaml` as `packages/<g>/*` — was outside the population entirely.
+   *
+   * MEASURED on this repository when it was found: `packages/dag-nodes/*` is twenty manifests, none
+   * of them carried a pin, every one resolved to Node 24.19.0 against a root declaring 22.14.0, and
+   * each has a `test` script — so `pnpm test` ran them on an undeclared runtime while this scan
+   * reported the workspace single-valued over 67 of its 87 manifests.
+   *
+   * Red-proofed rather than reasoned about: restoring the one-level walk AND deleting a nested pin
+   * makes the scan report PASSED over 67 manifests. A guard whose population excludes the failures
+   * is a guard that cannot fire — the same shape as the defect the item is about, one level up.
+   *
+   * `workspace-packages.mjs` was written for exactly this class (INFRA-021) and this scan was a
+   * twenty-first copy of it, which is why the fix is to delegate rather than to add a second glob.
+   */
+  it('sees an unpinned package in a NESTED group', () => {
+    const root = makeRoot({ node: '22.14.0' });
+    const nested = addNestedPackage(root, 'dag-nodes', 'file-read', { private: true });
+
+    const { findings } = findDeclaredPinFindings(root);
+    expect(findings.map((f) => f.file)).toContain(nested);
+    expect(findings[0].problem).toMatch(/no `volta` field/);
+  });
+
+  it('counts a nested package in the size it declares', () => {
+    const root = makeRoot({ node: '22.14.0' });
+    addPackage(root, 'top-level', { volta: { extends: '../../package.json' } });
+    addNestedPackage(root, 'dag-nodes', 'nested', { volta: { extends: '../../../package.json' } });
+
+    // Two packages, two manifests. Under the one-level walk this was 1, and the scan called the
+    // workspace single-valued on the strength of it.
+    expect(listWorkspaceManifests(root)).toHaveLength(2);
+    expect(readExaminedManifestCount(root)).toBe(2);
+    expect(findDeclaredPinFindings(root).findings).toEqual([]);
+  });
+
+  it('resolves a nested package through its three-level extends', () => {
+    const root = makeRoot({ node: '22.14.0' });
+    const nested = addNestedPackage(root, 'dag-nodes', 'tool', {
+      volta: { extends: '../../../package.json' },
+    });
+
+    expect(resolveManifestPin(root, nested)).toEqual({ ok: true, version: '22.14.0' });
+
+    // The depth is the whole point, and it is the mistake a copy-paste makes: `../../`, correct for
+    // a TOP-LEVEL package, resolves from a nested one to the GROUP directory, which has no
+    // manifest. The first cut of this case mutated the manifest PATH instead of the extends target,
+    // so it compared a package with itself and passed either way.
+    const wrongDepth = addNestedPackage(root, 'dag-nodes', 'copied', {
+      volta: { extends: '../../package.json' },
+    });
+    expect(resolveManifestPin(root, wrongDepth)).toMatchObject({ ok: false });
+    expect(findDeclaredPinFindings(root).findings.map((f) => f.file)).toContain(wrongDepth);
   });
 });

--- a/scripts/harness/scan-node-version-single-valued.mjs
+++ b/scripts/harness/scan-node-version-single-valued.mjs
@@ -30,35 +30,42 @@
  * Exit code 0 = clean, 1 = findings.
  */
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 
 import { requireGovernedTree } from './governed-tree.mjs';
+import { listWorkspacePackageDirs } from './workspace-packages.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const ROOT_MANIFEST = path.join(WORKSPACE_ROOT, 'package.json');
-const WORKSPACE_DIRS = ['packages', 'apps'];
-
 /** The one place the version literal is allowed to live. */
 export function readRootPin(rootManifestPath = ROOT_MANIFEST) {
   const manifest = JSON.parse(readFileSync(rootManifestPath, 'utf8'));
   return manifest.volta?.node;
 }
 
-/** Every workspace manifest path, relative to the workspace root. */
+/**
+ * Every workspace manifest path, relative to the workspace root.
+ *
+ * Delegated to `workspace-packages.mjs`, the single owner of "what package directories exist"
+ * (INFRA-021). This function used to be a one-level `readdirSync` over `['packages', 'apps']`, which
+ * is the exact defect that owner was written for — and this scan was a twenty-first copy of it.
+ *
+ * MEASURED when it was replaced: `packages/dag-nodes/*` is a NESTED group declared in
+ * `pnpm-workspace.yaml`, so its twenty manifests were outside the population. None carried a pin,
+ * every one of them resolved to Node 24.19.0 against a root that declares 22.14.0, and each has a
+ * `test` script — so `pnpm test` ran them on an undeclared runtime while this scan reported the
+ * workspace single-valued over 67 of its 87 manifests.
+ *
+ * A guard whose population excludes the failures is a guard that cannot fire, which is the same
+ * shape as the defect the whole item is about, one level up.
+ */
 export function listWorkspaceManifests(root = WORKSPACE_ROOT) {
-  const manifests = [];
-  for (const dir of WORKSPACE_DIRS) {
-    const absolute = path.join(root, dir);
-    if (!existsSync(absolute)) continue;
-    for (const entry of readdirSync(absolute, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const manifest = path.join(dir, entry.name, 'package.json');
-      if (existsSync(path.join(root, manifest))) manifests.push(manifest);
-    }
-  }
-  return manifests.sort();
+  return listWorkspacePackageDirs(root)
+    .map((dir) => path.join(path.relative(root, dir), 'package.json'))
+    .filter((manifest) => existsSync(path.join(root, manifest)))
+    .sort();
 }
 
 /**


### PR DESCRIPTION
Issue #1768. The pins and the scan were **both already in place**, and the workspace was still not single-valued.

## What the guard could not see

`scan-node-version-single-valued` enumerated `packages/*` and `apps/*` **one level deep**. `packages/dag-nodes/*` is a NESTED group declared in `pnpm-workspace.yaml`, so its twenty manifests were outside the population entirely.

Measured on this tree before the fix:

- 20 of 20 nested manifests carried no `volta` field
- every one resolved to **Node 24.19.0** against a root declaring **22.14.0**
- each has a `test` script, so `pnpm test` ran them on an undeclared runtime — the exact condition this item exists to remove
- the scan reported the workspace single-valued over **67 of its 87** manifests

**Red-proofed rather than argued:** restore the one-level walk *and* delete a nested pin, and the scan reports `passed`. A guard whose population excludes the failures is a guard that cannot fire — the same shape as the defect it guards, one level up.

## The fix is delegation, not a second glob

`scripts/harness/workspace-packages.mjs` exists for precisely this class. Its own header records it:

> several harness scans used a one-level `readdirSync` loop and therefore silently skipped NESTED package groups (INFRA-021)

This scan was one more copy. It now calls `listWorkspacePackageDirs`; the declared size goes 67 → 87.

The twenty manifests then get `volta.extends`. Appended as **text** rather than round-tripped through `json.dumps`, which re-encoded the em-dash in seven `description` fields to `—` — changing lines this edit had no business touching.

## Verified by running it, not by reading the config

`cd packages/dag-nodes/file-read && node -v` now reports `v22.14.0` where it reported `v24.19.0`, and that package's suite passes (2 files, 9 tests) on the declared runtime.

## One of the new cases was wrong first

`resolves a nested package through its three-level extends` mutated the manifest **path** instead of the `extends` **target**, so it compared a package with itself and passed either way. Rewritten around a second fixture whose `extends` is the `../../` a copy-paste from a top-level sibling produces — which resolves to the group directory, where no manifest exists.

| mutation | fails |
|---|---|
| the one-level population restored | exactly 3 — every new nested case |
| one nested pin deleted | exactly 1, naming that manifest |

## Verification

- `pnpm harness:scan` — 129 passed, 2 skipped
- `npx vitest run scripts/harness/__tests__/` — 225 files, 4277 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgVrA6oYyme61j1AwV6VD