### PR TITLE
docs(harness): the entry point routes past a canonical doc and half its own hook card

### DIFF
--- a/.agents/tasks/DOCS-027-entry-point-names-no-command.md
+++ b/.agents/tasks/DOCS-027-entry-point-names-no-command.md
@@ -1,0 +1,96 @@
+---
+title: 'DOCS-027: the entry point routes 105 npm scripts by pointer alone, so the handful the rules require every session costs a discovery turn'
+status: todo
+created: 2026-08-22
+priority: medium
+urgency: later
+area: AGENTS.md, .agents/rules/verification.md, scripts/harness/
+depends_on: []
+---
+
+# DOCS-027: naming the session-critical commands at the entry point
+
+## Problem
+
+`AGENTS.md` routes every command to `package.json` and names none:
+
+> Commands live in the root `package.json` `scripts` — run `pnpm run` to list them, including every
+> `harness:*` entry point.
+
+Routing is the file's stated design ("it routes, and it does not inline", `AGENTS.md:5-6`), and the
+reason is real: every line is re-injected after every compaction and paid on every turn.
+
+The cost falls on the other side. An agent that needs the verification command cannot get it from the
+auto-loaded context; it must spend a turn on `pnpm run`, which prints **213 lines for 105 scripts**
+(66 of them `harness:*`). That turn buys the same small set of commands each time, because the rules
+themselves converge on a stable handful — counted across `.agents/rules/*.md`:
+
+| Command                    | Times named in the rules |
+| -------------------------- | ------------------------ |
+| `pnpm harness:scan`        | 8                        |
+| `pnpm harness:pre-push`    | 5                        |
+| `pnpm build`               | 4                        |
+| `pnpm test`                | 2                        |
+| `pnpm harness:verify`      | 2                        |
+| `pnpm harness:conformance` | 2                        |
+
+So the fact is already duplicated — 23+ times, across rule files that are not auto-loaded — while the
+one document that IS auto-loaded carries none of it.
+
+## Why this is filed rather than fixed in place
+
+`AGENTS.md` § Mandatory Rules: an argument against a rule is the input to an amendment, never an
+exemption, and the minimum evidence that an amendment was attempted is a filed backlog item. This is
+that item. The routing sentence stays as written until this is decided.
+
+## What the constraint actually is
+
+Worth stating precisely, because it is weaker than it first reads. The prohibition `read them there,
+never from a copy` (`AGENTS.md:50`) attaches to **toolchain versions**, not to commands — versions
+have a scan (`node-version-single-valued`) enforcing the single value. The commands sentence carries
+no such prohibition. What binds an inline command list is only the general pair:
+
+- `it routes, and it does not inline` (`AGENTS.md:6`)
+- `Never duplicate content across levels. Each fact has exactly one owner document.` (`AGENTS.md:18`)
+
+Both are about drift and per-turn cost, and both are satisfiable by a derived copy that cannot drift.
+
+## Directions considered
+
+1. **Status quo.** Keep the pointer. Zero added lines; every session keeps paying the discovery turn,
+   and the 23 existing copies in the rules stay unguarded.
+2. **Hand-written block in `AGENTS.md`.** Cheapest to write, and the one direction the principles
+   genuinely refuse: a hand-copied list has no owner and drifts silently, which is the failure
+   `Each fact has exactly one owner document` exists to prevent.
+3. **Derived block, mechanically guarded.** `AGENTS.md` carries a short generated block; a harness
+   scan fails when the block and `package.json` disagree. The fact keeps one owner (`package.json`);
+   the entry point carries a copy that cannot go stale. This is the pattern the repo already uses —
+   `hook-override-declarations` derives a hook's accepted override forms from the hook source rather
+   than trusting a hand-written declaration.
+4. **Name the keys only.** List the script KEYS (`build`, `test`, `harness:scan`, `harness:pre-push`)
+   without command bodies. Six words, no bodies to drift; still a hand-maintained set, and a renamed
+   script leaves it wrong with nothing failing.
+
+## Recommendation
+
+Direction 3, scoped to the commands the rules already require — the six in the table above — and no
+more. It resolves the tension rather than trading one side away: the entry point stops costing a
+discovery turn, and the guard makes the copy unable to disagree with its owner. Direction 4 is the
+fallback if the scan is judged more machinery than the saving is worth.
+
+The decision belongs to the owner; this item does not presume it.
+
+## Test Plan
+
+- New scan added under `scripts/harness/`, registered in `run-all-scans.mjs`, with a test that it
+  goes RED when the block and `package.json` disagree (a generated block whose guard cannot fail is
+  the same defect one layer up — `HARNESS-101`, `wiring-guardian`).
+- `pnpm harness:scan` green.
+- `pnpm harness:test:contracts` green.
+- Prove the guard fires: mutate one command in the block, confirm the scan exits non-zero, restore.
+
+## User Execution Test Scenarios
+
+Not applicable — documentation/governance change only; it delivers no runnable user-facing behavior.
+Verification is the harness scan in `## Test Plan`, per `.agents/tasks/README.md` (documentation-only
+and governance-only changes must not invent a user execution test scenario).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ every compaction, so every line here is paid on every turn: it routes, and it do
 | [.agents/rules/agent-conduct.md](.agents/rules/agent-conduct.md)                       | **Agent conduct (RCP)** — authoritative for how the agent communicates, reasons and decides                         |
 | [.agents/rules/memory-mirroring.md](.agents/rules/memory-mirroring.md)                 | Session/host memory MUST be mirrored into `.agents/memory/`                                                         |
 | [.agents/rules/enforcement-architecture.md](.agents/rules/enforcement-architecture.md) | Enforcement architecture — incl. **"Silence is not success"**: nothing may complete quietly on an error             |
+| [ARCHITECTURE.md](ARCHITECTURE.md)                                                     | System architecture — canonical, guarded by `harness.config.json` → `architectureDocs`                              |
 | [.agents/project-structure.md](.agents/project-structure.md)                           | Package listing and dependency rules                                                                                |
 | [.agents/skills/index.md](.agents/skills/index.md)                                     | All procedural workflow skills                                                                                      |
 | [.agents/tasks/README.md](.agents/tasks/README.md)                                     | **Tasks** — the record of a unit of work (the problem), and its lifecycle                                           |
@@ -74,8 +75,10 @@ The most-hit refusals, in imperative form. Reasoning lives in [git-branch.md](.a
 - **A merge needs**: CI green, a reviewer verdict quoting the _exact_ current base and head, `ACTIONABLE FINDINGS: 0`, and every review thread **answered and resolved** — fixing a finding is not answering it.
 - **Cut branches from a freshly-fetched `origin/develop`**, one at a time.
 - **An open PR's diff is frozen** except to resolve a reported finding.
+- **Never enumerate files in a way that follows symlinks** (`find -L`, `grep -R`, `rg --follow`): in a pnpm workspace it reaches the dependency store, where a write is invisible to `git status` and to every scan.
+- **Never wait in the foreground** — a `sleep` budget over 60s, or a loop polling a remote status. Run it in the background, or use `Monitor`.
 
-Each has a documented override — the FORM differs and is not interchangeable. Most are **inline** (`MERGE_GATE_ACK=1 gh pr merge …`), which excuses only the statement they prefix. A few are read from the **environment** (`HOOK_EDIT_ACK`, `LOCKFILE_CHURN_ACK`), which means they stay armed until unset rather than for one command. [git-branch.md](.agents/rules/git-branch.md) § "Which Form An Override Takes" is the owner; `hook-override-declarations` derives the accepted forms from the hook source and refuses a declaration that names the wrong one. An override is a visible choice, used after verifying by hand what the hook could not reach — never a way past a gate you have not satisfied.
+Each has a documented override — the FORM differs and is not interchangeable. Most are **inline** (`MERGE_GATE_ACK=1 gh pr merge …`), which excuses only the statement they prefix. Two are read from the **environment** (`HOOK_EDIT_ACK`, `LOCKFILE_CHURN_ACK`), which means they stay armed until unset rather than for one command, and some accept **either** form (`BULK_EDIT_ACK`, `FOREGROUND_WAIT_ACK`, the `BRANCH_GUARD_*` hatches). [git-branch.md](.agents/rules/git-branch.md) § "Which Form An Override Takes" is the owner; `hook-override-declarations` derives the accepted forms from the hook source and refuses a declaration that names the wrong one. An override is a visible choice, used after verifying by hand what the hook could not reach — never a way past a gate you have not satisfied.
 
 ## Common Pitfalls
 
@@ -92,12 +95,9 @@ Procedural workflows and domain-specific rules. See [.agents/skills/index.md](.a
 
 - **Rules** (`.agents/rules/`): mandatory constraints. Rules always win on conflict.
 - **Skills** (`.agents/skills/`): procedural workflows and domain-specific rules. Skills must not redefine rules.
-- **Specs** (`packages/*/docs/SPEC.md`): package-level contracts and domain truth.
-- If skill text conflicts with a rule, the rule wins.
 
 ## Owner Knowledge Policy
 
-- Each workspace package owns its specification in `docs/SPEC.md`.
 - Detailed domain truth lives in specs, ADRs, or contract definitions — not in this file.
 - The `spec-writing-standard` skill defines SPEC.md required sections and quality gates.
 - When modifying a package, check if `docs/SPEC.md` reflects the current architecture and update if needed.


### PR DESCRIPTION
## What this is

An audit of what the auto-loaded agent context actually reaches. `CLAUDE.md` is a 7-line router that
imports `AGENTS.md`, so the context paid on every turn is those two files together. Three gaps, two
fixed here and one filed.

Everything the audit checked and found **clean** is worth stating, because it is most of it: all 20
document links resolve, all 24 files under `.agents/rules/` are reachable from `rules/index.md`,
every named script exists (`scan-conflict-markers.mjs`, `harness:review:record`,
`scan-hook-override-declarations.mjs`, `scan-node-version-single-valued.mjs`), the toolchain claims
match `package.json`, and 58/58 packages carry `docs/SPEC.md`.

## 1. A canonical architecture document the entry point does not reach

`ARCHITECTURE.md` is declared canonical by `.agents/harness.config.json`
(`architectureDocs.files[0]`, enforced by `check-dependency-direction` Rule 9) and named by
`common-mistakes.md` row 81 as a surface to sweep at GATE-COMPLETE. It was absent from the document
tree — the table `AGENTS.md` calls *"the single list, so no fact is stated twice."*

Its siblings `.agents/project-structure.md` and `.agents/specs/ARCHITECTURE-MAP.md` are both
reachable. Only the root one was not.

## 2. The hook card named two of four armed overrides

`.claude/settings.json` wires six PreToolUse Bash hooks. Two of them —
`bulk-edit-guard.sh` (`BULK_EDIT_ACK`) and `no-foreground-wait.sh` (`FOREGROUND_WAIT_ACK`) — refuse
commands and advertise an override, and neither appeared on the card.

`git-branch.md:523-526` lists all four, so the SSOT was intact; the incomplete copy was the
auto-loaded one, which is the exact case the card exists for ("that file is not auto-loaded, and a
blocked turn costs far more than these lines"). `no-foreground-wait.sh`'s own header records **61
turns lost to Bash timeouts in 34 days** — that is not a rare refusal.

The card also presented the override FORM as a binary. `git-branch.md`'s table has three — inline,
environment, and **either** — and both variables added here are `either`.

## 3. Holding the ratchet

`routing-document-size` freezes `AGENTS.md` at 112 lines; the additions pushed it to 115. The scan's
own instruction is to lower something else first, so three lines went — each one restating a fact the
same file already carries:

| removed | already stated at |
| --- | --- |
| `- **Specs** (packages/*/docs/SPEC.md): package-level contracts and domain truth.` | `:12`, `:46` |
| `- If skill text conflicts with a rule, the rule wins.` | `:96` |
| `- Each workspace package owns its specification in docs/SPEC.md.` | `:12`, `:46` |

No fact is lost. The file's own principle — *each fact has exactly one owner document* — is why those
were the right three to drop.

## 4. Filed, not fixed: DOCS-027

The entry point names none of the **105** npm scripts and routes to `pnpm run`, which prints **213
lines**. The handful the rules actually require every session are already copied **23 times** across
`.agents/rules/*.md` — files that are not auto-loaded — while the one document that IS auto-loaded
carries none of them.

Changing that routing sentence is an amendment, and `AGENTS.md` is explicit that the minimum evidence
an amendment was attempted is a filed backlog item. So `DOCS-027` records the problem, the measured
evidence, four directions, and a recommendation, and changes nothing.

One correction it carries: the prohibition `read them there, never from a copy` attaches to
**toolchain versions**, not to commands. What actually constrains an inline command list is only the
general pair at `:6` and `:18`, both of which a mechanically-derived block would satisfy.

## Verification

- `pnpm harness:scan` — **132/132 green**.
- The two failures this change first produced were real and are fixed, not suppressed:
  `consistency` (the term is "user execution test scenario") and `routing-document-size` (112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc8Cy57xP1AyHj8LsDGqcx
