### PR TITLE
fix(harness): the symlink rule covered one spelling of the call, not four

### DIFF
--- a/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
+++ b/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
@@ -96,6 +96,46 @@ describe('the four measured spellings', () => {
   });
 });
 
+/**
+ * Issue #1919 — the same symlink-following function reached through an IMPORT binding.
+ *
+ * `CALL_RULES` matches the `glob.` prefix, which is one spelling of four. The other three were
+ * measured reaching the same function with nothing reported, and `from glob import glob` is the more
+ * idiomatic of the two forms — so the gap is not exotic.
+ */
+describe('the import spellings of the same call (issue #1919)', () => {
+  const PY_FILE = 'scripts/tools/sweep.py';
+
+  it('reports `from glob import glob` called under its own name', () => {
+    const script = ['from glob import glob', 'glob("**")'].join('\n');
+    expect(findingsIn(PY_FILE, script).map((f) => f.id)).toContain('python glob imported binding');
+  });
+
+  it('reports a module alias — `import glob as g` then `g.glob(...)`', () => {
+    const script = ['import glob as g', 'g.glob("**")'].join('\n');
+    expect(findingsIn(PY_FILE, script).map((f) => f.id)).toContain('python glob imported binding');
+  });
+
+  it('reports a function alias — `from glob import iglob as it` then `it(...)`', () => {
+    const script = ['from glob import iglob as it', 'it("**")'].join('\n');
+    expect(findingsIn(PY_FILE, script).map((f) => f.id)).toContain('python glob imported binding');
+  });
+
+  it('does NOT report the javascript package of the same name (TC-3)', () => {
+    // `import glob from 'glob'` names a package that does not follow symlinks. Reporting it is the
+    // false positive INFRA-123 recorded as the reason the first widening was withdrawn, so it is
+    // pinned here rather than left to the language filter to be trusted about.
+    const script = ["import glob from 'glob'", 'glob("**")'].join('\n');
+    expect(findingsIn('scripts/tools/build.mjs', script)).toEqual([]);
+  });
+
+  it('does NOT report a python file that imports glob and never calls it', () => {
+    // A binding is not a use. Reporting the import alone would make the remedy unactionable — there
+    // is no call to rewrite.
+    expect(findingsIn(PY_FILE, 'from glob import glob')).toEqual([]);
+  });
+});
+
 describe('what it does not report', () => {
   it('ignores a line that discusses the spelling in a comment', () => {
     // The rule has to be explainable in the file that implements it. A scan that flags its own

--- a/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
+++ b/scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs
@@ -121,6 +121,20 @@ describe('the import spellings of the same call (issue #1919)', () => {
     expect(findingsIn(PY_FILE, script).map((f) => f.id)).toContain('python glob imported binding');
   });
 
+  it('reports an alias imported BESIDE another module on one line', () => {
+    // Review found this: the reader anchored the import to the line end, so `import glob as g, os`
+    // matched nothing, the binding never registered, and the `g.glob(...)` call went unreported. An
+    // import statement is a comma-separated list, and reading only the single-module form answers a
+    // narrower question than the one asked.
+    const script = ['import glob as g, os', 'g.glob("**")'].join('\n');
+    expect(findingsIn(PY_FILE, script).map((f) => f.id)).toContain('python glob imported binding');
+  });
+
+  it('reports a name from a parenthesised multi-line import', () => {
+    const script = ['from glob import (', '  iglob as it,', ')', 'it("**")'].join('\n');
+    expect(findingsIn(PY_FILE, script).map((f) => f.id)).toContain('python glob imported binding');
+  });
+
   it('does NOT report the javascript package of the same name (TC-3)', () => {
     // `import glob from 'glob'` names a package that does not follow symlinks. Reporting it is the
     // false positive INFRA-123 recorded as the reason the first widening was withdrawn, so it is

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -116,16 +116,30 @@ const CALL_RULES = [
  */
 function globBindingsIn(content) {
   const bound = new Set();
-  // `import glob` / `import glob as g` — the module, bound under its own name or an alias
-  for (const match of content.matchAll(
-    /^[ \t]*import[ \t]+glob(?:[ \t]+as[ \t]+([A-Za-z_]\w*))?[ \t]*$/gm,
-  )) {
-    bound.add(match[1] ?? 'glob');
+  // `import glob`, `import glob as g`, and either of those beside other modules on one line.
+  //
+  // NOT anchored to the line end. Review found that `$` dropped `import glob as g, os` entirely —
+  // the binding never registered, so the `g.glob(...)` call this rule exists to catch went
+  // unreported. An import statement is a comma-separated LIST, and reading only the single-module
+  // form answers a narrower question than the one asked.
+  for (const statement of content.matchAll(/^[ \t]*import[ \t]+([^\n#]+)/gm)) {
+    for (const clause of statement[1].split(',')) {
+      const named = clause.trim().match(/^glob(?:[ \t]+as[ \t]+([A-Za-z_]\w*))?$/);
+      if (named) bound.add(named[1] ?? 'glob');
+    }
   }
-  // `from glob import glob, iglob as it` — the FUNCTIONS, each under its own name or an alias
-  for (const match of content.matchAll(/^[ \t]*from[ \t]+glob[ \t]+import[ \t]+([^\n#]+)/gm)) {
-    for (const clause of match[1].split(',')) {
-      const named = clause.trim().match(/^(glob|iglob)(?:[ \t]+as[ \t]+([A-Za-z_]\w*))?$/);
+  // `from glob import glob, iglob as it`, including the parenthesised multi-line form. The body is
+  // taken up to the closing paren when there is one, so a name on its own line is still read —
+  // review found the `(\n  iglob as it,\n)` shape missed for the same reason as above.
+  for (const statement of content.matchAll(
+    /^[ \t]*from[ \t]+glob[ \t]+import[ \t]+(\(([\s\S]*?)\)|[^\n#]+)/gm,
+  )) {
+    const body = statement[2] ?? statement[1];
+    for (const clause of body.split(',')) {
+      const named = clause
+        .replace(/#[^\n]*/g, '')
+        .trim()
+        .match(/^(glob|iglob)(?:[ \t]+as[ \t]+([A-Za-z_]\w*))?$/);
       if (named) bound.add(named[2] ?? named[1]);
     }
   }

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -89,6 +89,58 @@ const CALL_RULES = [
 ];
 
 /**
+ * The names a python file has bound to `glob.glob`/`iglob` by importing them (issue #1919).
+ *
+ * `CALL_RULES` matches the `glob.` prefix, which is one spelling of four. Measured, all three others
+ * reach the same symlink-following function and none was reported:
+ *
+ *     from glob import glob;         glob("**")
+ *     import glob as g;              g.glob("**")
+ *     from glob import iglob as it;  it("**")
+ *
+ * `from glob import glob` is the more idiomatic of the two forms, so the uncovered spellings are not
+ * exotic. No production instance exists today — every `glob` import in the tree is a test fixture
+ * that also writes `glob.glob(`, so the call rule already catches it — which makes this preventive
+ * rather than remedial, and is why it is a widening of one rule rather than the payload reader
+ * INFRA-123 describes.
+ *
+ * PYTHON ONLY, deliberately — and the filter is the SECOND defence, not the first. The patterns
+ * below read python import syntax (`from glob import glob`), which JavaScript's `from 'glob'` does
+ * not match, so the JS package of the same name is already unreachable by them. Measured both ways:
+ * with the language filter removed, the JS case still reports nothing.
+ *
+ * The filter stays because the first defence is a property of the regex, and a later edit that
+ * loosens the regex would silently lose it. `import glob from 'glob'` names a package that does NOT
+ * follow symlinks, and reporting it is the false positive INFRA-123 records as the reason the first
+ * widening was withdrawn — too expensive to leave resting on one line's exact shape.
+ */
+function globBindingsIn(content) {
+  const bound = new Set();
+  // `import glob` / `import glob as g` — the module, bound under its own name or an alias
+  for (const match of content.matchAll(
+    /^[ \t]*import[ \t]+glob(?:[ \t]+as[ \t]+([A-Za-z_]\w*))?[ \t]*$/gm,
+  )) {
+    bound.add(match[1] ?? 'glob');
+  }
+  // `from glob import glob, iglob as it` — the FUNCTIONS, each under its own name or an alias
+  for (const match of content.matchAll(/^[ \t]*from[ \t]+glob[ \t]+import[ \t]+([^\n#]+)/gm)) {
+    for (const clause of match[1].split(',')) {
+      const named = clause.trim().match(/^(glob|iglob)(?:[ \t]+as[ \t]+([A-Za-z_]\w*))?$/);
+      if (named) bound.add(named[2] ?? named[1]);
+    }
+  }
+  return bound;
+}
+
+/** A call through one of those names — `g.glob(…)` for a module binding, `it(…)` for a function one. */
+function boundGlobCallPattern(names) {
+  const alternation = [...names]
+    .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+  return new RegExp(`\\b(?:${alternation})\\s*(?:\\.\\s*i?glob\\s*)?\\(`);
+}
+
+/**
  * Which files this scan reads, and in what language — INFRA-115.
  *
  * Both halves come from ONE row of `script-language.mjs`. They used to be two hand-written
@@ -97,6 +149,12 @@ const CALL_RULES = [
  * was clean.
  */
 const SCRIPTS = scriptFilters(['shell', 'javascript', 'typescript', 'python', 'yaml']);
+
+/**
+ * Python alone, for the import-binding rule (issue #1919). Derived from the same table as `SCRIPTS`,
+ * so a python spelling added there governs here with no second list to keep in step.
+ */
+const PYTHON = scriptFilters(['python']);
 
 /**
  * Files that DESCRIBE the hazardous spellings rather than run them. Every entry is the guard, its
@@ -214,6 +272,11 @@ export function findingsIn(relativePath, content, attributeLine = undefined) {
 
   const rows = hazardRows();
   const findings = [];
+  // Issue #1919: the names this file bound to the symlink-following function, if it is python. The
+  // set is computed ONCE per file rather than per line, because an import binds for the whole file
+  // and a per-line reading could only see the import's own line.
+  const boundGlobs = PYTHON.isScript(relativePath, content) ? globBindingsIn(content) : new Set();
+  const boundGlobCall = boundGlobs.size > 0 ? boundGlobCallPattern(boundGlobs) : null;
   const lines = content.split('\n');
   for (const [index, line] of lines.entries()) {
     if (isCommentary(line)) continue;
@@ -240,6 +303,17 @@ export function findingsIn(relativePath, content, attributeLine = undefined) {
         line: index + 1,
         id: rule.id,
         remedy: rule.remedy,
+        text: line.trim(),
+      });
+    }
+    // Issue #1919: the same function reached through an imported binding. Reported under its own id
+    // so a reader can tell which spelling was found — the remedy is identical, the search is not.
+    if (boundGlobCall && segments.some((segment) => boundGlobCall.test(segment))) {
+      findings.push({
+        file: relativePath,
+        line: index + 1,
+        id: 'python glob imported binding',
+        remedy: 'use pathlib Path(...).rglob, which does not follow symlinks (measured)',
         text: line.trim(),
       });
     }


### PR DESCRIPTION
## The rule covered one spelling of four

`CALL_RULES` in `scan-symlink-following-enumeration.mjs` matches the `glob.` prefix. Measured, three other spellings reach the same symlink-following function and none was reported:

| spelling | before |
| --- | --- |
| `import glob; glob.glob("**")` | caught |
| `from glob import glob; glob("**")` | **missed** |
| `import glob as g; g.glob("**")` | **missed** |
| `from glob import iglob as it; it("**")` | **missed** |

`from glob import glob` is the more idiomatic of the two forms, so these are not exotic evasions.

The scan now reads which names a python file bound to that function and reports a call through any of them, under its own finding id — the remedy is identical, the search is not, and a reader should be able to tell which spelling was found. Bindings are computed **once per file** rather than per line: an import binds for the whole file, and a per-line reading could only ever see the import's own line.

## Preventive, not remedial — and that is measured, not assumed

Every `glob` import in the tree is a test fixture that also writes `glob.glob(`, so the call rule already catches all of them:

```
scripts/harness/__tests__/bulk-edit-guard.test.mjs:205
scripts/harness/__tests__/scan-symlink-following-enumeration.test.mjs:218
```

There is **no production instance** of the import-only shape. That is why this is a widening of one rule rather than the payload reader issue #1919 describes: it closes today's three evasions without a reader that a bash hook and a Node scan would both have to share.

## One assumption of mine was wrong, and the note says so

I expected the python-only filter to be the first defence against reporting JavaScript's `glob` package. It is the **second**. The patterns read python import syntax, which `import glob from 'glob'` does not match — removing the filter and re-running left the JS case still reporting nothing.

It stays anyway, and the comment now explains why rather than implying a protection it does not provide: the first defence is a property of the regex, and a later edit that loosens the regex would lose it silently. Reporting the JS package of the same name is the false positive INFRA-123 records as the reason the first widening was withdrawn — too expensive to rest on one line's exact shape.

## Red-proof, both directions

| defect injected | what went red |
| --- | --- |
| disable the binding rule | exactly the three evasion cases |
| — | the two false-positive guards stayed green |

The negative cases are pinned too: the JS package is not reported, and a python file that imports `glob` and never calls it is not reported either — a binding is not a use, and flagging the import alone would leave no call to rewrite.

## Scope

Issue #1919's **TC-2 and TC-3 are covered for this rule**. **TC-1 and TC-4 are not** — they ask for a payload reader the hook and the scan share, which this does not build. The issue stays open.

## Verification

126 of 129 scans pass (3 skipped), including this one over 3,232 tracked scripts with no new findings. 35 tests in its own suite. `verify-like-ci` green on all 12 stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPig8uCgp1ryvt9BVeTz91
