### PR TITLE
docs(tasks): the harness test suite leaks a temp directory per test (INFRA-126)

### DIFF
--- a/.agents/tasks/INFRA-126-harness-tests-leak-a-temp-dir-per-test.md
+++ b/.agents/tasks/INFRA-126-harness-tests-leak-a-temp-dir-per-test.md
@@ -1,0 +1,128 @@
+---
+title: 'INFRA-126: the harness test suite leaks a temp directory per test, and exhausting /tmp inodes stops every push on the host'
+status: todo
+created: 2026-08-22
+priority: high
+urgency: now
+area: scripts/harness/__tests__, scripts/harness
+depends_on: []
+---
+
+# INFRA-126: the test suite leaks a temp directory per test
+
+## Problem
+
+Every push from this clone failed with `no space left on device`, raised by zsh writing its own cwd
+file. It was not a space problem. `df -h /tmp` showed **4.3G free at 45%** while `df -i /tmp` showed
+**1048576 of 1048576 inodes used, 100%**.
+
+The filesystem had run out of INODES, and the error names the wrong resource — which is why the
+first reading was "the disk is full" and the first instinct was to look for large files.
+
+## Cause
+
+Not the scans. The harness **test suite**: a test creates a temp directory per case and never
+removes it, so every run of the pre-push contracts tier and every CI run adds more.
+
+Measured on this tree:
+
+|                                                        | count        |
+| ------------------------------------------------------ | ------------ |
+| harness test files that create temp directories        | 158          |
+| of those, files with NO `afterAll`/`afterEach` cleanup | **85 (54%)** |
+
+The five largest populations on disk, each from a test file with **zero** cleanup blocks:
+
+| prefix                           | dirs on disk | test file                              |
+| -------------------------------- | ------------ | -------------------------------------- |
+| `robota-measurement-provenance-` | 315          | `scan-measurement-provenance.test.mjs` |
+| `robota-dist-freshness-`         | 225          | `scan-dist-freshness.test.mjs`         |
+| `robota-task-agreement-`         | 216          | `check-task-archival.test.mjs`         |
+| `robota-sdk-public-surface-`     | 162          | `check-sdk-public-surface.test.mjs`    |
+| `robota-spec-frontmatter-`       | 153          | `check-spec-doc-frontmatter.test.mjs`  |
+
+**Rate, measured rather than estimated.** One run of `scan-measurement-provenance.test.mjs` — 42
+tests — left **41 new directories** behind. Roughly one per test case. At the peak **58,856**
+`robota-*` directories were sitting at the top level of `/tmp`.
+
+The pattern that works is already in the tree, in the files that do clean up:
+
+```js
+const scratch = [];
+afterAll(() => {
+  while (scratch.length > 0) rmSync(scratch.pop(), { recursive: true, force: true });
+});
+```
+
+## Why the obvious detector under-reports it
+
+Worth recording, because it produced a reassuring wrong number first. A survey matching
+`mkdtempSync` alone returns **26 of 96 (27%)** — and none of the five worst offenders appear in it,
+because they use the **async `mkdtemp` from `node:fs/promises`**. The instrument was narrower than
+the population and the shortfall read as good news. Counting both spellings gives 85 of 158 (54%).
+
+The nearest recorded shape is `common-mistakes` entry 91 — a measurement taken with the instrument
+not fully assembled reports on itself rather than on the subject. There it is a guard probed outside
+its fixtures; here it is a survey regex narrower than the population it surveys.
+
+A second instance happened while cleaning up after the rate measurement above, and it is entry 92
+exactly: `find /tmp -maxdepth 1 ... -exec rm -rf {} +` with stderr suppressed reported nothing,
+removed nothing, and read as done. The directory count was unchanged and only a re-count caught it.
+A loop removing one directory at a time, each verified with `[ ! -d "$d" ]`, removed all 35.
+
+## Directions
+
+1. **Add cleanup to the 85 files.** Mechanical, large, and leaves nothing preventing the 86th.
+2. **A shared `makeTemp()` helper** the tests import, owning creation and teardown together, plus a
+   scan refusing a bare `mkdtemp`/`mkdtempSync` in `__tests__`. Fixes the instances and closes the
+   class. The scan is the part that makes 1 stay done.
+3. **Reap by age at suite start** — cheap, hides the defect, and races a concurrent session's
+   in-flight directory. Rejected unless it is a stopgap under 1 or 2.
+
+Recommendation: 2, with 1 as its burn-down. Note the scan must match BOTH spellings, which is the
+whole lesson of the section above.
+
+**The scan refuses a direct call REGARDLESS of teardown, and that is deliberate.** The tempting
+alternative — flag a direct call only when the file has no teardown — puts the scan in the business
+of deciding whether a given directory is cleaned up, which it cannot see: "the file contains
+`rmSync` somewhere" is not "this directory is removed". It would also be wrong in the safe
+direction on real code. Six test files added in one session use a bare `mkdtempSync` and DO clean up
+correctly via a `scratch` array and an `afterAll`; a teardown-conditional scan passes them, and a
+scan that passes correct-but-unsanctioned code teaches nothing about the rule it enforces.
+
+Making `makeTemp()` the only sanctioned creator removes the judgement entirely: the subject becomes
+the CALL SITE, which is textual and exact, rather than the teardown, which is behavioural and is not.
+It also fixes the denominator — the burn-down is every direct call under `__tests__` (**158 files**),
+not only the 85 that currently leak.
+
+## Test Plan
+
+- Count `robota-*` directories at `/tmp` top level before and after one full contracts-tier run; the
+  delta must be **0**.
+- Per-file check on the five worst offenders: run each alone, assert no new directory survives.
+- The new scan goes RED on any `__tests__` file calling `mkdtemp` or `mkdtempSync` directly —
+  **including one that cleans up correctly**, since the rule is "use `makeTemp()`", not "clean up
+  somehow". Fixtures for both spellings, because a scan catching only the sync form reproduces the
+  defect it was written for, and one fixture that creates AND removes its directory, to pin that the
+  verdict does not depend on teardown.
+- `pnpm harness:scan` green.
+
+## Notes for whoever takes it
+
+- **Do not reap indiscriminately.** Several sessions share this clone and a directory younger than
+  the longest test run may be in use. The cleanup that recovered the host spared everything touched
+  within the hour, and that is worth stating as a property rather than a courtesy: from outside the
+  process there is NO way to tell an in-flight temp directory from an abandoned one. An age
+  threshold is a guess at that distinction, which is why direction 3 is a stopgap and not a fix —
+  and it is the same property a `makeTemp()` owner removes, because the creator is the only thing
+  that knows when it is finished with the directory.
+- Registering the new scan touches `run-all-scans.mjs`. Several sessions edit that file; a
+  registration is one entry, so rebase onto the integration branch first and the lines will not
+  overlap. The scan module and its tests are separate files nobody contends, so they can land even
+  if the registration has to wait.
+
+## User Execution Test Scenarios
+
+Not applicable — this is repository test-hygiene and harness infrastructure; it delivers no
+user-facing behavior. Verification is the before/after directory count in `## Test Plan`, per
+`.agents/tasks/README.md`.


### PR DESCRIPTION
## What happened

Every push from this clone started failing with `no space left on device`, raised by zsh writing its
own cwd file. **It was not a space problem.**

```
df -h /tmp   ->  4.3G free, 45% used
df -i /tmp   ->  1048576 / 1048576 inodes, 100%
```

The filesystem was out of **inodes**, and the error names the wrong resource — which is why the
first reading was "the disk is full" and the first instinct was to hunt for large files.

## Cause — the test suite, not the scans

The first diagnosis was "the scans don't clean up", inferred from directory names matching scan
names. Checking which process actually creates them gives a different answer: it is the harness
**test suite**.

| | count |
| --- | --- |
| harness test files that create temp directories | 158 |
| of those, with NO `afterAll`/`afterEach` cleanup | **85 (54%)** |

The five largest populations on disk, each from a test file with **zero** cleanup blocks:

| prefix | dirs | test file |
| --- | --- | --- |
| `robota-measurement-provenance-` | 315 | `scan-measurement-provenance.test.mjs` |
| `robota-dist-freshness-` | 225 | `scan-dist-freshness.test.mjs` |
| `robota-task-agreement-` | 216 | `check-task-archival.test.mjs` |
| `robota-sdk-public-surface-` | 162 | `check-sdk-public-surface.test.mjs` |
| `robota-spec-frontmatter-` | 153 | `check-spec-doc-frontmatter.test.mjs` |

**Rate, measured rather than estimated.** One run of `scan-measurement-provenance.test.mjs` — 42
tests — left **41 directories** behind. About one per case. The suite runs on every push via the
pre-push contracts tier and again in CI, across several sessions sharing this clone. At peak there
were **58,856** `robota-*` directories at the top level of `/tmp`.

## Two method notes, both recorded because both nearly gave the wrong answer

**A narrower instrument gave the more reassuring number.** A survey matching `mkdtempSync` alone
reports 26 of 96 (27%) — and misses *every one* of the five worst offenders, which use the **async
`mkdtemp` from `node:fs/promises`**. Counting both spellings: 85 of 158 (54%). This is
`common-mistakes` 91 in a new domain.

**A suppressed error read as success.** Cleaning up after the rate measurement,
`find /tmp -maxdepth 1 … -exec rm -rf {} +` with stderr suppressed reported nothing, removed
nothing, and looked done. The directory count was unchanged and only a re-count caught it. A loop
removing one at a time, each verified with `[ ! -d "$d" ]`, removed all 35. That is
`common-mistakes` 92 exactly.

## Recommended direction, and why the scan is unconditional

A shared `makeTemp()` owning creation and teardown together, plus a scan refusing a **direct**
`mkdtemp`/`mkdtempSync` under `__tests__`, with every direct call as the burn-down.

The scan refuses a direct call **regardless of teardown**, which is deliberate:

- A teardown-conditional scan must decide whether a given directory is cleaned up, and it cannot see
  that — *"the file contains `rmSync` somewhere"* is not *"this directory is removed"*.
- It would pass code that is correct but unsanctioned. Six test files added in one session use a
  bare `mkdtempSync` and **do** clean up properly; a conditional scan waves them through and teaches
  nothing about the rule.
- It fixes the denominator: the burn-down is **every direct call — 158 files** — not the 85 that
  happen to leak today.

Reaping by age is recorded as **rejected except as a stopgap**, and the reason is a property rather
than a courtesy: from outside the process there is no way to tell an in-flight temp directory from an
abandoned one. An age threshold is a guess at that distinction — and it is the same property
`makeTemp()` removes, since the creator is the only thing that knows when it is finished.

## Scope

**Filed, not fixed.** The remediation is 158 files plus a scan and its fixtures — a different review
from recording the cause. This PR adds one task file and nothing else.

Two other sessions are working in this clone; both were consulted. The contradiction fixed before
push (Directions described an unconditional scan while the Test Plan described a conditional one —
two different scans) was caught by one of them from the description alone.

## Verification

`pnpm harness:scan` — **130 passed, 3 skipped, 0 failed**. `work-item-id-collision` green with the
new ID, which was re-verified free against both the tracked tree and GitHub issue titles immediately
before writing the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc8Cy57xP1AyHj8LsDGqcx
