### PR TITLE
feat(agent-transport-webrtc,agent-remote-pairing): consume the cross-device grant (issue #1865)

### DIFF
--- a/.agents/tasks/SEC-011-same-user-proof-for-cross-device-handoff.md
+++ b/.agents/tasks/SEC-011-same-user-proof-for-cross-device-handoff.md
@@ -127,6 +127,60 @@ signaling server that reads every byte still cannot authorize a transfer or read
 | TC-09 | Unit test | Consent denied                                    | A normal refusal, distinct from an authentication failure  |
 | TC-10 | Unit test | Trust level is not interchangeable with SEC-010's | A local admission cannot authorize a cross-device transfer |
 
+## Implementation status
+
+The cryptographic boundary landed as PR #1834. The two consumers issue #1812 assigned elsewhere — the
+channel gate and the CLI — plus the two open design questions, landed as issue #1865:
+
+| Piece                                                             | Package                                |
+| ----------------------------------------------------------------- | -------------------------------------- |
+| The channel gate consuming the grant, verdict INJECTED            | `agent-transport-webrtc`               |
+| Consent at the destination, after the proof and failing closed    | `agent-transport-webrtc` + `agent-cli` |
+| Revocation DISTRIBUTION — a root-signed, expiring, monotonic list | `agent-remote-pairing`                 |
+| Root ROTATION — dual-signed, bounded overlap                      | `agent-remote-pairing`                 |
+
+### The two design questions, and what was decided
+
+**Revocation distribution.** A revocation is the one security statement whose ABSENCE is the attack:
+a certificate that never arrives simply fails to authenticate, while a revocation that never arrives
+silently authorizes a device the user retired. So an attacker who can influence distribution needs to
+forge nothing — they withhold, or they replay an older list.
+
+That rules out an unsigned list (anyone edits it, and removing an entry IS the attack) and a signed
+list with no expiry (self-authenticating and still replayable). What landed is signed by the same
+user root as a device certificate — so any machine that can verify a certificate can verify a list,
+and distribution needs no trusted channel — and it carries `expiresAt` plus a monotonic `issuedAt`.
+A holder past the expiry REFUSES rather than reading the list as "nothing is revoked", because a
+stale list is indistinguishable from a withheld one. An empty list is a real statement, which is why
+one is issued on a schedule rather than only when something is revoked.
+
+**Rotation.** Two problems wear one word, and they need opposite answers.
+
+_Hygiene_ — the key is fine and is being replaced. Continuity is wanted, and a rotation statement
+signed by BOTH roots provides it: the old to say "this succeeds me", the new to prove it exists and
+consents. Without the countersignature anyone holding the old key could name a public key they do NOT
+hold as successor, and every verifier would move to an identity nobody can issue certificates for —
+a lock-out by a statement that verifies perfectly.
+
+_Compromise_ — someone else has the key. This mechanism cannot help, because the attacker can sign
+the same statement naming a root of their choosing. **A compromised root is not rotated, it is
+abandoned**: new root, new `userId`, every device re-enrolled out of band. No function is offered
+that looks like it handles this, because a `rotate` that silently did the wrong thing under
+compromise would be worse than none.
+
+### Test-plan coverage
+
+TC-01 through TC-07 were covered by PR #1834. TC-08 (revoked device; a device caught mid-rotation),
+TC-09 (consent denied, as a refusal distinct from an authentication failure) and TC-10 (the trust
+level is not interchangeable with SEC-010's — the gate refuses an admission that claims the stronger
+level) are covered now.
+
+### What remains
+
+The CARRIER. Nothing yet constructs a WebRTC channel for a hand-off, so the gate's `handoffGrant`
+option and the CLI's consent builder have no product wiring them together. That is the same gap
+issue #1864 left with `/handoff`'s adapter, and it is one composition rather than two.
+
 ## User Execution Test Scenarios
 
 Deferred until the recommendation is accepted, for the same reason SEC-010's was: what a user can run

--- a/packages/agent-cli/src/__tests__/handoff-consent.test.ts
+++ b/packages/agent-cli/src/__tests__/handoff-consent.test.ts
@@ -1,6 +1,6 @@
 import type { IActionRequest, TActionResponse } from '@robota-sdk/agent-core';
 import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { createHandoffConsent } from '../handoff/handoff-consent.js';
 

--- a/packages/agent-cli/src/__tests__/handoff-consent.test.ts
+++ b/packages/agent-cli/src/__tests__/handoff-consent.test.ts
@@ -1,0 +1,108 @@
+import type { IActionRequest, TActionResponse } from '@robota-sdk/agent-core';
+import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createHandoffConsent } from '../handoff/handoff-consent.js';
+
+/**
+ * SEC-011 (issue #1865) — the consent prompt at the DESTINATION.
+ *
+ * There is exactly one way to return true, and it needs a person to have chosen it. Every case here
+ * is one of the ways that does NOT happen, because those are the ones that decide whether the step
+ * is a control or a formality.
+ */
+
+const ADMISSION: IPeerAdmission = {
+  admitted: true,
+  trust: 'same-user-different-host',
+  origin: { sessionId: 'desktop-session-1' },
+};
+
+function harness(answer?: TActionResponse, renderer = true) {
+  const asked: IActionRequest[] = [];
+  const consent = createHandoffConsent({
+    getUserInteraction: () =>
+      renderer
+        ? {
+            ask: async (request: IActionRequest) => {
+              asked.push(request);
+              return answer ?? { type: 'answer', values: ['accept'] };
+            },
+          }
+        : undefined,
+    deviceLabel: 'this laptop',
+  });
+  return { asked, consent };
+}
+
+describe('there is one way to say yes', () => {
+  it('accepts when the person chooses to accept', async () => {
+    const { consent } = harness({ type: 'answer', values: ['accept'] });
+    expect(await consent(ADMISSION)).toBe(true);
+  });
+
+  it.each([
+    ['the person declines', { type: 'answer', values: ['decline'] } as TActionResponse],
+    ['the prompt is dismissed', { type: 'cancelled' } as TActionResponse],
+    ['the answer is empty', { type: 'answer', values: [] } as TActionResponse],
+    [
+      'an option nobody offered comes back',
+      { type: 'answer', values: ['maybe'] } as TActionResponse,
+    ],
+  ])('refuses when %s', async (_label, answer) => {
+    const { consent } = harness(answer);
+    expect(await consent(ADMISSION)).toBe(false);
+  });
+
+  it('refuses when no renderer is attached, without waiting for one', async () => {
+    // A session that started running here because nobody was present to decline it is the failure
+    // this step exists to prevent.
+    const { consent, asked } = harness(undefined, false);
+    expect(await consent(ADMISSION)).toBe(false);
+    expect(asked).toHaveLength(0);
+  });
+
+  it('reads the renderer at ASK time, not when it was configured', async () => {
+    // A session can lose its renderer between being configured and a transfer arriving. A captured
+    // port would prompt into nothing and wait forever — a hang rather than a refusal.
+    let attached = true;
+    const consent = createHandoffConsent({
+      getUserInteraction: () =>
+        attached ? { ask: async () => ({ type: 'answer', values: ['accept'] }) } : undefined,
+      deviceLabel: 'this laptop',
+    });
+    expect(await consent(ADMISSION)).toBe(true);
+    attached = false;
+    expect(await consent(ADMISSION)).toBe(false);
+  });
+});
+
+describe('what the prompt tells the person', () => {
+  it('names the proven origin and this machine', async () => {
+    const { consent, asked } = harness();
+    await consent(ADMISSION);
+
+    expect(asked[0]?.title).toContain('desktop-session-1');
+    expect(asked[0]?.title).toContain('this laptop');
+  });
+
+  it('says what taking the session means HERE, not just that a transfer is offered', async () => {
+    // The destination is not being asked the source's question. It is being asked whether to run
+    // someone else's work with this machine's credential, files and shell.
+    const { consent, asked } = harness();
+    await consent(ADMISSION);
+
+    const description = asked[0]?.description ?? '';
+    expect(description).toContain("THIS machine's provider credential");
+    expect(description).toContain('its files, its shell');
+    expect(description).toContain('read-only');
+  });
+
+  it('falls back to a neutral name rather than inventing one when the origin is absent', async () => {
+    const { consent, asked } = harness();
+    await consent({ admitted: true, trust: 'same-user-different-host' });
+
+    expect(asked[0]?.title).toContain('another device');
+    expect(asked[0]?.title).not.toContain('undefined');
+  });
+});

--- a/packages/agent-cli/src/handoff/handoff-consent.ts
+++ b/packages/agent-cli/src/handoff/handoff-consent.ts
@@ -1,0 +1,81 @@
+/**
+ * SEC-011 (issue #1865): the consent prompt at the DESTINATION.
+ *
+ * The source end asks its operator before it gives a session away (`/handoff`, issue #1864). This is
+ * the other end: before a session arrives on THIS machine and starts running here, the person at
+ * this keyboard is asked.
+ *
+ * ## Why both ends, and not just the source
+ *
+ * They are not the same question. The source is asked whether to lose the session; the destination
+ * is asked whether to take on someone else's work — which means this machine's provider credential,
+ * this machine's files, and this machine's shell. A grant proves the same USER authorised the
+ * transfer; it does not establish that the person is sitting here right now, or that they meant
+ * this machine.
+ *
+ * ## Denial fails closed, and so does silence
+ *
+ * There is exactly one way to return true, and it needs a person to have chosen it. No renderer, a
+ * dismissed prompt, or anything other than the accept option all return false — and the gate turns
+ * that into a refusal that never exposes the session.
+ */
+
+import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
+import type { IUserInteraction } from '@robota-sdk/agent-core';
+
+/** What the prompt needs, beyond the verified admission. */
+export interface IHandoffConsentContext {
+  /**
+   * The interactive port, or undefined when no renderer is attached.
+   *
+   * Read at ASK time rather than captured, because a session can lose its renderer between being
+   * configured and a transfer arriving — and a captured port would then prompt into nothing and
+   * wait forever, which is a hang rather than a refusal.
+   */
+  readonly getUserInteraction: () => IUserInteraction | undefined;
+  /** This machine's name, so the prompt can say where the session would land. */
+  readonly deviceLabel: string;
+}
+
+/**
+ * Build the consent callback the channel gate calls after a grant verifies.
+ *
+ * Takes the verified admission so the prompt names a PROVEN origin. The gate guarantees the
+ * ordering; this signature is the shape that makes it impossible to ask any earlier.
+ */
+export function createHandoffConsent(
+  context: IHandoffConsentContext,
+): (admission: IPeerAdmission) => Promise<boolean> {
+  return async (admission) => {
+    const ask = context.getUserInteraction();
+    // No human is attached. Refused, never guessed — a session that started running here because
+    // nobody was present to decline it is the failure this whole step exists to prevent.
+    if (ask === undefined) return false;
+
+    const origin = admission.origin?.sessionId ?? 'another device';
+    // The copy below is HUMAN-facing: it is rendered into a dialog for the person at this keyboard
+    // and never reaches a model. `prompt-prose` cannot tell the two apart — its subject is
+    // model-facing instruction prose in a neutral library, and it matches a description property
+    // plus a second-person marker, which a consent prompt naturally has. Recorded in that scan's
+    // frozen baseline by its own documented path for a reviewed prompt literal, rather than reworded
+    // to dodge the marker: the sentence about the signature is what tells the reader why they are
+    // being asked rather than merely warned.
+    const answer = await ask.ask({
+      id: `handoff-inbound:${origin}`,
+      title: `Accept a session from ${origin} onto ${context.deviceLabel}?`,
+      description: [
+        'The transfer is signed by your user key, so it really is yours. What it means here:',
+        `  - the session will run on ${context.deviceLabel}, using THIS machine's provider credential`,
+        '  - its tools will act on THIS machine — its files, its shell, its processes',
+        '  - the other machine becomes read-only for that session once this one confirms',
+      ].join('\n'),
+      options: [
+        { value: 'accept', label: `Take the session onto ${context.deviceLabel}` },
+        { value: 'decline', label: 'Decline' },
+      ],
+    });
+    // One way to say yes. Everything else — a dismissal, an empty answer, an option nobody offered —
+    // is a decline, because the safe reading of "I did not get a clear yes" is no.
+    return answer.type === 'answer' && answer.values.includes('accept');
+  };
+}

--- a/packages/agent-interface-transport/src/peer-message-contracts.ts
+++ b/packages/agent-interface-transport/src/peer-message-contracts.ts
@@ -39,8 +39,17 @@ import type { TDriverId } from './driver-contracts.js';
  * rendezvous produces. `token-only` means a credential was presented and nothing about origin was
  * proven — correct for a remote peer, and NOT interchangeable with the first however convenient a
  * single boolean would be.
+ *
+ * `same-user-different-host` (SEC-011, issue #1865) is what a verified cross-device hand-off grant
+ * produces: the same user, provably, on a machine that is provably NOT this one. It sits BETWEEN the
+ * other two and is interchangeable with neither. Against `same-user-same-host` the difference is
+ * load-bearing — a check that wanted same-machine (a guarded 0700 directory the kernel vouched for)
+ * must never be satisfied by a signature that says nothing about where the peer runs. Against
+ * `token-only` the difference is that a user root key signed the device certificate, so the origin
+ * IS proven; collapsing it downward would throw away the thing the grant exists to establish.
  */
-export type TPeerTrust = 'same-user-same-host' | 'token-only' | 'unproven';
+export type TPeerTrust =
+  'same-user-same-host' | 'same-user-different-host' | 'token-only' | 'unproven';
 
 /**
  * Who a message came from.

--- a/packages/agent-remote-pairing/docs/SPEC.md
+++ b/packages/agent-remote-pairing/docs/SPEC.md
@@ -33,36 +33,42 @@ detection is a **directional, nonce-bound HMAC key-confirmation** bound to both 
 
 ## Public API Surface
 
-| Export                      | Kind     | Description                                                                                           |
-| --------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| `generatePairingSecret`     | function | Fresh 256-bit secret + 128-bit rendezvous (base64url).                                                |
-| `generateNonce`             | function | Fresh per-handshake nonce.                                                                            |
-| `toPairingUrl`              | function | Encode `{ rendezvous, secret }` into a URL **fragment**.                                              |
-| `parsePairingUrl`           | function | Read `{ rendezvous, secret }` from a pairing URL fragment.                                            |
-| `extractDtlsFingerprint`    | function | Parse the `a=fingerprint` value from an SDP (throws if absent).                                       |
-| `deriveSessionKey`          | function | HKDF a domain-separated session key (Stage-E use).                                                    |
-| `computeConfirmations`      | function | This peer's outgoing + expected-peer directional confirmations.                                       |
-| `verifyPeerConfirmation`    | function | Isomorphic timing-safe (double-HMAC) equality of two confirmations.                                   |
-| `startPairingHandshake`     | function | Drive the confirmation exchange; resolves accept-with-session-key, hard-rejects on mismatch/timeout.  |
-| `generateIdentityKeyPair`   | function | ECDSA-P256 identity keypair (REMOTE-012 E3); `extractable:false` for the device, `true` for the host. |
-| `exportPublicKey`           | function | Export a public key as base64url SPKI — the value the counterpart pins.                               |
-| `importPublicKey`           | function | Import a base64url SPKI public key for verify.                                                        |
-| `exportKeyPairJwk`          | function | Host-only: export an extractable keypair to JWKs (0600 on-disk file).                                 |
-| `importKeyPairJwk`          | function | Host-only: reload a keypair from persisted JWKs.                                                      |
-| `deriveIdentityId`          | function | Stable non-secret id = base64url `SHA-256(SPKI)` (deviceId / hostIdentityId).                         |
-| `signChallenge`             | function | Sign the channel-bound reconnect transcript (E3).                                                     |
-| `verifyChallenge`           | function | Verify a counterpart's reconnect signature against its pinned public key (fail-closed).               |
-| `startDeviceReconnect`      | function | Device-side mutual reconnect controller; verifies the host before accept.                             |
-| `startHostReconnect`        | function | Host-side mutual reconnect controller; verifies the device before accept.                             |
-| `deriveReconnectSeed`       | function | HKDF a per-device reconnect seed from the pairing `sessionKey` (REMOTE-013 E4).                       |
-| `deriveReconnectRendezvous` | function | HKDF a fresh reconnect rendezvous id from `(seed, counter)` — single-use room per reconnect (E4).     |
-| `generateUserRootKeyPair`   | function | SEC-011: the USER's root ECDSA keypair — one per person, not per machine.                             |
-| `deriveUserId`              | function | SEC-011: stable `SHA-256(SPKI)` id of a user root.                                                    |
-| `issueDeviceCertificate`    | function | SEC-011: sign a device key into this user's set. Same root ⇒ same user.                               |
-| `verifyDeviceCertificate`   | function | SEC-011: check a certificate against an expected user, now — signature first, then the signed fields. |
-| `verifyDevicePossession`    | function | SEC-011: confirm the presenter HOLDS the device key its certificate names.                            |
-| `issueHandoffGrant`         | function | SEC-011: authorize ONE transfer, to ONE destination, over ONE channel.                                |
-| `verifyHandoffGrant`        | function | SEC-011: verify a grant against this destination, transfer and channel.                               |
+| Export                      | Kind     | Description                                                                                                                                              |
+| --------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `generatePairingSecret`     | function | Fresh 256-bit secret + 128-bit rendezvous (base64url).                                                                                                   |
+| `generateNonce`             | function | Fresh per-handshake nonce.                                                                                                                               |
+| `toPairingUrl`              | function | Encode `{ rendezvous, secret }` into a URL **fragment**.                                                                                                 |
+| `parsePairingUrl`           | function | Read `{ rendezvous, secret }` from a pairing URL fragment.                                                                                               |
+| `extractDtlsFingerprint`    | function | Parse the `a=fingerprint` value from an SDP (throws if absent).                                                                                          |
+| `deriveSessionKey`          | function | HKDF a domain-separated session key (Stage-E use).                                                                                                       |
+| `computeConfirmations`      | function | This peer's outgoing + expected-peer directional confirmations.                                                                                          |
+| `verifyPeerConfirmation`    | function | Isomorphic timing-safe (double-HMAC) equality of two confirmations.                                                                                      |
+| `startPairingHandshake`     | function | Drive the confirmation exchange; resolves accept-with-session-key, hard-rejects on mismatch/timeout.                                                     |
+| `generateIdentityKeyPair`   | function | ECDSA-P256 identity keypair (REMOTE-012 E3); `extractable:false` for the device, `true` for the host.                                                    |
+| `exportPublicKey`           | function | Export a public key as base64url SPKI — the value the counterpart pins.                                                                                  |
+| `importPublicKey`           | function | Import a base64url SPKI public key for verify.                                                                                                           |
+| `exportKeyPairJwk`          | function | Host-only: export an extractable keypair to JWKs (0600 on-disk file).                                                                                    |
+| `importKeyPairJwk`          | function | Host-only: reload a keypair from persisted JWKs.                                                                                                         |
+| `deriveIdentityId`          | function | Stable non-secret id = base64url `SHA-256(SPKI)` (deviceId / hostIdentityId).                                                                            |
+| `signChallenge`             | function | Sign the channel-bound reconnect transcript (E3).                                                                                                        |
+| `verifyChallenge`           | function | Verify a counterpart's reconnect signature against its pinned public key (fail-closed).                                                                  |
+| `startDeviceReconnect`      | function | Device-side mutual reconnect controller; verifies the host before accept.                                                                                |
+| `startHostReconnect`        | function | Host-side mutual reconnect controller; verifies the device before accept.                                                                                |
+| `deriveReconnectSeed`       | function | HKDF a per-device reconnect seed from the pairing `sessionKey` (REMOTE-013 E4).                                                                          |
+| `deriveReconnectRendezvous` | function | HKDF a fresh reconnect rendezvous id from `(seed, counter)` — single-use room per reconnect (E4).                                                        |
+| `generateUserRootKeyPair`   | function | SEC-011: the USER's root ECDSA keypair — one per person, not per machine.                                                                                |
+| `deriveUserId`              | function | SEC-011: stable `SHA-256(SPKI)` id of a user root.                                                                                                       |
+| `issueDeviceCertificate`    | function | SEC-011: sign a device key into this user's set. Same root ⇒ same user.                                                                                  |
+| `verifyDeviceCertificate`   | function | SEC-011: check a certificate against an expected user, now — signature first, then the signed fields.                                                    |
+| `verifyDevicePossession`    | function | SEC-011: confirm the presenter HOLDS the device key its certificate names.                                                                               |
+| `issueHandoffGrant`         | function | SEC-011: authorize ONE transfer, to ONE destination, over ONE channel.                                                                                   |
+| `verifyHandoffGrant`        | function | SEC-011: verify a grant against this destination, transfer and channel.                                                                                  |
+| `issueRevocationList`       | function | SEC-011 (issue #1865): sign the retired device ids for this user. Signed by the user ROOT, so distribution needs no trusted channel.                     |
+| `verifyRevocationList`      | function | SEC-011: verify a list against this user and this moment. Expiry and a monotonic `issuedAt` are what make withholding and rollback fail closed.          |
+| `revocationUnavailable`     | function | SEC-011: the message a verifier gives when it holds no usable list. Exists so nobody writes `?? []`, which reads as a safe default and is the fail-open. |
+| `issueRootRotation`         | function | SEC-011: sign a root handover with BOTH roots — the old to say it succeeds, the new to prove it exists and consents.                                     |
+| `verifyRootRotation`        | function | SEC-011: verify a rotation against the root this machine trusts today. HYGIENE only — a compromised root is abandoned, not rotated.                      |
+| `previousRootStillAccepted` | function | SEC-011: is a certificate from the retiring root still acceptable? Takes the VERDICT, so the bound cannot be read off an unverified statement.           |
 
 ### SEC-011 — same USER, across two computers (#1812)
 

--- a/packages/agent-remote-pairing/src/__tests__/revocation-list.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/revocation-list.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveUserId,
+  generateUserRootKeyPair,
+  issueDeviceCertificate,
+  verifyDeviceCertificate,
+} from '../user-identity.js';
+import {
+  issueRevocationList,
+  revocationUnavailable,
+  verifyRevocationList,
+  type IRevocationList,
+} from '../revocation-list.js';
+import { generateIdentityKeyPair } from '../device-identity.js';
+
+/**
+ * SEC-011 (issue #1865) — how a revocation reaches the machine doing the checking.
+ *
+ * A revocation is the one security statement whose ABSENCE is the attack: a certificate that never
+ * arrives simply fails to authenticate, while a revocation that never arrives silently authorizes a
+ * device the user retired. So every case here is about what happens when the list is missing, old,
+ * rolled back, or edited — not about the happy path, which is one line.
+ */
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+async function user() {
+  const root = await generateUserRootKeyPair(true);
+  return { root, userId: await deriveUserId(root.publicKey) };
+}
+
+async function list(
+  overrides: Partial<Parameters<typeof issueRevocationList>[0]> = {},
+  signer?: CryptoKey,
+  userId?: string,
+): Promise<{ list: IRevocationList; root: CryptoKeyPair; userId: string }> {
+  const u = await user();
+  const claims = {
+    userId: userId ?? u.userId,
+    revokedDeviceIds: [] as readonly string[],
+    issuedAt: NOW,
+    expiresAt: NOW + HOUR,
+    ...overrides,
+  };
+  return {
+    list: await issueRevocationList(claims, signer ?? u.root.privateKey),
+    root: u.root,
+    userId: u.userId,
+  };
+}
+
+describe('a usable list', () => {
+  it('verifies and hands back exactly the ids it was signed over', async () => {
+    const { list: l, root, userId } = await list({ revokedDeviceIds: ['dev-a', 'dev-b'] });
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: root.publicKey,
+      expectedUserId: userId,
+      now: NOW + 1,
+    });
+    expect(verdict.usable).toBe(true);
+    expect(verdict.revokedDeviceIds).toEqual(['dev-a', 'dev-b']);
+  });
+
+  it('an EMPTY list is a statement, not an absence', async () => {
+    // "Nothing is revoked as of now" is exactly why a list is issued on a schedule rather than only
+    // when something is revoked — a user who has revoked nothing still needs a fresh one, or every
+    // verifier goes permanently stale.
+    const { list: l, root, userId } = await list({ revokedDeviceIds: [] });
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: root.publicKey,
+      expectedUserId: userId,
+      now: NOW + 1,
+    });
+    expect(verdict.usable).toBe(true);
+    expect(verdict.revokedDeviceIds).toEqual([]);
+  });
+
+  it('signs the same statement to the same bytes whatever order it was assembled in', async () => {
+    // Without the sort, a re-issue with a reordered array is a different signature over an identical
+    // statement — and two verifiers comparing bytes would call them different lists.
+    const u = await user();
+    const a = await issueRevocationList(
+      { userId: u.userId, revokedDeviceIds: ['b', 'a'], issuedAt: NOW, expiresAt: NOW + HOUR },
+      u.root.privateKey,
+    );
+    const b = await issueRevocationList(
+      { userId: u.userId, revokedDeviceIds: ['a', 'b'], issuedAt: NOW, expiresAt: NOW + HOUR },
+      u.root.privateKey,
+    );
+    // ECDSA is randomised, so the SIGNATURES differ. What must match is that each verifies against
+    // the other's claim ordering — which is what proves the signed bytes are the same.
+    const verdict = await verifyRevocationList(
+      { ...b, revokedDeviceIds: ['b', 'a'] },
+      { rootPublicKey: u.root.publicKey, expectedUserId: u.userId, now: NOW + 1 },
+    );
+    expect(verdict.usable).toBe(true);
+    expect(a.signature).not.toBe(b.signature);
+  });
+});
+
+describe('every claim is inside the signature', () => {
+  it.each([
+    ['revokedDeviceIds', { revokedDeviceIds: [] as readonly string[] }],
+    ['issuedAt', { issuedAt: NOW - HOUR }],
+    ['expiresAt', { expiresAt: NOW + 100 * HOUR }],
+  ])('editing %s invalidates it', async (_field, edit) => {
+    // The whole point: an attacker who can reach the list must not be able to REMOVE an entry, push
+    // the expiry out, or roll the issue time back while the signature still verifies.
+    const { list: l, root, userId } = await list({ revokedDeviceIds: ['dev-a'] });
+    const verdict = await verifyRevocationList(
+      { ...l, ...edit },
+      { rootPublicKey: root.publicKey, expectedUserId: userId, now: NOW + 1 },
+    );
+    expect(verdict.usable).toBe(false);
+    expect(verdict.rejection).toBe('signature-invalid');
+  });
+
+  it("a list signed by another root is not this user's", async () => {
+    const other = await user();
+    const mine = await user();
+    const l = await issueRevocationList(
+      { userId: mine.userId, revokedDeviceIds: ['dev-a'], issuedAt: NOW, expiresAt: NOW + HOUR },
+      other.root.privateKey,
+    );
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: mine.root.publicKey,
+      expectedUserId: mine.userId,
+      now: NOW + 1,
+    });
+    expect(verdict.usable).toBe(false);
+    expect(verdict.rejection).toBe('signature-invalid');
+  });
+
+  it('a genuine list for a DIFFERENT user is refused, not silently applied', async () => {
+    const other = await user();
+    const l = await issueRevocationList(
+      { userId: other.userId, revokedDeviceIds: ['dev-a'], issuedAt: NOW, expiresAt: NOW + HOUR },
+      other.root.privateKey,
+    );
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: other.root.publicKey,
+      expectedUserId: 'someone-else',
+      now: NOW + 1,
+    });
+    expect(verdict.usable).toBe(false);
+    expect(verdict.rejection).toBe('user-mismatch');
+  });
+});
+
+describe('freshness, which is what makes withholding fail closed', () => {
+  it('refuses an expired list rather than reading it as "no revocations"', async () => {
+    const { list: l, root, userId } = await list({ revokedDeviceIds: ['dev-a'] });
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: root.publicKey,
+      expectedUserId: userId,
+      now: NOW + HOUR,
+    });
+    expect(verdict.usable).toBe(false);
+    expect(verdict.rejection).toBe('stale');
+    // Nothing usable comes back. A caller cannot accidentally read an empty array off a refusal.
+    expect(verdict.revokedDeviceIds).toBeUndefined();
+  });
+
+  it('accepts it one millisecond before it expires, so the bound is the bound', async () => {
+    const { list: l, root, userId } = await list();
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: root.publicKey,
+      expectedUserId: userId,
+      now: NOW + HOUR - 1,
+    });
+    expect(verdict.usable).toBe(true);
+  });
+
+  it('refuses a genuine OLDER list once a newer one has been accepted', async () => {
+    // The rollback. Both lists are signed and unexpired; the older one simply predates the
+    // revocation the attacker cares about, and replaying it is the whole attack.
+    const u = await user();
+    const older = await issueRevocationList(
+      { userId: u.userId, revokedDeviceIds: [], issuedAt: NOW, expiresAt: NOW + HOUR },
+      u.root.privateKey,
+    );
+    const verdict = await verifyRevocationList(older, {
+      rootPublicKey: u.root.publicKey,
+      expectedUserId: u.userId,
+      now: NOW + 1,
+      newestAcceptedAt: NOW + 60_000,
+    });
+    expect(verdict.usable).toBe(false);
+    expect(verdict.rejection).toBe('superseded');
+  });
+
+  it('accepts a list issued at exactly the high-water mark — a re-delivery is not a rollback', async () => {
+    const { list: l, root, userId } = await list();
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: root.publicKey,
+      expectedUserId: userId,
+      now: NOW + 1,
+      newestAcceptedAt: NOW,
+    });
+    expect(verdict.usable).toBe(true);
+  });
+
+  it('accepts the first list on a machine with no high-water mark', async () => {
+    const { list: l, root, userId } = await list();
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: root.publicKey,
+      expectedUserId: userId,
+      now: NOW + 1,
+    });
+    expect(verdict.usable).toBe(true);
+  });
+});
+
+describe('the list actually retires a device', () => {
+  it('a revoked id fails certificate verification with an intact signature', async () => {
+    // The join: this module produces the ids, `verifyDeviceCertificate` consumes them, and the
+    // certificate below is genuine — it is the revocation that refuses it.
+    const u = await user();
+    const device = await generateIdentityKeyPair(true);
+    const certificate = await issueDeviceCertificate({
+      rootPrivateKey: u.root.privateKey,
+      userId: u.userId,
+      devicePublicKey: device.publicKey,
+      issuedAt: NOW,
+      expiresAt: NOW + HOUR,
+    });
+
+    const before = await verifyDeviceCertificate(certificate, {
+      rootPublicKey: u.root.publicKey,
+      expectedUserId: u.userId,
+      now: NOW + 1,
+    });
+    expect(before.valid).toBe(true);
+
+    const l = await issueRevocationList(
+      {
+        userId: u.userId,
+        revokedDeviceIds: [certificate.deviceId],
+        issuedAt: NOW,
+        expiresAt: NOW + HOUR,
+      },
+      u.root.privateKey,
+    );
+    const verdict = await verifyRevocationList(l, {
+      rootPublicKey: u.root.publicKey,
+      expectedUserId: u.userId,
+      now: NOW + 1,
+    });
+    expect(verdict.usable).toBe(true);
+
+    const after = await verifyDeviceCertificate(certificate, {
+      rootPublicKey: u.root.publicKey,
+      expectedUserId: u.userId,
+      now: NOW + 1,
+      revokedDeviceIds: verdict.revokedDeviceIds,
+    });
+    expect(after.valid).toBe(false);
+    expect(after.rejection).toBe('revoked');
+  });
+});
+
+describe('what a verifier says when it has nothing usable', () => {
+  it('names the tempting fail-open and refuses it in the same sentence', async () => {
+    // The shape at a call site would be `list?.revokedDeviceIds ?? []`, which reads as a safe
+    // default and is the exact fail-open. The message exists so nobody writes it.
+    const message = revocationUnavailable('stale');
+    expect(message).toContain('stale');
+    expect(message).toContain('nothing is revoked');
+  });
+});

--- a/packages/agent-remote-pairing/src/__tests__/root-rotation.test.ts
+++ b/packages/agent-remote-pairing/src/__tests__/root-rotation.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  issueRootRotation,
+  previousRootStillAccepted,
+  verifyRootRotation,
+} from '../root-rotation.js';
+import {
+  deriveUserId,
+  generateUserRootKeyPair,
+  issueDeviceCertificate,
+  verifyDeviceCertificate,
+} from '../user-identity.js';
+import { exportPublicKey, generateIdentityKeyPair } from '../device-identity.js';
+
+/**
+ * SEC-011 (issue #1865) — rotating the user root, and the case this mechanism deliberately does NOT
+ * handle.
+ *
+ * The lock-out case is the one worth reading first: without the successor's countersignature, a
+ * statement naming a public key nobody holds verifies perfectly and moves every verifier to an
+ * identity that can never issue a certificate again.
+ */
+
+const NOW = 1_700_000_000_000;
+const DAY = 86_400_000;
+
+async function root() {
+  const pair = await generateUserRootKeyPair(true);
+  return { pair, userId: await deriveUserId(pair.publicKey) };
+}
+
+async function rotation(overrides: Partial<Parameters<typeof issueRootRotation>[0]> = {}) {
+  const previous = await root();
+  const next = await root();
+  const value = await issueRootRotation({
+    previousUserId: previous.userId,
+    nextUserId: next.userId,
+    previousRootPrivateKey: previous.pair.privateKey,
+    nextRootKeyPair: next.pair,
+    rotatedAt: NOW,
+    previousValidUntil: NOW + 7 * DAY,
+    ...overrides,
+  });
+  return { rotation: value, previous, next };
+}
+
+describe('a rotation both roots signed', () => {
+  it('is accepted, and names the successor a verifier should start trusting', async () => {
+    const { rotation: r, previous, next } = await rotation();
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW + 1,
+    });
+    expect(verdict.accepted).toBe(true);
+    expect(verdict.nextUserId).toBe(next.userId);
+    expect(verdict.nextRootPublicKey).toBe(await exportPublicKey(next.pair.publicKey));
+  });
+
+  it('bounds how long the retiring root stays acceptable', async () => {
+    const { rotation: r, previous } = await rotation();
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW + 1,
+    });
+    expect(previousRootStillAccepted(verdict, NOW + DAY)).toBe(true);
+    expect(previousRootStillAccepted(verdict, NOW + 7 * DAY)).toBe(false);
+  });
+
+  it('says no for a verdict that was never accepted, rather than reading a bound off it', async () => {
+    // The tempting spelling at a call site reads `previousValidUntil` off the raw statement. Taking
+    // the VERDICT means the only way to ask is to have verified first.
+    expect(previousRootStillAccepted({ accepted: false }, NOW)).toBe(false);
+  });
+});
+
+describe('the successor must countersign, or the user is locked out', () => {
+  it('refuses a statement the named successor did not sign', async () => {
+    // The attack: anyone holding the old key names a public key they do NOT hold. Everything the
+    // retiring root signed is genuine, and every verifier would move to an identity nobody can
+    // issue certificates for.
+    const { rotation: r, previous } = await rotation();
+    const impostor = await root();
+    const forged = { ...r, nextRootPublicKey: await exportPublicKey(impostor.pair.publicKey) };
+
+    const verdict = await verifyRootRotation(forged, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW + 1,
+    });
+    // Editing the named key breaks what the PREVIOUS root signed first — which is the point: the
+    // successor's key is inside the retiring root's signature, so it cannot be swapped afterwards.
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.rejection).toBe('previous-signature-invalid');
+  });
+
+  it('refuses when the countersignature alone is wrong', async () => {
+    const { rotation: r, previous } = await rotation();
+    const other = await rotation();
+    const verdict = await verifyRootRotation(
+      { ...r, nextSignature: other.rotation.nextSignature },
+      {
+        previousRootPublicKey: previous.pair.publicKey,
+        expectedPreviousUserId: previous.userId,
+        now: NOW + 1,
+      },
+    );
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.rejection).toBe('next-signature-invalid');
+  });
+});
+
+describe('every claim is inside both signatures', () => {
+  it.each([
+    ['previousValidUntil', { previousValidUntil: NOW + 3650 * DAY }],
+    ['rotatedAt', { rotatedAt: NOW - DAY }],
+    ['nextUserId', { nextUserId: 'someone-else' }],
+  ])('editing %s invalidates it', async (_field, edit) => {
+    const { rotation: r, previous } = await rotation();
+    const verdict = await verifyRootRotation(
+      { ...r, ...edit },
+      {
+        previousRootPublicKey: previous.pair.publicKey,
+        expectedPreviousUserId: previous.userId,
+        now: NOW + 1,
+      },
+    );
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.rejection).toBe('previous-signature-invalid');
+  });
+});
+
+describe('what a verifier refuses on its own terms', () => {
+  it('refuses a rotation away from a root it does not hold', async () => {
+    // A genuine rotation for someone else's identity is not this machine's business, and applying
+    // it would move a verifier onto an unrelated user's root.
+    const { rotation: r, previous } = await rotation();
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: 'a-different-user',
+      now: NOW + 1,
+    });
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.rejection).toBe('wrong-previous-root');
+  });
+
+  it('refuses one dated in the future', async () => {
+    const { rotation: r, previous } = await rotation();
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW - 1,
+    });
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.rejection).toBe('not-yet-valid');
+  });
+
+  it('refuses an overlap that ends before it begins', async () => {
+    // Malformed, not "no overlap". Reading it as zero overlap would silently invalidate every
+    // enrolled device at a moment the signer may not have intended.
+    const { rotation: r, previous } = await rotation({ previousValidUntil: NOW - DAY });
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW + 1,
+    });
+    expect(verdict.accepted).toBe(false);
+    expect(verdict.rejection).toBe('overlap-inverted');
+  });
+
+  it('accepts a zero-length overlap, which is a tight window rather than a malformed one', async () => {
+    // The boundary the case above is about. Without this, "inverted" and "immediate" would be one
+    // rejection and a user who wanted no grace period could not express it.
+    const { rotation: r, previous } = await rotation({ previousValidUntil: NOW });
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW + 1,
+    });
+    expect(verdict.accepted).toBe(true);
+    expect(previousRootStillAccepted(verdict, NOW + 1)).toBe(false);
+  });
+});
+
+describe('a device caught mid-rotation (TC-08)', () => {
+  it('keeps working inside the overlap and stops at its end, with the same certificate', async () => {
+    // The certificate never changes. What changes is whether the root that signed it is still
+    // acceptable — which is the whole point of a bounded overlap: enrolled devices keep working
+    // while they are re-certified, and there is a deadline for doing it.
+    const previous = await root();
+    const next = await root();
+    const device = await generateIdentityKeyPair(true);
+    const certificate = await issueDeviceCertificate({
+      rootPrivateKey: previous.pair.privateKey,
+      userId: previous.userId,
+      devicePublicKey: device.publicKey,
+      issuedAt: NOW,
+      expiresAt: NOW + 30 * DAY,
+    });
+
+    const r = await issueRootRotation({
+      previousUserId: previous.userId,
+      nextUserId: next.userId,
+      previousRootPrivateKey: previous.pair.privateKey,
+      nextRootKeyPair: next.pair,
+      rotatedAt: NOW,
+      previousValidUntil: NOW + 7 * DAY,
+    });
+    const verdict = await verifyRootRotation(r, {
+      previousRootPublicKey: previous.pair.publicKey,
+      expectedPreviousUserId: previous.userId,
+      now: NOW + 1,
+    });
+    expect(verdict.accepted).toBe(true);
+
+    // Inside the window the certificate still verifies against the retiring root.
+    expect(previousRootStillAccepted(verdict, NOW + DAY)).toBe(true);
+    const inside = await verifyDeviceCertificate(certificate, {
+      rootPublicKey: previous.pair.publicKey,
+      expectedUserId: previous.userId,
+      now: NOW + DAY,
+    });
+    expect(inside.valid).toBe(true);
+
+    // Past it, the certificate is unchanged and still cryptographically intact — and the rotation is
+    // what refuses it. Asserting the certificate alone would miss that: it does not expire until day
+    // 30, so nothing about the certificate says the device should stop.
+    expect(previousRootStillAccepted(verdict, NOW + 8 * DAY)).toBe(false);
+    const stillIntact = await verifyDeviceCertificate(certificate, {
+      rootPublicKey: previous.pair.publicKey,
+      expectedUserId: previous.userId,
+      now: NOW + 8 * DAY,
+    });
+    expect(stillIntact.valid).toBe(true);
+  });
+
+  it('a certificate re-issued by the SUCCESSOR is a different user id, and that is the migration', async () => {
+    // The successor has its own `userId` — derived from its own key — so a verifier that moved on
+    // expects certificates naming it. A re-certified device is not the old certificate patched; it
+    // is a new one, and the id is what makes the two impossible to confuse.
+    const previous = await root();
+    const next = await root();
+    const device = await generateIdentityKeyPair(true);
+    const reissued = await issueDeviceCertificate({
+      rootPrivateKey: next.pair.privateKey,
+      userId: next.userId,
+      devicePublicKey: device.publicKey,
+      issuedAt: NOW,
+      expiresAt: NOW + 30 * DAY,
+    });
+
+    expect(next.userId).not.toBe(previous.userId);
+    const underNext = await verifyDeviceCertificate(reissued, {
+      rootPublicKey: next.pair.publicKey,
+      expectedUserId: next.userId,
+      now: NOW + 1,
+    });
+    expect(underNext.valid).toBe(true);
+
+    // And a verifier still expecting the OLD user refuses it, rather than accepting a certificate
+    // for an identity it has not been told to trust.
+    const underPrevious = await verifyDeviceCertificate(reissued, {
+      rootPublicKey: next.pair.publicKey,
+      expectedUserId: previous.userId,
+      now: NOW + 1,
+    });
+    expect(underPrevious.valid).toBe(false);
+    expect(underPrevious.rejection).toBe('user-mismatch');
+  });
+});

--- a/packages/agent-remote-pairing/src/index.ts
+++ b/packages/agent-remote-pairing/src/index.ts
@@ -63,3 +63,33 @@ export type {
   IVerifyGrantOptions,
   TGrantRejection,
 } from './handoff-authorization.js';
+// SEC-011 (issue #1865): how a revocation reaches the machine doing the checking. Signed by the same
+// user root as a certificate, so distribution needs no trusted channel — and bounded by an expiry,
+// because a stale list is indistinguishable from one an attacker withheld.
+export {
+  issueRevocationList,
+  revocationUnavailable,
+  verifyRevocationList,
+} from './revocation-list.js';
+export type {
+  IRevocationList,
+  IRevocationListClaims,
+  IRevocationVerdict,
+  IVerifyRevocationListOptions,
+  TRevocationRejection,
+} from './revocation-list.js';
+// SEC-011 (issue #1865): rotating the user root. Hygiene only — a COMPROMISED root is abandoned, not
+// rotated, because an attacker holding it can sign the same statement. See the module header.
+export {
+  issueRootRotation,
+  previousRootStillAccepted,
+  verifyRootRotation,
+} from './root-rotation.js';
+export type {
+  IIssueRotationOptions,
+  IRootRotation,
+  IRootRotationClaims,
+  IRotationVerdict,
+  IVerifyRotationOptions,
+  TRotationRejection,
+} from './root-rotation.js';

--- a/packages/agent-remote-pairing/src/revocation-list.ts
+++ b/packages/agent-remote-pairing/src/revocation-list.ts
@@ -1,0 +1,174 @@
+/**
+ * SEC-011 (issue #1865): how a revocation REACHES the machine doing the checking.
+ *
+ * `verifyDeviceCertificate` already accepts `revokedDeviceIds` and refuses a listed device with an
+ * intact signature. What was undecided is where that list comes from — and the item names this as
+ * the substantive open design question, correctly, because the naive answers all fail the same way.
+ *
+ * ## The failure that shapes the design
+ *
+ * A revocation is the one security statement whose ABSENCE is the attack. A certificate that never
+ * arrives simply does not authenticate; a revocation that never arrives silently authorizes a device
+ * the user retired. So an attacker who can influence distribution does not need to forge anything —
+ * they withhold, or they replay yesterday's list.
+ *
+ * That rules out two shapes immediately:
+ *
+ *   an UNSIGNED list          anyone on the path edits it, and removing an entry is the whole attack
+ *   a signed list with NO expiry   self-authenticating and still replayable: last week's list is
+ *                             genuinely signed, and it does not mention the device revoked since
+ *
+ * ## What this is instead
+ *
+ * A list signed by the USER ROOT — the same key that signs device certificates, so any machine that
+ * can verify a certificate can already verify a list, and distribution needs no trusted channel. It
+ * can travel over the signaling server, on the data channel, in a file, or by hand.
+ *
+ * And it carries `expiresAt`. A verifier holding a list past that point does not fall back to "no
+ * revocations": it refuses, because a stale list is indistinguishable from a withheld one, and the
+ * safe reading of "I cannot tell whether this device was retired" is not "it was not".
+ *
+ * `issuedAt` is monotonic per user, so a verifier that has seen a newer list refuses an older one
+ * even while both are unexpired. Without that, an attacker who captured any past list could roll a
+ * verifier backwards to a moment before the revocation they care about.
+ *
+ * ## What this module does NOT do
+ *
+ * It does not fetch, cache, or schedule. Where a list is stored and how often it is refreshed are
+ * deployment decisions, and a primitive that also fetched would need a transport — which is how a
+ * crypto module ends up with a network dependency and an untestable path.
+ */
+
+import { ab, toBase64Url } from './crypto-primitives.js';
+
+const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
+const webcrypto = globalThis.crypto;
+const encoder = new TextEncoder();
+
+function fromBase64Url(value: string): Uint8Array {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='));
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+/** Everything a revocation list binds, before it is signed. */
+export interface IRevocationListClaims {
+  /** Whose devices these are. A list for another root is another person's. */
+  readonly userId: string;
+  /**
+   * The retired device ids. An EMPTY list is a real statement — "nothing is revoked as of now" — and
+   * is exactly why the list is issued on a schedule rather than only when something is revoked. A
+   * user who has revoked nothing still needs a fresh list, or every verifier is permanently stale.
+   */
+  readonly revokedDeviceIds: readonly string[];
+  /** Monotonic per user. A verifier that has seen a newer list refuses an older one. */
+  readonly issuedAt: number;
+  /** Past this, a holder must refuse rather than read the list as "no revocations". */
+  readonly expiresAt: number;
+}
+
+export interface IRevocationList extends IRevocationListClaims {
+  /** base64url ECDSA signature by the USER ROOT private key over every claim above. */
+  readonly signature: string;
+}
+
+/** The bytes a list signature covers — every claim, in a fixed order, versioned. */
+function listBytes(claims: IRevocationListClaims): Uint8Array {
+  return encoder.encode(
+    JSON.stringify([
+      'robota.device-revocation-list.v1',
+      claims.userId,
+      // Sorted, so two lists with the same members produce the same bytes whatever order they were
+      // assembled in. Without this a re-issue with a reordered array is a different signature over
+      // an identical statement, and a verifier comparing bytes would call them different lists.
+      [...claims.revokedDeviceIds].sort(),
+      claims.issuedAt,
+      claims.expiresAt,
+    ]),
+  );
+}
+
+/** Sign a revocation list for this user. */
+export async function issueRevocationList(
+  claims: IRevocationListClaims,
+  rootPrivateKey: CryptoKey,
+): Promise<IRevocationList> {
+  const signature = await webcrypto.subtle.sign(SIGN_PARAMS, rootPrivateKey, ab(listBytes(claims)));
+  return { ...claims, signature: toBase64Url(new Uint8Array(signature)) };
+}
+
+/**
+ * Why a list was not accepted. Closed vocabulary, so a caller cannot soften one into a pass.
+ *
+ * `stale` and `superseded` are separate because they call for different operator responses: the
+ * first says nobody has issued a list recently enough, the second says this specific list is behind
+ * one this machine already holds — which is what a rollback attempt looks like.
+ */
+export type TRevocationRejection = 'signature-invalid' | 'user-mismatch' | 'stale' | 'superseded';
+
+export interface IRevocationVerdict {
+  readonly usable: boolean;
+  /** The ids to pass to `verifyDeviceCertificate`. Present ONLY when usable. */
+  readonly revokedDeviceIds?: readonly string[];
+  readonly rejection?: TRevocationRejection;
+}
+
+export interface IVerifyRevocationListOptions {
+  readonly rootPublicKey: CryptoKey;
+  readonly expectedUserId: string;
+  readonly now: number;
+  /**
+   * `issuedAt` of the newest list this machine has already accepted, if any.
+   *
+   * Supplied rather than remembered here for the same reason nothing is fetched here: where a
+   * machine keeps its high-water mark is a deployment decision. Absent means "this is the first",
+   * which is correct on a fresh machine and is NOT a way to bypass the check — a caller that
+   * discards its mark is choosing to accept a rollback, and that choice is visible at the call site.
+   */
+  readonly newestAcceptedAt?: number;
+}
+
+/**
+ * Verify a revocation list against this user and this moment.
+ *
+ * The signature is checked FIRST, for the same reason as everywhere else in this package: every
+ * later comparison must be about fields the root actually signed, not about attacker-supplied values
+ * that merely travelled alongside a signature.
+ */
+export async function verifyRevocationList(
+  list: IRevocationList,
+  options: IVerifyRevocationListOptions,
+): Promise<IRevocationVerdict> {
+  const { signature, ...claims } = list;
+  const signatureOk = await webcrypto.subtle.verify(
+    SIGN_PARAMS,
+    options.rootPublicKey,
+    ab(fromBase64Url(signature)),
+    ab(listBytes(claims)),
+  );
+  if (!signatureOk) return { usable: false, rejection: 'signature-invalid' };
+
+  if (claims.userId !== options.expectedUserId)
+    return { usable: false, rejection: 'user-mismatch' };
+  if (options.now >= claims.expiresAt) return { usable: false, rejection: 'stale' };
+  if (options.newestAcceptedAt !== undefined && claims.issuedAt < options.newestAcceptedAt) {
+    return { usable: false, rejection: 'superseded' };
+  }
+  return { usable: true, revokedDeviceIds: claims.revokedDeviceIds };
+}
+
+/**
+ * What a verifier should do when it has no usable list: refuse, and say why.
+ *
+ * Stated as a function rather than left to each call site, because the tempting shape at a call site
+ * is `revokedDeviceIds: list?.revokedDeviceIds ?? []` — which reads as a safe default and is the
+ * exact fail-OPEN this module exists to prevent. An empty array means "nothing is revoked", and an
+ * absent list does not say that.
+ */
+export function revocationUnavailable(rejection: TRevocationRejection): string {
+  return (
+    `no usable device revocation list (${rejection}). Refusing rather than proceeding: an absent ` +
+    'or stale list is indistinguishable from one an attacker withheld, and reading it as ' +
+    '"nothing is revoked" is how a retired device keeps working.'
+  );
+}

--- a/packages/agent-remote-pairing/src/root-rotation.ts
+++ b/packages/agent-remote-pairing/src/root-rotation.ts
@@ -1,0 +1,227 @@
+/**
+ * SEC-011 (issue #1865): rotating the user root key, and what happens to what it signed.
+ *
+ * ## Rotation is two different problems wearing one word
+ *
+ * **Hygiene.** The key is fine; the user is replacing it on a schedule, or moving it to better
+ * storage. Continuity is wanted: the devices already enrolled should keep working while they are
+ * re-certified. That is what this module does.
+ *
+ * **Compromise.** Someone else has the key. Continuity is exactly what must NOT be preserved — and
+ * this mechanism cannot provide it, because an attacker holding the old private key can sign the
+ * very same statement naming a root of their choosing. A rotation chain rooted in the old key is
+ * worthless the moment the old key is the thing that failed.
+ *
+ * **So a compromised root is not rotated. It is abandoned.** The user generates a new root, gets a
+ * new `userId`, and re-enrols every device out of band — the old identity is not repaired, it is
+ * left behind, and every verifier that learns the new root learns it the way it learned the first
+ * one. This module deliberately offers no path that looks like it handles that case, because a
+ * function named `rotate` that silently did the wrong thing under compromise would be worse than
+ * none at all.
+ *
+ * ## Why BOTH roots sign
+ *
+ * The old root signs because it is the only thing that can say "this succeeds me" — a statement
+ * signed by the new key alone is an assertion by a stranger.
+ *
+ * The new root signs because otherwise anyone holding the old key could name a public key they do
+ * NOT hold as the successor, and every verifier would then move to an identity nobody can issue
+ * certificates for. The user would be locked out by a statement that verified perfectly. Requiring
+ * the successor to countersign is what makes "the named key exists and consents" checkable.
+ *
+ * ## The overlap window is bounded, and it is not optional
+ *
+ * `previousValidUntil` is a claim, inside the signature. Without a bound the old root would be
+ * acceptable forever and the rotation would have changed nothing; with an unsigned bound anyone on
+ * the path could extend it. A verifier past that moment refuses certificates from the old root even
+ * though the rotation statement itself still verifies — the statement stays true, the permission it
+ * granted has run out.
+ */
+
+import { ab, toBase64Url } from './crypto-primitives.js';
+import { exportPublicKey } from './device-identity.js';
+
+const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
+const webcrypto = globalThis.crypto;
+const encoder = new TextEncoder();
+
+function fromBase64Url(value: string): Uint8Array {
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='));
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+/** Everything a rotation binds, before either root signs it. */
+export interface IRootRotationClaims {
+  /** The root being retired. */
+  readonly previousUserId: string;
+  /** The root taking over. */
+  readonly nextUserId: string;
+  /** base64url SPKI of the successor, so a verifier needs nothing else to start trusting it. */
+  readonly nextRootPublicKey: string;
+  readonly rotatedAt: number;
+  /**
+   * Certificates signed by the PREVIOUS root stay acceptable until this moment.
+   *
+   * A bound, not a courtesy. Unbounded overlap means the rotation changed nothing, and the whole
+   * point of re-certifying devices is that there is a deadline to do it by.
+   */
+  readonly previousValidUntil: number;
+}
+
+export interface IRootRotation extends IRootRotationClaims {
+  /** base64url ECDSA signature by the PREVIOUS root — "this key succeeds me". */
+  readonly previousSignature: string;
+  /** base64url ECDSA signature by the NEXT root — "I exist, and I accept". */
+  readonly nextSignature: string;
+}
+
+/** The bytes both signatures cover — every claim, in a fixed order, versioned. */
+function rotationBytes(claims: IRootRotationClaims): Uint8Array {
+  return encoder.encode(
+    JSON.stringify([
+      'robota.user-root-rotation.v1',
+      claims.previousUserId,
+      claims.nextUserId,
+      claims.nextRootPublicKey,
+      claims.rotatedAt,
+      claims.previousValidUntil,
+    ]),
+  );
+}
+
+export interface IIssueRotationOptions {
+  readonly previousUserId: string;
+  readonly nextUserId: string;
+  readonly previousRootPrivateKey: CryptoKey;
+  readonly nextRootKeyPair: CryptoKeyPair;
+  readonly rotatedAt: number;
+  readonly previousValidUntil: number;
+}
+
+/**
+ * Sign a rotation with both roots.
+ *
+ * Takes the successor's KEY PAIR rather than its private key alone, because the public half is what
+ * goes into the claims — and a caller that supplied them separately could sign over one key while
+ * countersigning with another, producing a statement that verifies and names the wrong successor.
+ */
+export async function issueRootRotation(options: IIssueRotationOptions): Promise<IRootRotation> {
+  const claims: IRootRotationClaims = {
+    previousUserId: options.previousUserId,
+    nextUserId: options.nextUserId,
+    nextRootPublicKey: await exportPublicKey(options.nextRootKeyPair.publicKey),
+    rotatedAt: options.rotatedAt,
+    previousValidUntil: options.previousValidUntil,
+  };
+  const bytes = ab(rotationBytes(claims));
+  const [previousSignature, nextSignature] = await Promise.all([
+    webcrypto.subtle.sign(SIGN_PARAMS, options.previousRootPrivateKey, bytes),
+    webcrypto.subtle.sign(SIGN_PARAMS, options.nextRootKeyPair.privateKey, bytes),
+  ]);
+  return {
+    ...claims,
+    previousSignature: toBase64Url(new Uint8Array(previousSignature)),
+    nextSignature: toBase64Url(new Uint8Array(nextSignature)),
+  };
+}
+
+/**
+ * Why a rotation was not accepted. Closed vocabulary, so a caller cannot soften one into a pass.
+ *
+ * The two signature rejections are separate because they mean different things: the first says the
+ * retiring root did not authorise this, the second says the named successor did not countersign —
+ * which is the lock-out attempt, and an operator needs to be able to tell them apart.
+ */
+export type TRotationRejection =
+  | 'previous-signature-invalid'
+  | 'next-signature-invalid'
+  | 'wrong-previous-root'
+  | 'not-yet-valid'
+  | 'overlap-inverted';
+
+export interface IRotationVerdict {
+  readonly accepted: boolean;
+  /** The successor to start trusting. Present ONLY when accepted. */
+  readonly nextUserId?: string;
+  readonly nextRootPublicKey?: string;
+  /** Until when certificates from the previous root remain acceptable. Present ONLY when accepted. */
+  readonly previousValidUntil?: number;
+  readonly rejection?: TRotationRejection;
+}
+
+export interface IVerifyRotationOptions {
+  /** The root this verifier trusts TODAY. A rotation away from any other root is not its business. */
+  readonly previousRootPublicKey: CryptoKey;
+  readonly expectedPreviousUserId: string;
+  readonly now: number;
+}
+
+/**
+ * Verify a rotation against the root this machine currently trusts.
+ *
+ * Both signatures are checked FIRST, for the reason this package checks signatures first everywhere:
+ * every later comparison must be about fields that were actually signed.
+ */
+export async function verifyRootRotation(
+  rotation: IRootRotation,
+  options: IVerifyRotationOptions,
+): Promise<IRotationVerdict> {
+  const { previousSignature, nextSignature, ...claims } = rotation;
+  const bytes = ab(rotationBytes(claims));
+
+  const previousOk = await webcrypto.subtle.verify(
+    SIGN_PARAMS,
+    options.previousRootPublicKey,
+    ab(fromBase64Url(previousSignature)),
+    bytes,
+  );
+  if (!previousOk) return { accepted: false, rejection: 'previous-signature-invalid' };
+
+  // The successor's key comes from the claims the PREVIOUS root just signed, never from anywhere
+  // else — which is what makes the countersignature a check rather than a formality.
+  const nextRootPublicKey = await webcrypto.subtle.importKey(
+    'spki',
+    ab(fromBase64Url(claims.nextRootPublicKey)),
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify'],
+  );
+  const nextOk = await webcrypto.subtle.verify(
+    SIGN_PARAMS,
+    nextRootPublicKey,
+    ab(fromBase64Url(nextSignature)),
+    bytes,
+  );
+  if (!nextOk) return { accepted: false, rejection: 'next-signature-invalid' };
+
+  if (claims.previousUserId !== options.expectedPreviousUserId) {
+    return { accepted: false, rejection: 'wrong-previous-root' };
+  }
+  if (options.now < claims.rotatedAt) return { accepted: false, rejection: 'not-yet-valid' };
+  if (claims.previousValidUntil < claims.rotatedAt) {
+    // An overlap that ends before it begins is not a tight window, it is a malformed statement — and
+    // reading it as "no overlap" would silently invalidate every enrolled device at a moment the
+    // signer may not have intended.
+    return { accepted: false, rejection: 'overlap-inverted' };
+  }
+  return {
+    accepted: true,
+    nextUserId: claims.nextUserId,
+    nextRootPublicKey: claims.nextRootPublicKey,
+    previousValidUntil: claims.previousValidUntil,
+  };
+}
+
+/**
+ * Is a certificate from the PREVIOUS root still acceptable at `now`?
+ *
+ * A function rather than a comparison at each call site, because the tempting spelling is
+ * `now < rotation.previousValidUntil` against the raw statement — which reads the bound off an
+ * unverified object. This takes the VERDICT, so the only way to ask is to have verified first.
+ */
+export function previousRootStillAccepted(verdict: IRotationVerdict, now: number): boolean {
+  return verdict.accepted && verdict.previousValidUntil !== undefined
+    ? now < verdict.previousValidUntil
+    : false;
+}

--- a/packages/agent-transport-webrtc/docs/SPEC.md
+++ b/packages/agent-transport-webrtc/docs/SPEC.md
@@ -115,24 +115,25 @@ reserved for E4). Without `reconnect`, the gate is exactly the B4 first-pair-onl
 
 ## Public API Surface
 
-| Export                        | Kind     | Description                                                                                              |
-| ----------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`.                                    |
-| `IWebRtcTransportOptions`     | type     | Construction options.                                                                                    |
-| `IIceServer`                  | type     | A STUN/TURN server (`urls` + optional `username`/`credential`; REMOTE-010).                              |
-| `IHostReconnectConfig`        | type     | E3 host reconnect/enrollment config for the gate (host identity + device resolver + enroll; REMOTE-012). |
-| `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).                                                |
-| `WsSignalingClient`           | class    | Production `ISignalingClient` over a `ws` socket to the relay (REMOTE-004).                              |
-| `IWsSignalingClientOptions`   | type     | `WsSignalingClient` options (url, rendezvous, onError, onReady, socket factory).                         |
-| `IWebSocketLike`              | type     | Minimal socket surface `WsSignalingClient` needs (injectable in tests).                                  |
-| `ISignalingClient`            | type     | Signaling port (send/onSignal/close by rendezvous).                                                      |
-| `ILocalPeerProof`             | type     | SEC-010 local-peer proof port the gate consumes: `redeem` plus an admission observer.                    |
-| `ILocalProofFrame`            | type     | The frame a local peer presents to show it reached the guarded rendezvous.                               |
-| `localProofFrame`             | function | Build that frame. Beside the judge that reads it, so a sender cannot drift from the shape checked.       |
-| `ISignalMessage`              | type     | Opaque SDP/ICE envelope.                                                                                 |
-| `TSignalKind`                 | type     | `'offer' \| 'answer' \| 'ice'`.                                                                          |
-| `loadWerift`                  | function | Lazy-load the optional `werift` peer dep (throws on absence).                                            |
-| `IWeriftModule`               | type     | The subset of the werift surface this transport constructs.                                              |
+| Export                        | Kind     | Description                                                                                                                                 |
+| ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WebRtcTransport`             | class    | `IConfigurableTransport` carrying a session over an `RTCDataChannel`.                                                                       |
+| `IWebRtcTransportOptions`     | type     | Construction options.                                                                                                                       |
+| `IIceServer`                  | type     | A STUN/TURN server (`urls` + optional `username`/`credential`; REMOTE-010).                                                                 |
+| `IHostReconnectConfig`        | type     | E3 host reconnect/enrollment config for the gate (host identity + device resolver + enroll; REMOTE-012).                                    |
+| `createInMemorySignalingPair` | function | In-process signaling pair for loopback/tests (no server).                                                                                   |
+| `WsSignalingClient`           | class    | Production `ISignalingClient` over a `ws` socket to the relay (REMOTE-004).                                                                 |
+| `IWsSignalingClientOptions`   | type     | `WsSignalingClient` options (url, rendezvous, onError, onReady, socket factory).                                                            |
+| `IWebSocketLike`              | type     | Minimal socket surface `WsSignalingClient` needs (injectable in tests).                                                                     |
+| `ISignalingClient`            | type     | Signaling port (send/onSignal/close by rendezvous).                                                                                         |
+| `ILocalPeerProof`             | type     | SEC-010 local-peer proof port the gate consumes: `redeem` plus an admission observer.                                                       |
+| `ILocalProofFrame`            | type     | The frame a local peer presents to show it reached the guarded rendezvous.                                                                  |
+| `localProofFrame`             | function | Build that frame. Beside the judge that reads it, so a sender cannot drift from the shape checked.                                          |
+| `handoffGrantFrame`           | function | SEC-011 (issue #1865): build the frame a source presents to show it holds a grant for this transfer. Beside its judge, for the same reason. |
+| `ISignalMessage`              | type     | Opaque SDP/ICE envelope.                                                                                                                    |
+| `TSignalKind`                 | type     | `'offer' \| 'answer' \| 'ice'`.                                                                                                             |
+| `loadWerift`                  | function | Lazy-load the optional `werift` peer dep (throws on absence).                                                                               |
+| `IWeriftModule`               | type     | The subset of the werift surface this transport constructs.                                                                                 |
 
 ## Extension Points
 

--- a/packages/agent-transport-webrtc/src/__tests__/admission-steps.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/admission-steps.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { nextAdmissionStep } from '../admission-steps.js';
+
+/**
+ * The ordering carries the security argument, so it is asserted directly rather than only through a
+ * channel: each step must run on a channel the previous one has already bound.
+ */
+
+const PROOF = {};
+
+describe('what a channel still owes', () => {
+  it('owes nothing when nothing is configured — the handshake alone admits', () => {
+    expect(nextAdmissionStep({}, 'pairing')).toBe(null);
+  });
+
+  it.each([
+    ['only the rendezvous', { localPeer: PROOF }, 'local-proof'],
+    ['only the grant', { handoffGrant: PROOF }, 'handoff-grant'],
+    ['both — the rendezvous first', { localPeer: PROOF, handoffGrant: PROOF }, 'local-proof'],
+  ])('with %s configured, owes %s', (_label, configured, expected) => {
+    expect(nextAdmissionStep(configured, 'pairing')).toBe(expected);
+  });
+
+  it('owes the grant once the rendezvous has run', () => {
+    expect(nextAdmissionStep({ localPeer: PROOF, handoffGrant: PROOF }, 'local-proof')).toBe(
+      'handoff-grant',
+    );
+  });
+
+  it('owes nothing once both have run', () => {
+    expect(nextAdmissionStep({ localPeer: PROOF, handoffGrant: PROOF }, 'handoff-grant')).toBe(
+      null,
+    );
+  });
+
+  it('does not re-demand the rendezvous after the grant state is reached', () => {
+    // The loop this prevents: a gate that asked for the rendezvous again from `handoff-grant` would
+    // never admit anyone, because the peer has no second nonce to present.
+    expect(nextAdmissionStep({ localPeer: PROOF }, 'handoff-grant')).toBe(null);
+  });
+
+  it('owes nothing after a rendezvous-only channel has satisfied it', () => {
+    expect(nextAdmissionStep({ localPeer: PROOF }, 'local-proof')).toBe(null);
+  });
+});

--- a/packages/agent-transport-webrtc/src/__tests__/handoff-grant-gate.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/handoff-grant-gate.test.ts
@@ -1,0 +1,401 @@
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-transport/testing';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  handoffGrantFrame,
+  judgeHandoffGrant,
+  type IHandoffGrantProof,
+} from '../handoff-grant-gate.js';
+import { PairingGate, type IPairingGateOptions } from '../pairing-gate.js';
+import { type ILocalPeerProof } from '../local-peer-proof.js';
+
+import type { startPairingHandshake, TPairingFrame } from '@robota-sdk/agent-remote-pairing';
+import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
+import type { createWsHandler } from '@robota-sdk/agent-transport-protocol';
+
+/**
+ * SEC-011 (issue #1865) — the cross-device grant bound to the admitted channel.
+ *
+ * Driven with a stub handshake and a stub verifier: this package must implement no cryptographic
+ * policy, so what is asserted here is the GATE's ordering and fail-closed behaviour, never the
+ * grant's signature, expiry or replay rules — those are proven where they live, in
+ * `agent-remote-pairing`.
+ */
+
+const ADMITTED: IPeerAdmission = {
+  admitted: true,
+  trust: 'same-user-different-host',
+  origin: { sessionId: 'peer_laptop' },
+};
+const REFUSED: IPeerAdmission = {
+  admitted: false,
+  trust: 'unproven',
+  reason: 'channel-substituted',
+};
+const LOCAL_ADMITTED: IPeerAdmission = {
+  admitted: true,
+  trust: 'same-user-same-host',
+  origin: { sessionId: 'peer_a' },
+};
+
+function makeHandshakeStub() {
+  let resolveResult!: (value: { sessionKey: string }) => void;
+  const start: typeof startPairingHandshake = (options) => {
+    const controller = {
+      result: new Promise<{ sessionKey: string }>((res) => {
+        resolveResult = res;
+      }),
+      onFrame: (_frame: TPairingFrame) => {},
+    };
+    options.send({ t: 'pair-nonce', nonce: 'stub' });
+    return controller;
+  };
+  return { start, accept: () => resolveResult({ sessionKey: 'k' }) };
+}
+
+function makeGate(handoffGrant?: IHandoffGrantProof, over: Partial<IPairingGateOptions> = {}) {
+  const channel = { send: vi.fn(), close: vi.fn() };
+  const sessionOnMessage = vi.fn();
+  const createHandler: typeof createWsHandler = () => ({
+    onMessage: sessionOnMessage,
+    cleanup: vi.fn(),
+  });
+  const hs = makeHandshakeStub();
+  const gate = new PairingGate({
+    channel,
+    session: createTestInteractiveSession(),
+    secret: 's',
+    role: 'initiator',
+    localFingerprint: 'AA',
+    remoteFingerprint: 'BB',
+    startHandshake: hs.start,
+    createHandler,
+    ...(handoffGrant ? { handoffGrant } : {}),
+    ...over,
+  });
+  return { gate, channel, sessionOnMessage, hs };
+}
+
+const grantFrame = (grant: unknown = { handoffId: 'h1', signature: 'sig' }) =>
+  JSON.stringify(handoffGrantFrame(grant));
+
+/** The verifier is async, so every case must let its promise settle before asserting. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('the session is not exposed until a grant is presented and verified', () => {
+  it('a handshake that accepts is NOT enough on its own', async () => {
+    // The whole point of the binding. The handshake proves the channel terminates at the peer that
+    // knew the secret; it says nothing about WHO that peer is, so it must not open the session.
+    const verify = vi.fn(async () => ADMITTED);
+    const { gate, sessionOnMessage, hs } = makeGate({ verify });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+    await settle();
+
+    expect(verify).not.toHaveBeenCalled();
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+
+  it('presenting an admitted grant after the handshake opens the session', async () => {
+    const { gate, sessionOnMessage, hs } = makeGate({ verify: async () => ADMITTED });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(sessionOnMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('a refused grant closes the channel and never builds a session handler', async () => {
+    // "Fail closed before content". Refusing after exposure is not refusing.
+    const { gate, channel, sessionOnMessage, hs } = makeGate({ verify: async () => REFUSED });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(channel.close).toHaveBeenCalled();
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+
+  it('with no grant configured the gate is unchanged — the handshake alone opens the session', async () => {
+    // The other direction. Without it every case above could be passing because the gate refuses
+    // everything, and requiring a grant is opt-in precisely because an ordinary remote peer has
+    // none to present.
+    const { gate, sessionOnMessage, hs } = makeGate();
+
+    hs.accept();
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(sessionOnMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('what the consumer is told', () => {
+  it('is told about a refusal, not only about a success', async () => {
+    // A consumer told only about successes cannot distinguish "no hand-off was offered" from "a
+    // hand-off was refused", and the second is the one that belongs in front of a person.
+    const onAdmission = vi.fn();
+    const { gate, hs } = makeGate({ verify: async () => REFUSED, onAdmission });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+
+    expect(onAdmission).toHaveBeenCalledWith(REFUSED);
+  });
+
+  it('carries the trust level through, not a boolean', async () => {
+    const onAdmission = vi.fn();
+    const { gate, hs } = makeGate({ verify: async () => ADMITTED, onAdmission });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+
+    expect(onAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({ trust: 'same-user-different-host' }),
+    );
+  });
+});
+
+describe('a cross-device grant cannot become a same-host claim', () => {
+  it('refuses an admission that claims same-user-same-host', async () => {
+    // #1812 pins that the two levels are different values, and this is the substitution it forbids
+    // by name: a grant proves the USER, not the machine. A verifier returning the stronger level
+    // would satisfy every check that wanted the kernel-enforced rendezvous.
+    const onAdmission = vi.fn();
+    const { gate, channel, sessionOnMessage, hs } = makeGate({
+      verify: async () => LOCAL_ADMITTED,
+      onAdmission,
+    });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+    expect(channel.close).toHaveBeenCalled();
+    expect(onAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({ admitted: false, trust: 'unproven' }),
+    );
+  });
+
+  it('admits the same verdict when its trust is the cross-device level', async () => {
+    // The paired direction: what is refused above is the LEVEL, not the shape. Without this the
+    // case above could pass on a gate that refuses every admission it is handed.
+    const { gate, sessionOnMessage, hs } = makeGate({ verify: async () => ADMITTED });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(sessionOnMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the rendezvous and the grant are demanded in order, not instead of each other', () => {
+  const localProof = (admission: IPeerAdmission): ILocalPeerProof => ({ redeem: () => admission });
+
+  it('the rendezvous alone does not open the session when a grant is also required', async () => {
+    const { gate, sessionOnMessage, hs } = makeGate(
+      { verify: async () => ADMITTED },
+      { localPeer: localProof(LOCAL_ADMITTED) },
+    );
+
+    hs.accept();
+    await settle();
+    gate.onInbound(JSON.stringify({ t: 'local-proof', nonce: 'n1' }));
+    await settle();
+    // The session frame is sent while the gate is still waiting for the grant. It is refused — and
+    // that refusal is the assertion: content reaching the session here would mean the second step
+    // was decorative.
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+    await settle();
+
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+
+  it('a hand-off between two sessions on ONE machine opens it once BOTH are satisfied', async () => {
+    const { gate, sessionOnMessage, hs } = makeGate(
+      { verify: async () => ADMITTED },
+      { localPeer: localProof(LOCAL_ADMITTED) },
+    );
+
+    hs.accept();
+    await settle();
+    gate.onInbound(JSON.stringify({ t: 'local-proof', nonce: 'n1' }));
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(sessionOnMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('anything that is not a grant, in the grant state, closes the channel', async () => {
+    // The strict reading of "fail closed before content": while a grant is owed, a frame that is not
+    // one is a refusal, not something to ignore and keep waiting through. Ignoring it would leave a
+    // peer able to hold the gate open indefinitely by sending noise.
+    const { gate, channel, sessionOnMessage, hs } = makeGate({ verify: async () => ADMITTED });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+    await settle();
+
+    expect(channel.close).toHaveBeenCalled();
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+
+  it('a refused rendezvous closes before the grant is ever asked for', async () => {
+    const verify = vi.fn(async () => ADMITTED);
+    const { gate, channel, hs } = makeGate(
+      { verify },
+      {
+        localPeer: localProof({ admitted: false, trust: 'unproven', reason: 'replayed' }),
+      },
+    );
+
+    hs.accept();
+    await settle();
+    gate.onInbound(JSON.stringify({ t: 'local-proof', nonce: 'n1' }));
+    await settle();
+
+    expect(channel.close).toHaveBeenCalled();
+    expect(verify).not.toHaveBeenCalled();
+  });
+});
+
+describe('the person at this machine, asked after the proof', () => {
+  it('is asked only once the grant verified, and with the PROVEN verdict', async () => {
+    // Asking first would let anyone who can open a channel raise a dialog claiming to be any device
+    // they like. The order is the control.
+    const order: string[] = [];
+    const consent = vi.fn(async () => {
+      order.push('consent');
+      return true;
+    });
+    const admission = await judgeHandoffGrant(handoffGrantFrame({ h: 1 }), {
+      verify: async () => {
+        order.push('verify');
+        return ADMITTED;
+      },
+      consent,
+    });
+
+    expect(order).toEqual(['verify', 'consent']);
+    expect(consent).toHaveBeenCalledWith(ADMITTED);
+    expect(admission.admitted).toBe(true);
+  });
+
+  it('is NOT asked when the grant did not verify', async () => {
+    const consent = vi.fn(async () => true);
+    await judgeHandoffGrant(handoffGrantFrame({ h: 1 }), {
+      verify: async () => REFUSED,
+      consent,
+    });
+    expect(consent).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the person declines, and says which step declined', async () => {
+    const admission = await judgeHandoffGrant(handoffGrantFrame({ h: 1 }), {
+      verify: async () => ADMITTED,
+      consent: async () => false,
+    });
+    expect(admission.admitted).toBe(false);
+    // Not reported as an authorization failure: the operator must not be left reading
+    // "unauthorized" when what happened is that they said no.
+    expect(admission.reason).toContain('declined');
+  });
+
+  it('refuses when asking throws — a prompt that could not be shown is not a yes', async () => {
+    const admission = await judgeHandoffGrant(handoffGrantFrame({ h: 1 }), {
+      verify: async () => ADMITTED,
+      consent: async () => {
+        throw new Error('no interactive renderer is attached');
+      },
+    });
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toContain('no interactive renderer is attached');
+  });
+
+  it('admits with no consent configured, so the requirement is opt-in and not vacuous', async () => {
+    // The other direction. Without it every case above could be passing on a judge that refuses
+    // everything once a grant verifies.
+    const admission = await judgeHandoffGrant(handoffGrantFrame({ h: 1 }), {
+      verify: async () => ADMITTED,
+    });
+    expect(admission.admitted).toBe(true);
+  });
+
+  it('closes the channel when the person declines, through the whole gate', async () => {
+    const { gate, channel, sessionOnMessage, hs } = makeGate({
+      verify: async () => ADMITTED,
+      consent: async () => false,
+    });
+
+    hs.accept();
+    await settle();
+    gate.onInbound(grantFrame());
+    await settle();
+    gate.onInbound(JSON.stringify({ type: 'submit', prompt: 'p' }));
+
+    expect(channel.close).toHaveBeenCalled();
+    expect(sessionOnMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('the judge, asked directly', () => {
+  it('refuses when no verifier is configured', async () => {
+    // Unreachable through the gate, and a fail-OPEN if it ever were.
+    const admission = await judgeHandoffGrant(handoffGrantFrame({}), undefined);
+    expect(admission.admitted).toBe(false);
+    expect(admission.trust).toBe('unproven');
+  });
+
+  it.each([
+    ['a frame of the wrong kind', { t: 'local-proof', nonce: 'n1' }],
+    ['a grant frame with no grant', { t: 'handoff-grant' }],
+    ['not an object at all', 'handoff-grant'],
+    ['null', null],
+  ])('refuses %s', async (_label, parsed) => {
+    const admission = await judgeHandoffGrant(parsed, { verify: async () => ADMITTED });
+    expect(admission.admitted).toBe(false);
+  });
+
+  it('refuses — rather than throwing — when the verifier throws', async () => {
+    // Fail CLOSED. A verifier that throws has not reached a decision, and "not reached" is not
+    // "allowed". Letting it propagate would park the gate with the channel open, which is a hang:
+    // fail-open wearing a crash's clothes.
+    const admission = await judgeHandoffGrant(handoffGrantFrame({ x: 1 }), {
+      verify: async () => {
+        throw new Error('the key store is unreachable');
+      },
+    });
+    expect(admission.admitted).toBe(false);
+    expect(admission.reason).toContain('the key store is unreachable');
+  });
+
+  it('hands the verifier exactly what the frame carried', async () => {
+    // The gate is an envelope, not an interpreter: a gate that reshaped the grant on the way through
+    // would break the signature over claims the verifier then could not check.
+    const grant = { handoffId: 'h1', nonce: 'n', signature: 'sig' };
+    const verify = vi.fn(async () => ADMITTED);
+    await judgeHandoffGrant(handoffGrantFrame(grant), { verify });
+    expect(verify).toHaveBeenCalledWith(grant);
+  });
+});

--- a/packages/agent-transport-webrtc/src/admission-steps.ts
+++ b/packages/agent-transport-webrtc/src/admission-steps.ts
@@ -1,0 +1,49 @@
+/**
+ * Which admission step a channel still owes before the session may be exposed.
+ *
+ * Extracted from `pairing-gate.ts` because it is the one decision in that file that is a pure
+ * function of configuration and state — and because it is the ORDERING that carries the security
+ * argument, so it deserves to be readable and testable without a channel, a handshake or a session.
+ *
+ * The order is not arbitrary. Each step must run on a channel the previous one has already bound:
+ *
+ *   handshake     binds the CHANNEL — it terminates at the peer that knew the secret
+ *   local-proof   binds the ENVIRONMENT — that peer reached a 0700 directory owned by this user
+ *   handoff-grant binds the TRANSFER — one user, one destination, one channel, signed
+ *
+ * Each is opt-in, and configuring two means requiring both. That is strictly more restrictive than
+ * requiring either, which is the safe direction — and it is the correct reading for a hand-off
+ * between two sessions on ONE machine, which legitimately has both to present.
+ */
+
+/** The step still owed, or null when the session may be exposed. */
+export type TAdmissionStep = 'local-proof' | 'handoff-grant' | null;
+
+/** What the gate has configured. Named structurally so this module needs none of the gate's types. */
+export interface IConfiguredAdmissionSteps {
+  readonly localPeer?: unknown;
+  readonly handoffGrant?: unknown;
+}
+
+/**
+ * The next step, given what is configured and what has already run.
+ *
+ * `completed` is the gate's current state rather than a set of finished steps, because the states
+ * ARE the record: reaching `handoff-grant` is only possible by having satisfied `local-proof` when
+ * one was required.
+ */
+export function nextAdmissionStep(
+  configured: IConfiguredAdmissionSteps,
+  completed: string,
+): TAdmissionStep {
+  if (
+    configured.localPeer !== undefined &&
+    completed !== 'local-proof' &&
+    completed !== 'handoff-grant'
+  ) {
+    return 'local-proof';
+  }
+  if (configured.handoffGrant !== undefined && completed !== 'handoff-grant')
+    return 'handoff-grant';
+  return null;
+}

--- a/packages/agent-transport-webrtc/src/handoff-grant-gate.ts
+++ b/packages/agent-transport-webrtc/src/handoff-grant-gate.ts
@@ -1,0 +1,186 @@
+/**
+ * SEC-011 (issue #1865): the channel gate consumes the cross-device hand-off grant.
+ *
+ * The same shape SEC-010's local-proof step established, for the same reason. #1810 is explicit that
+ * this package must not implement cryptographic policy, so nothing here verifies a signature,
+ * decides an expiry, or knows what revocation is. The gate holds the state machine; the verdict is
+ * injected and reported.
+ *
+ * ## What the grant proves, and what the channel proves
+ *
+ * The pairing handshake binds the CHANNEL: after it, this data channel provably terminates at the
+ * peer that knew the secret, and the DTLS fingerprints are covered so it cannot be spliced. It says
+ * nothing about who that peer is.
+ *
+ * The grant binds the TRANSFER: one user, one source device, one destination, one `handoffId`, one
+ * `sessionId`, one nonce, and the fingerprint of the channel it may be presented over. It says
+ * nothing about whether the channel it arrived on is the one it names.
+ *
+ * Presenting the grant OVER the already-bound channel is what joins them, and the fingerprint claim
+ * is what makes the join checkable: a grant lifted from one channel and replayed on another names a
+ * fingerprint the verifier does not observe. That is `channel-substituted`, and it is a distinct
+ * rejection precisely so it cannot be softened into a pass.
+ *
+ * ## Why it runs after the handshake and before the session
+ *
+ * Both edges are load-bearing, and both for SEC-010's reasons.
+ *
+ * BEFORE the handshake completes, the channel is not authenticated — a grant presented there would
+ * be handed to an unproven counterpart, and this step would weaken what it exists to strengthen.
+ *
+ * BEFORE the session is exposed, because "fail closed before content" is the first failure rule. A
+ * peer that never presents a grant must not have been talking to the session already; refusing it
+ * afterwards is not refusing it.
+ *
+ * ## The trust it produces is its own
+ *
+ * `same-user-different-host` is not `same-user-same-host`. #1812 pins that they are different values
+ * and this gate is the reason: a cross-device authorization must never satisfy a check that wanted
+ * same-machine. It travels as a value on the admission rather than being re-derived from a boolean
+ * by whoever reads it next.
+ */
+
+import type { IPeerAdmission } from '@robota-sdk/agent-interface-transport';
+
+/** The frame a source device presents to show it holds a grant for this transfer. */
+export interface IHandoffGrantFrame {
+  readonly t: 'handoff-grant';
+  /**
+   * The signed grant, carried opaquely.
+   *
+   * `unknown` on purpose: this package cannot import the grant type without importing the package
+   * that owns the crypto, and typing it structurally here would create a second declaration of a
+   * signed object's shape — which is how a field ends up checked in one copy and not the other.
+   * The verifier owns the type; this gate owns the envelope.
+   */
+  readonly grant: unknown;
+}
+
+/**
+ * The cross-device authorization this gate requires before exposing the session.
+ *
+ * Absent → the gate behaves exactly as before. Requiring a grant is opt-in because an ordinary
+ * remote peer has no hand-off to authorize, and a gate that demanded one unconditionally would
+ * refuse every legitimate remote session.
+ */
+export interface IHandoffGrantProof {
+  /**
+   * Judge a presented grant. Owned by the verifier — this package asks and does not decide.
+   *
+   * Async because verifying a signature is: `verifyHandoffGrant` returns a promise, and a
+   * synchronous seam here would force the owner to block or to pre-verify, and pre-verifying means
+   * deciding before the channel that the grant is bound to even exists.
+   *
+   * Returns the admission the consumer receives, so the trust level travels as a value.
+   */
+  readonly verify: (grant: unknown) => Promise<IPeerAdmission>;
+  /**
+   * Ask the person at THIS machine whether to accept the transfer. Absent → no consent is required.
+   *
+   * Called ONLY on a verdict the verifier admitted, and given that verdict, for two reasons that
+   * both matter:
+   *
+   * The prompt can then name a PROVEN origin. Asking before verification would let anyone who can
+   * open a channel raise a dialog on someone's machine claiming to be any device they like, which
+   * turns the consent step into an attack surface instead of a control.
+   *
+   * And consent is not cryptographic policy, so it does not belong inside `verify`. A verifier that
+   * also asked a human would make "is this grant valid" and "does this person want it" one answer,
+   * and the first is the one that must be decidable without a person present.
+   *
+   * Returning false — or throwing, or having no renderer to ask — refuses. Denial fails CLOSED.
+   */
+  readonly consent?: (admission: IPeerAdmission) => Promise<boolean>;
+  /**
+   * Fired on the outcome, admitted or not.
+   *
+   * On BOTH, deliberately: a consumer told only about successes cannot distinguish "no hand-off was
+   * offered" from "a hand-off was refused", and those call for different operator responses — the
+   * second is the one that belongs in front of a person.
+   */
+  readonly onAdmission?: (admission: IPeerAdmission) => void;
+}
+
+/**
+ * True when a parsed pre-accept value is a grant frame.
+ *
+ * Module-private: `judgeHandoffGrant` is the only thing that should ask. Exporting it would offer a
+ * caller a way to check the shape and then act on it without going through the judge, which is how
+ * an admission decision ends up made in two places.
+ */
+function isHandoffGrantFrame(value: unknown): value is IHandoffGrantFrame {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { t?: unknown }).t === 'handoff-grant' &&
+    (value as { grant?: unknown }).grant !== undefined
+  );
+}
+
+/** A refusal shaped like every other admission, so no caller has to special-case the failure path. */
+function refuse(reason: string): IPeerAdmission {
+  return { admitted: false, trust: 'unproven', reason };
+}
+
+/**
+ * Judge one pre-accept frame against the configured grant proof.
+ *
+ * Every path that is not an admitted verification returns a refusal — including a missing config,
+ * which cannot happen through the gate but would be a fail-OPEN if it ever did.
+ */
+export async function judgeHandoffGrant(
+  parsed: unknown,
+  proof: IHandoffGrantProof | undefined,
+): Promise<IPeerAdmission> {
+  if (proof === undefined)
+    return refuse('no hand-off grant verifier is configured for this channel');
+  if (!isHandoffGrantFrame(parsed)) {
+    return refuse('expected a handoff-grant frame carrying the signed grant');
+  }
+  try {
+    const admission = await proof.verify(parsed.grant);
+    // The verifier owns the verdict, but not the ability to widen it. A cross-device grant cannot
+    // establish that the peer is on THIS machine, so an admission claiming it did is refused rather
+    // than passed on — an implementation that returned the stronger level would otherwise satisfy
+    // every check that wanted same-machine, which is the one substitution #1812 forbids by name.
+    if (admission.admitted && admission.trust === 'same-user-same-host') {
+      return refuse(
+        'the grant verifier returned same-user-same-host. A cross-device grant proves the user, ' +
+          'not the machine — see SEC-010 for what same-host requires.',
+      );
+    }
+    if (!admission.admitted || proof.consent === undefined) return admission;
+    // The person, after the proof. A refusal here is not a weaker outcome than a cryptographic one:
+    // the session is equally not exposed, and the reason says which step declined so the operator is
+    // not left reading "unauthorized" when what happened is that they said no.
+    if (!(await proof.consent(admission))) {
+      return refuse('the person at this machine declined the transfer');
+    }
+    return admission;
+  } catch (error) {
+    // allow-fallback: fail-CLOSED, not a fallback to a degraded path. A verifier that throws has not
+    // reached a decision, and "not reached" is not "allowed" — the refusal below is strictly more
+    // restrictive than the success path, never less. Letting it propagate would be worse: the throw
+    // unwinds through the channel's message subscription and leaves the gate parked in its grant
+    // state with the channel open, which is a hang — fail-open wearing a crash's clothes.
+    return refuse(
+      `the grant verifier could not decide: ${
+        error instanceof Error ? error.message : 'unknown error'
+      }`,
+    );
+  }
+}
+
+/**
+ * Build the frame a source device presents on the channel.
+ *
+ * Lives beside the judge that reads it, so the two cannot drift: a sender that hand-built the object
+ * would keep compiling after the frame gains a field, and the failure would surface as a refusal on
+ * the far side with no hint that the SENDER is the stale half.
+ *
+ * Deliberately not a "send" — it returns the frame and leaves transmission to whoever owns the
+ * channel, for the same reason `localProofFrame` does.
+ */
+export function handoffGrantFrame(grant: unknown): IHandoffGrantFrame {
+  return { t: 'handoff-grant', grant };
+}

--- a/packages/agent-transport-webrtc/src/index.ts
+++ b/packages/agent-transport-webrtc/src/index.ts
@@ -5,6 +5,10 @@ export type { IHostReconnectConfig } from './pairing-gate.js';
 // composition root only needs to SUPPLY the port and, on the peer side, know the frame's shape.
 export { localProofFrame } from './local-peer-proof.js';
 export type { ILocalPeerProof, ILocalProofFrame } from './local-peer-proof.js';
+// SEC-011 (issue #1865): the cross-device hand-off grant gate. The verdict is injected — this
+// package implements no cryptographic policy.
+export { handoffGrantFrame } from './handoff-grant-gate.js';
+export type { IHandoffGrantFrame, IHandoffGrantProof } from './handoff-grant-gate.js';
 export { createInMemorySignalingPair } from './signaling.js';
 export type { ISignalingClient, ISignalMessage, TSignalKind } from './signaling.js';
 export { WsSignalingClient } from './ws-signaling-client.js';

--- a/packages/agent-transport-webrtc/src/pairing-gate-options.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate-options.ts
@@ -1,0 +1,91 @@
+/**
+ * The contract a `PairingGate` is constructed with (REMOTE-008 / -012 / -013, SEC-010, SEC-011).
+ *
+ * Separated from the gate itself because they are different responsibilities: this file says what a
+ * caller must supply, and `pairing-gate.ts` says what the machine does with it. Keeping them
+ * together made one file that had to be read in full to answer either question.
+ *
+ * Re-exported from `pairing-gate.ts`, so every existing import keeps working — the split is a
+ * reading change, not a migration.
+ */
+
+import type {
+  IPairingResult,
+  startPairingHandshake,
+  TPairingRole,
+} from '@robota-sdk/agent-remote-pairing';
+import type {
+  IProtocolSession,
+  SessionResumeBridge,
+  createWsHandler,
+} from '@robota-sdk/agent-transport-protocol';
+
+import type { startReconnectController } from './pairing-controllers.js';
+
+import type { IHandoffGrantProof } from './handoff-grant-gate.js';
+import type { ILocalPeerProof } from './local-peer-proof.js';
+
+/** The minimal data-channel surface the gate drives (a werift `RTCDataChannel` satisfies it). */
+export interface IPairingChannel {
+  send(data: string): void;
+  close(): void;
+}
+
+/** E3 host reconnect/enrollment config. When present, the gate runs reactive (first-frame) mode detection. */
+export interface IHostReconnectConfig {
+  readonly hostIdentityId: string;
+  /** base64url SPKI advertised to a device at first-pair enrollment. */
+  readonly hostPublicSpki: string;
+  /** The host identity private key (signs reconnect challenges). */
+  readonly hostPrivateKey: CryptoKey;
+  /** Resolve a pinned device public key by id (undefined → unknown/revoked → fail closed). */
+  readonly resolveDevicePublicKey: (deviceId: string) => Promise<CryptoKey | undefined>;
+  /** Pin a device's public key on first-pair enrollment (deviceId, base64url SPKI). */
+  readonly onEnroll: (deviceId: string, deviceSpki: string) => void;
+}
+
+export interface IPairingGateOptions {
+  readonly channel: IPairingChannel;
+  readonly session: IProtocolSession;
+  readonly secret: string;
+  readonly role: TPairingRole;
+  readonly localFingerprint: string;
+  readonly remoteFingerprint: string;
+  /** Handshake timeout (ms); fail closed on expiry. */
+  readonly timeoutMs?: number;
+  /** REMOTE-008: fired once admission accepts + the session is exposed. Carries the first-pair result (E4). */
+  readonly onAccept?: (result?: IPairingResult) => void;
+  /** REMOTE-008: fired once admission rejects/times out + the channel closes (host lifecycle → teardown). */
+  readonly onReject?: () => void;
+  /** REMOTE-012 E3: host reconnect/enrollment config. Absent → B4 first-pair-only behavior (unchanged). */
+  readonly reconnect?: IHostReconnectConfig;
+  /**
+   * REMOTE-013 E4: a session-scoped {@link SessionResumeBridge}. When set, the paired session flows through the
+   * bridge (seq-stamped + buffered) instead of a fresh `createWsHandler`, so the session survives a channel
+   * drop and can replay on reconnect. Accept ATTACHES the channel as the bridge's sink; cleanup DETACHES it
+   * (never disposes — the bridge is owned by the transport across reconnects).
+   */
+  readonly resumeBridge?: SessionResumeBridge;
+  /**
+   * Post-accept session-frame delivery failure; owning transport performs drop cleanup.
+   *
+   * ARCH-030: was `TServerMessage['type'] | string`, which is just `string` — a union that reads as a
+   * narrowing and is not one. Stated as what it is.
+   */
+  readonly onDeliveryError?: (error: Error, event: string) => void;
+  /** SEC-010: require a rendezvous nonce before exposing the session. Absent → unchanged behavior. */
+  readonly localPeer?: ILocalPeerProof;
+  /**
+   * SEC-011 (issue #1865): require a verified cross-device hand-off grant before exposing the
+   * session. Absent → unchanged behavior.
+   *
+   * Independent of `localPeer` rather than exclusive with it, and demanded AFTER it when both are
+   * set. They answer different questions — the rendezvous binds the environment, the grant binds the
+   * transfer — and a hand-off between two sessions on ONE machine legitimately has both. Requiring
+   * both is strictly more restrictive than requiring either, which is the safe direction.
+   */
+  readonly handoffGrant?: IHandoffGrantProof;
+  /** Injection seams (default to the real implementations). */
+  readonly startHandshake?: typeof startPairingHandshake;
+  readonly createHandler?: typeof createWsHandler;
+}

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -28,6 +28,17 @@ import {
 } from '@robota-sdk/agent-remote-pairing';
 import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
 
+import { nextAdmissionStep } from './admission-steps.js';
+import type {
+  IHostReconnectConfig,
+  IPairingChannel,
+  IPairingGateOptions,
+} from './pairing-gate-options.js';
+
+// Re-exported so every existing import of these names keeps working: the split moved where they are
+// DECLARED, and moving where they are imported from would be a migration this change is not.
+export type { IHostReconnectConfig, IPairingChannel, IPairingGateOptions };
+import { judgeHandoffGrant, type IHandoffGrantProof } from './handoff-grant-gate.js';
 import { judgeLocalProof, type ILocalPeerProof } from './local-peer-proof.js';
 import { pairingChannel } from './pairing-channel-lifecycle.js';
 import { startFirstPairController, startReconnectController } from './pairing-controllers.js';
@@ -37,67 +48,13 @@ import { attachSession } from './session-attachment.js';
 import type { IEnrollFrame } from './pairing-frames.js';
 import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
 
-/** The minimal data-channel surface the gate drives (a werift `RTCDataChannel` satisfies it). */
-export interface IPairingChannel {
-  send(data: string): void;
-  close(): void;
-}
-
-/** E3 host reconnect/enrollment config. When present, the gate runs reactive (first-frame) mode detection. */
-export interface IHostReconnectConfig {
-  readonly hostIdentityId: string;
-  /** base64url SPKI advertised to a device at first-pair enrollment. */
-  readonly hostPublicSpki: string;
-  /** The host identity private key (signs reconnect challenges). */
-  readonly hostPrivateKey: CryptoKey;
-  /** Resolve a pinned device public key by id (undefined → unknown/revoked → fail closed). */
-  readonly resolveDevicePublicKey: (deviceId: string) => Promise<CryptoKey | undefined>;
-  /** Pin a device's public key on first-pair enrollment (deviceId, base64url SPKI). */
-  readonly onEnroll: (deviceId: string, deviceSpki: string) => void;
-}
-
-export interface IPairingGateOptions {
-  readonly channel: IPairingChannel;
-  readonly session: IProtocolSession;
-  readonly secret: string;
-  readonly role: TPairingRole;
-  readonly localFingerprint: string;
-  readonly remoteFingerprint: string;
-  /** Handshake timeout (ms); fail closed on expiry. */
-  readonly timeoutMs?: number;
-  /** REMOTE-008: fired once admission accepts + the session is exposed. Carries the first-pair result (E4). */
-  readonly onAccept?: (result?: IPairingResult) => void;
-  /** REMOTE-008: fired once admission rejects/times out + the channel closes (host lifecycle → teardown). */
-  readonly onReject?: () => void;
-  /** REMOTE-012 E3: host reconnect/enrollment config. Absent → B4 first-pair-only behavior (unchanged). */
-  readonly reconnect?: IHostReconnectConfig;
-  /**
-   * REMOTE-013 E4: a session-scoped {@link SessionResumeBridge}. When set, the paired session flows through the
-   * bridge (seq-stamped + buffered) instead of a fresh `createWsHandler`, so the session survives a channel
-   * drop and can replay on reconnect. Accept ATTACHES the channel as the bridge's sink; cleanup DETACHES it
-   * (never disposes — the bridge is owned by the transport across reconnects).
-   */
-  readonly resumeBridge?: SessionResumeBridge;
-  /**
-   * Post-accept session-frame delivery failure; owning transport performs drop cleanup.
-   *
-   * ARCH-030: was `TServerMessage['type'] | string`, which is just `string` — a union that reads as a
-   * narrowing and is not one. Stated as what it is.
-   */
-  readonly onDeliveryError?: (error: Error, event: string) => void;
-  /** SEC-010: require a rendezvous nonce before exposing the session. Absent → unchanged behavior. */
-  readonly localPeer?: ILocalPeerProof;
-  /** Injection seams (default to the real implementations). */
-  readonly startHandshake?: typeof startPairingHandshake;
-  readonly createHandler?: typeof createWsHandler;
-}
-
 type TGateState =
   | 'awaiting-mode'
   | 'pairing'
   | 'enrolling'
   | 'reconnecting'
   | 'local-proof'
+  | 'handoff-grant'
   | 'accepted'
   | 'closed';
 
@@ -172,6 +129,16 @@ export class PairingGate {
       this.options.localPeer?.onAdmission?.(admission);
       if (admission.admitted) this.accept(this.pendingResult, this.pendingViaReconnect);
       else this.rejectAndClose();
+      return;
+    }
+
+    if (this.state === 'handoff-grant') {
+      // Verifying a signature is async, and this handler is not. The promise is consumed here rather
+      // than returned so a rejection cannot escape into the channel's message subscription — an
+      // unhandled rejection would leave the gate parked in this state with the channel open, which
+      // is a hang. `judgeHandoffGrant` already converts a throw into a refusal; this is the second
+      // layer, because a gate that can hang is a gate that fails open by waiting.
+      void this.judgeGrantFrame(parsed);
       return;
     }
 
@@ -258,13 +225,14 @@ export class PairingGate {
 
   private accept(result?: IPairingResult, viaReconnect = false): void {
     if (this.state === 'closed' || this.state === 'accepted') return;
-    // SEC-010 TC-08: the handshake bound the CHANNEL; the rendezvous nonce binds the ENVIRONMENT.
-    // Demanded here rather than earlier because the channel must already be authenticated, and
-    // before anything below because that is where the session becomes reachable.
-    if (this.options.localPeer && this.state !== 'local-proof') {
+    // The steps this channel still owes. Demanded here rather than earlier because the handshake
+    // must already have bound the channel, and before anything below because that is where the
+    // session becomes reachable. The ordering argument lives in `admission-steps.ts`.
+    const owed = nextAdmissionStep(this.options, this.state);
+    if (owed !== null) {
       this.pendingResult = result ?? this.pendingResult;
       this.pendingViaReconnect = viaReconnect;
-      this.state = 'local-proof';
+      this.state = owed;
       return;
     }
     const attached = attachSession(this.options, viaReconnect, (error, event) =>
@@ -274,6 +242,17 @@ export class PairingGate {
     this.handlerCleanup = attached.cleanup;
     this.state = 'accepted';
     this.options.onAccept?.(result);
+  }
+
+  /** The async half of the `handoff-grant` state, kept off the synchronous message path. */
+  private async judgeGrantFrame(parsed: unknown): Promise<void> {
+    const admission = await judgeHandoffGrant(parsed, this.options.handoffGrant);
+    // A channel torn down while the signature was being checked must not be re-accepted by a verdict
+    // that arrives afterwards. Checked after the await, because that is the window it exists for.
+    if (this.state !== 'handoff-grant') return;
+    this.options.handoffGrant?.onAdmission?.(admission);
+    if (admission.admitted) this.accept(this.pendingResult, this.pendingViaReconnect);
+    else this.rejectAndClose();
   }
 
   private rejectAndClose(): void {

--- a/scripts/harness/prompt-prose-baseline.json
+++ b/scripts/harness/prompt-prose-baseline.json
@@ -1,4 +1,8 @@
 {
+  "packages/agent-cli/src/handoff/handoff-consent.ts": {
+    "count": 1,
+    "hashes": ["23413b20664a"]
+  },
   "packages/agent-cli/src/init/init-command.ts": {
     "count": 1,
     "hashes": ["cdec64dd55b0"]


### PR DESCRIPTION
Closes #1865

The cryptographic boundary landed as PR #1834 and nothing called it. Measured before starting: **no file in `agent-transport-webrtc` or `agent-cli` referenced any of it.** Four parts — the two consumers issue #1812 assigned elsewhere, and the two design questions the item names as open.

## 1. The channel gate consumes the grant

The same shape SEC-010's local-proof step established, for the same reason: this package implements **no cryptographic policy**. Nothing here verifies a signature, decides an expiry, or knows what revocation is. The verdict is injected.

- the handshake binds the **channel**; the grant binds the **transfer**
- presenting the grant over the already-bound channel joins them, and the fingerprint claim makes the join checkable — a grant lifted from one channel and replayed on another names a fingerprint the verifier does not observe
- it runs **after** the handshake (before it, the channel is not authenticated) and **before** the session is exposed (a peer that never presents one must not already have been talking to the session)

And it refuses an admission claiming `same-user-same-host`. A grant proves the **user**, not the machine — the one substitution #1812 forbids by name. `TPeerTrust` gains `same-user-different-host`, which sits between the other two and is interchangeable with neither.

`admission-steps.ts` holds the ordering, extracted because it is the part carrying the security argument. The rendezvous and the grant are demanded **in sequence rather than as alternatives**: a hand-off between two sessions on one machine legitimately has both, and requiring both is the safe direction.

## 2. Consent at the destination

The source end asks whether to lose the session. This end asks whether to take on someone else's work with **this machine's** credential, files and shell. Different questions.

Asked only **after** the grant verifies, so the prompt names a proven origin — asking first would let anyone who can open a channel raise a dialog claiming to be any device they like. There is exactly one way to return true: no renderer, a dismissal, an empty answer, and an option nobody offered all refuse.

## 3. Revocation distribution — the substantive open question

A revocation is the one security statement whose **absence is the attack**. A certificate that never arrives fails to authenticate; a revocation that never arrives silently authorizes a device the user retired. So an attacker who can influence distribution forges nothing — they withhold, or replay an older list.

| shape | why it fails |
|---|---|
| unsigned list | anyone on the path edits it, and removing an entry *is* the attack |
| signed, no expiry | self-authenticating and still replayable — last week's list is genuine and does not mention the device revoked since |

What landed is **signed by the same user root as a device certificate**, so any machine that can verify a certificate can verify a list and distribution needs no trusted channel — plus `expiresAt` and a monotonic `issuedAt`. Past the expiry a holder **refuses** rather than reading the list as "nothing is revoked". An empty list is a real statement, which is why one is issued on a schedule rather than only when something is revoked.

`revocationUnavailable()` exists so nobody writes `?? []` at a call site, which reads as a safe default and is the exact fail-open.

## 4. Rotation — two problems wearing one word

**Hygiene**: both roots sign. The old to say "this succeeds me", the new to prove it exists and consents. Without the countersignature, anyone holding the old key could name a public key they do **not** hold as successor — locking the user out with a statement that verifies perfectly.

**Compromise**: not handled, deliberately and by name. An attacker holding the old key can sign the same statement, so a rotation chain rooted in it is worthless the moment that key is the thing that failed. A compromised root is **abandoned** — new root, new `userId`, every device re-enrolled out of band. No function is offered that looks like it handles that case, because a `rotate` that silently did the wrong thing under compromise would be worse than none.

## Proved by breaking it

Six defects planted, each turning exactly the intended cases red:

| planted defect | went red |
|---|---|
| the verifier's throw propagating instead of refusing | the fail-closed case |
| the same-host upgrade allowed | the substitution case |
| the gate step skipped entirely | 6 ordering cases |
| the revocation expiry check removed | the withheld-list case |
| the rollback check removed | the superseded case |
| `revokedDeviceIds` dropped from the signed bytes | the tamper case |

**TC-08, TC-09 and TC-10** of the SEC-011 test plan are covered (TC-01–07 came with PR #1834). 79 new cases in all. `verify-like-ci` 12/12 PASS; 132 scans pass.

## Two harness findings addressed rather than worked around

- `pairing-gate.ts` crossed the 300-line ceiling. The options **contract** moved to its own module and is re-exported, so no import changes — a reading change, not a migration.
- `prompt-prose` reported the consent copy as model-facing instruction prose. It is **human**-facing: rendered into a dialog, never sent to a model. Recorded in that scan's frozen baseline by its own documented path rather than reworded to dodge the second-person marker, with the reason written at the literal. The scan cannot tell a consent prompt from a system prompt; that limitation is now written down where the next person hits it.

## What remains, and it is one composition

Nothing yet constructs a WebRTC channel for a hand-off, so the gate's `handoffGrant` option and the CLI's consent builder have no product wiring them together — the same gap #1864 left with `/handoff`'s adapter. One carrier closes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s