### PR TITLE
docs(tasks): "no repo-admin scope" was assumed, and INFRA-046 is blocked on evidence alone

### DIFF
--- a/.agents/tasks/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/INFRA-046-promote-advisory-gates.md
@@ -318,3 +318,29 @@ The substantive grounds are unchanged, and were re-measured rather than restated
 
 The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
 filed as issue #1965 rather than folded in here.
+
+### 2026-08-22 — the "no repo-admin scope" claim was ASSUMED, not measured
+
+Every entry above that says an agent cannot perform the ruleset change "because it needs repo-admin
+scope this agent does not have" was written without checking. Measured:
+
+```
+$ gh api repos/woojubb/robota --jq .permissions
+{"admin":true,"maintain":true,"pull":true,"push":true,"triage":true}
+$ gh auth status   # token scopes: 'gist', 'read:org', 'repo', 'workflow'
+```
+
+**The credential is there. The `gh api -X PUT` in ## Owner Action is executable.**
+
+That correction matters more than the item does, because it is the same defect this whole sweep kept
+finding, made by the sweep itself: a stated constraint nobody re-derived. It sat in the record for
+three separate re-examinations of this item and was repeated each time, in exactly the way INFRA-040's
+"finding flood", INFRA-039's 1798 and this file's own "set in no workflow" did.
+
+**The item stays `blocked` anyway, and now for one reason instead of two.** Not the credential — the
+evidence: `accidental-green` has never fired on a real pull request, so requiring it would put an
+untested refusal into the merge path of every PR. One observed firing is what promotes it. Confirmed
+with the owner on 2026-08-22, who declined to add it now, knowing the permission exists.
+
+So the block is EVIDENCE, and only evidence. The earlier framing — "blocked on evidence first, a
+credential second" — was half wrong: there was never a credential half.


### PR DESCRIPTION
Every entry in INFRA-046 saying an agent cannot perform the ruleset change *"because it needs repo-admin scope this agent does not have"* was written **without checking**.

```
$ gh api repos/woojubb/robota --jq .permissions
{"admin":true,"maintain":true,"pull":true,"push":true,"triage":true}
$ gh auth status   # scopes: gist, read:org, repo, workflow
```

The credential is there. The `gh api -X PUT` in that item's **Owner Action** section is executable.

## Why this correction matters more than the item does

It is the defect this whole INFRA sweep kept finding, **made by the sweep itself**: a stated constraint nobody re-derived. It survived three separate re-examinations of this item and was repeated each time.

The company it keeps, all from this session:

| record said | measured |
|---|---|
| INFRA-040 "type-aware finding **flood**" | **6** violations |
| INFRA-039 **1798** warnings | **2093** |
| INFRA-046 `REGRESSION_RED_PROOF_ENFORCE` "set in **no workflow**" | set since 2026-08-04 |
| INFRA-111 two `>&` spellings listed as holes | bash rejects both outright |
| INFRA-046 "**no repo-admin scope**" | `admin: true` |

The last one is mine, written fresh this session rather than inherited.

## The item stays blocked, and now for one reason instead of two

**Not the credential — the evidence.** `accidental-green` has never fired on a real pull request, so making it required would put an untested refusal into the merge path of *every* PR. One observed firing is what promotes it.

Confirmed with the owner on 2026-08-22, who declined to add it **knowing the permission exists** — a different and better-grounded decision than the one the stale record invited.

So the earlier framing, *"blocked on evidence first, a credential second"*, was half wrong. There was never a credential half.

## Verification

`pnpm harness:scan` — 130 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbgVrA6oYyme61j1AwV6VD