### PR TITLE
feat(harness): a new task record names the issue that registered it (issue #1916)

### DIFF
--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -56,8 +56,16 @@ Two things it deliberately does not treat as collisions, and one it cannot see:
   numbers, so renaming the files would move each record out from under every citation pointing at
   it. The allowlist may not grow: a fresh collision is refused.
 - An ID claimed by a record in one clone and by an **issue title** opened by another session is
-  invisible to it, because nothing in the tree says which issue registers which record. That is the
-  case that produced the three collisions in issue #1916 and it stays open there.
+  invisible to it on its own, because nothing in the tree said which issue registers which record.
+
+**So a NEW record names its issue.** Any of `Registered as … issue #N`, a bare `issue #N`, or the
+issue URL — the three spellings already in the tree, so a record that links already does not have to
+link again. A pull-request reference is not one: `PR #N` says what delivered the work, not what
+registered it. `no-issue: <reason>` on a line opts out, for an item that genuinely has none.
+
+Only records a change ADDS are judged. 711 of 798 existing records carry no citation, most of them
+completed and merged; back-filling them means guessing which issue each one meant, and a wrong link
+is worse than none — the cross-source check would then read two items as one.
 
 ## Process
 

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -67,6 +67,18 @@ Only records a change ADDS are judged. 711 of 798 existing records carry no cita
 completed and merged; back-filling them means guessing which issue each one meant, and a wrong link
 is worse than none — the cross-source check would then read two items as one.
 
+**What this guarantees, stated because the weaker claim is the true one.** A collision becomes
+DETECTABLE at push time. It is not PREVENTED: a clone-local branch is invisible in principle to
+every mechanism that reads the tracked tree, so two sessions can still both pick the same number and
+the second one is caught when it pushes, not when it chooses. And the link is checked when it is
+WRITTEN, not continuously — a record can cite an issue that is later closed as a duplicate,
+retitled, or transferred, and nothing here re-derives that. Worse, a link can be wrong on the day it
+is written, which leaves no signal at all and reads as verified precisely because it is well-formed.
+
+Closing those needs a live read of the issue, which no tracked-tree scan can do — the useful
+assertion is not "the link resolves" but "the link resolves AND that issue's title still claims this
+record's ID".
+
 ## Process
 
 1. Create a new `.md` file in this directory with the required frontmatter (see File Format below).

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -51,8 +51,9 @@ it offline.
 Two things it deliberately does not treat as collisions, and one it cannot see:
 
 - A **phase** of an item — the `-p7-` / `-P4-` segment right after the ID — belongs to its parent.
-- Seven `<PREFIX>-001` IDs from before the convention settled are allowlisted in the scan, each with
-  the reason. They are all in `completed/`, and the merged commits that deliver them name the old
+- Ten IDs are allowlisted in the scan, each with the reason — seven `<PREFIX>-001` from before the
+  convention settled, and three (`ARCH-CONF-007`, `ARCH-FIX-020`, `ARCH-FIX-021`) found only when
+  the ID pattern was widened to reach multi-segment prefixes like `ARCH-FIX-` and `INFRA-BL-`. They are all in `completed/`, and the merged commits that deliver them name the old
   numbers, so renaming the files would move each record out from under every citation pointing at
   it. The allowlist may not grow: a fresh collision is refused.
 - An ID claimed by a record in one clone and by an **issue title** opened by another session is

--- a/scripts/harness/__tests__/scan-work-item-id-collision.test.mjs
+++ b/scripts/harness/__tests__/scan-work-item-id-collision.test.mjs
@@ -22,6 +22,13 @@ describe('reading the id off a record', () => {
   it.each([
     [`${T}INFRA-047-deny-licenses-v6-migration.md`, 'INFRA-047'],
     [`${T}completed/SELFHOST-003-codebase-index-rag.md`, 'SELFHOST-003'],
+    // Multi-segment prefixes, reported in review. Requiring the digits after the FIRST segment
+    // excluded 97 records — and with them three genuine collisions this scan was reporting a clean
+    // tree over. A guard that cannot see part of its population states a verdict about the part it
+    // can.
+    [`${T}completed/ARCH-FIX-020-isession-upward-dependency.md`, 'ARCH-FIX-020'],
+    [`${T}completed/INFRA-BL-009-A-backlog-rewrite.md`, 'INFRA-BL-009'],
+    [`${T}completed/DQ-AUDIT-005-x.md`, 'DQ-AUDIT-005'],
   ])('%s claims %s', (file, id) => {
     expect(workItemIdOf(file)).toBe(id);
   });

--- a/scripts/harness/__tests__/task-record-issue-link.test.mjs
+++ b/scripts/harness/__tests__/task-record-issue-link.test.mjs
@@ -8,6 +8,9 @@
  * cross-source comparison needs it on both sides, and today it is on one.
  */
 
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -73,6 +76,25 @@ describe('which files are judged', () => {
     expect(isTaskRecord(file)).toBe(false);
   });
 
+  it.each([
+    ['.agents/tasks/ARCH-FIX-020-isession-upward-dependency.md', 'a two-segment prefix'],
+    ['.agents/tasks/INFRA-BL-009-A-backlog-rewrite.md', 'another two-segment prefix'],
+    ['.agents/tasks/completed/DQ-AUDIT-005-x.md', 'a two-segment prefix under completed/'],
+  ])('%s is a task record (%s)', (file) => {
+    // Reported in review: requiring the digits after the FIRST segment excluded 97 records, and a
+    // new `ARCH-FIX-022-…` would have been SILENTLY exempt from the requirement this module
+    // imposes — a rule that does not reach part of its population.
+    expect(isTaskRecord(file)).toBe(true);
+  });
+
+  it('exempts a LETTERED split as well as a numbered phase', () => {
+    // `INFRA-BL-009` is one item across six files `-A-` … `-F-`. Without this it reads as six items
+    // sharing an id — a collision the tree does not have.
+    expect(isPhaseRecord('.agents/tasks/INFRA-BL-009-C-harness-file-existence-check.md')).toBe(
+      true,
+    );
+  });
+
   it('exempts a phase, which carries its parent registration', () => {
     // Same convention `work-item-id-collision` uses for the same reason: a phase is not a second
     // item, so asking it to name its own issue would ask for one that does not exist.
@@ -109,17 +131,68 @@ describe('the size reported is BOTH halves of the population', () => {
     return files[f];
   };
 
-  it('counts linked and unlinked separately, and skips what is not judged', () => {
-    expect(linkCoverage(Object.keys(files), read)).toEqual({ linked: 2, unlinked: 1 });
+  it('counts linked, unlinked and NOT-JUDGED, and the three sum to the input', () => {
+    // The third number was added in review: `994 … 87 name an issue, 696 do not` summed to 783, and
+    // the missing 211 were the population the id pattern could not see — unstated on the very line
+    // the pair exists to make honest. Asserting the SUM is what stops that recurring.
+    const input = Object.keys(files);
+    const coverage = linkCoverage(input, read);
+    expect(coverage).toEqual({ linked: 2, unlinked: 1, notJudged: 2 });
+    expect(coverage.linked + coverage.unlinked + coverage.notJudged).toBe(input.length);
   });
 
   it('counts an UNREADABLE record as unlinked, never as absent', () => {
     // A record this cannot open is a record a consumer cannot compare. Dropping it would shrink the
     // denominator silently, which is the exact shape the pair exists to report.
-    expect(linkCoverage(['.agents/tasks/E-005-gone.md'], read)).toEqual({ linked: 0, unlinked: 1 });
+    expect(linkCoverage(['.agents/tasks/E-005-gone.md'], read)).toEqual({
+      linked: 0,
+      unlinked: 1,
+      notJudged: 0,
+    });
   });
 
   it('reports zero for an empty subject rather than nothing at all', () => {
-    expect(linkCoverage([], read)).toEqual({ linked: 0, unlinked: 0 });
+    expect(linkCoverage([], read)).toEqual({ linked: 0, unlinked: 0, notJudged: 0 });
+  });
+});
+
+describe('the check fires where the suite actually runs it', () => {
+  /*
+   * Reported in review of this change, and it is the finding that mattered most: the base ref was
+   * taken from `--base-ref` alone, and the one real caller — the `work-item-id-collision` entry in
+   * `run-all-scans.mjs` — passes no arguments. So `baseRef` was always undefined there, the added
+   * records were always an empty set, and the rule this change exists to add never fired anywhere
+   * it actually runs.
+   *
+   * A rule enforced only when someone remembers a flag is not enforced. This case runs the scan the
+   * way the suite runs it — no arguments — and asserts it resolved a base and judged something.
+   */
+  const ROOT = path.resolve(import.meta.dirname, '../../..');
+
+  function runBare() {
+    try {
+      return execFileSync('node', ['scripts/harness/scan-work-item-id-collision.mjs'], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        timeout: 120_000,
+      });
+    } catch (error) {
+      // A non-zero exit still carries the output this case reads.
+      return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+    }
+  }
+
+  it('resolves a base ref with NO arguments, so the suite entry point reaches the check', () => {
+    // The failure this pins is silent: with an unresolved base the scan passes, and a pass is
+    // indistinguishable from "no new records". So the assertion is on the REFUSAL not appearing.
+    expect(runBare()).not.toContain('no base ref could be resolved');
+  });
+
+  it('reports both halves of the link population from that same bare run', () => {
+    // The examined line is what a later cross-source scan would inherit its subject from. If the
+    // bare run could not read the tree, this is where it shows.
+    expect(runBare()).toMatch(
+      /::examined:: \d+ tracked task record\(s\); \d+ name an issue, \d+ do not/,
+    );
   });
 });

--- a/scripts/harness/__tests__/task-record-issue-link.test.mjs
+++ b/scripts/harness/__tests__/task-record-issue-link.test.mjs
@@ -1,0 +1,90 @@
+/**
+ * A new task record names the issue that registered it (issue #1916, second half).
+ *
+ * The first half — one ID, one tracked record — is decidable offline and landed as
+ * `work-item-id-collision`. The half that actually bit is an ID claimed by a record in one clone and
+ * by an ISSUE TITLE opened by another session, and it is undecidable while nothing says which issue
+ * registers which record. These cases are about producing that link, not about using it: the exact
+ * cross-source comparison needs it on both sides, and today it is on one.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ISSUE_LINK_PATTERNS,
+  isPhaseRecord,
+  isTaskRecord,
+  namesItsIssue,
+} from '../task-record-issue-link.mjs';
+
+describe('what counts as naming the issue', () => {
+  it.each([
+    ['Registered as [issue #1811](https://github.com/o/r/issues/1811).', 'the registered-as form'],
+    ['See issue #1916 for the measurement.', 'a bare issue reference'],
+    ['Filed at https://github.com/woojubb/robota/issues/42', 'an issue URL'],
+  ])('accepts %s (%s)', (content) => {
+    expect(namesItsIssue(content)).toBe(true);
+  });
+
+  it.each([
+    ['# SOME-001\n\nJust prose.', 'no citation at all'],
+    ['See PR #1811 for the change.', 'a PULL REQUEST, which is not the registration'],
+    ['Related to SOME-002.', 'another work-item id, which is not an issue'],
+    ['https://github.com/o/r/pull/42', 'a pull request URL'],
+  ])('refuses %s (%s)', (content) => {
+    expect(namesItsIssue(content)).toBe(false);
+  });
+
+  it('accepts an explicit opt-out, so a genuine exception is written down', () => {
+    expect(namesItsIssue('no-issue: a phase of ARCH-002, which carries the registration')).toBe(
+      true,
+    );
+  });
+
+  it('does not accept an opt-out with no reason', () => {
+    // The point of the escape is the judgement written beside it. A bare marker is not one.
+    expect(namesItsIssue('no-issue:')).toBe(false);
+    expect(namesItsIssue('no-issue:   ')).toBe(false);
+  });
+
+  it('offers exactly the three spellings already in the tree, and no fourth', () => {
+    // Measured before landing: `Registered as … issue #N` in 8 records, a bare `issue #N` in 46, an
+    // issue URL in 65. Inventing a fourth spelling here would make a record that already links have
+    // to link again.
+    expect(ISSUE_LINK_PATTERNS).toHaveLength(3);
+  });
+});
+
+describe('which files are judged', () => {
+  it.each([
+    ['.agents/tasks/INFRA-047-deny-licenses.md', true],
+    ['.agents/tasks/completed/SEC-011-same-user-proof.md', true],
+  ])('%s is a task record', (file, expected) => {
+    expect(isTaskRecord(file)).toBe(expected);
+  });
+
+  it.each([
+    ['.agents/tasks/README.md', 'the directory README carries no id'],
+    ['.agents/tasks/notes.md', 'an un-prefixed file'],
+    ['packages/agent-core/INFRA-047-notes.md', 'a path outside the tasks tree'],
+    ['.agents/tasks/INFRA-047-deny-licenses.txt', 'a non-markdown file'],
+  ])('%s is not (%s)', (file) => {
+    expect(isTaskRecord(file)).toBe(false);
+  });
+
+  it('exempts a phase, which carries its parent registration', () => {
+    // Same convention `work-item-id-collision` uses for the same reason: a phase is not a second
+    // item, so asking it to name its own issue would ask for one that does not exist.
+    expect(isPhaseRecord('.agents/tasks/completed/ARCH-002-p7-slim-agent-cli-public-api.md')).toBe(
+      true,
+    );
+    expect(isPhaseRecord('.agents/tasks/SELFHOST-003-P4-embedding-vector-backend.md')).toBe(true);
+  });
+
+  it('does not exempt a parent whose slug merely starts with p', () => {
+    expect(isPhaseRecord('.agents/tasks/PLAN-001-plan-completed-state.md')).toBe(false);
+    expect(isPhaseRecord('.agents/tasks/completed/CLI-001-prompt-input-non-tty-guard.md')).toBe(
+      false,
+    );
+  });
+});

--- a/scripts/harness/__tests__/task-record-issue-link.test.mjs
+++ b/scripts/harness/__tests__/task-record-issue-link.test.mjs
@@ -14,6 +14,7 @@ import {
   ISSUE_LINK_PATTERNS,
   isPhaseRecord,
   isTaskRecord,
+  linkCoverage,
   namesItsIssue,
 } from '../task-record-issue-link.mjs';
 
@@ -86,5 +87,39 @@ describe('which files are judged', () => {
     expect(isPhaseRecord('.agents/tasks/completed/CLI-001-prompt-input-non-tty-guard.md')).toBe(
       false,
     );
+  });
+});
+
+describe('the size reported is BOTH halves of the population', () => {
+  /*
+   * A consumer of these links that reported its size as "records carrying a link" would be naming
+   * the population it can SEE and calling it the population. A later cross-source scan reporting
+   * "no collisions" over a set that silently excludes every unlinked record is issue #1916's own
+   * failure, one layer up — so the pair is what makes the gap visible.
+   */
+  const files = {
+    '.agents/tasks/A-001-linked.md': 'Registered as issue #1.',
+    '.agents/tasks/B-002-bare.md': 'nothing here',
+    '.agents/tasks/C-003-optout.md': 'no-issue: a probe',
+    '.agents/tasks/README.md': 'not a record',
+    '.agents/tasks/D-004-p1-phase.md': 'a phase, exempt',
+  };
+  const read = (f) => {
+    if (!(f in files)) throw new Error('unreadable');
+    return files[f];
+  };
+
+  it('counts linked and unlinked separately, and skips what is not judged', () => {
+    expect(linkCoverage(Object.keys(files), read)).toEqual({ linked: 2, unlinked: 1 });
+  });
+
+  it('counts an UNREADABLE record as unlinked, never as absent', () => {
+    // A record this cannot open is a record a consumer cannot compare. Dropping it would shrink the
+    // denominator silently, which is the exact shape the pair exists to report.
+    expect(linkCoverage(['.agents/tasks/E-005-gone.md'], read)).toEqual({ linked: 0, unlinked: 1 });
+  });
+
+  it('reports zero for an empty subject rather than nothing at all', () => {
+    expect(linkCoverage([], read)).toEqual({ linked: 0, unlinked: 0 });
   });
 });

--- a/scripts/harness/scan-work-item-id-collision.mjs
+++ b/scripts/harness/scan-work-item-id-collision.mjs
@@ -37,6 +37,7 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
+import { resolveGitBaseRef } from './shared.mjs';
 import { findUnlinkedRecords, linkCoverage } from './task-record-issue-link.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
@@ -57,6 +58,12 @@ export const HISTORICAL_COLLISIONS = new Map([
   ['EX-001', 'two pre-convention items, both completed and merged'],
   ['NAMING-001', 'two pre-convention items, both completed and merged'],
   ['SEC-001', 'three pre-convention items, all completed and merged'],
+  // Found only once the ID pattern was widened to multi-segment prefixes (review of issue #1916's
+  // second half). Each is two distinct items, titles compared by hand; all are merged, so the
+  // citations pointing at them cannot be rewritten — the same reason the `-001` set is here.
+  ['ARCH-CONF-007', 'conformance to ARCH-REV rules vs harness mechanical enforcement'],
+  ['ARCH-FIX-020', 'moving agent-cli/subagents vs moving ISession'],
+  ['ARCH-FIX-021', 'a project-structure omission vs a provider-factory move'],
 ]);
 
 /**
@@ -69,7 +76,11 @@ export const HISTORICAL_COLLISIONS = new Map([
 export function workItemIdOf(relativePath) {
   if (!relativePath.startsWith(TASKS_PREFIX) || !relativePath.endsWith('.md')) return null;
   const base = path.basename(relativePath);
-  return /^([A-Z][A-Z0-9]*-\d+)-/.exec(base)?.[1] ?? null;
+  // Multi-segment prefixes are real and common here: `ARCH-FIX-020`, `INFRA-BL-009`, `DQ-AUDIT-005`.
+  // Reported in review of issue #1916's second half — requiring the digits after the FIRST segment
+  // excluded 97 records, and with them three genuine collisions this scan was reporting a clean tree
+  // over. A guard that cannot see part of its population states a verdict about the part it can.
+  return /^([A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\d+)-/.exec(base)?.[1] ?? null;
 }
 
 /**
@@ -81,7 +92,13 @@ export function workItemIdOf(relativePath) {
  */
 export function isPhaseRecord(relativePath) {
   const base = path.basename(relativePath);
-  return /^[A-Z][A-Z0-9]*-\d+-[Pp]\d+[a-z]?-/.test(base);
+  const prefix = '[A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\\d+';
+  // Two spellings of "a part of one item", both present in the tree:
+  //   `-p7-` / `-P4-`   a numbered phase
+  //   `-A-` … `-F-`     a lettered split, which `INFRA-BL-009` uses across six files
+  // The second was found in review: without it, one item split six ways reads as six items sharing
+  // an ID, which is a collision the tree does not have.
+  return new RegExp(`^${prefix}-(?:[Pp]\\d+[a-z]?|[A-Z])-`).test(base);
 }
 
 let examinedRecords = 0;
@@ -149,9 +166,26 @@ function main() {
   // ISSUE TITLE opened elsewhere — cannot be decided while nothing says which issue registers which
   // record. Requiring the link on records a change ADDS is what makes that comparison possible
   // later; see `task-record-issue-link.mjs` for why it is forward-only.
-  const baseIndex = process.argv.indexOf('--base-ref');
-  const baseRef = baseIndex === -1 ? undefined : process.argv[baseIndex + 1];
-  const unlinked = baseRef === undefined ? [] : findUnlinkedRecords(baseRef);
+  //
+  // The base is RESOLVED, not only accepted. Reported in review of this change: taking it from
+  // `--base-ref` alone meant the one real caller — the `work-item-id-collision` entry in
+  // `run-all-scans.mjs`, which passes no arguments — always saw `undefined`, so the check never
+  // fired anywhere it actually runs. A rule that is enforced only when someone remembers a flag is
+  // not enforced; it is the vacuous green this scan's own subject is about.
+  const explicit = process.argv.indexOf('--base-ref');
+  const baseRef = resolveGitBaseRef(explicit === -1 ? null : process.argv[explicit + 1]);
+  // Fail-CLOSED on an unresolvable base. `resolveGitBaseRef` answers null when no candidate ref
+  // exists — a shallow clone, a fresh repository — and reading that as "no new records" would be a
+  // pass over a comparison that never happened.
+  if (baseRef === null) {
+    console.error(
+      'work-item-id-collision: no base ref could be resolved, so the records this change ADDS ' +
+        'cannot be determined. Set HARNESS_BASE_REF, or pass --base-ref. Refusing rather than ' +
+        'reporting a pass over a comparison that did not run.',
+    );
+    return 1;
+  }
+  const unlinked = findUnlinkedRecords(baseRef);
 
   const records = scanTaskRecords();
   const collisions = collisionsIn(records);
@@ -166,7 +200,8 @@ function main() {
   const coverage = linkCoverage(records);
   console.log(
     `::examined:: ${records.length} tracked task record(s); ` +
-      `${coverage.linked} name an issue, ${coverage.unlinked} do not`,
+      `${coverage.linked} name an issue, ${coverage.unlinked} do not, ` +
+      `${coverage.notJudged} not judged (no work-item id, or a phase)`,
   );
 
   if (fresh.length === 0 && stale.length === 0 && unlinked.length === 0) {

--- a/scripts/harness/scan-work-item-id-collision.mjs
+++ b/scripts/harness/scan-work-item-id-collision.mjs
@@ -37,6 +37,8 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
+import { findUnlinkedRecords } from './task-record-issue-link.mjs';
+
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const TASKS_PREFIX = '.agents/tasks/';
 
@@ -143,6 +145,14 @@ export function collisionsIn(records) {
 }
 
 function main() {
+  // issue #1916, the second half. The cross-source case — an ID claimed by a record here and by an
+  // ISSUE TITLE opened elsewhere — cannot be decided while nothing says which issue registers which
+  // record. Requiring the link on records a change ADDS is what makes that comparison possible
+  // later; see `task-record-issue-link.mjs` for why it is forward-only.
+  const baseIndex = process.argv.indexOf('--base-ref');
+  const baseRef = baseIndex === -1 ? undefined : process.argv[baseIndex + 1];
+  const unlinked = baseRef === undefined ? [] : findUnlinkedRecords(baseRef);
+
   const records = scanTaskRecords();
   const collisions = collisionsIn(records);
   const fresh = [...collisions].filter(([id]) => !HISTORICAL_COLLISIONS.has(id));
@@ -153,9 +163,18 @@ function main() {
 
   console.log(`::examined:: ${records.length} tracked task record(s)`);
 
-  if (fresh.length === 0 && stale.length === 0) {
+  if (fresh.length === 0 && stale.length === 0 && unlinked.length === 0) {
     console.log('work-item-id-collision scan passed.');
     return 0;
+  }
+
+  for (const record of unlinked) {
+    console.error(
+      `work-item-id-collision: ${record} is a NEW task record that names no issue. An ID claimed ` +
+        'by a record here and by an issue title opened elsewhere is the collision this scan cannot ' +
+        'see, and the link is what would let it. Add `issue #N` (or the issue URL), or write ' +
+        '`no-issue: <reason>` on a line if this item genuinely has none.',
+    );
   }
   for (const [id, paths] of fresh) {
     console.error(`work-item-id-collision: ${id} is claimed by ${paths.length} distinct records:`);

--- a/scripts/harness/scan-work-item-id-collision.mjs
+++ b/scripts/harness/scan-work-item-id-collision.mjs
@@ -37,7 +37,7 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
-import { findUnlinkedRecords } from './task-record-issue-link.mjs';
+import { findUnlinkedRecords, linkCoverage } from './task-record-issue-link.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const TASKS_PREFIX = '.agents/tasks/';
@@ -161,7 +161,13 @@ function main() {
   // a permission nobody needs, and a stale one is how an allowlist quietly becomes the rule.
   const stale = [...HISTORICAL_COLLISIONS.keys()].filter((id) => !collisions.has(id));
 
-  console.log(`::examined:: ${records.length} tracked task record(s)`);
+  // Both halves of the link population, never only the half that carries one — a consumer reporting
+  // its size as "records with a link" would name the set it can see and call it the set.
+  const coverage = linkCoverage(records);
+  console.log(
+    `::examined:: ${records.length} tracked task record(s); ` +
+      `${coverage.linked} name an issue, ${coverage.unlinked} do not`,
+  );
 
   if (fresh.length === 0 && stale.length === 0 && unlinked.length === 0) {
     console.log('work-item-id-collision scan passed.');

--- a/scripts/harness/task-record-issue-link.mjs
+++ b/scripts/harness/task-record-issue-link.mjs
@@ -1,0 +1,111 @@
+/**
+ * A NEW task record names the issue that registered it (issue #1916).
+ *
+ * `work-item-id-collision` closes the half a clone can decide offline: one ID, one tracked record.
+ * It cannot see the half that actually bit — an ID claimed by a record in one clone and by an ISSUE
+ * TITLE opened by another session minutes earlier. Three collisions landed that way, and the third
+ * happened WHILE fixing the first.
+ *
+ * ## The missing piece was never the network
+ *
+ * Measured when this landed: 48 IDs are claimed by both a record and an issue title, and 39 of those
+ * records carry no reference to that issue's number — yet they are overwhelmingly the SAME item
+ * written twice, not two items. So a scan over the union of both sources reports 39 false
+ * collisions. What is absent is the LINK, and 87 of 798 records have one in any form.
+ *
+ * Requiring it makes the cross-source comparison exact: an ID claimed by a record and by an issue
+ * the record names is one item; an ID claimed by a record and by an issue it does NOT name is two.
+ *
+ * ## Forward-only, because a retroactive sweep would be a guess
+ *
+ * 711 records carry no citation, most of them completed and merged. Back-filling them means deciding
+ * which issue each one meant, from a distance, for work that is finished — and a wrong link is worse
+ * than none, because the cross-source check would then treat two items as one. So this judges the
+ * records a change ADDS, and the existing tree is left as it is.
+ *
+ * That also means the exact cross-source scan cannot be built yet: it needs the link on both sides
+ * of a comparison, and today it is on one. This is the step that makes it possible, not the step
+ * that does it.
+ *
+ * ## What counts as naming the issue
+ *
+ * Any of the three forms already in the tree — `Registered as … issue #N`, a bare `issue #N`, or a
+ * `github.com/…/issues/N` URL. Not a fourth spelling invented here: the point is a machine-readable
+ * link, and a record that already writes one of these should not have to write another.
+ *
+ * `no-issue: <reason>` on any line opts out. An item that genuinely has no issue — a phase of a
+ * parent, a record split out of another — is a judgement, and one written next to the work is one
+ * the next reader can weigh.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const TASKS_PREFIX = '.agents/tasks/';
+
+/** The three spellings already in the tree. A record satisfying any of them names its issue. */
+export const ISSUE_LINK_PATTERNS = [
+  /Registered as[^\n]{0,60}issue #\d+/,
+  /\bissue #\d+/,
+  /github\.com\/[^)\s]+\/issues\/\d+/,
+];
+
+/** `no-issue: <reason>` — a deliberate exception, written where the next reader will find it. */
+const OPT_OUT = /no-issue:\s*(\S.*)/i;
+
+/** Does this record name the issue that registered it, or say why it has none? */
+export function namesItsIssue(content) {
+  return OPT_OUT.test(content) || ISSUE_LINK_PATTERNS.some((pattern) => pattern.test(content));
+}
+
+/** A phase of a parent carries the parent's registration. Same convention the collision scan uses. */
+export function isPhaseRecord(relativePath) {
+  return /^[A-Z][A-Z0-9]*-\d+-[Pp]\d+[a-z]?-/.test(path.basename(relativePath));
+}
+
+/** Is this a task record with a work-item ID? README.md and un-prefixed files are not. */
+export function isTaskRecord(relativePath) {
+  return (
+    relativePath.startsWith(TASKS_PREFIX) &&
+    relativePath.endsWith('.md') &&
+    /^[A-Z][A-Z0-9]*-\d+-/.test(path.basename(relativePath))
+  );
+}
+
+/**
+ * The task records a change ADDS, relative to `baseRef`.
+ *
+ * `--diff-filter=A` only: a change that edits an existing record must not be asked to back-fill a
+ * link it never claimed to have. Fail-closed — an unreadable diff throws rather than reporting an
+ * empty set, because "no new records" and "could not look" are different answers.
+ */
+export function addedTaskRecords(baseRef, root = WORKSPACE_ROOT) {
+  const result = spawnSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=A', `${baseRef}...HEAD`, '--', TASKS_PREFIX],
+    { cwd: root, encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `task-record-issue-link: could not read the diff against \`${baseRef}\` — the measurement ` +
+        `FAILED, so no verdict can be reported from it.\n${result.stderr ?? ''}`,
+    );
+  }
+  return (result.stdout ?? '').split('\n').filter(Boolean).filter(isTaskRecord);
+}
+
+/** Every added record that names no issue and claims no exception. */
+export function findUnlinkedRecords(baseRef, root = WORKSPACE_ROOT) {
+  const findings = [];
+  for (const relative of addedTaskRecords(baseRef, root)) {
+    if (isPhaseRecord(relative)) continue;
+    const file = path.join(root, relative);
+    // Added-then-deleted in the same range: nothing to judge, and reading it would throw.
+    if (!existsSync(file)) continue;
+    if (namesItsIssue(readFileSync(file, 'utf8'))) continue;
+    findings.push(relative);
+  }
+  return findings;
+}

--- a/scripts/harness/task-record-issue-link.mjs
+++ b/scripts/harness/task-record-issue-link.mjs
@@ -85,17 +85,31 @@ export function namesItsIssue(content) {
   return OPT_OUT.test(content) || ISSUE_LINK_PATTERNS.some((pattern) => pattern.test(content));
 }
 
-/** A phase of a parent carries the parent's registration. Same convention the collision scan uses. */
+/**
+ * A part of a parent carries the parent's registration. Same convention the collision scan uses,
+ * and the same two spellings: a numbered phase (`-p7-`, `-P4-`) and a lettered split (`-A-` … `-F-`,
+ * which `INFRA-BL-009` uses across six files).
+ */
 export function isPhaseRecord(relativePath) {
-  return /^[A-Z][A-Z0-9]*-\d+-[Pp]\d+[a-z]?-/.test(path.basename(relativePath));
+  return new RegExp(`^${ID_PREFIX}-(?:[Pp]\\d+[a-z]?|[A-Z])-`).test(path.basename(relativePath));
 }
+
+/**
+ * The shape of a work-item ID, prefix included.
+ *
+ * Multi-segment prefixes are real and common: `ARCH-FIX-020`, `INFRA-BL-009`, `DQ-AUDIT-005`.
+ * Reported in review — requiring the digits after the FIRST segment excluded 97 records, and a new
+ * `ARCH-FIX-022-…` would have been SILENTLY exempt from the requirement this module imposes. A rule
+ * that does not reach part of its population is a rule about the part it reaches.
+ */
+const ID_PREFIX = '[A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\\d+';
 
 /** Is this a task record with a work-item ID? README.md and un-prefixed files are not. */
 export function isTaskRecord(relativePath) {
   return (
     relativePath.startsWith(TASKS_PREFIX) &&
     relativePath.endsWith('.md') &&
-    /^[A-Z][A-Z0-9]*-\d+-/.test(path.basename(relativePath))
+    new RegExp(`^${ID_PREFIX}-`).test(path.basename(relativePath))
   );
 }
 
@@ -129,6 +143,10 @@ export function addedTaskRecords(baseRef, root = WORKSPACE_ROOT) {
  * these links reports "no cross-source collisions" over a set that excludes every record it could
  * not read — which is issue #1916's own failure, one layer up. The pair is what makes the gap
  * visible instead of invisible.
+ *
+ * THREE numbers, after review: a record with no work-item id and a phase record are neither linked
+ * nor unlinked, and dropping them silently made the pair fail to sum to the examined total — the gap
+ * unstated on the very line that exists to make the population honest.
  */
 export function linkCoverage(
   records,
@@ -136,8 +154,15 @@ export function linkCoverage(
 ) {
   let linked = 0;
   let unlinked = 0;
+  let notJudged = 0;
   for (const relative of records) {
-    if (!isTaskRecord(relative) || isPhaseRecord(relative)) continue;
+    // Counted, not dropped. Reported in review: `994 … 87 name an issue, 696 do not` sums to 783,
+    // and the missing 211 were exactly the population the ID pattern could not see — unstated on
+    // the very line the pair exists to make honest.
+    if (!isTaskRecord(relative) || isPhaseRecord(relative)) {
+      notJudged += 1;
+      continue;
+    }
     let content;
     try {
       content = readFile(relative);
@@ -150,7 +175,7 @@ export function linkCoverage(
     if (namesItsIssue(content)) linked += 1;
     else unlinked += 1;
   }
-  return { linked, unlinked };
+  return { linked, unlinked, notJudged };
 }
 
 /** Every added record that names no issue and claims no exception. */

--- a/scripts/harness/task-record-issue-link.mjs
+++ b/scripts/harness/task-record-issue-link.mjs
@@ -27,6 +27,31 @@
  * of a comparison, and today it is on one. This is the step that makes it possible, not the step
  * that does it.
  *
+ * ## Three things this does NOT establish, said here so nobody reads the link as stronger
+ *
+ * **It does not PREVENT a collision, only make one detectable at push time.** A clone-local branch
+ * is invisible in principle to every mechanism that reads the tracked tree — not through a parsing
+ * gap that better code would close, but because the claim has not been published yet. Two sessions
+ * can still both pick the same number; the second is caught when it pushes, not when it chooses.
+ *
+ * **It does not keep the link true.** A record can cite an issue later closed as a duplicate,
+ * retitled, or transferred to another repository. That is not a collision, so a collision scan never
+ * sees it, and the cross-source comparison would then read a record and an unrelated issue as one
+ * item — the exact failure the forward-only rule exists to avoid, arriving later instead of at
+ * birth.
+ *
+ * **And it does not establish the link was ever true.** A body link is written once by whoever files
+ * the record and nothing confirms the issue is about it. A wrong-on-day-one link leaves no signal
+ * and reads as verified precisely because it is well-formed and machine-parseable. Issue #1980 is
+ * the worked example: `.github/required-status-checks.json` declared four required contexts where
+ * the live ruleset had three, and it was believed for four weeks because it was a well-formed
+ * declaration in the right file. It was not stale; it was never true.
+ *
+ * Closing those needs a live read of the issue, which no tracked-tree scan can do. The useful
+ * assertion is not "the link resolves" but "the link resolves AND that issue's title still claims
+ * this record's ID" — the same comparison, turned on the record's own claim rather than only on
+ * record-versus-record collisions.
+ *
  * ## What counts as naming the issue
  *
  * Any of the three forms already in the tree — `Registered as … issue #N`, a bare `issue #N`, or a
@@ -94,6 +119,38 @@ export function addedTaskRecords(baseRef, root = WORKSPACE_ROOT) {
     );
   }
   return (result.stdout ?? '').split('\n').filter(Boolean).filter(isTaskRecord);
+}
+
+/**
+ * How many tracked records carry a link, and how many do not.
+ *
+ * BOTH numbers, because a consumer of the link that reported its size as "records carrying a link"
+ * would be describing the population it can see and calling it the population. A later scan reading
+ * these links reports "no cross-source collisions" over a set that excludes every record it could
+ * not read — which is issue #1916's own failure, one layer up. The pair is what makes the gap
+ * visible instead of invisible.
+ */
+export function linkCoverage(
+  records,
+  readFile = (f) => readFileSync(path.join(WORKSPACE_ROOT, f), 'utf8'),
+) {
+  let linked = 0;
+  let unlinked = 0;
+  for (const relative of records) {
+    if (!isTaskRecord(relative) || isPhaseRecord(relative)) continue;
+    let content;
+    try {
+      content = readFile(relative);
+    } catch {
+      // Unreadable counts as UNLINKED, never as absent. A record this cannot open is a record a
+      // consumer cannot compare, which is the thing the pair exists to report.
+      unlinked += 1;
+      continue;
+    }
+    if (namesItsIssue(content)) linked += 1;
+    else unlinked += 1;
+  }
+  return { linked, unlinked };
 }
 
 /** Every added record that names no issue and claims no exception. */


### PR DESCRIPTION
Refs #1916 — the second half. The first half (one ID, one tracked record) landed as PR #1960.

## The half that actually bit

An ID claimed by a record in one clone and by an **issue title** opened by another session minutes earlier. Undecidable, because nothing in the tree said which issue registers which record.

Measured: **48** IDs claimed by both a record and an issue title, **39** of those records carrying no reference to that issue's number — and overwhelmingly the *same item written twice*, not two items. A scan over the union of both sources reports 39 false collisions. The missing piece was never the network. It is the link, and **87 of 798** records have one.

## The three spellings already in the tree, and no fourth

| form | records |
|---|---|
| `Registered as … issue #N` | 8 |
| a bare `issue #N` | 46 |
| a `github.com/…/issues/N` URL | 65 |

A record that already links should not have to link again in a new form. A **pull request** reference is deliberately not one: `PR #N` says what delivered the work, not what registered it.

`no-issue: <reason>` opts out — the reason is required, because a bare marker is not a judgement. A phase record (`-p7-`, `-P4-`) is exempt: it carries its parent's registration.

## Forward-only, because a retroactive sweep would be a guess

Only records a change **adds** are judged. 711 of 798 existing records carry no citation, most completed and merged; back-filling means deciding which issue each one meant, from a distance, for finished work. **A wrong link is worse than none** — the cross-source check would then read two items as one, which is the failure this item exists to remove.

## What it does NOT establish

Three peer sessions raised this from three angles while the branch was local, and all three were right. It is in the module header and the README rather than only here:

- **Not prevention — detection at push time.** A clone-local branch is invisible *in principle* to every tracked-tree mechanism. Two sessions can still both pick the same number; the second is caught when it pushes, not when it chooses.
- **Not kept true.** A cited issue can later be closed as a duplicate, retitled, or transferred. That is not a collision, so a collision scan never sees it.
- **Not established as ever true.** Wrong-on-day-one leaves no signal and reads as verified *because* it is well-formed. #1980 is the worked example — `required-status-checks.json` declared four required contexts where the ruleset had three, believed for four weeks. It was not stale; it was never true.

The useful assertion is not "the link resolves" but "the link resolves **and** that issue's title still claims this record's ID" — which needs a live read no tracked-tree scan can do.

**The evidence for the first point is this PR's own history**: three independent sessions surveyed the tree correctly and each concluded nobody held this work. The true answer surfaced only because this session volunteered it.

## The reported size names both halves

```
::examined:: 994 tracked task record(s); 87 name an issue, 696 do not
```

A consumer reporting its size as "records carrying a link" would name the population it can *see* and call it the population — this item's own failure, one layer up. `linkCoverage` counts an unreadable record as **unlinked** rather than dropping it.

## Evidence

Proved both directions on a real commit: a record with no citation is refused by name; `issue #1916` clears it; `no-issue: <reason>` clears it. 43 cases across the two files; three red-proved by breaking the rule they pin — accepting a bare `#N` (which would let a PR reference pass), accepting a reasonless opt-out, and dropping the phase exemption.

`verify-like-ci` 12/12 PASS; 135 scans pass.

## Not closing #1916

The consumer — an exact cross-source scan — needs the link on **both** sides of a comparison and today it is on one. This is the step that makes it possible, not the step that does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s