### PR TITLE
chore(tasks): complete PEER-004 and PEER-006, whose work merged as issue #1863

### DIFF
--- a/.agents/tasks/completed/PEER-004-local-discovery-reaches-the-operator.md
+++ b/.agents/tasks/completed/PEER-004-local-discovery-reaches-the-operator.md
@@ -1,7 +1,8 @@
 ---
 title: 'PEER-004: local peer discovery was built and called by nothing'
-status: in-progress
+status: done
 created: 2026-08-19
+completed: 2026-08-21
 priority: high
 urgency: now
 area: packages/agent-cli, packages/agent-command, packages/agent-framework

--- a/.agents/tasks/completed/PEER-006-peers-send-reaches-the-other-session.md
+++ b/.agents/tasks/completed/PEER-006-peers-send-reaches-the-other-session.md
@@ -1,7 +1,8 @@
 ---
 title: 'PEER-006: the carrier and the ingress exist, and nothing joins them'
-status: in-progress
+status: done
 created: 2026-08-20
+completed: 2026-08-21
 priority: high
 urgency: now
 area: packages/agent-cli, packages/agent-command
@@ -60,10 +61,11 @@ One new module in `agent-cli` joins the three ends, and the command surface grow
 - [x] TC-04: a peer-supplied `origin.driverId` does not become the attributed driver id.
 - [x] TC-05: sending to this session's own id is refused.
 - [x] TC-06: `/peers send` with a missing target or missing text explains what it needs.
-- [ ] TC-07: the receiving operator sees the peer origin rendered — the turn is submitted with
-      `turnSource: 'peer'` and a derived driver id, and what the TUI does with that is the renderer's
-      own behaviour rather than this change's. Left open deliberately: ticking it would claim a
-      rendering nobody in this change measured.
+- [x] TC-07: the receiving operator sees the peer origin rendered. Left open by this change on
+      purpose — ticking it would have claimed a rendering nobody here had measured — and closed by
+      PEER-007 (issue #1915, PR #1935), which measured it: the receiving session rendered
+      `peer:<sender-session-id>` against a control session that rendered `You:`, with the two labels
+      mutually exclusive across the transcripts. Ticked on that measurement, not on this change's.
 - [x] TC-08: two sessions exchange in BOTH directions.
 - [x] TC-09: the flow and its concurrency behaviour are documented for the CLI.
 - [x] TC-10: `pnpm harness:pre-push` green.


### PR DESCRIPTION
## What was stale

`PEER-004` and `PEER-006` sat at `status: in-progress` in the backlog root while their work was on `develop` and issue #1863 was closed. That is the shape `backlog-placement` exists to catch, sitting one status field away from being caught — the scan reports a terminal-status file in the root, not an open-status file whose work has shipped.

## PEER-006's TC-07, and why the tick cites a different change

It was left open on purpose, and the reason was right when it was written:

> the receiving operator sees the peer origin rendered … Left open deliberately: ticking it would claim a rendering nobody in this change measured.

PEER-007 (issue #1915, PR #1935) then measured exactly it: the receiving session rendered `peer:<sender-session-id>` while a control session rendered `You:`, and the two labels were mutually exclusive across the transcripts — the peer-driven one had zero `You:`, the operator one zero `peer:`.

So the tick is on that measurement and the entry says so. A tick that cites the wrong change is how an unmeasured claim acquires a checkbox, which is the thing the original author was avoiding.

## The user-execution evidence

Captured 2026-08-20 by driving two real `pnpm cli:dev` sessions through PTYs on one host as one user, including **both directions** — each session labelled the *other* one, because a single direction would pass even with the label wired to the wrong end. Merged with issue #1863; this change only moves the records.

## One thing worth flagging about the commit

`git mv` moved the *index* version, so the `status: done` edit was not in the first commit — `rename 100%` was the tell, and `git status` still showed both files modified afterwards. Amended so the frontmatter change and the move land together, which the Completion Steps require as a single atomic act.

## Verification

`backlog-placement` and `task-archival` both pass (115 active task files, 875 archived). 126 of 129 scans (3 skipped). `verify-like-ci` green on all 12 stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPig8uCgp1ryvt9BVeTz91
