### PR TITLE
docs(harness): correct the issue-link header's central number, and record the instance that happened while reviewing it

### DIFF
--- a/scripts/harness/task-record-issue-link.mjs
+++ b/scripts/harness/task-record-issue-link.mjs
@@ -8,10 +8,22 @@
  *
  * ## The missing piece was never the network
  *
- * Measured when this landed: 48 IDs are claimed by both a record and an issue title, and 39 of those
- * records carry no reference to that issue's number — yet they are overwhelmingly the SAME item
- * written twice, not two items. So a scan over the union of both sources reports 39 false
- * collisions. What is absent is the LINK, and 87 of 798 records have one in any form.
+ * Measured with the predicates this module ships — `namesItsIssue` and `ISSUE_LINK_PATTERNS` — over
+ * the 48 IDs claimed by BOTH a record and an issue title:
+ *
+ *   44  the record names that issue's own number
+ *    3  the record names a DIFFERENT issue (`ARCH-037`→#1805 cites 1764/1773; `ARCH-039`→#1828
+ *       cites 1764; `HARNESS-074`→#1619 cites 1615)
+ *    1  the record names none at all (`HARNESS-058`→#1571)
+ *
+ * So the gap is FOUR citation lines in four named files, not a wait for new records to accumulate.
+ * A first cut of this header said 39, which was a frontmatter-only count carried over from the
+ * item's discussion, and two attempts to re-derive it here produced 39 and then 2 — both from a
+ * `#\d+\b` pattern whose `\b` does nothing after a digit. The number that survived was the one a
+ * reviewer measured independently and this session then reproduced. Recorded because the wrong
+ * figure was the load-bearing one: it made the burn-down look unbounded when it is four lines.
+ *
+ * Across the whole tree the link is on 87 of 798 records.
  *
  * Requiring it makes the cross-source comparison exact: an ID claimed by a record and by an issue
  * the record names is one item; an ID claimed by a record and by an issue it does NOT name is two.

--- a/scripts/harness/task-record-issue-link.mjs
+++ b/scripts/harness/task-record-issue-link.mjs
@@ -25,6 +25,18 @@
  *
  * Across the whole tree the link is on 87 of 798 records.
  *
+ * ## The best instance of this defect happened while fixing it
+ *
+ * The three collisions this item was opened for were between two CLONES, minutes apart. A fourth
+ * happened during the review of this module: a reviewer read the branch at one head, posted a clean
+ * verdict, and merged — and by then the head had moved by one commit. The merge took the corrected
+ * CODE and left the uncorrected HEADER, which is this file's own subject with the halves swapped:
+ * the part a future reader trusts was the part that was wrong.
+ *
+ * The window there was not another clone and not minutes. It was seconds on one pull request, and
+ * re-reading the head immediately before writing would have closed it. That is the general shape —
+ * a claim true when written, acted on after the facts moved — and it does not need two machines.
+ *
  * Requiring it makes the cross-source comparison exact: an ID claimed by a record and by an issue
  * the record names is one item; an ID claimed by a record and by an issue it does NOT name is two.
  *


### PR DESCRIPTION
Refs #1916. Follow-up to PR #2011, which merged the corrected **code** and left the uncorrected **header**.

## What was wrong

The module header said 39 records claim an ID that an issue title also claims while naming no issue — carried over from the item's discussion, where it was a **frontmatter-only** count. This module's predicate is `namesItsIssue`, which reads the body.

Measured with the predicates the module actually ships, over the 48 IDs claimed by both a record and an issue title:

| | |
|---|---|
| **44** | the record names that issue's own number |
| **3** | the record names a **different** issue — `ARCH-037` (issue #1805) cites 1764/1773; `ARCH-039` (issue #1828) cites 1764; `HARNESS-074` (issue #1619) cites 1615 |
| **1** | the record names none at all — `HARNESS-058` (issue #1571) |

So the gap is **four citation lines in four named files**, not a wait for new records to accumulate. The header made a bounded, nameable burn-down look unbounded — and it is the number a reader would act on.

The three-citing-a-different-issue case is the more interesting one: a well-formed, machine-parseable link pointing at the wrong thing. That is the never-true shape with four live instances, and it is a stronger argument for "the link resolves **and** that issue still claims this ID" than prose about it.

## How this session got the number wrong twice

Re-deriving it here produced **39**, then **2**, then **44**. The first two used a number pattern ending in `\b` — which matches nothing after a digit, so a record citing `#1617` failed to match `#1617`. Three measurements of one population, two wrong through the same one-character defect, and the one that held was produced independently by a reviewer and then reproduced here.

That post-mortem is in the header, not only in the commit: the next person to re-measure will reach for the same pattern.

## The fourth instance of this defect happened while reviewing the fix

The three collisions #1916 was opened for were between two **clones**, minutes apart — which invites the reading that the defect needs a second machine. It does not.

PR #2011 was reviewed at one head, given a clean verdict, and merged — and the head had moved by one commit in between. The merge took the corrected code and left the uncorrected header: **this module's own subject with the halves swapped**, the half a future reader trusts being the wrong one.

Seconds, one pull request, one person. Re-reading the head immediately before writing would have closed it. Recorded in the module so the next reader does not treat multi-clone work as the precondition.

`verify-like-ci` 12/12 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s