### PR TITLE
docs(tasks): INFRA-126 says what shipped, and why it is not done

### DIFF
--- a/.agents/tasks/INFRA-126-harness-tests-leak-a-temp-dir-per-test.md
+++ b/.agents/tasks/INFRA-126-harness-tests-leak-a-temp-dir-per-test.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-126: the harness test suite leaks a temp directory per test, and exhausting /tmp inodes stops every push on the host'
-status: todo
+status: in-progress
 created: 2026-08-22
 priority: high
 urgency: now
@@ -94,6 +94,27 @@ Making `makeTemp()` the only sanctioned creator removes the judgement entirely: 
 the CALL SITE, which is textual and exact, rather than the teardown, which is behavioural and is not.
 It also fixes the denominator — the burn-down is every direct call under `__tests__` (**158 files**),
 not only the 85 that currently leak.
+
+## What shipped, and what has not
+
+The MECHANISM is on `main`: `scripts/harness/__tests__/make-temp.mjs` as the sanctioned creator, and
+the `temp-dir-owner` floor refusing a direct call in either spelling regardless of teardown —
+registered, classified in `MANDATORY_TREE_GUARDS` and in `measurement-provenance` `covered`, with its
+own tests.
+
+**The leak is capped, not closed.** 155 files still call `mkdtemp`/`mkdtempSync` directly and are
+frozen in `temp-dir-owner-baseline.json`; each still leaves a directory per test case on every run.
+What the floor prevents is a 156th, and what the burn-down measures is the distance to zero.
+
+So this record stays open, and `in-progress` rather than `done`: the defect it names — the suite
+exhausting `/tmp` inodes — is still reachable from those 155, only more slowly and without growing.
+It becomes `done` when the frozen set is empty, at which point the baseline file is itself the
+evidence and can be removed with the floor left in place.
+
+Five files were migrated as the first burn-down step and measured at ZERO leaked directories across a
+real run. That measurement is what establishes migration works, rather than that it compiles: the
+first cut of the helper registered its teardown lazily, passed every unit assertion, and removed
+nothing.
 
 ## Test Plan
 


### PR DESCRIPTION
INFRA-126's mechanism reached `main` through PR #1983 and the promotion. The record still said
`todo`. A peer measured it and flagged it rather than leaving a scan to find it later.

## Corrected to `in-progress`, not to `done`

That distinction is the substantive part of this change.

**The leak is capped, not closed.** 155 files still call `mkdtemp`/`mkdtempSync` directly and are
frozen in `temp-dir-owner-baseline.json`; each still leaves a directory per test case on every run.
What the floor prevents is a **156th**. The defect this record names — the suite exhausting `/tmp`
inodes — is still reachable from those 155, only more slowly and without growing.

The record now carries the terminal condition it never had: **`done` when the frozen set is empty**,
at which point the baseline is itself the evidence and can be deleted with the floor left in place.

## Why a sentence and not a checkbox

Completion criteria live in the spec-doc by this tree's own separation — `.agents/tasks/README.md`:
*"A spec-doc is a plan under a gate pipeline: prior art, alternatives, a decision, TC-numbered
completion criteria, a test plan. A Task is the problem statement."*

Measured before deciding: **96 of 110 active records (87%) carry no checkbox at all.** A Task without
criteria is the documented shape, not an escape from `unmet-criteria`.

That measurement also killed an issue I was about to file. The peer's suggestion was that a record
with zero criteria is a hole in the done-gate; filing it would have been filing against the
documented separation and against 96 records.

## What survives from the observation

Narrower, and it belongs to the other scan rather than here: `unmet-criteria` judges criteria **that
exist**, which is correct — but for 87% of records there is nothing to judge, so its declared size
should say how many of the records it judged carried criteria at all. That is `common-mistakes` 93's
rule applied to a gate: *a report states what it could not see, or its number reads as coverage.*

## Also recorded

The new section notes that five files were migrated and measured at **zero leaked directories** over
a real run — the measurement rather than the compile, because the first cut of the helper registered
its teardown lazily, passed every unit assertion, and removed nothing.

## Verification

`pnpm harness:scan` — **134 passed, 2 skipped, 0 failed**. Implementation confirmed on `origin/main`
by reading the ref, not by trusting the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc8Cy57xP1AyHj8LsDGqcx
