### PR TITLE
fix(lint): the warning count is back under its ceiling, and the ceiling is now true

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:coverage:packages": "pnpm --filter \"./packages/**\" run --if-present test:coverage",
     "test:coverage:apps": "pnpm --filter \"./apps/**\" run --if-present test:coverage",
     "typecheck": "pnpm run -r --workspace-concurrency=-1 --if-present typecheck",
-    "lint": "eslint packages apps --ext .ts,.tsx --cache --max-warnings 2093",
+    "lint": "eslint packages apps --ext .ts,.tsx --cache --max-warnings 2092",
     "lint:fix": "eslint packages apps --ext .ts,.tsx --cache --fix && prettier --write .",
     "lint:fix:staged": "scripts/harness/with-repo-lock.sh pnpm exec lint-staged",
     "dev": "pnpm run -r --if-present dev",

--- a/packages/agent-command/src/context/context-breakdown.ts
+++ b/packages/agent-command/src/context/context-breakdown.ts
@@ -8,17 +8,10 @@
 
 import { CONTEXT_ESTIMATE_CHARS_PER_TOKEN } from '@robota-sdk/agent-core';
 import {
-  addCommandContextReference,
-  clearCommandContextReferences,
-  DEFAULT_AUTO_COMPACT_THRESHOLD,
   listCommandContextReferences,
   readAutoCompactThreshold,
   readAutoCompactThresholdSource,
   readCommandContextState,
-  removeCommandContextReference,
-  resetAutoCompactThresholdSetting,
-  setCommandAutoCompactThreshold,
-  writeAutoCompactThresholdSetting,
 } from '@robota-sdk/agent-framework';
 
 import { formatAutoCompactLine } from './context-command.js';

--- a/packages/agent-command/src/context/context-command.ts
+++ b/packages/agent-command/src/context/context-command.ts
@@ -1,4 +1,3 @@
-import { CONTEXT_ESTIMATE_CHARS_PER_TOKEN } from '@robota-sdk/agent-core';
 import {
   addCommandContextReference,
   clearCommandContextReferences,

--- a/packages/agent-core/src/services/execution-pipeline.ts
+++ b/packages/agent-core/src/services/execution-pipeline.ts
@@ -2,7 +2,6 @@ import { EXECUTION_EVENTS } from './execution-constants';
 import { buildFinalResult } from './execution-failure';
 import { forceSummaryCall } from './execution-forced-summary';
 import { executeRound } from './execution-round';
-import { callProviderWithIdleTimeout } from './execution-round-provider';
 import {
   type IResolvedProviderInfo,
   type IExecutionContext,
@@ -11,13 +10,11 @@ import {
   PREVIEW_LENGTH,
 } from './execution-types';
 import { callPluginHook } from './plugin-hook-dispatcher';
-import { randomId } from '../utils/random-id.js';
 
 import type { ExecutionEventEmitter } from './execution-event-emitter';
 import type { TPluginWithHooks } from './plugin-hook-dispatcher';
 import type { ToolExecutionService } from './tool-execution-service';
-import type { IAgentConfig, TExecutionEventData } from '../interfaces/agent';
-import type { IChatOptions } from '../interfaces/provider';
+import type { IAgentConfig } from '../interfaces/agent';
 import type { TMetadata } from '../interfaces/types';
 import type { ConversationStore } from '../managers/conversation-history-manager';
 import type { ILogger } from '../utils/logger';

--- a/packages/agent-remote-pairing/src/revocation-list.ts
+++ b/packages/agent-remote-pairing/src/revocation-list.ts
@@ -45,9 +45,13 @@ const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
 const webcrypto = globalThis.crypto;
 const encoder = new TextEncoder();
 
+/** base64 encodes 3 bytes into 4 characters, so a padded string's length is a multiple of this. */
+const BASE64_QUANTUM = 4;
+
 function fromBase64Url(value: string): Uint8Array {
   const padded = value.replace(/-/g, '+').replace(/_/g, '/');
-  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='));
+  const quantised = Math.ceil(padded.length / BASE64_QUANTUM) * BASE64_QUANTUM;
+  const binary = atob(padded.padEnd(quantised, '='));
   return Uint8Array.from(binary, (c) => c.charCodeAt(0));
 }
 

--- a/packages/agent-remote-pairing/src/root-rotation.ts
+++ b/packages/agent-remote-pairing/src/root-rotation.ts
@@ -45,9 +45,13 @@ const SIGN_PARAMS = { name: 'ECDSA', hash: 'SHA-256' } as const;
 const webcrypto = globalThis.crypto;
 const encoder = new TextEncoder();
 
+/** base64 encodes 3 bytes into 4 characters, so a padded string's length is a multiple of this. */
+const BASE64_QUANTUM = 4;
+
 function fromBase64Url(value: string): Uint8Array {
   const padded = value.replace(/-/g, '+').replace(/_/g, '/');
-  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, '='));
+  const quantised = Math.ceil(padded.length / BASE64_QUANTUM) * BASE64_QUANTUM;
+  const binary = atob(padded.padEnd(quantised, '='));
   return Uint8Array.from(binary, (c) => c.charCodeAt(0));
 }
 

--- a/packages/agent-transport-webrtc/src/pairing-gate-options.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate-options.ts
@@ -20,8 +20,6 @@ import type {
   createWsHandler,
 } from '@robota-sdk/agent-transport-protocol';
 
-import type { startReconnectController } from './pairing-controllers.js';
-
 import type { IHandoffGrantProof } from './handoff-grant-gate.js';
 import type { ILocalPeerProof } from './local-peer-proof.js';
 

--- a/packages/agent-transport-webrtc/src/pairing-gate.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate.ts
@@ -24,9 +24,7 @@ import {
   importPublicKey,
   startPairingHandshake,
   type IPairingResult,
-  type TPairingRole,
 } from '@robota-sdk/agent-remote-pairing';
-import { createWsHandler, type SessionResumeBridge } from '@robota-sdk/agent-transport-protocol';
 
 import { nextAdmissionStep } from './admission-steps.js';
 import type {
@@ -38,15 +36,14 @@ import type {
 // Re-exported so every existing import of these names keeps working: the split moved where they are
 // DECLARED, and moving where they are imported from would be a migration this change is not.
 export type { IHostReconnectConfig, IPairingChannel, IPairingGateOptions };
-import { judgeHandoffGrant, type IHandoffGrantProof } from './handoff-grant-gate.js';
-import { judgeLocalProof, type ILocalPeerProof } from './local-peer-proof.js';
+import { judgeHandoffGrant } from './handoff-grant-gate.js';
+import { judgeLocalProof } from './local-peer-proof.js';
 import { pairingChannel } from './pairing-channel-lifecycle.js';
 import { startFirstPairController, startReconnectController } from './pairing-controllers.js';
 import { isEnrollFrame, isPairingFrame, isReconnectFrame } from './pairing-frames.js';
 import { attachSession } from './session-attachment.js';
 
 import type { IEnrollFrame } from './pairing-frames.js';
-import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
 
 type TGateState =
   | 'awaiting-mode'

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -4,7 +4,7 @@
   "packages/agent-cli/src/cli.ts": 463,
   "packages/agent-cli/src/remote-control/remote-control-controller.ts": 462,
   "packages/agent-cli/src/utils/cli-args.ts": 316,
-  "packages/agent-command/src/context/context-command.ts": 306,
+  "packages/agent-command/src/context/context-command.ts": 305,
   "packages/agent-command/src/provider/provider-setup-flow.ts": 320,
   "packages/agent-core/src/abstracts/abstract-ai-provider.ts": 306,
   "packages/agent-core/src/abstracts/abstract-module.ts": 315,

--- a/scripts/harness/lint-warning-baseline.json
+++ b/scripts/harness/lint-warning-baseline.json
@@ -1,3 +1,3 @@
 {
-  "warnings": 2093
+  "warnings": 2092
 }


### PR DESCRIPTION
## Why

`pnpm harness:verify:release` — the only CI path that runs the root `lint` script — reports

```
✖ 2115 problems (0 errors, 2115 warnings)     ceiling: --max-warnings 2093
```

`release-grade verification` is a **required** context on `protect-main`, so the next promotion would
have gone red on it. Found by running the gate locally before opening a promotion PR.

## What the measurement actually said, after two wrong readings

**Reading 1 — wrong.** I attributed the rise by grepping `git show --stat` output for changed paths,
concluded the only code commit since the baseline contributed 2 warnings, and looked elsewhere.
`--stat` **abbreviates long paths**, so two of that commit's six files were never in the text being
matched. A presentation layer was asked a question only the data layer can answer.

**Reading 2 — per-file diff of two `-f json` reports.** All 21 of the rise came from that one commit:

```
+7  packages/agent-transport-webrtc/src/pairing-gate.ts
+7  packages/agent-transport-webrtc/src/handoff-grant-gate.ts
+2  packages/agent-remote-pairing/src/revocation-list.ts
+2  packages/agent-remote-pairing/src/root-rotation.ts
+2  packages/agent-transport-webrtc/src/admission-steps.ts
+1  packages/agent-transport-webrtc/src/pairing-gate-options.ts
```

**And the baseline was never true.** Measured at `f67006212`, the commit that recorded it:

```
WARNINGS AT THE BASELINE COMMIT f67006212: 2094
```

Recorded ceiling: 2093. It was one low the day it was written. I measured this **before** touching
the file, because "correct a mis-record" and "weaken a gate to unblock myself" produce an identical
diff, and without the number I'd have picked whichever story suited me.

## What is fixed, and what is deliberately not

**Not fixed — 11 of the 21.** They are `unknown` in type-guard signatures:

```ts
function isHandoffGrantFrame(value: unknown): value is IHandoffGrantFrame
readonly verify: (grant: unknown) => Promise<IPeerAdmission>;
```

That is the construct the rule's **own message** recommends (*"type guards at boundaries"*).
Rewriting it to satisfy a counter would make correct code worse.

**Fixed — unambiguous only:** 19 dead import bindings removed, and the base64 quantum in
`fromBase64Url` given a name instead of two bare `4`s.

**Ceiling and baseline drop 2093 → 2092**, the measured value of the tree. A ratchet may fall.

## Verification

- `pnpm run lint`: **2092 problems, 0 errors** — re-run on the **committed** tree, because
  `eslint --fix` touches staged files and the tree I verified is not automatically the tree I
  committed. Confirmed by reading `git show HEAD:package.json`, not `git diff`.
- Four edited packages typecheck.
- Their suites: **155 files, 1597 tests, all passing.**
- `file-size` refused the shrink until the gain was locked; baseline regenerated in the same change
  (80 burn-down entries), as the scan instructs.
- Whole-workspace pre-push: **132 of 133 scans**, the one failure being that `file-size` refusal,
  now green.

Typecheck caught one wrong deletion mid-fix: the warning was on `context-command.ts` and I removed
the same-named import from `context-breakdown.ts`, where it is used. Restored, correct one removed.

## Separate defect, filed not folded in

Issue #1984 — this ratchet's **only** CI execution path is `release-grade verification`, which runs
on `main` PRs only. Its first execution in its entire life was this pre-flight. A guard nothing
routinely triggers cannot fire, the same family as one whose input cannot vary.

ACTIONABLE FINDINGS: 0

Refs INFRA-039