### PR TITLE
feat(harness): refuse a second record claiming a work-item ID (issue #1916)

### DIFF
--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -41,6 +41,24 @@ parent issue produces several related Tasks, the parent `AGREEMENT` Task and pai
 shared boundary and child relationship; the `AGREEMENT` is complete only after every declared child is
 complete.
 
+## Work-item IDs
+
+An ID is how a commit message, a pull request body, a review comment and a rule section all point at
+one record, so **one ID names one item**. `work-item-id-collision` in `pnpm harness:scan` refuses a
+push in which two distinct records claim one ID, and it reads only the tracked tree — a clone judges
+it offline.
+
+Two things it deliberately does not treat as collisions, and one it cannot see:
+
+- A **phase** of an item — the `-p7-` / `-P4-` segment right after the ID — belongs to its parent.
+- Seven `<PREFIX>-001` IDs from before the convention settled are allowlisted in the scan, each with
+  the reason. They are all in `completed/`, and the merged commits that deliver them name the old
+  numbers, so renaming the files would move each record out from under every citation pointing at
+  it. The allowlist may not grow: a fresh collision is refused.
+- An ID claimed by a record in one clone and by an **issue title** opened by another session is
+  invisible to it, because nothing in the tree says which issue registers which record. That is the
+  case that produced the three collisions in issue #1916 and it stays open there.
+
 ## Process
 
 1. Create a new `.md` file in this directory with the required frontmatter (see File Format below).

--- a/scripts/harness/__tests__/scan-work-item-id-collision.test.mjs
+++ b/scripts/harness/__tests__/scan-work-item-id-collision.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * The collision guard is asked BOTH directions (issue #1916).
+ *
+ * A guard that only ever reports the tree clean is indistinguishable from one that reports
+ * everything clean, so every case here has a sibling that proves the opposite verdict is reachable.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  HISTORICAL_COLLISIONS,
+  collisionsIn,
+  examinedRecordCount,
+  isPhaseRecord,
+  scanTaskRecords,
+  workItemIdOf,
+} from '../scan-work-item-id-collision.mjs';
+
+const T = '.agents/tasks/';
+
+describe('reading the id off a record', () => {
+  it.each([
+    [`${T}INFRA-047-deny-licenses-v6-migration.md`, 'INFRA-047'],
+    [`${T}completed/SELFHOST-003-codebase-index-rag.md`, 'SELFHOST-003'],
+  ])('%s claims %s', (file, id) => {
+    expect(workItemIdOf(file)).toBe(id);
+  });
+
+  it.each([
+    [`${T}README.md`, 'a file with no id'],
+    [`${T}completed/lowercase-123-thing.md`, 'a lowercase prefix, which is not an id'],
+    ['packages/agent-core/INFRA-047-notes.md', 'a path outside the tasks tree'],
+    [`${T}INFRA-047-deny-licenses.txt`, 'a non-markdown file'],
+  ])('%s claims nothing (%s)', (file) => {
+    expect(workItemIdOf(file)).toBe(null);
+  });
+});
+
+describe('a phase of an item is not a second claim on its id', () => {
+  it.each([
+    [
+      `${T}completed/ARCH-002-p7-slim-agent-cli-public-api.md`,
+      'lowercase p, as ARCH-002 spells it',
+    ],
+    [`${T}completed/ARCH-003-p8a-framework-interaction-tests.md`, 'a lettered phase'],
+    [`${T}SELFHOST-003-P4-embedding-vector-backend.md`, 'uppercase P, as SELFHOST-003 spells it'],
+  ])('%s is a phase (%s)', (file) => {
+    expect(isPhaseRecord(file)).toBe(true);
+  });
+
+  it.each([
+    [`${T}completed/ARCH-002-slim-agent-cli-tui-plugin-injection.md`, 'the parent itself'],
+    [`${T}completed/CLI-001-prompt-input-non-tty-guard.md`, 'an ordinary record'],
+    [`${T}PLAN-001-plan-completed-state.md`, 'a word that merely starts with p'],
+  ])('%s is not a phase (%s)', (file) => {
+    expect(isPhaseRecord(file)).toBe(false);
+  });
+});
+
+describe('what counts as a collision', () => {
+  it('reports an id two distinct records claim', () => {
+    expect([
+      ...collisionsIn([`${T}INFRA-900-one-thing.md`, `${T}INFRA-900-another-thing.md`]).keys(),
+    ]).toEqual(['INFRA-900']);
+  });
+
+  it('reports nothing when each id has one record', () => {
+    expect(collisionsIn([`${T}INFRA-900-one.md`, `${T}INFRA-901-two.md`]).size).toBe(0);
+  });
+
+  it('does not report a parent with many phases', () => {
+    // The shape the tree really holds: ARCH-002 is one item in 20 files.
+    expect(
+      collisionsIn([
+        `${T}completed/ARCH-002-slim-agent-cli-tui-plugin-injection.md`,
+        `${T}completed/ARCH-002-p7-slim-agent-cli-public-api.md`,
+        `${T}completed/ARCH-002-p8-extract-command-module-factory.md`,
+      ]).size,
+    ).toBe(0);
+  });
+
+  it('reports two PARENTS even when each has phases', () => {
+    // The exemption is for the phase files, not for the id. Two parents is two items.
+    expect([
+      ...collisionsIn([
+        `${T}ARCH-900-first-parent.md`,
+        `${T}ARCH-900-p1-first-phase.md`,
+        `${T}ARCH-900-second-parent.md`,
+      ]).keys(),
+    ]).toEqual(['ARCH-900']);
+  });
+});
+
+describe('the tree it actually runs on', () => {
+  it('finds every collision in the live tree inside the allowlist', () => {
+    // The scan's own pass condition, asserted against the real tree rather than a fixture: no id
+    // collides that is not already recorded as historical.
+    const live = collisionsIn(scanTaskRecords());
+    expect([...live.keys()].filter((id) => !HISTORICAL_COLLISIONS.has(id))).toEqual([]);
+  });
+
+  it('still finds the historical collisions, so the allowlist is not excusing nothing', () => {
+    // An allowlist over an empty set is a guard that has stopped measuring. This is the falsifiable
+    // half: if a later change renumbers one of these, this goes red and names it.
+    const live = collisionsIn(scanTaskRecords());
+    expect([...HISTORICAL_COLLISIONS.keys()].filter((id) => !live.has(id))).toEqual([]);
+  });
+
+  it('examines a tree of real size', () => {
+    // The live half: a subject that silently shrank to nothing passes every rule it has, so the
+    // floor is asserted against the tree the scan actually runs on.
+    expect(scanTaskRecords().length).toBeGreaterThan(500);
+  });
+});
+
+describe('the reported size is the size of what was read', () => {
+  // HARNESS-057. Asserted against an exact number, and asserted AGAIN after a second run with a
+  // different subject — a counter that is only ever read once cannot be shown to move, and one that
+  // does not move is a constant printed on the pass line.
+  const three = [
+    '.agents/tasks/INFRA-900-one.md',
+    '.agents/tasks/INFRA-901-two.md',
+    '.agents/tasks/INFRA-902-three.md',
+  ];
+
+  it('counts what the reader returned', () => {
+    scanTaskRecords({ list: () => three });
+    expect(examinedRecordCount()).toBe(3);
+  });
+
+  it('moves on a SECOND run rather than holding the first answer', () => {
+    scanTaskRecords({ list: () => three });
+    expect(examinedRecordCount()).toBe(3);
+    scanTaskRecords({ list: () => three.slice(0, 1) });
+    expect(examinedRecordCount()).toBe(1);
+  });
+
+  it('reports zero for an empty subject rather than the previous count', () => {
+    scanTaskRecords({ list: () => three });
+    scanTaskRecords({ list: () => [] });
+    expect(examinedRecordCount()).toBe(0);
+  });
+});

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -79,6 +79,7 @@
     "transport-admission",
     "transport-conformance",
     "vitest-resource-ceiling",
+    "work-item-id-collision",
     "workflow-permissions",
     "workflow-provenance",
     "workspace-refs"

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -1,6 +1,6 @@
 {
   "item": "HARNESS-087",
-  "reason": "Every harness module carrying the declaration marker is classified here. `covered` meets the floor and is re-measured each run, so losing coverage is a regression finding rather than a quiet move to the debt list. `pending` was recorded unmet when the floor was adopted \u2014 the counter is not exported, or nothing asserts its value \u2014 and an entry that comes to meet the floor is itself a finding.",
+  "reason": "Every harness module carrying the declaration marker is classified here. `covered` meets the floor and is re-measured each run, so losing coverage is a regression finding rather than a quiet move to the debt list. `pending` was recorded unmet when the floor was adopted — the counter is not exported, or nothing asserts its value — and an entry that comes to meet the floor is itself a finding.",
   "covered": [
     "scripts/harness/check-contract-disposition.mjs",
     "scripts/harness/check-fixture-floor.mjs",
@@ -35,6 +35,7 @@
     "scripts/harness/scan-symlink-following-enumeration.mjs",
     "scripts/harness/scan-tool-classification.mjs",
     "scripts/harness/scan-transport-conformance.mjs",
+    "scripts/harness/scan-work-item-id-collision.mjs",
     "scripts/harness/scan-workflow-permissions.mjs",
     "scripts/harness/scan-workflow-provenance.mjs",
     "scripts/harness/verify-doc-split-preservation.mjs"

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -461,6 +461,11 @@ export const SCAN_COMMANDS = [
     name: 'symlink-following-enumeration',
     command: ['node', 'scripts/harness/scan-symlink-following-enumeration.mjs'],
   },
+  // issue #1916. Reads only the tracked tree, so it is hermetic and a clone can judge it offline.
+  {
+    name: 'work-item-id-collision',
+    command: ['node', 'scripts/harness/scan-work-item-id-collision.mjs'],
+  },
   // INFRA-102. Only the DECLARED edge runs here: it is hermetic. The `--measured` edge asks the
   // host toolchain what a workspace script actually runs on, which no manifest edit can make true
   // (Volta binds a package tool to its install-time Node), so it is a developer-run check.

--- a/scripts/harness/scan-work-item-id-collision.mjs
+++ b/scripts/harness/scan-work-item-id-collision.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+/**
+ * One work-item ID names one item (issue #1916).
+ *
+ * A work-item ID (`INFRA-nnn`, `PEER-nnn`, `ARCH-nnn`) is allocated by reading the current highest
+ * number and adding one. Nothing owns the allocation, so two items can hold one ID and the tree does
+ * not say so. Three collisions landed in one session, and the third happened WHILE fixing the first:
+ * the number re-derived to had been taken by an issue opened between two reads.
+ *
+ * WHAT THIS CLOSES, AND WHAT IT DOES NOT. This is the half a repository can decide by itself and
+ * decide exactly: an ID held by two distinct TRACKED RECORDS. That is a fact about the tree, so a
+ * clone can judge it offline and a push can be refused on it.
+ *
+ * The half it does not close is the one that actually bit. Those three collisions were between a
+ * record in one clone and an ISSUE TITLE opened by another session — and nothing in this tree says
+ * which issue registers which record, so the comparison cannot be made. Measured: 48 IDs are claimed
+ * by both a record and an issue title, 39 of those records carry no reference to that issue's
+ * number, and they are overwhelmingly the SAME item written twice rather than two items. A scan over
+ * the union of both sources would report those 39 as collisions. The missing piece is not the
+ * network — it is the link, and 7 of 795 records carry one.
+ *
+ * THE HISTORICAL SET IS ALLOWLISTED, NOT RENUMBERED. Seven IDs collide today. Every one is a
+ * `<PREFIX>-001` from before the convention settled, every one is in `completed/`, and the commits
+ * and pull requests that delivered them name the old numbers and cannot be rewritten. Renaming the
+ * files would move the record out from under every citation that points at it, which is the failure
+ * this scan exists to prevent, applied to itself.
+ *
+ * PHASE FILES ARE NOT COLLISIONS. `ARCH-002-p7-…` and `ARCH-003-p8a-…` are one item split into
+ * phases, a convention this repository already uses 30 times. A phase file is recognised by the
+ * `-p<N>` segment directly after the ID and is attributed to its parent.
+ *
+ * Usage:
+ *   node scripts/harness/scan-work-item-id-collision.mjs
+ */
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const TASKS_PREFIX = '.agents/tasks/';
+
+/**
+ * The IDs that collide today, each with why it is not being renumbered.
+ *
+ * An entry here is a statement that the collision is HISTORICAL and unrewritable, not that it is
+ * acceptable. A NEW id must never be added: the whole point is that a fresh collision is refused
+ * before it can be pushed.
+ */
+export const HISTORICAL_COLLISIONS = new Map([
+  ['CLI-001', 'two pre-convention items, both completed and merged'],
+  ['CLI-002', 'two pre-convention items, both completed and merged'],
+  ['DOC-001', 'two pre-convention items, both completed and merged'],
+  ['DOCS-001', 'two pre-convention items, both completed and merged'],
+  ['EX-001', 'two pre-convention items, both completed and merged'],
+  ['NAMING-001', 'two pre-convention items, both completed and merged'],
+  ['SEC-001', 'three pre-convention items, all completed and merged'],
+]);
+
+/**
+ * The ID a record claims, or null when the path claims none.
+ *
+ * `.agents/tasks/HARNESS-070-lint-warnings-have-no-ceiling.md` claims `HARNESS-070`. The example is
+ * a LIVE record on purpose: `named-artifact-resolves` does not index `completed/`, since an archive
+ * names a tree that has moved on, so a citation into it resolves to nothing.
+ */
+export function workItemIdOf(relativePath) {
+  if (!relativePath.startsWith(TASKS_PREFIX) || !relativePath.endsWith('.md')) return null;
+  const base = path.basename(relativePath);
+  return /^([A-Z][A-Z0-9]*-\d+)-/.exec(base)?.[1] ?? null;
+}
+
+/**
+ * Is this the record of a PHASE of its ID's item rather than a second item claiming the ID?
+ *
+ * The segment right after the ID: `-p7-`, `-p8a-`, `-P4-`. Case-insensitive because both spellings
+ * are in the tree (`ARCH-002-p7-…`, `SELFHOST-003-P4-…`), and asserting one of them here would
+ * report the other as a collision it is not.
+ */
+export function isPhaseRecord(relativePath) {
+  const base = path.basename(relativePath);
+  return /^[A-Z][A-Z0-9]*-\d+-[Pp]\d+[a-z]?-/.test(base);
+}
+
+let examinedRecords = 0;
+
+/**
+ * How many tracked task records the last read returned. The size the pass line reports.
+ *
+ * HARNESS-057: a scan states the size of what it examined, so a subject that silently shrank to
+ * nothing cannot pass every rule it has by virtue of holding nothing.
+ */
+export function examinedRecordCount() {
+  return examinedRecords;
+}
+
+/** The default subject: every tracked file under the tasks tree, as repository-relative paths. */
+function gitTrackedTaskRecords(root) {
+  const result = spawnSync('git', ['ls-files', '-z', '--', TASKS_PREFIX], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    // Fail-closed. A collision guard that cannot read the tree has verified nothing, and reporting
+    // a pass over an unread tree is the defect one level up from the one it is looking for.
+    throw new Error(
+      `work-item-id-collision: could not list tracked files under ${TASKS_PREFIX} ` +
+        `(git exit ${result.status}): ${(result.stderr ?? '').trim() || 'no stderr'}`,
+    );
+  }
+  return (result.stdout ?? '').split('\0').filter(Boolean);
+}
+
+/**
+ * Read the subject and record its size. The finder the counter above is asserted through.
+ *
+ * `list` is injectable so a test can hand it a subject of a size it chose — the counter is only
+ * meaningful if a case can prove it MOVED, and a live tree that grows by one record a day cannot be
+ * asserted against an exact number without the assertion becoming maintenance.
+ */
+export function scanTaskRecords({ root = WORKSPACE_ROOT, list = gitTrackedTaskRecords } = {}) {
+  const records = list(root);
+  examinedRecords = records.length;
+  return records;
+}
+
+/**
+ * Group the records by ID, counting only the ones that CLAIM the ID rather than extend it.
+ *
+ * Returns `Map(id → string[])` holding every id with two or more claimants, allowlist included —
+ * the caller decides what to report, so a test can see the allowlisted ones too.
+ */
+export function collisionsIn(records) {
+  const byId = new Map();
+  for (const record of records) {
+    const id = workItemIdOf(record);
+    if (id === null || isPhaseRecord(record)) continue;
+    byId.set(id, [...(byId.get(id) ?? []), record]);
+  }
+  return new Map(
+    [...byId].filter(([, paths]) => paths.length > 1).map(([id, p]) => [id, p.sort()]),
+  );
+}
+
+function main() {
+  const records = scanTaskRecords();
+  const collisions = collisionsIn(records);
+  const fresh = [...collisions].filter(([id]) => !HISTORICAL_COLLISIONS.has(id));
+
+  // The allowlist is not allowed to outlive what it excuses. An entry whose id no longer collides is
+  // a permission nobody needs, and a stale one is how an allowlist quietly becomes the rule.
+  const stale = [...HISTORICAL_COLLISIONS.keys()].filter((id) => !collisions.has(id));
+
+  console.log(`::examined:: ${records.length} tracked task record(s)`);
+
+  if (fresh.length === 0 && stale.length === 0) {
+    console.log('work-item-id-collision scan passed.');
+    return 0;
+  }
+  for (const [id, paths] of fresh) {
+    console.error(`work-item-id-collision: ${id} is claimed by ${paths.length} distinct records:`);
+    for (const p of paths) console.error(`  ${p}`);
+  }
+  if (fresh.length > 0) {
+    console.error(
+      'A work-item ID is how a commit message, a pull request body and a rule section point at ' +
+        'one record. Pick the next free number and rename BEFORE pushing — once the citations are ' +
+        'merged the correction can only be a forwarding note.',
+    );
+  }
+  for (const id of stale) {
+    console.error(
+      `work-item-id-collision: ${id} is allowlisted as a historical collision but no longer ` +
+        'collides. Remove it from HISTORICAL_COLLISIONS.',
+    );
+  }
+  return 1;
+}
+
+// Not a `file://` string comparison: that is false whenever the path holds a character a URL
+// escapes, and it fails toward silence — `main()` would not run and the exit would read as a pass.
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  process.exit(main());
+}


### PR DESCRIPTION
Refs #1916 — closes the half a repository can decide by itself. The half that produced the three reported collisions stays open, and this PR says why.

## What it does

`scripts/harness/scan-work-item-id-collision.mjs` refuses an ID held by two distinct tracked records. It reads only the tracked tree, so it is hermetic — a clone judges it offline, and a push carrying a fresh collision is refused at pre-push rather than at review.

## Measured first, and the measurement changed the shape

Twelve IDs are held by more than one record.

**Five are one item split into phases.** `ARCH-002` is one item in 20 files; `ARCH-003`, `SELFHOST-003`, `SELFHOST-008`, `SELFHOST-011` likewise. The convention already exists in the tree in two spellings (`-p7-`, `-P4-`), so the scan recognises the segment right after the ID case-insensitively — asserting one spelling would report the other as a collision it is not.

**Seven are genuine, and they have exactly one shape:**

| ID | records |
|---|---|
| `CLI-001`, `CLI-002`, `DOC-001`, `DOCS-001`, `EX-001`, `NAMING-001` | 2 each |
| `SEC-001` | 3 |

Every one is a `<PREFIX>-001` from before the convention settled, and every one is in `completed/`. Allowlisted rather than renumbered: the merged commits and PRs that deliver them name the old numbers and cannot be rewritten, so renaming the files would move each record out from under every citation pointing at it — which is the failure this scan exists to prevent, applied to itself. **The allowlist may not grow**, and it is checked for staleness in the same run: an entry whose ID no longer collides is itself a finding.

## What it does NOT close

The three collisions in the item were between a record in one clone and an **issue title** opened by another session. This scan cannot see that, and the reason is not the network:

- **48** IDs are claimed by both a record and an issue title
- **39** of those records carry no reference to that issue's number
- but they are overwhelmingly the **same item written twice**, not two items

So a scan over the union of both sources — option 1 as the item describes it — would report those 39 as collisions. The missing piece is the **link** between a record and its registering issue, and **7 of 795** records carry one. Option 1 is therefore narrower than the item estimated, and would not have caught the three that motivated it.

That is left on the issue rather than guessed at here.

## Evidence

22 cases, both directions on every rule. Two are the ones that keep the guard honest:

- the scan finds **no** collision outside the allowlist in the live tree
- the scan **still finds the seven** — an allowlist over an empty set is a guard that has stopped measuring, and if a later change renumbers one, that case goes red and names it

And proved against the real tree rather than a fixture — a second `HARNESS-070` record planted into the tracked tree:

```
work-item-id-collision: HARNESS-070 is claimed by 2 distinct records:
  .agents/tasks/HARNESS-070-a-planted-second-claim.md
  .agents/tasks/HARNESS-070-lint-warnings-have-no-ceiling.md
exit=1
```

exit 0 once removed.

132 scans pass (129 + 3 skipped). `verify-like-ci` 12/12 PASS. The convention and its two exemptions are written in `.agents/tasks/README.md`, which is where the ID rules already live.

## Three things the harness's own scans caught while building this, all fixed

- the `import.meta.url === \`file://…\`` execution guard fails toward silence on any path a URL escapes
- the declared size had no reader a test could run, and no case asserting it against an exact number after a *second* run — the counter is now read through an injectable finder so a case can prove it moves
- `named-artifact-resolves` refuses a citation into `completed/`, because an archive names a tree that has moved on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s