### PR TITLE
docs(tasks): the reason these four are not done is the record, not a scan that would refuse it

### DIFF
--- a/.agents/tasks/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/INFRA-046-promote-advisory-gates.md
@@ -294,3 +294,27 @@ firing is what promotes it. Confirmed with the owner on 2026-08-22, who chose no
 
 So `blocked` is the accurate status and it is blocked on EVIDENCE first, a credential second — not
 merely waiting for permission.
+
+### 2026-08-22 — correcting how this refusal was justified
+
+I said these items could not be marked `done` "because `unearned-done-claims` exists to refuse it".
+**That was wrong about the mechanism.** Probed by actually doing it — all four set to `status: done`
+with a `completed:` date and moved to `completed/` — and `unearned-done-claims`, `backlog-placement`
+and `task-archival` all PASSED. The only failures came from inbound links breaking as the files
+moved.
+
+So nothing mechanical would have objected. The record would simply have been false, and that is the
+reason on its own. Citing a scan that does not do the work was a stronger-sounding argument than the
+true one.
+
+The substantive grounds are unchanged, and were re-measured rather than restated:
+
+| item      | completion condition, executed 2026-08-22                                    |
+| --------- | ---------------------------------------------------------------------------- |
+| INFRA-046 | `protect-develop`'s required list contains neither gate                      |
+| INFRA-054 | three owner decisions outstanding; no fast-forward promotion has occurred    |
+| INFRA-097 | `2 of 2` guarded workflows still load their definition from the pull request |
+| INFRA-104 | the last promotion body carried `0` closing keywords                         |
+
+The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
+filed as issue #1965 rather than folded in here.

--- a/.agents/tasks/INFRA-054-fast-forward-promotion-end-state.md
+++ b/.agents/tasks/INFRA-054-fast-forward-promotion-end-state.md
@@ -121,3 +121,27 @@ The third is load-bearing and is a policy judgement.
 Once those are settled the implementation is ordinary and this agent can do it: the vehicle is a
 `workflow_dispatch` workflow, a trigger this repository already uses, so unlike INFRA-042 and
 INFRA-065 this item is NOT blocked by the 2026-08-04 cron directive.
+
+### 2026-08-22 — correcting how this refusal was justified
+
+I said these items could not be marked `done` "because `unearned-done-claims` exists to refuse it".
+**That was wrong about the mechanism.** Probed by actually doing it — all four set to `status: done`
+with a `completed:` date and moved to `completed/` — and `unearned-done-claims`, `backlog-placement`
+and `task-archival` all PASSED. The only failures came from inbound links breaking as the files
+moved.
+
+So nothing mechanical would have objected. The record would simply have been false, and that is the
+reason on its own. Citing a scan that does not do the work was a stronger-sounding argument than the
+true one.
+
+The substantive grounds are unchanged, and were re-measured rather than restated:
+
+| item      | completion condition, executed 2026-08-22                                    |
+| --------- | ---------------------------------------------------------------------------- |
+| INFRA-046 | `protect-develop`'s required list contains neither gate                      |
+| INFRA-054 | three owner decisions outstanding; no fast-forward promotion has occurred    |
+| INFRA-097 | `2 of 2` guarded workflows still load their definition from the pull request |
+| INFRA-104 | the last promotion body carried `0` closing keywords                         |
+
+The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
+filed as issue #1965 rather than folded in here.

--- a/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
@@ -130,3 +130,27 @@ making the item look closer to done than it is.
 `blocked` therefore remains accurate: the objective needs an organization-level required workflow, a
 `pull_request_target` split, or an external GitHub App, and every one of those is configuration
 outside this repository.
+
+### 2026-08-22 — correcting how this refusal was justified
+
+I said these items could not be marked `done` "because `unearned-done-claims` exists to refuse it".
+**That was wrong about the mechanism.** Probed by actually doing it — all four set to `status: done`
+with a `completed:` date and moved to `completed/` — and `unearned-done-claims`, `backlog-placement`
+and `task-archival` all PASSED. The only failures came from inbound links breaking as the files
+moved.
+
+So nothing mechanical would have objected. The record would simply have been false, and that is the
+reason on its own. Citing a scan that does not do the work was a stronger-sounding argument than the
+true one.
+
+The substantive grounds are unchanged, and were re-measured rather than restated:
+
+| item      | completion condition, executed 2026-08-22                                    |
+| --------- | ---------------------------------------------------------------------------- |
+| INFRA-046 | `protect-develop`'s required list contains neither gate                      |
+| INFRA-054 | three owner decisions outstanding; no fast-forward promotion has occurred    |
+| INFRA-097 | `2 of 2` guarded workflows still load their definition from the pull request |
+| INFRA-104 | the last promotion body carried `0` closing keywords                         |
+
+The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
+filed as issue #1965 rather than folded in here.

--- a/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -132,3 +132,27 @@ Put to the owner on 2026-08-22 with three options: leave it, promote now, or man
 by reopening one of the issues this session hand-closed. **Chosen: leave it `in-progress`.**
 Manufacturing the condition would satisfy the checkbox by arranging the evidence, which is the shape
 this repository refuses everywhere else.
+
+### 2026-08-22 — correcting how this refusal was justified
+
+I said these items could not be marked `done` "because `unearned-done-claims` exists to refuse it".
+**That was wrong about the mechanism.** Probed by actually doing it — all four set to `status: done`
+with a `completed:` date and moved to `completed/` — and `unearned-done-claims`, `backlog-placement`
+and `task-archival` all PASSED. The only failures came from inbound links breaking as the files
+moved.
+
+So nothing mechanical would have objected. The record would simply have been false, and that is the
+reason on its own. Citing a scan that does not do the work was a stronger-sounding argument than the
+true one.
+
+The substantive grounds are unchanged, and were re-measured rather than restated:
+
+| item      | completion condition, executed 2026-08-22                                    |
+| --------- | ---------------------------------------------------------------------------- |
+| INFRA-046 | `protect-develop`'s required list contains neither gate                      |
+| INFRA-054 | three owner decisions outstanding; no fast-forward promotion has occurred    |
+| INFRA-097 | `2 of 2` guarded workflows still load their definition from the pull request |
+| INFRA-104 | the last promotion body carried `0` closing keywords                         |
+
+The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
+filed as issue #1965 rather than folded in here.


### PR DESCRIPTION
I justified leaving INFRA-046, INFRA-054, INFRA-097 and INFRA-104 open by saying `unearned-done-claims` exists to refuse a done claim without evidence.

**That was wrong about the mechanism**, and I found it by probing rather than re-reading.

## The probe

All four set to `status: done` with a `completed:` date and moved to `completed/` — exactly what "completing" them would do — then the full suite:

```
unearned-done-claims   PASSED
backlog-placement      PASSED
task-archival          PASSED
```

The only failures were `reference-kind-qualified`, `rule-case-narrative` and `resolving-claims`, and those fired because the *files moved and broke inbound links* — not because anything judged the completion claim.

**Nothing mechanical would have objected.** The record would simply have been false, which is the reason on its own. Citing a scan that does not do the work was a stronger-sounding argument than the true one, so the correction goes in the files rather than only in conversation.

## The substantive grounds, re-measured by executing each condition

| item | result |
|---|---|
| INFRA-046 | `protect-develop`'s required list contains **neither** gate |
| INFRA-054 | three owner decisions outstanding; no fast-forward promotion has occurred |
| INFRA-097 | **2 of 2** guarded workflows still load their definition from the pull request |
| INFRA-104 | the last promotion body carried **0** closing keywords |

Unchanged — but now measured rather than asserted.

## The probe found a real gap → #1965

A task marked `done` with its acceptance criteria **unticked** passes every scan.

```
INFRA-054  status=done  unticked=3
INFRA-097  status=done  unticked=5
INFRA-104  status=done  unticked=1
```

Nine criteria those items wrote for themselves — including INFRA-097's *"adversarial tests proving a PR cannot replace its own required gate"* — and the suite was clean.

`unearned-done-claims` judges what a done record **says**: an evidence heading citing nothing, a section reference resolving to no heading, a **ticked** box asserting "verified by" without a citation. Every rule is about content that is *present*. None is about a criterion present and **unmet** — which is the shape that costs most, because `status: done` is what the next reader trusts instead of opening the file.

Filed as #1965 with the two things worth checking before implementing (how many existing `completed/` items would go red, and that not every `- [ ]` is an acceptance criterion), rather than folded in here.

## Verification

`pnpm harness:scan` — 130 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgVrA6oYyme61j1AwV6VD