### PR TITLE
fix(hooks,harness): one table, two readers, and the wrapped import went through (issue #1957)

### DIFF
--- a/.claude/hooks/bulk-edit-guard.sh
+++ b/.claude/hooks/bulk-edit-guard.sh
@@ -364,7 +364,21 @@ while read -r PL_INTERP PL_START PL_LEN; do
   PL_TEXT="${COMMAND:$((PL_START - 1)):$PL_LEN}"
   while IFS=$'\t' read -r PR_ID PR_LANG PR_PATTERN PR_REMEDY; do
     [[ -z "$PR_ID" || "$PR_LANG" != "$PL_LANG" ]] && continue
-    if printf '%s' "$PL_TEXT" | grep -qE "$PR_PATTERN"; then
+    # This table has two readers, and they did not agree on what it says. The scan compiles each
+    # pattern with `new RegExp`, where `\t` is a tab, `\n` is a newline, and one match may span
+    # lines. `grep -E` reads none of that: inside a bracket `\t` is the two characters `\` and `t`,
+    # and grep matches one line at a time regardless. So `[ \t]` never matched a tab here, and the
+    # parenthesised multi-line import — the form `black` and `ruff format` produce — was reported by
+    # the scan and waved through by the hook.
+    #
+    # A real newline cannot be put in the pattern either: grep reads a newline in a pattern as a
+    # SEPARATOR between alternative patterns, so a class holding one becomes two patterns and the
+    # first has an unmatched `[`. Fold the newline out of BOTH sides onto one sentinel instead. The
+    # payload then holds no newline to break a line-oriented match, and `^` anchors to the start of
+    # the payload — which is what the scan's `new RegExp` already means by it. No row spells `\n`
+    # today; the mapping is here so that one would mean on this side what it means on the other.
+    PR_EXPANDED=$(printf '%s' "$PR_PATTERN" | sed -e 's/\\t/\t/g' -e 's/\\n/\x01/g')
+    if printf '%s' "$PL_TEXT" | tr '\n' '\001' | grep -qE "$PR_EXPANDED"; then
       add_finding "$PR_ID follows symlinks. $PR_REMEDY"
     fi
   done <<< "$PAYLOAD_ROWS"

--- a/scripts/harness/__tests__/payload-language.one-owner.test.mjs
+++ b/scripts/harness/__tests__/payload-language.one-owner.test.mjs
@@ -50,6 +50,15 @@ const G = `gl${'ob'}`;
 const IMPORT_SPELLING = `from ${G} import ${G}`;
 const ALIAS_SPELLING = `import ${G} as g; g.${G}(1)`;
 const JS_SPELLING = `import ${G} from '${G}'`;
+/**
+ * The form a formatter produces. `black` and `ruff format` break an import list onto its own lines
+ * once it is long enough, and every reader of this table has to mean the same thing by it — the JS
+ * side matches across lines, the grep side does not and reads `\n` in a bracket as two dead
+ * characters. Both halves were reported clean on this shape while the single-line one was blocked.
+ */
+const WRAPPED_SPELLING = `from ${G} import (\n    escape,  # noqa\n    i${G} as it,\n)`;
+/** The same list with no enumerator in it: `escape` quotes a pattern, it does not walk a tree. */
+const WRAPPED_SAFE = `from ${G} import (\n    escape,\n)`;
 
 /**
  * THE TABLE. One row, asked of the hook and of the scan.
@@ -59,6 +68,17 @@ const JS_SPELLING = `import ${G} from '${G}'`;
 const CASES = [
   ['python, the import spelling', `python3 -c "${IMPORT_SPELLING}"`, true],
   ['python, the alias spelling', `python3 -c "${ALIAS_SPELLING}"`, true],
+  ['python, the import list a formatter wrapped', `python3 -c "${WRAPPED_SPELLING}"`, true],
+  // Separated by TABS. The table spells its whitespace class `[ \t]`, which grep reads as the three
+  // characters space, backslash and `t` — never a tab — while the scan's `new RegExp` reads a tab.
+  // Both readers now expand the escape, and this row is what says so.
+  ['python, separated by tabs', `python3 -c "from\t${G}\timport\t${G}"`, true],
+  // Precision, not just reach: the hazardous name is not the first in that list, and the widening
+  // that reaches it must not become "a parenthesised glob import is always hazardous".
+  ['python, a wrapped list holding no enumerator', `python3 -c "${WRAPPED_SAFE}"`, false],
+  // The wrapped shape carrying the SAME text in JavaScript. The single-line row below proves the
+  // language check on the flat spelling; this proves the widening did not escape it.
+  ['javascript, carrying the wrapped PYTHON spelling', `node -e "${WRAPPED_SPELLING}"`, false],
   ['python, single-quoted payload', `python3 -c '${IMPORT_SPELLING}'`, true],
   ['a versioned interpreter', `python3.12 -c "${IMPORT_SPELLING}"`, true],
   ['python, the safe sibling', 'python3 -c "import pathlib; pathlib.Path(1).rglob(2)"', false],
@@ -236,6 +256,15 @@ describe('the three payload sources a committed file can carry', () => {
   it('does NOT read a heredoc body whose interpreter is a different language', () => {
     const document = `node <<'EOF'\n${JS_SPELLING}\nEOF\n`;
     expect(findingsIn('scripts/x.sh', document)).toEqual([]);
+  });
+
+  it('names the matched text even when the match spans lines', () => {
+    // A finding whose subject is empty is a finding the reader cannot act on. The text was found by
+    // searching for a matching LINE, and the wrapped import has none — so this shape was reported
+    // with the file, the line and nothing to look at.
+    const [finding] = findingsIn('scripts/x.py', `${WRAPPED_SPELLING}\n`);
+    expect(finding.id).toBe('python glob import');
+    expect(finding.text).toContain(`i${G}`);
   });
 
   it('a JavaScript file carrying the same TEXT is not reported', () => {

--- a/scripts/harness/__tests__/payload-language.one-owner.test.mjs
+++ b/scripts/harness/__tests__/payload-language.one-owner.test.mjs
@@ -73,6 +73,19 @@ const CASES = [
   // characters space, backslash and `t` — never a tab — while the scan's `new RegExp` reads a tab.
   // Both readers now expand the escape, and this row is what says so.
   ['python, separated by tabs', `python3 -c "from\t${G}\timport\t${G}"`, true],
+  // Reported in review of this change. The first cut of the parenthesised branch required a boundary
+  // character between `(` and the name, which `( glob)` and every wrapped form supply and `(glob)`
+  // does not — so the tightest spelling of the very shape this item widened for was the one left
+  // out. `import(glob)` has the same cause one token earlier: legal python, no whitespace to match.
+  ['python, no space after the open paren', `python3 -c "from ${G} import (${G})"`, true],
+  ['python, no space after import', `python3 -c "from ${G} import(${G})"`, true],
+  // The other side of that boundary: it is what keeps a name that merely CONTAINS the spelling out.
+  [
+    'python, a longer name containing the spelling',
+    `python3 -c "from ${G} import (escape_${G}als)"`,
+    false,
+  ],
+  ['python, no space and no paren', `python3 -c "from ${G} import${G}"`, false],
   // Precision, not just reach: the hazardous name is not the first in that list, and the widening
   // that reaches it must not become "a parenthesised glob import is always hazardous".
   ['python, a wrapped list holding no enumerator', `python3 -c "${WRAPPED_SAFE}"`, false],

--- a/scripts/harness/__tests__/payload-language.one-owner.test.mjs
+++ b/scripts/harness/__tests__/payload-language.one-owner.test.mjs
@@ -149,6 +149,32 @@ describe('both enforcers reach the same verdict on one case table', () => {
   }
 });
 
+describe('the hook reads this table the way the scan does', () => {
+  /*
+   * The two rows for these spellings in CASES above already assert both enforcers. These cases
+   * exist anyway, and are not redundant with them for two reasons.
+   *
+   * They name the MECHANISM rather than a verdict: what changed is not that one more spelling is
+   * hazardous, it is that `grep -E` was reading this table differently from `new RegExp` —
+   * interpreting neither `\t` nor `\n`, and matching one line at a time. Both halves of that are
+   * only visible with the hook's answer isolated from the scan's.
+   *
+   * And a table row is invisible to `check-regression-red-proof.mjs`, which reads added case titles
+   * out of the diff: a row's title is built at runtime, so a row added here is judged as a
+   * pre-existing case and its red does not count as proof. These titles are literal, so they do.
+   */
+  it('expands the table escapes, so a TAB-separated import is blocked', () => {
+    // Without the expansion `[ \t]` is the three characters space, backslash and `t` — never a tab.
+    expect(hookVerdict(`python3 -c "from\t${G}\timport\t${G}"`)).toBe(2);
+  });
+
+  it('matches across a line break, so a WRAPPED import list is blocked', () => {
+    // grep is line-oriented and a newline cannot be put in its pattern (it reads one as a separator
+    // between alternative patterns). Both sides fold the newline onto a sentinel instead.
+    expect(hookVerdict(`python3 -c "${WRAPPED_SPELLING}"`)).toBe(2);
+  });
+});
+
 describe('the reader names the interpreter and the extent', () => {
   function payloadsOf(command) {
     const result = spawnSync(

--- a/scripts/harness/payload-language-hazards.tsv
+++ b/scripts/harness/payload-language-hazards.tsv
@@ -23,5 +23,5 @@
 #   pattern    an ERE, matched against the payload TEXT
 #   remedy     the safe sibling, stated at the finding
 id	language	pattern	remedy
-python glob import	python	(^|[^A-Za-z0-9_.])from[ \t]+glob[ \t]+import[ \t]+(\([^)]*[^A-Za-z0-9_.)])?(glob|iglob)\b	use pathlib Path(...).rglob, which does not follow symlinks (measured)
+python glob import	python	(^|[^A-Za-z0-9_.])from[ \t]+glob[ \t]+import[ \t]*(\(([^)]*[^A-Za-z0-9_.)])?|[ \t])(glob|iglob)\b	use pathlib Path(...).rglob, which does not follow symlinks (measured)
 python glob alias	python	(^|[^A-Za-z0-9_.])import[ \t]+glob[ \t]+as[ \t]+[A-Za-z_][A-Za-z0-9_]*	use pathlib Path(...).rglob, which does not follow symlinks (measured)

--- a/scripts/harness/payload-language-hazards.tsv
+++ b/scripts/harness/payload-language-hazards.tsv
@@ -23,5 +23,5 @@
 #   pattern    an ERE, matched against the payload TEXT
 #   remedy     the safe sibling, stated at the finding
 id	language	pattern	remedy
-python glob import	python	(^|[^A-Za-z0-9_.])from[ \t]+glob[ \t]+import[ \t]+(glob|iglob)\b	use pathlib Path(...).rglob, which does not follow symlinks (measured)
+python glob import	python	(^|[^A-Za-z0-9_.])from[ \t]+glob[ \t]+import[ \t]+(\([^)]*[^A-Za-z0-9_.)])?(glob|iglob)\b	use pathlib Path(...).rglob, which does not follow symlinks (measured)
 python glob alias	python	(^|[^A-Za-z0-9_.])import[ \t]+glob[ \t]+as[ \t]+[A-Za-z_][A-Za-z0-9_]*	use pathlib Path(...).rglob, which does not follow symlinks (measured)

--- a/scripts/harness/scan-symlink-following-enumeration.mjs
+++ b/scripts/harness/scan-symlink-following-enumeration.mjs
@@ -431,7 +431,11 @@ function payloadFindings(relativePath, content, embeddedPayloads) {
         line: payload.line,
         id: row.id,
         remedy: row.remedy,
-        text: (payload.text.split('\n').find((l) => new RegExp(row.pattern).test(l)) ?? '').trim(),
+        // The matched SUBSTRING, not the first matching line. A parenthesised import — the form a
+        // formatter produces — matches across lines, so no single line matches it and the
+        // line-by-line search returned '': the finding named the file and named no text. Collapse
+        // the run of whitespace so a multi-line subject still reports as one readable line.
+        text: (new RegExp(row.pattern).exec(payload.text)?.[0] ?? '').replace(/\s+/g, ' ').trim(),
       });
     }
   }


### PR DESCRIPTION
Closes #1957

## The defect

`scripts/harness/payload-language-hazards.tsv` has two readers. The scan compiles each row with `new RegExp`; `.claude/hooks/bulk-edit-guard.sh` matches it with `grep -E`. They did not read it the same way.

`grep -E` interprets neither `\t` nor `\n` — inside a bracket they are the two characters `\` and `t` — and it matches one line at a time regardless. So on the hook side `[ \t]` never matched a tab, and no pattern could match across a line break.

Measured on `origin/develop` at `795480b96`:

| payload | hook | scan |
| --- | --- | --- |
| `from glob import glob` | blocked | reported |
| `from glob import (\n  escape,  # noqa\n  iglob as it,\n)` | **passed** | **not reported** |

That second shape is what `black` and `ruff format` produce the moment an import list outgrows the line length. It is the one evasion nobody has to intend.

## What changed

- **`.claude/hooks/bulk-edit-guard.sh`** expands the two escapes the scan already honours, and folds the newline out of *both* the pattern and the payload onto one sentinel. A real newline cannot go in a grep pattern at all — grep reads it as a separator between alternative patterns, so a class holding one becomes two patterns and the first has an unmatched `[`. That was measured, not assumed.
- **the import row** now reads the parenthesised body, so a name on its own line is read and a name that is not first in the list still is. Bounded by the closing paren, so `from glob import (escape,)` stays clean. No nested quantifier — the `js/redos` shape this scan was once reported for is not reintroduced; measured flat at 0.6ms against a 4000-item non-matching body.
- **`scripts/harness/scan-symlink-following-enumeration.mjs`** reports the matched substring rather than the first matching line. No single line matches the wrapped form, so it was reported with a file, a line, and an empty subject.

## Evidence

Three cases added to the shared verdict table, each **red against this branch's parent**:

```
× python, the import list a formatter wrapped: the hook
× python, the import list a formatter wrapped: the scan
× python, separated by tabs: the hook
× names the matched text even when the match spans lines
```

Two more pin precision rather than reach, and pass in **both** states — so they are not proving the fix, they are fencing it:

- a wrapped list holding only `escape` is not an enumerator and is not reported
- the same wrapped text in a `node -e` payload is still not reported — the false positive INFRA-123 recorded as the reason the first widening was withdrawn

`payload-language.one-owner.test.mjs` 45 passed · full harness suite 4326 passed · live scan 3234 tracked scripts, still clean · `verify-like-ci` 12/12 PASS.

## Done-when, from the issue

- [x] the parenthesised multi-line import is reported, with the same finding id as the single-line form (`python glob import`)
- [x] a case pins it, and a second pins that the JavaScript package of the same name is still not reported
- [x] the live scan still reports nothing across the tracked scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s