### PR TITLE
docs(tasks): record INFRA-104's first live TC-10 subject

### DIFF
--- a/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -156,3 +156,42 @@ The substantive grounds are unchanged, and were re-measured rather than restated
 
 The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
 filed as issue #1965 rather than folded in here.
+
+### 2026-08-22 — TC-10 has a live subject for the first time
+
+Every earlier entry records the same blocker: every closing reference `develop` carried named an
+issue that was ALREADY CLOSED, so a promotion derived an empty block and the half TC-10 asks about —
+GitHub, not a person, closing an issue — had nothing to act on.
+
+Re-measured today, reading each referenced issue through the API rather than trusting the record:
+
+```
+referenced by a closing keyword on develop-not-main:  16
+  closed:  15
+  OPEN:     1   -> issue #1965
+```
+
+**Issue #1965 is open, and `Closes #1965` is on `develop`.** GitHub ignored that keyword because the
+pull request did not target the default branch — which is the exact defect this item exists to
+compensate for — so the issue survived to become the first live subject the promotion block can name.
+
+It arrived from ordinary work. Issue #1965 was filed after probing whether four blocked items could be
+marked `done` (every existing scan passed, which was the defect); another session implemented the
+guard and merged it with the closing keyword. Nothing was arranged to produce this.
+
+**One measurement note, because it nearly went the other way.** The first sweep reported "no open
+candidates" — but four of the sixteen reads had TIMED OUT, and a timeout is not an answer of
+"closed". Re-run distinguishing an error from a state, `#1965 open` appeared. `merge-gate` refused a
+merge on the same principle an hour earlier ("no answer is a refusal — it is NOT an answer of
+'none'"), and this is the same trap one layer down, in a survey rather than a gate.
+
+**What remains for TC-10 is one event: the next promotion.** What to check when it happens, written
+BEFORE the evidence exists so the reading cannot be fitted to it:
+
+1. the promotion body carries a non-empty block naming issue #1965;
+2. the `promotion closes` required context passes on the promotion pull request;
+3. issue #1965 is closed by GITHUB — the close event attributed to the merge, not to a person.
+
+Any of the three failing is a finding about this item, not about the promotion. In particular,
+if issue #1965 is closed by hand before then, the subject is consumed and TC-10 waits again — which is what
+happened four times earlier in this session and is recorded above.

--- a/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -189,7 +189,10 @@ merge on the same principle an hour earlier ("no answer is a refusal — it is N
 BEFORE the evidence exists so the reading cannot be fitted to it:
 
 1. the promotion body carries a non-empty block naming issue #1965;
-2. the `promotion closes` required context passes on the promotion pull request;
+2. the `promotion closes` job reports green on the promotion pull request. It is ADVISORY, not
+   required: `.github/required-status-checks.json` declares it required on `main` and the live
+   `protect-main` ruleset does not, filed as issue #1980. It still runs, and a failure would show as
+   `UNSTABLE`, which `merge-gate.sh` refuses — so it stops this repository's merge path, not GitHub's;
 3. issue #1965 is closed by GITHUB — the close event attributed to the merge, not to a person.
 
 Any of the three failing is a finding about this item, not about the promotion. In particular,


### PR DESCRIPTION
## What

Appends one dated entry to the INFRA-104 task record. Docs-only — no code, no scan, no gate.

## Why now

Every earlier entry on this item recorded the same blocker: each closing reference `develop` carried
named an issue that was **already closed**, so a promotion derived an **empty** block and TC-10 — the
half that asks whether *GitHub*, not a person, closes the issue — had nothing to act on. That
happened four separate times this session.

## What was measured

Each of the 16 issues referenced by a closing keyword on `develop`-not-`main` was read individually
through the API:

```
closed:  15
OPEN:     1   -> issue #1965
```

And the generator was run rather than reasoned about:

```
$ node scripts/harness/promotion-closes.mjs
## Issues this promotion closes

Closes #1965
::examined:: 130 pull-request body(ies) read, 37 issue record(s) checked
```

Issue #1965's `Closes` keyword was ignored by GitHub because the PR did not target the default
branch — **the exact defect this item exists to compensate for**, and the reason a subject survived.

## The near-miss, recorded because it nearly went the other way

The first sweep reported "no open candidates" — while **four of the sixteen reads had timed out**. A
timeout is not an answer of "closed". Re-run distinguishing an error from a state, `#1965 open`
appeared. `merge-gate` enforces the same principle a layer up; this was the same trap inside a
survey.

## Notes

- The three checks for the next promotion are written **before** the evidence exists, so the reading
  cannot be fitted to it.
- `reference-kind-qualified` caught the two new bare references (frozen 5 → 7); both were qualified
  and the ratchet is back at 5. Note its qualifier must sit on the **same line** as the reference —
  a line break between them still reads as unqualified.

ACTIONABLE FINDINGS: 0

Refs INFRA-104