### PR TITLE
test(ci): DO NOT MERGE — INFRA-047's GPL fixture, to be read and closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "devDependencies": {
+    "@substrate/connect-extension-protocol": "2.2.2",
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
     "@commitlint/cli": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
   "author": "Robota SDK Team",
   "license": "AGPL-3.0-only OR LicenseRef-Commercial",
   "devDependencies": {
-    "@substrate/connect-extension-protocol": "2.2.2",
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
     "@commitlint/cli": "^21.2.1",
@@ -180,6 +179,7 @@
   },
   "packageManager": "pnpm@8.15.4",
   "dependencies": {
+    "@substrate/connect-extension-protocol": "2.2.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^3.25.76"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
+      '@substrate/connect-extension-protocol':
+        specifier: 2.2.2
+        version: 2.2.2
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -81,9 +84,6 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1)(vitest@3.2.6)
-      '@substrate/connect-extension-protocol':
-        specifier: 2.2.2
-        version: 2.2.2
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -9730,7 +9730,7 @@ packages:
 
   /@substrate/connect-extension-protocol@2.2.2:
     resolution: {integrity: sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==}
-    dev: true
+    dev: false
 
   /@swc/core-darwin-arm64@1.15.46:
     resolution: {integrity: sha512-IsISIT22EfktVJrlvIpnAxG2u/A9aob9l99HMlx80x72WlFmFPk1V3UhkEzx86eJP8hw049KTFv/RISho2cq2Q==}
@@ -11281,7 +11281,7 @@ packages:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 8.0.16(@types/node@22.19.21)(tsx@4.23.1)
+      vite: 8.0.16(@types/node@20.19.43)(esbuild@0.28.1)(tsx@4.23.1)
     dev: true
 
   /@vitest/pretty-format@3.2.6:
@@ -23381,7 +23381,7 @@ packages:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
         version: 9.6.1(@stryker-mutator/core@9.6.1)(vitest@3.2.6)
+      '@substrate/connect-extension-protocol':
+        specifier: 2.2.2
+        version: 2.2.2
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -9723,6 +9726,10 @@ packages:
       semver: 7.8.5
       tslib: 2.8.1
       vitest: 3.2.6(@types/node@20.19.43)(jsdom@25.0.1)(tsx@4.23.1)
+    dev: true
+
+  /@substrate/connect-extension-protocol@2.2.2:
+    resolution: {integrity: sha512-t66jwrXA0s5Goq82ZtjagLNd7DPGCNjHeehRlE/gcJmJ+G56C0W+2plqOMRicJ8XGR1/YFnUSEqUFiSNbjGrAA==}
     dev: true
 
   /@swc/core-darwin-arm64@1.15.46:


### PR DESCRIPTION
## ⛔ This PR exists to be read and closed. Do not merge.

INFRA-047 migrated `dependency-review` from `deny-licenses` to `allow-licenses` in #1339, and named **one** closing condition in its Test Plan that was never run:

> A test PR introducing a GPL dev-dep is BLOCKED under the new input (then closed).

The item recorded why it could not run pre-merge — `dependency-review` executes the config of the PR's *merge result* against the target branch, so the new allow-list only gates PRs opened **after** it landed. It landed on 2026-07-24. This is that PR.

Until it runs, "the allow-list actually blocks copyleft ingress" is an argument about a config file, not a measurement — which is precisely the shape the Test Plan was written to avoid.

## The fixture

`@substrate/connect-extension-protocol@2.2.2` — `GPL-3.0-only`, **zero dependencies**. Chosen for the zero: the lockfile moves by seven lines, so the check measures the license rule rather than a wave of transitive churn.

## Expected result

**`Dependency review` FAILS**, naming `GPL-3.0-only` as not in the allow-list.

A pass here is a defect in the allow-list, not a green.

The job is advisory (in neither branch ruleset's required checks) and `paths`-filtered on `**/package.json` and `pnpm-lock.yaml`, so this PR triggers it and blocks nothing.

Once the check reports, its output goes into the INFRA-047 record and this PR is closed and its branch deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgVrA6oYyme61j1AwV6VD