### PR TITLE
fix(harness): tell a quote DELIMITER from a quote that is data

### DIFF
--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -996,8 +996,18 @@ HOOK_SCAN_AWK='
           if ((mc == " " || mc == "\t" || mc == "\n") && rc ~ /[ \t\n]/) { break }
           if (mc == ";" || mc == "&" || mc == "|" || mc == ">" || mc == "<" || mc == ")") { break }
           started = 1
-          # A quote DELIMITER shows as a space in the mask and contributes no character.
-          if (mc == " ") { k++; continue }
+          # A quote DELIMITER contributes no character, and it has TWO spellings in the mask. The
+          # tokenizer turns it into a space when it read the region as a single-word token, and
+          # leaves the quote character ITSELF when the region contains whitespace. Only the first was
+          # skipped, so a target quoted around a space came back wearing its quotes —
+          # `"node_modules/a b"` — and the anchored store pattern no caller could match it. Measured
+          # across ten arrow spellings, every one permitted a write bash performs.
+          if (mc == " " || mc == "\"" || mc == "\047") { k++; continue }
+          # The `$` of `$'…'` / `$"…"` introduces the delimiter and is not part of the name either.
+          if (mc == "$" && (substr(mask, k + 1, 1) == "\"" || substr(mask, k + 1, 1) == "\047")) {
+            k++
+            continue
+          }
           # An unquoted backslash splices the next character.
           if (mc == "\\" && rc == "\\") { k++; continue }
           # Masked content is data, and here the data IS the name — read it from the original.

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -997,19 +997,38 @@ HOOK_SCAN_AWK='
           if (mc == ";" || mc == "&" || mc == "|" || mc == ">" || mc == "<" || mc == ")") { break }
           started = 1
           # A quote DELIMITER contributes no character, and it has TWO spellings in the mask. The
-          # tokenizer turns it into a space when it read the region as a single-word token, and
+          # tokenizer turns it into a SPACE when it read the region as a single-word token, and
           # leaves the quote character ITSELF when the region contains whitespace. Only the first was
           # skipped, so a target quoted around a space came back wearing its quotes —
-          # `"node_modules/a b"` — and the anchored store pattern no caller could match it. Measured
-          # across ten arrow spellings, every one permitted a write bash performs.
-          if (mc == " " || mc == "\"" || mc == "\047") { k++; continue }
-          # The `$` of `$'…'` / `$"…"` introduces the delimiter and is not part of the name either.
-          if (mc == "$" && (substr(mask, k + 1, 1) == "\"" || substr(mask, k + 1, 1) == "\047")) {
+          # `"node_modules/a b"` — and the store pattern, anchored on a separator, could not match it.
+          # Measured across the eleven write spellings this file drives, and both quotings: 22
+          # commands permitted, 18 of which bash performs (the other four are the `2>&` and `>>&`
+          # forms bash itself rejects, and are the deliberate over-report documented above).
+          #
+          # WHICH SPELLING IT IS, is decided by ROLE and not by character class. A quote is a
+          # delimiter only where it borders MASKED content: the tokenizer blanks what a delimiter
+          # encloses, so a quote beside a masked byte opened or closed a region, and a quote standing
+          # among visible characters is DATA the name keeps. Deciding by class instead deleted a
+          # quote belonging to the path — an escaped double quote came back with the quote gone,
+          # while bash writes it — and falsified the stated limit about a spliced character joining.
+          if (mc == " ") { k++; continue }
+          if ((mc == "\"" || mc == "\047") &&
+              (substr(mask, k - 1, 1) == "\001" || substr(mask, k + 1, 1) == "\001")) {
             k++
             continue
           }
-          # An unquoted backslash splices the next character.
-          if (mc == "\\" && rc == "\\") { k++; continue }
+          # The `$` of `$'…'` / `$"…"` introduces such a delimiter and is not part of the name either.
+          if (mc == "$" && (substr(mask, k + 1, 1) == "\"" || substr(mask, k + 1, 1) == "\047") &&
+              substr(mask, k + 2, 1) == "\001") {
+            k++
+            continue
+          }
+          # An unquoted backslash splices the next character, which the NAME then keeps.
+          if (mc == "\\" && rc == "\\") {
+            k++
+            if (k <= len) { word = word substr(s, k, 1); k++ }
+            continue
+          }
           # Masked content is data, and here the data IS the name — read it from the original.
           word = word rc
           k++

--- a/.claude/hooks/lib/command-scan.sh
+++ b/.claude/hooks/lib/command-scan.sh
@@ -1023,6 +1023,24 @@ HOOK_SCAN_AWK='
             k++
             continue
           }
+          # An EMPTY dollar-quote — `$` followed by a quote pair with nothing between — expands to
+          # nothing, so bash writes the bare path that follows it. Its mask is three VISIBLE
+          # characters: the region has no content, so neither quote has a \001 to border and the
+          # role test above reads all three as DATA. The name then kept them, and a store pattern
+          # anchored on a separator could not match `$''node_modules/x.json` — measured on the
+          # guard as verdict 0, permitted, while bash created the file inside the store.
+          #
+          # Only the dollar-introduced spelling is affected. A bare `''` / `""` is masked as two
+          # SPACES by the single-word token path above and was already consumed; `$'x'` has content
+          # to border and was already consumed. Measured, all four, rather than reasoned about.
+          #
+          # Here the PAIR is the delimiter — there is no content to decide by — so all three
+          # characters go at once.
+          if (mc == "$" && (substr(mask, k + 1, 1) == "\"" || substr(mask, k + 1, 1) == "\047") &&
+              substr(mask, k + 2, 1) == substr(mask, k + 1, 1)) {
+            k += 3
+            continue
+          }
           # An unquoted backslash splices the next character, which the NAME then keeps.
           if (mc == "\\" && rc == "\\") {
             k++

--- a/scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs
+++ b/scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs
@@ -123,6 +123,8 @@ const QUOTED_STORE_PATHS = [
   ['single quotes around a space', "'node_modules/a dir/index.js'"],
   ['a dollar-quoted segment', "$'node_modules'/pkg/index.js"],
   ['a locale-quoted segment', '$"node_modules"/pkg/index.js'],
+  ['an empty dollar-quote', "$''node_modules/pkg/index.js"],
+  ['an empty locale-quote', '$""node_modules/pkg/index.js'],
 ];
 
 const fill = (shape, protectedPath) => shape.replaceAll('<P>', () => protectedPath);
@@ -190,6 +192,19 @@ describe('hook_redirect_targets names what a command writes to', () => {
     ['single quotes around a space', "'a dir/out.txt'", 'a dir/out.txt'],
     ['a dollar-quoted segment', "$'a dir'/out.txt", 'a dir/out.txt'],
     ['a locale-quoted segment', '$"a dir"/out.txt', 'a dir/out.txt'],
+    // An EMPTY dollar-quote expands to nothing, so bash writes the bare path that follows it. Both
+    // rows were absent, and the gap they left was not cosmetic: the delimiter test asks whether a
+    // quote BORDERS masked content, and an empty region has no masked content to border — the mask
+    // of `$''` is three visible characters with no \001 between them. All three were therefore read
+    // as data, the target came back as `$''node_modules/x.json`, and the store pattern (anchored on
+    // `(^|/)`) could not match it. Measured on the guard: verdict 0, permitted, while bash created
+    // the file inside the store.
+    // No space in these two, and that is the point rather than an omission. An empty quote encloses
+    // nothing, so it cannot hold a space together the way `$'a dir'` does — measured, bash reads
+    // `echo x > $''a dir/out.txt` as a redirect to `a` with `dir/out.txt` a separate word. A row
+    // expecting `a dir/out.txt` here would assert something bash does not do.
+    ['an empty dollar-quote', "$''a-dir/out.txt", 'a-dir/out.txt'],
+    ['an empty locale-quote', '$""a-dir/out.txt', 'a-dir/out.txt'],
   ];
 
   // A shape that already carries its own quotes is skipped: filling it would nest one quoting inside

--- a/scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs
+++ b/scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs
@@ -108,7 +108,11 @@ const WRITES_ELSEWHERE = [
 /** Everything both guards must permit, whatever the reason. */
 const WRITES_NOTHING = [...NAMES_NO_FILE, ...WRITES_ELSEWHERE];
 
-const fill = (shape, protectedPath) => shape.replaceAll('<P>', protectedPath);
+// The replacement is a FUNCTION, not a string. `String.replaceAll` reads `$'`, `$&` and `` $` `` in
+// a string replacement as patterns, so a path written `$'a dir'/out.txt` — a legitimate shell
+// dollar-quote — was rewritten into `a dir'/out.txt` before it ever reached a shell, and the row
+// asserting quote handling was quietly testing something else. A function replacement is literal.
+const fill = (shape, protectedPath) => shape.replaceAll('<P>', () => protectedPath);
 
 // ---------------------------------------------------------------------------------------------
 // 1. The reader itself.
@@ -152,6 +156,43 @@ describe('hook_redirect_targets names what a command writes to', () => {
 
   it('reports every target when a command has more than one', () => {
     expect(targetsOf('echo x > a.txt 2> b.txt')).toEqual(['a.txt', 'b.txt']);
+  });
+
+  /**
+   * A quote DELIMITER has two spellings in the mask, and only one of them was being skipped.
+   *
+   * The tokenizer turns a quote into a SPACE when it read the region as a single-word token, and
+   * leaves the quote CHARACTER ITSELF when the region contains whitespace. The reader skipped a
+   * space and appended the character, so a target quoted around a space came back wearing its
+   * quotes — `"node_modules/a b"` — and the store pattern, anchored on `(^|/)`, could not match it.
+   *
+   * Measured before the fix: every one of the ten write spellings permitted a command bash performs,
+   * for both a whitespace-bearing double-quoted target and a dollar-quoted one. The table is driven
+   * from `WRITES` so a spelling added there is covered here without being remembered.
+   */
+  const QUOTINGS = [
+    ['double quotes around a space', '"a dir/out.txt"', 'a dir/out.txt'],
+    ['single quotes around a space', "'a dir/out.txt'", 'a dir/out.txt'],
+    ['a dollar-quoted segment', "$'a dir'/out.txt", 'a dir/out.txt'],
+    ['a locale-quoted segment', '$"a dir"/out.txt', 'a dir/out.txt'],
+  ];
+
+  // A shape that already carries its own quotes is skipped: filling it would nest one quoting inside
+  // another and produce a command bash does not parse, which tests the fixture rather than the rule.
+  for (const [label, shape] of WRITES.filter(([, form]) => !/["']/.test(form))) {
+    for (const [quoteLabel, written, expected] of QUOTINGS) {
+      it(`strips the quotes of ${quoteLabel} after ${label}`, () => {
+        expect(targetsOf(`echo x ${fill(shape, written)}`)).toContain(expected);
+      });
+    }
+  }
+
+  it('leaves a quote that is not a delimiter alone', () => {
+    // The skip is for a DELIMITER. An expansion the shell would resolve still comes back unresolved,
+    // which is the reader's stated contract, and a mention inside a quoted argument is still not a
+    // redirection at all.
+    expect(targetsOf('echo x > $dir/out.txt')).toContain('$dir/out.txt');
+    expect(targetsOf('echo "a > b"')).toEqual([]);
   });
 });
 

--- a/scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs
+++ b/scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs
@@ -112,6 +112,19 @@ const WRITES_NOTHING = [...NAMES_NO_FILE, ...WRITES_ELSEWHERE];
 // a string replacement as patterns, so a path written `$'a dir'/out.txt` — a legitimate shell
 // dollar-quote — was rewritten into `a dir'/out.txt` before it ever reached a shell, and the row
 // asserting quote handling was quietly testing something else. A function replacement is literal.
+/**
+ * The same four quotings, written around a path INSIDE the store, for the guard-level rows.
+ *
+ * Kept beside the table rather than inside one describe, because two consumers ask it and a second
+ * copy is how the two guards drifted apart in the first place.
+ */
+const QUOTED_STORE_PATHS = [
+  ['double quotes around a space', '"node_modules/a dir/index.js"'],
+  ['single quotes around a space', "'node_modules/a dir/index.js'"],
+  ['a dollar-quoted segment', "$'node_modules'/pkg/index.js"],
+  ['a locale-quoted segment', '$"node_modules"/pkg/index.js'],
+];
+
 const fill = (shape, protectedPath) => shape.replaceAll('<P>', () => protectedPath);
 
 // ---------------------------------------------------------------------------------------------
@@ -166,9 +179,11 @@ describe('hook_redirect_targets names what a command writes to', () => {
    * space and appended the character, so a target quoted around a space came back wearing its
    * quotes — `"node_modules/a b"` — and the store pattern, anchored on `(^|/)`, could not match it.
    *
-   * Measured before the fix: every one of the ten write spellings permitted a command bash performs,
-   * for both a whitespace-bearing double-quoted target and a dollar-quoted one. The table is driven
-   * from `WRITES` so a spelling added there is covered here without being remembered.
+   * Measured before the fix, over the eleven write spellings this loop drives and the two quotings:
+   * 22 commands permitted by `bulk-edit-guard`, of which 18 create the file under a real bash. The
+   * other four are the `2>&` and `>>&` forms bash itself rejects — the deliberate over-report this
+   * file documents above, counted here rather than folded into the headline. The table is driven
+   * from `WRITES`, so a spelling added there is covered here without being remembered.
    */
   const QUOTINGS = [
     ['double quotes around a space', '"a dir/out.txt"', 'a dir/out.txt'],
@@ -187,10 +202,24 @@ describe('hook_redirect_targets names what a command writes to', () => {
     }
   }
 
-  it('leaves a quote that is not a delimiter alone', () => {
-    // The skip is for a DELIMITER. An expansion the shell would resolve still comes back unresolved,
-    // which is the reader's stated contract, and a mention inside a quoted argument is still not a
-    // redirection at all.
+  it('keeps a quote that is DATA rather than a delimiter', () => {
+    // The first cut decided by character class and deleted every quote it met, so a quote belonging
+    // to the path went with the delimiters — `a\"b.txt` came back `ab.txt` while bash writes
+    // `a"b.txt`. A delimiter is the quote that borders MASKED content; one standing among visible
+    // characters is data. These two rows are green only if the reader tells them apart.
+    expect(targetsOf('echo x > a\\"b.txt')).toContain('a"b.txt');
+    expect(targetsOf(`echo x > 'a"b'/out.txt`)).toContain('a"b/out.txt');
+  });
+
+  it('joins a spliced character to the name instead of ending it there', () => {
+    // The mode's stated limit says a spliced character is joined, and the splice branch skipped the
+    // backslash and let the loop meet the escaped character on its own terms — so an escaped SPACE
+    // hit the word break and the name ended at `a`. Bash writes `a b/node_modules/c`, which is
+    // inside the store, so the shortened name matched nothing and the write was permitted.
+    expect(targetsOf('echo x > a\\ b/node_modules/c')).toContain('a b/node_modules/c');
+  });
+
+  it('leaves an expansion unresolved, and reads no target from a quoted mention', () => {
     expect(targetsOf('echo x > $dir/out.txt')).toContain('$dir/out.txt');
     expect(targetsOf('echo "a > b"')).toEqual([]);
   });
@@ -285,6 +314,18 @@ describe('bulk-edit-guard refuses every spelling that writes into the store', ()
     it(`permits ${label}`, () => {
       expect(bulkEditVerdict(fill(shape, 'node_modules/pkg/index.js'))).toBe(0);
     });
+  }
+
+  // The quoting matrix, through the GUARD rather than the reader. The defect was reported as a
+  // guard-level bypass, and this file's mechanism is one table through every consumer — a doctrine
+  // it earned when a reader-level pass hid a statement-level miss for `>|`. A quoting fixed in the
+  // reader but not asked of the guard is the same shape of gap.
+  for (const [label, shape] of WRITES.filter(([, form]) => !/["']/.test(form))) {
+    for (const [quoteLabel, written] of QUOTED_STORE_PATHS) {
+      it(`refuses ${label} with ${quoteLabel}`, () => {
+        expect(bulkEditVerdict(`echo x ${fill(shape, written)}`)).toBe(2);
+      });
+    }
   }
 
   it('permits a write to a directory that merely CONTAINS the store name', () => {

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -228,6 +228,18 @@
       "timestamp": "2026-08-20T16:55:30.315Z",
       "ratio": "2/3",
       "reason": "Mine. Reporting which of issue #1930's checklist boxes an agent can close alone, I wrote that the issue would 'look 2/3 complete' with no percentage — a ratio over a countable set, which is exactly what the rule governs. The third instance this session and the fifth this file records from me, which is the argument for the scan rather than for intending harder."
+    },
+    {
+      "transcript": "e6c7afde-c768-4938-8c5d-8b79a51d3553.jsonl",
+      "timestamp": "2026-08-21T16:33:38.254Z",
+      "ratio": "84/100",
+      "reason": "Mine. A mid-work status table to the owner reported a CLAUDE.md audit score as \"84/100, B\" with no percentage (= 84%). Worth recording precisely because it is not the shape the earlier entries record: every one of those was a ratio of how far along something was, and this is a SCORE out of a fixed denominator. The scan cannot tell the two apart, and widening it to try would cost more than it catches -- a score written as N/100 in a completion table reads exactly like a progress ratio to a human skimming it too. So the rule as mechanised is right and the correction is the same either way: write the percentage in the same breath as the fraction, whatever the fraction means. Recorded rather than fixed because the transcript is append-only."
+    },
+    {
+      "transcript": "e6c7afde-c768-4938-8c5d-8b79a51d3553.jsonl",
+      "timestamp": "2026-08-21T16:36:24.601Z",
+      "ratio": "84/100",
+      "reason": "The message ACKNOWLEDGING the entry above committed the same violation, by quoting the offending fraction without the percentage while explaining that it lacked one. This file already records that exact shape three times (2026-08-15, 2026-08-17, 2026-08-19), which is the point: the habit is writing the fraction at all without its percentage, quotation included, and an intention to comply does not survive the very next message. Recorded as its own entry rather than folded into the first, because the repeat is the evidence."
     }
   ]
 }


### PR DESCRIPTION
## Problem

`hook_redirect_targets` appended a quote it should have consumed. A quote DELIMITER has TWO
spellings in the tokenizer's mask — a SPACE when the region was read as a single-word token, and the
quote CHARACTER ITSELF when the region contains whitespace. Only the first was skipped, so a target
quoted around a space came back wearing its quotes (`"node_modules/a b"`), and the store pattern,
anchored on a separator, could not match it. `bulk-edit-guard` therefore permitted writes into the
dependency store.

Measured across the eleven write spellings the table drives, and both quotings: 22 commands
permitted, 18 of which bash actually performs. (The other four are the `2>&` / `>>&` forms bash
itself rejects — the deliberate over-report already documented in the file.)

## Fix

Decide the spelling by **role, not character class**. A quote is a delimiter only where it borders
MASKED content: the tokenizer blanks what a delimiter encloses, so a quote beside a masked byte
opened or closed a region, while a quote standing among visible characters is DATA the name keeps.

Deciding by class instead — the first cut — deleted a quote belonging to the path (`a\"b.txt` came
back `ab.txt` while bash writes `a"b.txt`) and falsified the file's stated limit about a spliced
character joining. Both cases are now pinned by tests.

Also fixed: the splice branch skipped the backslash and let the loop meet the escaped character on
its own terms, so an escaped SPACE hit the word break and the name ended early.

## Test

`scripts/harness/__tests__/redirect-target-has-one-owner.test.mjs` — 168 rows green.

The quoting matrix runs through BOTH consumers, reader and guard. This file's doctrine is one table
through every consumer, earned when a reader-level pass hid a statement-level miss for `>|`; a
quoting fixed in the reader but not asked of the guard is that same gap.

It also fixes a defect in the fixture itself: `String.replaceAll` reads `$'`, `` $` `` and `$&` in a
STRING replacement as patterns, so `$'a dir'/out.txt` was rewritten before it ever reached a shell
and the row asserting quote handling was quietly testing something else. The replacement is a
function now, which is literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc8Cy57xP1AyHj8LsDGqcx
