### PR TITLE
docs(tasks): the four blocked INFRA items say what blocks them, and one had stale evidence

### DIFF
--- a/.agents/tasks/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/INFRA-046-promote-advisory-gates.md
@@ -133,11 +133,27 @@ A four-way recurrence audit measured what these two floors are currently worth:
   `ci.yml`'s `regression-red-proof (advisory)`, exits 0 on failure, and its enforcing branch is
   gated on `REGRESSION_RED_PROOF_ENFORCE` — **set in no workflow**. Same shape for
   `check-patch-coverage`.
+
+  > **Half of this is STALE as of 2026-08-04, re-measured 2026-08-22.** The flag IS set:
+  > `.github/workflows/ci.yml` carries `REGRESSION_RED_PROOF_ENFORCE: '1'` with the owner decision
+  > recorded beside it, and the job is now named `regression-red-proof (enforcing: accidental-green
+only)`. So it CAN fail, and "nothing can fail on it" below is no longer true of this gate.
+  >
+  > What still holds: it is not registered in `run-all-scans` — verified by grep, no entry — and
+  > that is correct rather than a gap. It reads `PR_BODY` and a merge-base diff, so it has no
+  > hermetic tree to judge; registering it would put a check that cannot reach a verdict into a
+  > suite whose passes are read as verdicts. `promotion-closes` is excluded from `harness:scan` for
+  > the same reason and says so.
+  >
+  > `check-patch-coverage` is unchanged: still advisory, still `PATCH_COVERAGE_ENFORCE`-gated, and
+  > excluded from the required list on the ground that a required context must be able to fail.
+
 - The defect it exists to catch recurred **twice in one session** (ARCH-004 RUNTIME-14, CORE-026
   RUNTIME-12) and is `common-mistakes` #82.
 
 So the repository has a built, tested floor for its accidental-green class and **nothing can fail on
-it**. The change is two environment variables and moving two contexts to required — the smallest
+it**. (Half-corrected above: the flag has since been set, so `regression-red-proof` CAN fail; only
+the required-list half remains.) The change is two environment variables and moving two contexts to required — the smallest
 mechanical prevention on the whole audit's list, against a class with confirmed recurrence.
 
 ## Promotion Audit 2026-07-31 — NOT PROMOTED (neither flag flipped)
@@ -255,3 +271,26 @@ duplicate build, not the advisory posture.
 
 So the block is not "waiting for a credential". It is waiting for evidence, and the credential after
 it. Recorded as `blocked` rather than `todo` so the distinction is readable.
+
+### 2026-08-22 — the remaining action, stated exactly, and why it is not taken
+
+Re-measured rather than repeated:
+
+| claim                                               | state                                                                                                    |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `REGRESSION_RED_PROOF_ENFORCE` set in no workflow   | **STALE** — set in `ci.yml`, with the 2026-08-04 owner decision recorded at the line                     |
+| `check-regression-red-proof` not in `run-all-scans` | **HOLDS**, and is correct: it reads `PR_BODY` and a merge-base diff, so it has no hermetic tree to judge |
+| the two contexts are not required                   | **HOLDS** — `protect-develop` (id 18715844) requires nine contexts and neither of these is among them    |
+
+The nine: `build`, `quality`, `scans`, `dependency audit`, `commitlint`, `tui-e2e`,
+`examples-typecheck`, `windows-shell`, `review-gate`.
+
+**The remaining action is one `gh api -X PUT` against that ruleset, and it needs repo-admin scope
+this agent does not have.** The command shape is in ## Owner Action above.
+
+**It should also not be run yet, on this item's own reasoning.** `accidental-green` has never fired
+on a real pull request, so requiring it would put an untested refusal in the merge path; one observed
+firing is what promotes it. Confirmed with the owner on 2026-08-22, who chose not to add it now.
+
+So `blocked` is the accurate status and it is blocked on EVIDENCE first, a credential second — not
+merely waiting for permission.

--- a/.agents/tasks/INFRA-054-fast-forward-promotion-end-state.md
+++ b/.agents/tasks/INFRA-054-fast-forward-promotion-end-state.md
@@ -103,3 +103,21 @@ Two further constraints measured on 2026-08-21, both of which narrow the design 
   `develop` is 62 commits ahead of `main`, and performing a promotion is a release action.
 
 Recorded as `blocked` rather than `todo`: the work is not unstarted, it is unauthorised.
+
+### 2026-08-22 — confirmed with the owner: blocked, decisions outstanding
+
+Re-stated so the block is actionable rather than vague. Three decisions, all from this item's own
+
+## Direction section, none of them technical:
+
+1. must `hotfix/*` route through `develop` first — without it, fast-forward breaks on the first
+   hotfix and `main-pr-source-guard` needs tightening;
+2. if Dependabot is re-enabled, does it target `develop`;
+3. is losing the promotion PR — and with it CodeQL's annotations on the promotion — acceptable,
+   given every promoted commit already passed CI on its own pull request.
+
+The third is load-bearing and is a policy judgement.
+
+Once those are settled the implementation is ordinary and this agent can do it: the vehicle is a
+`workflow_dispatch` workflow, a trigger this repository already uses, so unlike INFRA-042 and
+INFRA-065 this item is NOT blocked by the 2026-08-04 cron directive.

--- a/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
@@ -113,3 +113,20 @@ guarded workflow fails the PR — is still not taken, and for the reason the ent
 quietly would be the thing the item is about.
 
 Recorded as `blocked` rather than `todo` so it is not read as unstarted work.
+
+### 2026-08-22 — one candidate action re-examined and declined, with the owner
+
+`scan-workflow-provenance` DOES accept `--base-ref` — its own header documents it, and given one it
+fails a change that edits a guarded workflow and names which contexts that change can move. Wiring
+that into CI is the only step short of trusted provenance that an agent could take, so it was put to
+the owner rather than left unexamined.
+
+**Declined, and the reason is what the item is about rather than the wiring difficulty.** It would
+improve DETECTION — an edit becomes a PR-time failure instead of a standing advisory line — and it
+would not make the control plane trusted, because the guard would live in the same file the pull
+request under test can edit. Landing it would close no part of this item's stated objective while
+making the item look closer to done than it is.
+
+`blocked` therefore remains accurate: the objective needs an organization-level required workflow, a
+`pull_request_target` split, or an external GitHub App, and every one of those is configuration
+outside this repository.

--- a/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -120,3 +120,15 @@ repeat it without noticing.
 Left `in-progress` deliberately. The implementation, the required-context wiring and TC-01…TC-09 are
 complete; only the observation is outstanding, and manufacturing work to observe it would be worse
 than waiting for it to arise.
+
+### 2026-08-22 — re-measured, and the disposition confirmed with the owner
+
+`develop` is 70 commits ahead of `main`. Every `Closes` / `Fixes` / `Resolves` reference in the
+commits `develop` carries and `main` does not names an issue that is ALREADY CLOSED — re-checked
+against the live issue states, not against the record. So a promotion run today would derive an
+empty block for the second time, and TC-10 would still not be observed.
+
+Put to the owner on 2026-08-22 with three options: leave it, promote now, or manufacture a candidate
+by reopening one of the issues this session hand-closed. **Chosen: leave it `in-progress`.**
+Manufacturing the condition would satisfy the checkbox by arranging the evidence, which is the shape
+this repository refuses everywhere else.


### PR DESCRIPTION
The four INFRA items an agent cannot complete. That much was already recorded; what was not is **what exactly each waits on**, and whether the record was still true.

Re-measured rather than repeated — and one of them was wrong.

## INFRA-046 — half its evidence was stale

The 2026-07-28 audit says `REGRESSION_RED_PROOF_ENFORCE` is **"set in no workflow"** and concludes **"nothing can fail on it"**.

Both have been false since 2026-08-04. The flag is set in `ci.yml` with the owner decision recorded at the line, and the job is named `regression-red-proof (enforcing: accidental-green only)`. That gate *can* fail.

Corrected in place with the correction **visible**, not by rewriting the original — the audit's reasoning is still worth reading, and so is the fact that it aged.

**What still holds, verified:** it is not registered in `run-all-scans`. That is *correct rather than a gap*: it reads `PR_BODY` and a merge-base diff, so it has no hermetic tree to judge. Registering it would put a check that cannot reach a verdict into a suite whose passes are read as verdicts — which is exactly why `promotion-closes` is excluded, and says so.

**Remaining action:** one `gh api -X PUT` against `protect-develop` (id `18715844`; nine required contexts today, neither of these among them). Needs repo-admin scope. And it should not run yet, on the item's own reasoning: `accidental-green` has never fired on a real PR, so requiring it would put an untested refusal in the merge path. **Blocked on evidence first, a credential second.**

## INFRA-097 — one candidate action re-examined and declined

`scan-workflow-provenance` *does* accept `--base-ref`, and wiring it into CI is the only step short of trusted provenance an agent could take. So it was examined rather than left unmentioned.

Declined, and for the item's own reason: it improves **detection**, and it does not make the control plane trusted — the guard would live in the same file the PR under test can edit. Landing it would close no part of the objective while making the item *look* closer to done.

## INFRA-104 — measured again, not assumed

`develop` is 70 commits ahead of `main`, and every closing reference it carries names an issue that is already closed — checked against live issue state. A promotion today derives an **empty block for the second time**.

Manufacturing a candidate by reopening one of the issues this session hand-closed was offered and declined: satisfying a checkbox by arranging the evidence is the shape this repository refuses everywhere else.

## INFRA-054 — the block restated as three decisions

None technical; the load-bearing one is whether losing the promotion PR (and CodeQL's annotations on it) is acceptable. Once settled the implementation is ordinary and an agent can do it — its vehicle is `workflow_dispatch`, so unlike INFRA-042 and INFRA-065 it is **not** blocked by the 2026-08-04 cron directive.

## Verification

`pnpm harness:scan` — 129 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgVrA6oYyme61j1AwV6VD