### PR TITLE
feat(ci): a control plane the pull request cannot reach (INFRA-097, issue #1719)

### DIFF
--- a/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
@@ -21,11 +21,63 @@ never executing untrusted PR content with write credentials.
 
 ## Plan
 
-- [ ] Verify GitHub event/check attribution and ruleset capabilities for trusted required workflows.
-- [ ] Compare required-workflow/ruleset, split `pull_request_target`, and external GitHub App/check-run designs.
-- [ ] Specify exact SHA/ref identity, permissions, fork behavior, and branch-protection reconciliation.
-- [ ] Add adversarial tests proving a PR cannot replace its own required gate with an unconditional pass.
-- [ ] Roll out and validate code, docs-only, fork, retarget, cancellation, and genuine-finding paths.
+- [x] Verify GitHub event/check attribution and ruleset capabilities for trusted required workflows.
+- [x] Compare required-workflow/ruleset, split `pull_request_target`, and external GitHub App/check-run designs.
+- [x] Specify exact SHA/ref identity, permissions, fork behavior, and branch-protection reconciliation.
+- [x] Add adversarial tests proving a PR cannot replace its own required gate with an unconditional pass.
+- [ ] Roll out and validate code, docs-only, fork, retarget, cancellation, and genuine-finding paths. — allow-unmet-criterion: the context exists and runs, but making it REQUIRED is a live-ruleset edit and therefore the owner's; these paths cannot be validated as a gate until it is one
+
+## The comparison, and what MEASURING the account settled
+
+Two of the three candidate designs were ruled out by facts about this repository rather than by
+preference.
+
+**Organization-level required workflows — unavailable.** `gh api repos/woojubb/robota` reports
+`owner.type: User`. Required workflows are an organization feature on GitHub Enterprise Cloud, and a
+personal account has no organization to define one in. Not "harder"; absent.
+
+**An external GitHub App publishing the check — available but disproportionate.** The ruleset API
+does support pinning a required check to one publisher: each entry in `required_status_checks`
+carries an `integration_id`. Measured on the live `protect-develop` ruleset, all nine read
+`integration_id: none` — any app may publish any of those contexts today. Pinning them to an
+external app would give trusted provenance, and it costs a hosted service, a key to rotate, and a
+second failure point for a repository whose gates are otherwise self-hosted.
+
+**A split `pull_request_target` plane — available, in-repo, and what landed.**
+`pull_request_target` loads its definition from the BASE branch, so a pull request cannot change
+what it says about itself; the edit takes effect only after merge, which is after the gate it would
+have moved has run.
+
+### Why the existing required checks cannot simply move onto that plane
+
+`pull_request_target` runs with write credentials against the base. `build`, `quality`, `scans`,
+`tui-e2e` and the rest exist to COMPILE AND EXECUTE the pull request's code — doing that under those
+credentials is the classic pwn-request, a strictly worse hole than the one being closed. Measured:
+no workflow in this repository used `pull_request_target` before this change, so nothing was already
+carrying that risk.
+
+So the plane is split rather than moved. `.github/workflows/workflow-provenance-gate.yml` answers
+the one question that can be answered without running anything: does this pull request modify a file
+that a required check loads? It checks out the base and only the base, FETCHES the head without
+checking it out (reading a file name is not running the file), installs nothing — the scan it runs
+imports Node builtins and two files from the base — and holds `contents: read`.
+
+That turns a self-edit from VISIBLE into UNMERGEABLE, which is the difference between this and
+`workflow-provenance`.
+
+### The adversarial tests are about the gate, not its subject
+
+`scripts/harness/__tests__/workflow-provenance-gate.test.mjs`. The boundary here is a workflow file
+and a single added line breaches it, so each property is asserted against the file and each was
+proven by planting the breach: checking out the head ref, switching the trigger to `pull_request`,
+adding an install step, and widening the permissions each turned exactly the intended case red.
+
+### What remains, and it is one action
+
+Making `workflow provenance` a required context is a live-ruleset edit — the owner's. It is
+deliberately NOT registered in `.github/required-status-checks.json` yet: that registry is compared
+against the live ruleset by `ruleset-drift`, so registering it before the flip would make the
+registry state something untrue. The same held-membership shape `regression-red-proof` uses.
 
 ## Progress
 

--- a/.github/workflows/workflow-provenance-gate.yml
+++ b/.github/workflows/workflow-provenance-gate.yml
@@ -1,0 +1,83 @@
+name: Workflow Provenance Gate
+
+# INFRA-097 (issue #1719): a control plane the pull request cannot reach.
+#
+# THE GAP THIS CLOSES. A required check triggered by `pull_request` loads its workflow YAML from the
+# PR's merge revision, so the change carries the definition that judges it: edit the job, move the
+# verdict. INFRA-096 hardened the SCRIPTS those workflows load by checking them out from the base
+# SHA, and said plainly that this does not establish workflow provenance. `workflow-provenance`
+# makes such an edit VISIBLE. Neither makes the plane trusted, because both run on the plane.
+#
+# WHY THIS ONE IS DIFFERENT. `pull_request_target` loads its definition from the BASE branch. A pull
+# request cannot change what this file says about it — the edit only takes effect once it is merged,
+# which is after the gate it would have moved has already run. That is the whole property.
+#
+# THE HAZARD THAT COMES WITH IT, AND HOW IT IS AVOIDED. `pull_request_target` runs with write
+# credentials against the base. Checking out the PR's code and running it under those credentials is
+# the classic pwn-request, and it is a WORSE hole than the one this closes. So this job:
+#
+#   - checks out the BASE, and only the base
+#   - FETCHES the PR head without checking it out — reading a file NAME is not running the file
+#   - installs nothing; the scan it runs imports only Node builtins and files from the base
+#   - holds `contents: read` and nothing else
+#
+# That is also why the required checks themselves cannot simply move here: `build`, `quality`,
+# `scans` and the rest exist to compile and execute the PR's code, which is exactly what a trusted
+# plane must not do. The split is not a convenience — it is the only shape in which both halves can
+# be true at once.
+#
+# WHAT IT DECIDES. One question, and only one it can answer without running anything: does this pull
+# request modify a file that a required check loads? If it does, the change can move its own gate,
+# and this context fails. That makes a self-edit impossible to merge rather than merely visible.
+#
+# NOT YET REQUIRED. Making this context required is a live-ruleset change and therefore the owner's,
+# and `.github/required-status-checks.json` is compared against the live ruleset by `ruleset-drift`
+# — so registering it here before the flip would make that registry state something untrue. The same
+# held-membership shape `regression-red-proof` uses, and for the same reason.
+
+on:
+  pull_request_target:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+
+# Read-only, and stated rather than inherited. A `pull_request_target` job runs against the base with
+# whatever the default token grants; narrowing it here is what makes "this job cannot change
+# anything" a property of the file rather than a claim about its steps.
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-provenance-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  provenance:
+    name: workflow provenance
+    runs-on: ubuntu-latest
+    steps:
+      # The BASE, which is what `pull_request_target` checks out when no ref is named. Adding one
+      # that points at the pull request's head is the single line that would turn this file into the
+      # vulnerability it exists to avoid — a test refuses that spelling, and refuses it here in the
+      # comment too, which is why the shape is described rather than written out.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Judge the pull request's file list against the guarded workflows
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Fetch, do not check out. The objects arrive; nothing from them is executed, and the
+          # working tree stays on the base for the whole job.
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head"
+
+          # No install. The scan imports Node builtins and two files from the base checkout, so
+          # there is no dependency resolution step for a PR-supplied manifest to influence.
+          node scripts/harness/scan-workflow-provenance.mjs \
+            --base-ref "${BASE_SHA}" --head-ref FETCH_HEAD

--- a/scripts/harness/__tests__/scan-workflow-provenance.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-provenance.test.mjs
@@ -226,3 +226,45 @@ describe('workflow-provenance — this repository (INFRA-097)', () => {
     expect(selfLoading).toHaveLength(2);
   });
 });
+
+describe('judging a change from a checkout that is NOT that change (INFRA-097, issue #1719)', () => {
+  /*
+   * The trusted plane checks out the BASE, fetches the pull request head without checking it out,
+   * and asks about `FETCH_HEAD`. So the compared head has to be an ARGUMENT — a scan that always
+   * diffed `HEAD` would report on the base against itself, which is empty, and a gate reporting
+   * "nothing touched" while sitting on the wrong tree is a green that measured nothing.
+   *
+   * Driven against real history rather than a fixture, because the property under test is what the
+   * `git diff` range does, and a stubbed git would be asserting the stub.
+   */
+  const TOUCHED_CI = '024ca7128dda01e5470b14eb27aeaa3bc65a1995';
+
+  it('reports a guarded workflow touched by the NAMED head', () => {
+    const { findings } = findWorkflowProvenanceFindings(
+      WORKSPACE_ROOT,
+      `${TOUCHED_CI}~1`,
+      TOUCHED_CI,
+    );
+    expect(findings.map((f) => f.file)).toContain('.github/workflows/ci.yml');
+  });
+
+  it('reports nothing for the same base when the head is that base', () => {
+    // The paired direction. Without it the case above could be passing on a scan that reports every
+    // guarded workflow regardless of the range.
+    const { findings } = findWorkflowProvenanceFindings(
+      WORKSPACE_ROOT,
+      `${TOUCHED_CI}~1`,
+      `${TOUCHED_CI}~1`,
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('defaults to HEAD when no head is named, so existing callers are unchanged', () => {
+    // `--base-ref` alone has one caller already (the pre-push scan suite). The argument was ADDED,
+    // and a default that silently changed what those callers compare would be a migration nobody
+    // asked for.
+    const named = findWorkflowProvenanceFindings(WORKSPACE_ROOT, 'HEAD~1', 'HEAD').findings;
+    const defaulted = findWorkflowProvenanceFindings(WORKSPACE_ROOT, 'HEAD~1').findings;
+    expect(defaulted).toEqual(named);
+  });
+});

--- a/scripts/harness/__tests__/unmet-criteria.test.mjs
+++ b/scripts/harness/__tests__/unmet-criteria.test.mjs
@@ -66,6 +66,46 @@ describe('finding an unmet criterion', () => {
   it('ignores an unticked box under an exempt heading', () => {
     expect(findU5(lines('## Children\n- [ ] CHILD-001 is not this item'))).toEqual([]);
   });
+
+  it('keeps counting through a NESTED subheading inside a criteria section', () => {
+    /*
+     * Reported on a sibling implementation of this rule (pull request #1974), where the heading
+     * check is an allowlist: a `### Blocker items` under `## Completion criteria` matched nothing,
+     * the section ended there, and every criterion after it was dropped from the count IN SILENCE.
+     *
+     * The denylist direction here does not have that defect — a nested heading is judged like any
+     * other — but that is a consequence of a choice made for a different reason, and a property
+     * nothing asserts is a property the next refactor can spend. On the day a record first groups
+     * its criteria under subheadings, an under-reporting guard would show the count FALL, and a
+     * fall reads as progress.
+     */
+    const found = findU5(
+      lines(
+        [
+          '## Completion criteria',
+          '- [ ] first',
+          '',
+          '### Blocker items',
+          '- [ ] second, nested',
+          '- [ ] third, nested',
+        ].join('\n'),
+      ),
+    );
+    expect(found).toHaveLength(3);
+  });
+
+  it('still ENDS a criteria section at an exempt sibling, so nesting is not traded for over-reach', () => {
+    // The paired direction. A rule that counted everything after the first criteria heading would
+    // pass the case above and swallow the `Children` list — a silent over-report in place of a
+    // silent under-report, which is not an improvement.
+    const found = findU5(
+      lines(
+        ['## Acceptance', '- [ ] a criterion', '', '## Children', '- [ ] CHILD-001'].join('\n'),
+      ),
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toContain('a criterion');
+  });
 });
 
 describe('the escape is a decision written next to the thing it excuses', () => {

--- a/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
+++ b/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * INFRA-097 (issue #1719) — the trusted plane must stay trusted, and stay harmless.
+ *
+ * This file asserts properties of a WORKFLOW rather than of code, because the workflow is the
+ * security boundary here and a single added line is what would breach it. `pull_request_target`
+ * runs with write credentials against the base; a `ref:` pointing at the PR head would turn this
+ * gate into the pwn-request it exists to avoid, and that edit looks innocuous in a diff.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { readGuardedWorkflows } from '../scan-workflow-provenance.mjs';
+
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+const GATE_RELATIVE = '.github/workflows/workflow-provenance-gate.yml';
+const GATE = readFileSync(path.join(ROOT, GATE_RELATIVE), 'utf8');
+
+/** The job body, so an assertion about steps cannot be satisfied by a line in the header comment. */
+const STEPS = GATE.slice(GATE.indexOf('    steps:'));
+
+describe('the gate loads its definition from a place the pull request cannot edit', () => {
+  it('is triggered by pull_request_target, not pull_request', () => {
+    // The whole property. `pull_request` would load this file from the PR's merge revision, which is
+    // the exposure — the change would carry the definition that judges it.
+    expect(GATE).toMatch(/^on:\n\s{2}pull_request_target:/m);
+    expect(GATE).not.toMatch(/^\s{2}pull_request:/m);
+  });
+});
+
+describe('and never runs the pull request it is judging', () => {
+  it('checks out no explicit ref, so the base is what lands in the working tree', () => {
+    // The single line that would breach this: `ref: ${{ github.event.pull_request.head.sha }}`.
+    // Under `pull_request_target` that is PR code executing with write credentials against the base.
+    expect(STEPS).not.toMatch(/ref:\s*\$\{\{\s*github\.event\.pull_request\.head/);
+    expect(STEPS).not.toMatch(/ref:\s*\$\{\{\s*github\.head_ref/);
+  });
+
+  it('fetches the pull request head rather than checking it out', () => {
+    // Reading a file NAME is not running the file. That distinction is what lets the guard be
+    // trusted while its subject is not, so it is asserted rather than left to the reader.
+    expect(STEPS).toContain('git fetch');
+    expect(STEPS).toMatch(/pull\/\$\{?PR_NUMBER\}?\/head/);
+  });
+
+  it('installs nothing', () => {
+    // A dependency install runs whatever a PR-supplied manifest and lockfile ask for, which is PR
+    // code by another route. The scan this job runs imports Node builtins and base files only.
+    expect(STEPS).not.toMatch(/pnpm\s+install|npm\s+(ci|install)|yarn\s+install/);
+  });
+
+  it('holds contents: read and nothing else', () => {
+    const permissions = /^permissions:\n((?:\s{2}\S.*\n)+)/m.exec(GATE)?.[1] ?? '';
+    expect(permissions.trim()).toBe('contents: read');
+  });
+});
+
+describe('what it judges', () => {
+  it('runs the provenance scan against the base and the fetched head', () => {
+    expect(STEPS).toContain('scan-workflow-provenance.mjs');
+    expect(STEPS).toContain('--base-ref');
+    expect(STEPS).toContain('--head-ref FETCH_HEAD');
+  });
+
+  it('has something to guard — the registry names at least one required workflow', () => {
+    // A gate over an empty set passes forever. The scan itself fails closed on this, and asserting
+    // it here means the guarded set being emptied shows up as a test failure rather than as a green
+    // run over nothing.
+    const { workflows } = readGuardedWorkflows(ROOT);
+    expect(workflows.length).toBeGreaterThan(0);
+  });
+
+  it('is NOT itself in the guarded set, which would be circular', () => {
+    // If this file provided a required check, it would guard itself — and a change editing it would
+    // be judged by the edited version, which is the exposure one level up.
+    const { workflows } = readGuardedWorkflows(ROOT);
+    expect(workflows).not.toContain(GATE_RELATIVE);
+  });
+});

--- a/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
+++ b/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
@@ -12,7 +12,10 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { readGuardedWorkflows } from '../scan-workflow-provenance.mjs';
+import {
+  findWorkflowProvenanceFindings,
+  readGuardedWorkflows,
+} from '../scan-workflow-provenance.mjs';
 
 const ROOT = path.resolve(import.meta.dirname, '../../..');
 const GATE_RELATIVE = '.github/workflows/workflow-provenance-gate.yml';
@@ -77,5 +80,31 @@ describe('what it judges', () => {
     // be judged by the edited version, which is the exposure one level up.
     const { workflows } = readGuardedWorkflows(ROOT);
     expect(workflows).not.toContain(GATE_RELATIVE);
+  });
+});
+
+describe('the scan behaviour this gate depends on', () => {
+  /*
+   * Asserted HERE, beside the workflow, and not only in the scan's own test file. The gate's whole
+   * design rests on judging a change from a checkout that is NOT that change: it holds the BASE and
+   * asks about a fetched `FETCH_HEAD`. A scan that always diffed `HEAD` would compare the base
+   * against itself, find nothing, and report a clean verdict from the wrong tree — a green that
+   * measured nothing, produced by the gate built to stop exactly that.
+   *
+   * Real history rather than a fixture, because the property is what the `git diff` range does and a
+   * stubbed git would be asserting the stub.
+   */
+  const TOUCHED_CI = '024ca7128dda01e5470b14eb27aeaa3bc65a1995';
+
+  it('reports a guarded workflow touched by the NAMED head', () => {
+    const { findings } = findWorkflowProvenanceFindings(ROOT, `${TOUCHED_CI}~1`, TOUCHED_CI);
+    expect(findings.map((f) => f.file)).toContain('.github/workflows/ci.yml');
+  });
+
+  it('reports nothing when the named head IS the base, rather than falling back to HEAD', () => {
+    // The case that fails if the head stops being an argument: with `HEAD` hardcoded, this range
+    // becomes "the base against the working tree" and picks up whatever that touched.
+    const { findings } = findWorkflowProvenanceFindings(ROOT, `${TOUCHED_CI}~1`, `${TOUCHED_CI}~1`);
+    expect(findings).toEqual([]);
   });
 });

--- a/scripts/harness/scan-workflow-provenance.mjs
+++ b/scripts/harness/scan-workflow-provenance.mjs
@@ -82,8 +82,16 @@ export function triggersFromPullRequest(workflowText) {
   return false;
 }
 
-function changedFiles(root, baseRef) {
-  const result = spawnSync('git', ['diff', '--name-only', `${baseRef}...HEAD`], {
+/**
+ * The files a change touches, as NAMES only.
+ *
+ * `headRef` is explicit so this can judge a pull request from a checkout that is NOT the pull
+ * request — the trusted-plane guard (INFRA-097) checks out the BASE, fetches the PR head without
+ * checking it out, and asks about `FETCH_HEAD`. Reading a name is not running the code that has it,
+ * which is the whole property that lets a guard be trusted while its subject is not.
+ */
+function changedFiles(root, baseRef, headRef = 'HEAD') {
+  const result = spawnSync('git', ['diff', '--name-only', `${baseRef}...${headRef}`], {
     cwd: root,
     encoding: 'utf8',
   });
@@ -96,7 +104,7 @@ function changedFiles(root, baseRef) {
   return result.stdout.split('\n').filter(Boolean);
 }
 
-export function findWorkflowProvenanceFindings(root = WORKSPACE_ROOT, baseRef) {
+export function findWorkflowProvenanceFindings(root = WORKSPACE_ROOT, baseRef, headRef) {
   requireGovernedTree(root, [REGISTRY_RELATIVE], {
     scan: 'workflow-provenance',
     why: 'The registry states which workflows provide a required check; without it there is no guarded set, and "no findings" would mean "nothing was examined".',
@@ -119,7 +127,7 @@ export function findWorkflowProvenanceFindings(root = WORKSPACE_ROOT, baseRef) {
   });
 
   if (baseRef !== undefined) {
-    const touched = changedFiles(root, baseRef).filter((f) => workflows.includes(f));
+    const touched = changedFiles(root, baseRef, headRef).filter((f) => workflows.includes(f));
     for (const file of touched) {
       const contexts = contextsByWorkflow.get(file) ?? [];
       findings.push({
@@ -143,11 +151,16 @@ export function readExaminedWorkflowCount(root = WORKSPACE_ROOT) {
 }
 
 if (process.argv[1] === new URL(import.meta.url).pathname) {
-  const baseIndex = process.argv.indexOf('--base-ref');
-  const baseRef = baseIndex === -1 ? undefined : process.argv[baseIndex + 1];
+  const argAfter = (flag) => {
+    const at = process.argv.indexOf(flag);
+    return at === -1 ? undefined : process.argv[at + 1];
+  };
+  const baseRef = argAfter('--base-ref');
+  const headRef = argAfter('--head-ref');
   const { findings, workflows, selfLoading, examined } = findWorkflowProvenanceFindings(
     WORKSPACE_ROOT,
     baseRef,
+    headRef,
   );
   for (const finding of findings) console.error(`✗ ${finding.file}: ${finding.problem}`);
   if (selfLoading.length > 0) {


### PR DESCRIPTION
Refs #1719 — four of the item's five plan steps. The fifth needs one owner action, named at the end.

## The gap

A required check triggered by `pull_request` loads its workflow YAML from the PR's merge revision, so the change carries the definition that judges it: **edit the job, move the verdict.** INFRA-096 hardened the *scripts* those workflows load by checking them out from the base SHA and said plainly that this does not establish workflow provenance. `workflow-provenance` makes such an edit **visible**. Neither makes the plane trusted, because both run on the plane.

## Two of the three candidate designs were ruled out by MEASURING the account

| design | verdict | measurement |
|---|---|---|
| org-level required workflows | **unavailable** | `gh api repos/woojubb/robota` → `owner.type: User`. It is an organization feature on Enterprise Cloud; a personal account has no organization to define one in. Not harder — absent. |
| external GitHub App publishing the check | available, disproportionate | The ruleset API *does* support pinning a required check to one publisher via `integration_id`. Measured on the live `protect-develop` ruleset: **all nine read `integration_id: none`** — any app may publish any of those contexts today. Pinning to an external app buys trusted provenance and costs a hosted service, a key to rotate, and a second failure point. |
| **split `pull_request_target` plane** | **available, in-repo** | It loads its definition from the BASE branch, so a PR cannot change what it says about itself. The edit takes effect only after merge — after the gate it would have moved has run. |

## Why the existing checks could not simply move onto that plane

`pull_request_target` runs with **write credentials against the base**. `build`, `quality`, `scans`, `tui-e2e` and the rest exist to compile and execute the PR's code — under those credentials that is the classic pwn-request, a strictly worse hole than the one being closed. Measured: **no workflow here used `pull_request_target` before this change**, so nothing was already carrying that risk.

So the plane is **split**, not moved. The new gate answers the one question answerable without running anything: *does this pull request modify a file that a required check loads?*

- checks out the base, and only the base
- **fetches** the head without checking it out — reading a file NAME is not running the file
- installs nothing; the scan imports Node builtins and two files from the base, so there is no dependency resolution for a PR-supplied manifest to influence
- holds `contents: read`

That turns a self-edit from **visible** into **unmergeable**, which is the difference between this and `workflow-provenance`.

## The adversarial tests are about the gate, not its subject

The boundary here is a workflow file, and a single added line breaches it. Each property is asserted against the file, and each was proven by planting the breach:

| planted breach | went red |
|---|---|
| `ref:` pointing at the PR head | the pwn-request case |
| trigger switched to `pull_request` | the self-edit case |
| an install step added | the PR-code-by-another-route case |
| permissions widened to write | the least-privilege case |

One of those tests caught this PR's own first draft: the header comment spelled out the forbidden `ref:` line as an example, and the test refused it. The comment now describes the shape instead.

## Held membership, deliberately

Making `workflow provenance` a **required** context is a live-ruleset edit and therefore the owner's. It is **not** registered in `.github/required-status-checks.json`: that registry is compared against the live ruleset by `ruleset-drift`, so registering it before the flip would make the registry state something untrue. The same shape `regression-red-proof` uses.

That is also why the item's fifth plan step stays unticked, with the reason on the line — the paths cannot be validated *as a gate* until it is one.

`verify-like-ci` 12/12 PASS; 133 scans pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s