### PR TITLE
fix(ci): the license gate now says which part of the graph it judges (issue #1951)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -49,6 +49,36 @@ jobs:
         with:
           # Block the PR on a newly-introduced HIGH+ vulnerability.
           fail-on-severity: high
+          # SCOPE, stated rather than inherited (INFRA — issue #1951). The action defaults
+          # `fail-on-scopes` to `runtime` alone, and this file said nothing about it — so a
+          # development-scoped package was exempt from the license allow-list whatever its license
+          # was, and the empty `Licenses` group that produced reads exactly like "evaluated and
+          # allowed". Measured on PR #1950: the SAME package at the SAME version under
+          # `devDependencies` produced an empty group and SUCCESS, and under `dependencies` produced
+          # `@substrate/connect-extension-protocol@2.2.2 - License: GPL-3.0-only` and FAILURE.
+          #
+          # Extended rather than merely documented, because the cost was measured and is zero. Of the
+          # 668 packages present in `pnpm licenses list --dev` and absent from `--prod`, the count
+          # that would fail this allow-list is NONE. Seven carry a string that is not literally on the
+          # list; six are `OR` expressions whose every leaf is (`MIT OR Apache-2.0`, `(WTFPL OR MIT)`,
+          # `WTFPL OR ISC`) and the action matches per-leaf, and the seventh — `spawndamnit` — has no
+          # `license` field, only `SEE LICENSE IN LICENSE`, whose file is the MIT text verbatim. No
+          # copyleft leaf appears in the dev-only set at all: the `LGPL-3.0-or-later` and
+          # `AGPL-3.0-only OR LicenseRef-Commercial` entries the name-scoped exemptions below exist
+          # for are both reachable from `--prod`, so this puts no new weight on them.
+          #
+          # Two facts bound what this can cost later. The action gates the dependencies a PR ADDS,
+          # not the existing graph — so the measurement above bounds the migration at zero and the
+          # ongoing cost falls only on a future dev dependency under a license nobody has yet chosen
+          # to accept. And this check is ADVISORY (see the header): it annotates, it blocks nothing.
+          #
+          # The narrower policy is defensible — a dev-only dependency is not distributed, and the
+          # hazard this gate exists for is distribution. It is not what is written here, and flipping
+          # to it is deleting one word. What is not defensible is leaving it unsaid, which is what
+          # made INFRA-047's Test Plan specify a case that could not fail ("a test PR introducing a
+          # GPL dev-dep is BLOCKED"), and is the same shape INFRA-061 audited these workflows for: a
+          # green trusted for more than it measures.
+          fail-on-scopes: runtime, development
           # Reviewed re-accepts. This repo judges the SAME advisory with two tools — osv-scanner (the
           # `security audit` job, via osv-scanner.toml) and this one — and a suppression in one is NOT
           # read by the other, so an accepted advisory must be recorded in BOTH or the two gates

--- a/scripts/harness/__tests__/dependency-review-scope.test.mjs
+++ b/scripts/harness/__tests__/dependency-review-scope.test.mjs
@@ -1,0 +1,55 @@
+/**
+ * The license gate says which part of the dependency graph it judges (issue #1951).
+ *
+ * `actions/dependency-review-action` defaults `fail-on-scopes` to `runtime` alone. A workflow that
+ * sets no override therefore exempts every development-scoped package from the license allow-list
+ * whatever its license is — and the empty `Licenses` group that produces reads exactly like
+ * "evaluated and allowed". Measured on PR #1950: the same package at the same version under
+ * `devDependencies` produced an empty group and SUCCESS, and under `dependencies` produced
+ * `GPL-3.0-only` and FAILURE.
+ *
+ * That is a green trusted for more than it measures, and it is the reason INFRA-047's Test Plan
+ * specified a case that could not fail. The narrower policy is defensible; leaving it unsaid is not.
+ * So this asserts the DECLARATION, not one particular policy: an inherited default is what this
+ * file exists to stop, and a future owner narrowing the scope on purpose edits the expectation here
+ * along with the workflow, which is the visible decision the item asked for.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+const WORKFLOW_RELATIVE = '.github/workflows/dependency-review.yml';
+const WORKFLOW = readFileSync(path.join(ROOT, WORKFLOW_RELATIVE), 'utf8');
+
+/** The `with:` value of one input on the dependency-review step, or null when it is not set. */
+function stepInput(name) {
+  const match = new RegExp(`^\\s*${name}:\\s*(.+?)\\s*$`, 'm').exec(WORKFLOW);
+  return match ? match[1] : null;
+}
+
+describe('the license gate declares the scope it judges', () => {
+  it('sets fail-on-scopes rather than inheriting the action default', () => {
+    expect(
+      stepInput('fail-on-scopes'),
+      `${WORKFLOW_RELATIVE} must declare fail-on-scopes`,
+    ).not.toBe(null);
+  });
+
+  it('judges development dependencies as well as runtime ones', () => {
+    // Measured before extending: of the 668 packages in `pnpm licenses list --dev` and absent from
+    // `--prod`, ZERO fall outside the allow-list. Six of the seven that are not literal matches are
+    // `OR` expressions whose every leaf is listed, and the seventh is MIT by its LICENSE file.
+    const scopes = (stepInput('fail-on-scopes') ?? '').split(',').map((s) => s.trim());
+    expect(scopes).toContain('runtime');
+    expect(scopes).toContain('development');
+  });
+
+  it('still states the allow-list the scope is evaluated against', () => {
+    // A scope with no list behind it judges nothing. These are one setting in two halves, and a
+    // change that dropped either would leave the other reading as a working gate.
+    expect(stepInput('allow-licenses')).toContain('MIT');
+  });
+});


### PR DESCRIPTION
Closes #1951

## The gap

`actions/dependency-review-action` defaults `fail-on-scopes` to `runtime` alone, and `.github/workflows/dependency-review.yml` set no override. So a development-scoped package was exempt from the license allow-list whatever its license was — and the empty `Licenses` group that produces reads exactly like "evaluated and allowed".

Measured on PR #1950 — same package, same version, same lockfile entry, only the scope differing:

| form | `Licenses` group | check |
|---|---|---|
| `devDependencies` | empty | SUCCESS |
| `dependencies` | `@substrate/connect-extension-protocol@2.2.2 – License: GPL-3.0-only` | FAILURE |

## The decision, and why the measurement makes it

The item offers two options and says option 2 "would need the current dev graph measured first". Measured:

**Of the 668 packages present in `pnpm licenses list --dev` and absent from `--prod`, the count that would fail this allow-list is zero.**

Seven carry a string that is not literally on the list:

| package | expression |
|---|---|
| `@cloudflare/kv-asset-handler`, `@cloudflare/unenv-preset`, `wrangler` | `MIT OR Apache-2.0` |
| `opener`, `utf8-byte-length` | `(WTFPL OR MIT)` |
| `sanitize-filename` | `WTFPL OR ISC` |
| `spawndamnit` | `Unknown` to pnpm |

Six are `OR` expressions whose every leaf is on the list, and the action matches per-leaf via spdx-satisfies — which the workflow's own commentary already states. `spawndamnit` has no `license` field, only `SEE LICENSE IN LICENSE`; the file is the MIT text verbatim.

No copyleft leaf appears in the dev-only set at all. The `LGPL-3.0-or-later` (`@img/sharp-libvips-*`) and `AGPL-3.0-only OR LicenseRef-Commercial` (`@robota-sdk/*`) entries the name-scoped exemptions exist for are both reachable from `--prod`, so this puts no new weight on them.

Two facts bound the future cost:

- the action gates the dependencies a PR **adds**, not the existing graph — so the measurement bounds the migration at zero, and the ongoing cost falls only on a future dev dependency under a license nobody has yet chosen to accept
- the check is **advisory** — in neither ruleset's required-status-checks list. It annotates; it blocks nothing.

So option 1 (keep the exemption, state it) leaves a green that reads stronger than it measures — the shape INFRA-061 audited these workflows for. Option 2 costs nothing today, cannot block, and makes any future dev-only copyleft a visible decision rather than a silent exemption. Taking option 2, with the measurement recorded beside the rest of the policy commentary so the next reader does not redo it. **Narrowing later is deleting one word**, and the reasoning is then written down either way — which is the part the item says is actually missing.

## What the test pins

`scripts/harness/__tests__/dependency-review-scope.test.mjs` asserts the **declaration**, not one particular policy. An inherited default is what it exists to stop; an owner narrowing the scope on purpose edits the expectation beside the workflow, which is the visible decision the item asked for.

Red without the change: 2 of its 3 cases fail. `verify-like-ci` 12/12 PASS.

## Not claimed

That a dev dependency is a distribution hazard — it usually is not. And the three `Unknown`-to-pnpm packages are not all resolved: `@shinyoshiaki/jspack` and `rx.mini` are reachable from `--prod` and so were already inside today's gate, unchanged by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s