### PR TITLE
docs(tasks): INFRA-046's blocking evidence arrived, and INFRA-054's preconditions moved

### DIFF
--- a/.agents/tasks/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/INFRA-046-promote-advisory-gates.md
@@ -344,3 +344,64 @@ with the owner on 2026-08-22, who declined to add it now, knowing the permission
 
 So the block is EVIDENCE, and only evidence. The earlier framing — "blocked on evidence first, a
 credential second" — was half wrong: there was never a credential half.
+
+## 2026-08-22 (later) — the evidence this item was blocked on HAS ARRIVED
+
+The block was stated precisely, so it can be discharged precisely:
+
+> `accidental-green` has never fired on a real pull request, so requiring it would put an untested
+> refusal into the merge path of every PR. **One observed firing is what promotes it.**
+
+**It fired. Twice, on a real pull request, today.** PR #1983 (`feat/infra-126-temp-dir-owner`):
+
+```
+$ gh run list --branch feat/infra-126-temp-dir-owner
+  01:30  CI  failure     -> regression-red-proof (enforcing: accidental-green only)  FAILURE
+  01:44  CI  failure     -> regression-red-proof (enforcing: accidental-green only)  FAILURE
+  02:02  CI  success     -> regression-red-proof (enforcing: accidental-green only)  success
+```
+
+The head SHAs are deliberately not quoted here: the branch was deleted on merge, so they resolve
+for nobody. The durable citation is the pull request and its check runs.
+
+The verdict, read out of the failing run's log rather than from anyone's report of it:
+
+```
+❌  scripts/harness/run-all-scans.mjs: accidental-green-fail (all-pass)
+❌ accidental-green: a regression test passes even with the fix reversed — it guards nothing.
+   Rewrite it to FAIL on the pre-fix code, or opt out with `allow-green-at-base: <reason>`.
+```
+
+**It was right, and the defect it caught was real.** The author's `run-all-scans.mjs` registration
+hunk could be reversed with every changed test still passing — the wiring was proven only by hand.
+Their two attempted fixes landed in files the pairing cannot reach, so the tool kept refusing; the
+fix that satisfied it asserted against the IMPORTED `SCAN_COMMANDS` rather than the registry file's
+text. It went green only once the assertion could actually judge a reversal.
+
+So this was not a false positive, not a flake, and not a self-inflicted probe: a live pull request,
+an unguarded registration, a refusal, and a genuine repair.
+
+**The three inconclusive lines matter too, and in the gate's favour.** `examined-adoption-baseline.json`,
+`measurement-provenance-pending.json` and a newly-added file each reported `inconclusive` with a
+stated reason — _"the range added this file and never revised it, so there is no earlier state to
+reverse to… which is not a verdict."_ The tool distinguishes "cannot judge" from "judged and passed",
+which is the property that makes a refusal from it worth trusting.
+
+**Status stays `blocked`, and the reason is now different from what it was this morning.** The
+evidence condition is MET; what remains is the branch-protection change itself, which is an owner
+decision and was declined earlier today on grounds that no longer hold. The owner declined knowing
+the credential exists (`permissions.admin: true`) and knowing the gate had never fired. The second
+half of that is no longer true.
+
+**What promoting it would now mean, stated so the decision is not made on a summary:** adding
+`regression-red-proof` to `protect-develop`'s required list makes an `accidental-green` verdict block
+a merge. On today's evidence that refusal is reachable, correct, and repairable by the author without
+help — three rounds, no assistance, no override used. The counter-argument is cost: it took the
+author roughly thirty minutes and two wrong fixes to satisfy, and that lands on every PR that trips
+it.
+
+**Related, and it must be settled first or in the same change:** issue #1980 records that
+`protect-main`'s live required list does not match its declaration, and that the ruleset has not been
+modified since 2026-07-26. Any required-list edit touches the same surface, and `robota-4-aa` has
+been assigned a separate required-context addition for issue #1719. Three edits to two rulesets by
+two agents is exactly how the issue #1980 half-application happened.

--- a/.agents/tasks/INFRA-054-fast-forward-promotion-end-state.md
+++ b/.agents/tasks/INFRA-054-fast-forward-promotion-end-state.md
@@ -145,3 +145,55 @@ The substantive grounds are unchanged, and were re-measured rather than restated
 
 The gap the probe exposed — a `done` task with unticked acceptance criteria passes every scan — is
 filed as issue #1965 rather than folded in here.
+
+## 2026-08-22 — the preconditions re-measured, and one of the three has changed
+
+The section above says _"verified 2026-07-26, do not re-assume"_. Twenty-seven days and one
+promotion later, that instruction was followed rather than the figures being carried forward.
+
+| precondition                                              | 2026-07-26 | 2026-08-22         |
+| --------------------------------------------------------- | ---------- | ------------------ |
+| non-merge commits on `main` that `develop` has never seen | **10**     | **0**              |
+| the operating account can push directly to `main`         | yes        | **yes, unchanged** |
+| `ci.yml` triggers only `on: pull_request`                 | yes        | **yes, unchanged** |
+
+```
+$ git rev-list origin/develop..origin/main --no-merges | wc -l
+0
+$ gh api repos/woojubb/robota/rulesets/18715845 --jq .current_user_can_bypass
+always      # RepositoryRole id=5, bypass_mode=always
+```
+
+**What the change does and does not mean.** The ten commits are gone as a _backlog_ — every non-merge
+commit on `main` is now reachable from `develop`, so the residue INFRA-051 left behind has been
+absorbed by ordinary promotion. That removes the cleanup this item would otherwise have had to
+perform first.
+
+It does **not** unblock the item, and the reason is worth stating precisely because the number moving
+to zero is the kind of thing that reads as progress toward "safe now":
+
+> FF promotion is only safe once **nothing can** land directly on `main`.
+
+The measurement above is about what **has** landed. The blocking condition is about what **can**. All
+three capabilities the record named are intact:
+
+- `protect-main.bypass_actors` still carries `RepositoryRole id=5` with `bypass_mode: always`, and
+  `current_user_can_bypass` is still `always` — a direct push to `main` mechanically works today;
+- `main-pr-source-guard` still admits `hotfix/*` → `main` (`ci.yml:100`);
+- Dependabot is still disabled **by policy** (`.github/DEPENDABOT-DISABLED.md`, no `dependabot.yml`),
+  not by mechanism — the marker file is a note, not a gate.
+
+So the count reaching zero is a consequence of nobody having used those capabilities recently, not of
+their removal. A fast-forward promotion made safe by "nobody has done it lately" is safe until the
+first `hotfix/*`, and then `main` diverges with no merge available to reconcile it.
+
+**This is still an owner decision, and the decision is unchanged in shape:** fast-forward promotion
+requires closing the direct-write paths first — the bypass actor, the `hotfix/*` route, or an
+enforced back-merge for it — and each of those is a branch-protection change. What today's
+measurement removes is only the argument that a backlog of stray commits must be reconciled before
+any of that can be considered.
+
+**Related and newly relevant:** issue #1980 records that `protect-main`'s live required list does not
+match its declaration, and that the ruleset has not been modified since 2026-07-26 — the same day
+this item's preconditions were first measured. Any work here touches that ruleset, so issue #1980 should be
+settled first or in the same change.


### PR DESCRIPTION
Both items were blocked on conditions their own records told the next reader to **re-measure rather
than carry forward**. Followed that instruction.

## INFRA-046 — the evidence condition is MET

The block was stated exactly, which is what makes it dischargeable:

> `accidental-green` has never fired on a real pull request … **One observed firing is what promotes it.**

It fired twice, today, on PR #1983:

```
$ gh run list --branch feat/infra-126-temp-dir-owner
  01:30  CI  failure   -> regression-red-proof (enforcing: accidental-green only)  FAILURE
  01:44  CI  failure   -> regression-red-proof (enforcing: accidental-green only)  FAILURE
  02:02  CI  success   -> regression-red-proof (enforcing: accidental-green only)  success
```

Verdict read out of the failing run's log rather than from anyone's report of it:

```
❌  scripts/harness/run-all-scans.mjs: accidental-green-fail (all-pass)
❌ accidental-green: a regression test passes even with the fix reversed — it guards nothing.
```

**It was right.** The author's `run-all-scans.mjs` registration hunk could be reversed with every
changed test still passing — the wiring was proven only by hand. Two attempted fixes landed in files
the source-to-test pairing cannot reach; the one that satisfied it asserted against the imported
`SCAN_COMMANDS`. Three other verdicts in the same run reported `inconclusive` **with the reason**
("the range added this file and never revised it, so there is no earlier state to reverse to … which
is not a verdict"), which is the property that makes a refusal from this gate worth trusting.

Not a flake, not a false positive, not a self-inflicted probe.

## INFRA-054 — one precondition moved, and it does not unblock the item

| precondition (verified 2026-07-26) | today |
| --- | --- |
| non-merge commits on `main` unseen by `develop` | **10 → 0** |
| the operating account can push directly to `main` | yes, unchanged |
| `ci.yml` triggers only `on: pull_request` | yes, unchanged |

The entry says plainly why zero is not progress toward "safe now": the measurement is about what
**has** landed; the blocking condition is about what **can**. The bypass actor
(`RepositoryRole id=5`, `bypass_mode: always`), the `hotfix/*` route (`ci.yml:100`) and
Dependabot-disabled-**by-policy** (a marker file, not a gate) are all intact. A fast-forward
promotion made safe by "nobody has done it lately" is safe until the first `hotfix/*`.

## Both stay `blocked`

What changed is that the recorded reasons now describe what is true today. INFRA-046's remaining
half is a branch-protection decision, not an evidence gap.

## Citation note

The failing head SHAs are deliberately **not** quoted: the branch was deleted on merge, so they
resolve for nobody. `commit-msg`'s `claims-resolve` check caught that in the first draft of the
commit message, and the same correction was applied to the record.

ACTIONABLE FINDINGS: 0

Refs INFRA-046, INFRA-054