### PR TITLE
feat(ci): the provenance gate becomes requireable (INFRA-097, issue #1719)

### DIFF
--- a/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
@@ -81,6 +81,50 @@ registry state something untrue. The same held-membership shape `regression-red-
 
 ## Progress
 
+### 2026-08-22 — the requireable half, owner-assigned
+
+The owner assigned the fifth step, which the item had held as theirs. Making the context REQUIRED has
+prerequisites the item did not name, and they were found by trying:
+
+**The gate was inert for two hours and nothing said so.** `workflow-provenance-gate.yml` reached
+`develop` at 01:11 UTC and GitHub registered the workflow at **03:21:51 UTC — two seconds after the
+promotion that carried it to `main` merged**. A `pull_request_target` workflow is not registered until
+it lands on the DEFAULT branch, so pull requests #2010, #2011, #2012 and #2013 got no run at all,
+while pull request #2015 (opened at 03:28) got one four seconds after it opened. Measured through
+`gh api .../actions/workflows/workflow-provenance-gate.yml/runs`: `total_count` was 2, both after
+registration. Requiring the context before that moment would have blocked every open pull request
+permanently — the issue #1436 shape.
+
+**R7 was unsatisfied and would have shipped the retarget hole.** The trigger declared
+`types: [opened, synchronize, reopened]`. `edited` is the only activity a base retarget fires and
+GitHub's default set omits it, so a branch moved `develop`->`main` would have kept the conclusion it
+earned against the OLD base while branch protection reported the context satisfied — PR #1442's
+measured shape, on the other plane. Added.
+
+**R2 refused the fix as if it were the defect.** `scan-main-required-checks` read only
+`^  pull_request:`, so the one workflow whose plane is the entire point reported "declares no
+`pull_request:` trigger this scan can read". The rule is about whether a required context can FAIL,
+which is plane-independent; it now accepts either plane and names which one it found in every message.
+
+**The self-guarding case was inverted, not excepted.** A test asserted the gate must NOT be in the
+guarded set, reasoning that a change editing it "would be judged by the edited version". That is true
+of a `pull_request` workflow and false of this one — `pull_request_target` loads the definition from
+the base, which is why the plane was split. Once the gate provides a required context it SHOULD guard
+itself, and the test now asserts that plus the two properties that make it safe.
+
+Landed here: the `edited` type, the two-plane R2, the `workflow provenance` registration under BOTH
+branches in `.github/required-status-checks.json`, and a `guarded-workflow` relevance key so
+`verify-like-ci` does not mark the context irrelevant on exactly the diffs it judges (a workflow edit
+is not `code` to the `changes` classifier).
+
+**Not yet done, and it is the last action:** flipping the live rulesets. It is deliberately last —
+the declaration is now what `ruleset-drift` reconciles against, and the window between the two states
+is why this is a sequence rather than one edit.
+
+**Adjacent, measured, and NOT fixed here:** `protect-main` requires three contexts live while the
+declaration names four — `promotion closes` was never added. That is issue #1980 and it is a separate
+item; recorded because the live read for this step surfaced it again.
+
 ### 2026-08-17 — detection landed; trusted provenance remains an owner decision
 
 `scripts/harness/scan-workflow-provenance.mjs` is registered in `pnpm harness:scan`.

--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -88,6 +88,15 @@
           "local": {
             "notRunnable": "ci-mirror-map NOT_MIRRORED"
           }
+        },
+        {
+          "context": "workflow provenance",
+          "workflow": ".github/workflows/workflow-provenance-gate.yml",
+          "job": "provenance",
+          "verifies": "INFRA-097 / issue #1719 — the trusted control plane. It answers the one question that can be answered without running anything: does this pull request modify a file that a REQUIRED check loads? It runs on `pull_request_target`, which loads its own definition from the BASE branch, so a pull request cannot change what this gate says about it — an edit takes effect only after merge, which is after the gate it would have moved has run. It checks out the base and only the base, FETCHES the head without checking it out (reading a file name is not running the file), installs nothing, and holds `contents: read`. That is what turns a self-edit of the control plane from VISIBLE into UNMERGEABLE.",
+          "local": {
+            "notRunnable": "ci-mirror-map NOT_MIRRORED"
+          }
         }
       ],
       "deliberately_not_required": [
@@ -132,7 +141,7 @@
           "context": "promotion closes",
           "workflow": ".github/workflows/ci.yml",
           "job": "promotion-closes",
-          "verifies": "INFRA-104 \u2014 the promotion body carries a closing keyword for every OPEN issue the pull requests it promotes declared they close. GitHub reads closing keywords only on a default-branch pull request, so the keyword on each feature\u2192develop PR closes nothing (#1802 `Closes #1750`, #1816 `Closes #1722` \u2014 both merged, both issues left open) and the promotion is the only pull request that can carry them. The requirement is DERIVED from the promotion's own commit subjects, not from what the body claims: each `(#NNNN)` suffix resolves to that PR's body, each `Closes #N` in it is confirmed to be an OPEN issue (not a Task ID \u2014 PR #1801's body says `Closes PROV-007.`) through the issues API, and a derivation that cannot complete BLOCKS rather than reporting an empty requirement.",
+          "verifies": "INFRA-104 — the promotion body carries a closing keyword for every OPEN issue the pull requests it promotes declared they close. GitHub reads closing keywords only on a default-branch pull request, so the keyword on each feature→develop PR closes nothing (#1802 `Closes #1750`, #1816 `Closes #1722` — both merged, both issues left open) and the promotion is the only pull request that can carry them. The requirement is DERIVED from the promotion's own commit subjects, not from what the body claims: each `(#NNNN)` suffix resolves to that PR's body, each `Closes #N` in it is confirmed to be an OPEN issue (not a Task ID — PR #1801's body says `Closes PROV-007.`) through the issues API, and a derivation that cannot complete BLOCKS rather than reporting an empty requirement.",
           "local": {
             "entryPoint": "node scripts/harness/scan-promotion-closes.mjs --pr <n> --repo <owner/name>",
             "note": "the --pr argument is part of the entry point: the verdict is computed from a live pull request's commits, body and referenced issue states. With no PR there is nothing to judge, and a run that invented one would report a pass over a promotion it never saw."
@@ -145,6 +154,15 @@
           "verifies": "`pnpm harness:verify:release` — the only required context that executes the repository's code on a promotion: full build, full scan suite, harness suite, typecheck, lint, an unconditional osv-scanner, and the workspace test suites. SPANS, corrected by INFRA-063 because the earlier wording read as total: every workspace script named exactly `test` (via `pnpm run -r --if-present test`), plus every suite declared under another `test:*` name that `scripts/harness/release-test-suites.mjs` enumerates — `test:bin` today, and whatever is added next without anyone editing a list. DOES NOT SPAN, by declaration rather than by silence: `test:pty` (runs as the required `tui-e2e` context on the develop PR of every commit a promotion carries), `test:live` and `test:bun` (need provider credentials / a Bun toolchain no runner has), the `test:coverage` and `test:watch` variants of suites already run, and `apps/agent-app`'s Electron e2e pair, which no workflow runs at all and is recorded as debt. `scan-release-sweep-coverage.mjs` re-verifies each of those claims on every scan run and turns a new unaccounted-for `test:*` script red.",
           "local": {
             "entryPoint": "pnpm harness:verify:release"
+          }
+        },
+        {
+          "context": "workflow provenance",
+          "workflow": ".github/workflows/workflow-provenance-gate.yml",
+          "job": "provenance",
+          "verifies": "INFRA-097 / issue #1719 — the trusted control plane. It answers the one question that can be answered without running anything: does this pull request modify a file that a REQUIRED check loads? It runs on `pull_request_target`, which loads its own definition from the BASE branch, so a pull request cannot change what this gate says about it — an edit takes effect only after merge, which is after the gate it would have moved has run. It checks out the base and only the base, FETCHES the head without checking it out (reading a file name is not running the file), installs nothing, and holds `contents: read`. That is what turns a self-edit of the control plane from VISIBLE into UNMERGEABLE.",
+          "local": {
+            "notRunnable": "the verdict is computed from a live pull request's changed-file list against its base. Off a real pull request there is no file list to read, so a local run would either invent one or report a pass over a control plane it never inspected — the vacuity this gate exists to close."
           }
         }
       ],

--- a/.github/workflows/workflow-provenance-gate.yml
+++ b/.github/workflows/workflow-provenance-gate.yml
@@ -38,7 +38,12 @@ name: Workflow Provenance Gate
 on:
   pull_request_target:
     branches: [main, develop]
-    types: [opened, synchronize, reopened]
+    # `edited` is not decoration and not GitHub's default. Retargeting a pull request's base fires it
+    # and nothing else does, so without it a branch moved develop->main keeps the conclusion it
+    # earned against the OLD base while branch protection reports the context satisfied. Measured on
+    # throwaway PR #1442 for the `pull_request` plane; the same hazard applies here, and it is why
+    # `scan-main-required-checks` R7 treats an absent or `edited`-less `types:` as the FAILING case.
+    types: [opened, synchronize, reopened, edited]
 
 # Read-only, and stated rather than inherited. A `pull_request_target` job runs against the base with
 # whatever the default token grants; narrowing it here is what makes "this job cannot change

--- a/scripts/harness/__tests__/scan-main-required-checks.test.mjs
+++ b/scripts/harness/__tests__/scan-main-required-checks.test.mjs
@@ -322,16 +322,61 @@ describe('scan-main-required-checks parsing helpers', () => {
 
   it('reads the pull_request trigger, inline and block branch lists', () => {
     expect(pullRequestTrigger(TRIGGER)).toEqual({
+      kind: 'pull_request',
       branches: ['main', 'develop'],
       types: ['opened', 'synchronize', 'reopened', 'edited'],
       hasPathFilter: false,
     });
     expect(
       pullRequestTrigger('on:\n  pull_request:\n    branches:\n      - main\n      - develop\n'),
-    ).toEqual({ branches: ['main', 'develop'], types: undefined, hasPathFilter: false });
+    ).toEqual({
+      kind: 'pull_request',
+      branches: ['main', 'develop'],
+      types: undefined,
+      hasPathFilter: false,
+    });
     expect(
       pullRequestTrigger("on:\n  pull_request:\n    paths-ignore:\n      - '**/*.md'\n"),
-    ).toEqual({ branches: [], types: undefined, hasPathFilter: true });
+    ).toEqual({ kind: 'pull_request', branches: [], types: undefined, hasPathFilter: true });
+  });
+
+  // INFRA-097. The trusted control plane runs on `pull_request_target` BECAUSE `pull_request` loads
+  // its definition from the pull request under test. A reader that knew only the first would have
+  // reported R2 "declares no trigger this scan can read" for the one workflow whose plane is the
+  // point — refusing the fix as if it were the defect.
+  it('[R2] reads a pull_request_target trigger and names which plane it found', () => {
+    expect(
+      pullRequestTrigger(
+        'on:\n  pull_request_target:\n    branches: [main, develop]\n    types: [opened, synchronize, reopened, edited]\n',
+      ),
+    ).toEqual({
+      kind: 'pull_request_target',
+      branches: ['main', 'develop'],
+      types: ['opened', 'synchronize', 'reopened', 'edited'],
+      hasPathFilter: false,
+    });
+  });
+
+  // The two planes are distinguished, not conflated: `pull_request:` must not match the longer key,
+  // or a `pull_request_target`-only workflow would be reported under the wrong name in every message.
+  it('does not read `pull_request_target:` as `pull_request:`', () => {
+    const target = pullRequestTrigger(
+      'on:\n  pull_request_target:\n    branches: [main]\n    types: [edited]\n',
+    );
+    expect(target?.kind).toBe('pull_request_target');
+    const plain = pullRequestTrigger('on:\n  pull_request:\n    branches: [main]\n');
+    expect(plain?.kind).toBe('pull_request');
+    expect(pullRequestTrigger('on:\n  push:\n    branches: [main]\n')).toBeUndefined();
+  });
+
+  // R7 is about the RETARGET path and is plane-independent: `edited` is absent from GitHub's default
+  // activity set on both, so a base moved develop->main re-dispatches nothing either way.
+  it('[R7] applies to the target plane too — an `edited`-less types: is still the failing case', () => {
+    const trigger = pullRequestTrigger(
+      'on:\n  pull_request_target:\n    branches: [main]\n    types: [opened, synchronize]\n',
+    );
+    expect(trigger?.kind).toBe('pull_request_target');
+    expect(trigger?.types).not.toContain('edited');
   });
 
   // The scoping-bug class this suite already caught once (a `paths-ignore:` block list parsed as
@@ -340,6 +385,11 @@ describe('scan-main-required-checks parsing helpers', () => {
     const trigger = pullRequestTrigger(
       "on:\n  pull_request:\n    branches:\n      - main\n    types:\n      - edited\n    paths-ignore:\n      - '**/*.md'\n",
     );
-    expect(trigger).toEqual({ branches: ['main'], types: ['edited'], hasPathFilter: true });
+    expect(trigger).toEqual({
+      kind: 'pull_request',
+      branches: ['main'],
+      types: ['edited'],
+      hasPathFilter: true,
+    });
   });
 });

--- a/scripts/harness/__tests__/scan-workflow-provenance.test.mjs
+++ b/scripts/harness/__tests__/scan-workflow-provenance.test.mjs
@@ -78,8 +78,14 @@ describe('workflow-provenance — criteria are READ from the registry (INFRA-097
     const { workflows } = readGuardedWorkflows(WORKSPACE_ROOT);
 
     // Exactly the files that provide a required context today. Adding a required check in a new
-    // workflow must govern that workflow with no code change here.
-    expect(workflows).toEqual(['.github/workflows/ci.yml', '.github/workflows/review-gate.yml']);
+    // workflow must govern that workflow with no code change here — and INFRA-097 step 5 is the
+    // demonstration: registering `workflow provenance` put the gate itself into this set, derived,
+    // with nothing edited here.
+    expect(workflows).toEqual([
+      '.github/workflows/ci.yml',
+      '.github/workflows/review-gate.yml',
+      '.github/workflows/workflow-provenance-gate.yml',
+    ]);
   });
 
   it('names which contexts each guarded workflow provides', () => {
@@ -217,13 +223,20 @@ describe('workflow-provenance — a change that moves its own gate (INFRA-097)',
 });
 
 describe('workflow-provenance — this repository (INFRA-097)', () => {
-  it('reports both guarded workflows as PR-loaded, which is the exposure INFRA-097 tracks', () => {
+  it('reports two of three guarded workflows as PR-loaded — the third is the trusted plane', () => {
     const { selfLoading, examined } = findWorkflowProvenanceFindings(WORKSPACE_ROOT);
 
-    // If this ever shrinks, a trusted-provenance design landed and INFRA-097 should be revisited —
-    // which is exactly the signal the issue wants kept visible.
-    expect(examined).toBe(2);
+    // The earlier case asserted 2 of 2 and said: "if this ever shrinks, a trusted-provenance design
+    // landed and INFRA-097 should be revisited." It has. `workflow provenance` became a required
+    // context in step 5, which pulled its own workflow into the guarded set — and that workflow is
+    // the one file here that does NOT load from the pull request, because it runs on
+    // `pull_request_target`. So the ratio, not the count, is the live signal: the exposure is now
+    // named as two specific files rather than as "everything required".
+    expect(examined).toBe(3);
     expect(selfLoading).toHaveLength(2);
+    expect(selfLoading.map((finding) => finding.workflow ?? finding)).not.toContain(
+      '.github/workflows/workflow-provenance-gate.yml',
+    );
   });
 });
 

--- a/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
+++ b/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
@@ -31,6 +31,27 @@ describe('the gate loads its definition from a place the pull request cannot edi
     expect(GATE).toMatch(/^on:\n\s{2}pull_request_target:/m);
     expect(GATE).not.toMatch(/^\s{2}pull_request:/m);
   });
+
+  // A required context must be able to REPORT on every shape of pull request that can reach it, and
+  // a retarget is one of those shapes. `edited` is the only activity that fires when a base moves,
+  // and GitHub's default set omits it — so without this line a branch retargeted develop->main would
+  // keep the conclusion it earned against the OLD base while branch protection reports the context
+  // satisfied. Measured on throwaway PR #1442 for the other plane; `scan-main-required-checks` R7
+  // encodes it, and this asserts the gate itself satisfies the rule it is about to be required under.
+  it('handles `edited`, so a base retarget re-dispatches instead of keeping a stale conclusion', () => {
+    const types = /^\s{4}types:\s*\[(.*)\]/m.exec(GATE)?.[1] ?? '';
+    expect(types).toMatch(/\bedited\b/);
+    expect(types).toMatch(/\bopened\b/);
+    expect(types).toMatch(/\bsynchronize\b/);
+    expect(types).toMatch(/\breopened\b/);
+  });
+
+  // The other half of R2: a path filter means some pull-request shape never triggers the workflow at
+  // all, and a required context that never reports blocks the pull request forever with no way to
+  // satisfy it (the #1436 rollback).
+  it('carries no paths filter, so no pull request shape escapes it', () => {
+    expect(GATE).not.toMatch(/^\s{4}paths(-ignore)?:/m);
+  });
 });
 
 describe('and never runs the pull request it is judging', () => {
@@ -75,11 +96,23 @@ describe('what it judges', () => {
     expect(workflows.length).toBeGreaterThan(0);
   });
 
-  it('is NOT itself in the guarded set, which would be circular', () => {
-    // If this file provided a required check, it would guard itself — and a change editing it would
-    // be judged by the edited version, which is the exposure one level up.
+  // INFRA-097 step 5 CORRECTS this case rather than keeping it. It previously asserted the gate was
+  // NOT in the guarded set, reasoning that self-guarding meant "a change editing it would be judged
+  // by the edited version". That premise is true of a `pull_request` workflow and FALSE of this one,
+  // which is the whole reason the plane was split: `pull_request_target` loads its definition from
+  // the BASE, so a change editing this file is judged by the base's copy of it, and the edit takes
+  // effect only after merge — after the gate it would have moved has already run.
+  //
+  // So once this gate provides a required context it SHOULD guard itself: an edit to the control
+  // plane's own control plane is exactly the change that must not pass unnoticed. The safety is not
+  // the exclusion; it is `pull_request_target` plus checking out no head ref, both asserted above.
+  it('IS in the guarded set once it provides a required context, and that is safe', () => {
     const { workflows } = readGuardedWorkflows(ROOT);
-    expect(workflows).not.toContain(GATE_RELATIVE);
+    expect(workflows).toContain(GATE_RELATIVE);
+    // The two properties that make self-guarding safe rather than circular. If either regressed, the
+    // inclusion above would become the exposure the old assertion feared.
+    expect(GATE).toMatch(/^on:\n\s{2}pull_request_target:/m);
+    expect(STEPS).not.toMatch(/ref:\s*\$\{\{\s*github\.event\.pull_request\.head/);
   });
 });
 

--- a/scripts/harness/ci-mirror-map.mjs
+++ b/scripts/harness/ci-mirror-map.mjs
@@ -212,6 +212,15 @@ export const NOT_MIRRORED = [
   },
 
   {
+    context: 'workflow provenance',
+    reason:
+      "runs on `pull_request_target` and judges the pull request's CHANGED-FILE LIST against the workflows that provide a required context, reading both from the base. Off a real pull request there is no file list and no base to compare it to, so a local run would either invent one or report a pass over a control plane it never inspected — which is the vacuity INFRA-097 built this gate to close.",
+    relevance: 'guarded-workflow',
+    relevantWhen: 'the diff touches any file under `.github/workflows/`',
+    manualCommand:
+      'node scripts/harness/scan-workflow-provenance.mjs --base-ref <base-sha> --head-ref <head-sha>   (the arguments are part of the entry point: with neither, the scan reports the standing exposure and judges no change)',
+  },
+  {
     context: 'review-gate',
     reason:
       "reads GitHub's code-scanning API for this PR's merge ref and compares it against the base branch. Both sides only exist once CodeQL has analysed a real pull request, so there is nothing a local run could read — a mirror would either invent the input or report a pass over an analysis that was never performed, which is the exact defect INFRA-048 built this gate to close.",
@@ -224,7 +233,7 @@ export const NOT_MIRRORED = [
 ];
 
 /** The relevance keys the runner knows how to evaluate. */
-export const RELEVANCE_KEYS = ['manifest-or-lockfile', 'code'];
+export const RELEVANCE_KEYS = ['manifest-or-lockfile', 'code', 'guarded-workflow'];
 
 /**
  * `run:` steps of a mirrored job that are CI infrastructure rather than a check: provisioning the

--- a/scripts/harness/scan-main-required-checks.mjs
+++ b/scripts/harness/scan-main-required-checks.mjs
@@ -20,7 +20,12 @@
  * actually fail on a `main` PR:
  *
  *   R1  The context resolves to exactly one job in the declared workflow.
- *   R2  The workflow triggers on `pull_request` for `main`, with no `paths`/`paths-ignore` filter.
+ *   R2  The workflow triggers on `pull_request` OR `pull_request_target` for `main`, with no
+ *       `paths`/`paths-ignore` filter. Both planes dispatch off the base branch and both can carry a
+ *       required context, so accepting only the first would have made INFRA-097's trusted control
+ *       plane unrequireable — the plane exists precisely BECAUSE `pull_request` loads its definition
+ *       from the pull request under test. Which plane a workflow uses is a separate judgement from
+ *       whether its context can fail, and this rule is about the second.
  *       A path filter means some PR shape never triggers the workflow at all, and a required context
  *       that never REPORTS blocks the PR forever with no way to satisfy it (the #1436 review-gate
  *       rollback).
@@ -160,7 +165,19 @@ export function pullRequestTrigger(workflowText) {
   const text = stripComments(workflowText);
   const onBlock = /^on:\s*$\n((?:[ \t]+.*\n?)*)/m.exec(text);
   if (!onBlock) return undefined;
-  const prBlock = /^ {2}pull_request:\s*$\n((?:(?: {4}.*)?\n?)*)/m.exec(onBlock[1]);
+  // Either plane. `pull_request_target` is matched FIRST because `pull_request:` would not match it
+  // anyway (the colon differs), but ordering it explicitly keeps the intent readable: a control-plane
+  // gate uses the target plane on purpose, and a rule that only knew the other one would refuse the
+  // very shape INFRA-097 exists to install.
+  let kind;
+  let prBlock;
+  for (const candidate of ['pull_request_target', 'pull_request']) {
+    prBlock = new RegExp(`^ {2}${candidate}:\\s*$\\n((?:(?: {4}.*)?\\n?)*)`, 'm').exec(onBlock[1]);
+    if (prBlock) {
+      kind = candidate;
+      break;
+    }
+  }
   if (!prBlock) return undefined;
   const body = prBlock[1];
   const typesInline = / {4}types:[ \t]*\[(.*)\]/.exec(body);
@@ -188,7 +205,7 @@ export function pullRequestTrigger(workflowText) {
     : [...(branchesBlock?.[1] ?? '').matchAll(/^ {6}- +['"]?([^'"\n]+)['"]?$/gm)]
         .map((match) => match[1].trim())
         .filter(Boolean);
-  return { branches, types, hasPathFilter: /^ {4}paths(-ignore)?:/m.test(body) };
+  return { kind, branches, types, hasPathFilter: /^ {4}paths(-ignore)?:/m.test(body) };
 }
 
 /** Read and validate the declaration for a branch. Throws on anything that would make it vacuous. */
@@ -268,25 +285,27 @@ export function findRequiredCheckFindings(root = WORKSPACE_ROOT) {
     // R2 — the workflow must trigger for every PR to `main`, with no path filter.
     const trigger = pullRequestTrigger(workflowText);
     if (!trigger) {
-      report(`[R2] \`${workflow}\` declares no \`pull_request:\` trigger this scan can read.`);
+      report(
+        `[R2] \`${workflow}\` declares no \`pull_request:\` or \`pull_request_target:\` trigger this scan can read.`,
+      );
     } else {
       if (trigger.branches.length > 0 && !trigger.branches.includes(GOVERNED_BRANCH)) {
         report(
-          `[R2] \`${workflow}\`'s \`pull_request\` trigger does not cover \`${GOVERNED_BRANCH}\` (branches: ${trigger.branches.join(', ') || '(none)'}).`,
+          `[R2] \`${workflow}\`'s \`${trigger.kind}\` trigger does not cover \`${GOVERNED_BRANCH}\` (branches: ${trigger.branches.join(', ') || '(none)'}).`,
         );
       }
       if (trigger.hasPathFilter) {
         report(
-          `[R2] \`${workflow}\`'s \`pull_request\` trigger carries a \`paths\`/\`paths-ignore\` filter. Some PR shape then never triggers it, the context never reports, and the PR is blocked forever with no way to satisfy it.`,
+          `[R2] \`${workflow}\`'s \`${trigger.kind}\` trigger carries a \`paths\`/\`paths-ignore\` filter. Some PR shape then never triggers it, the context never reports, and the PR is blocked forever with no way to satisfy it.`,
         );
       }
       if (trigger.types === undefined) {
         report(
-          `[R7] \`${workflow}\`'s \`pull_request\` trigger declares no \`types:\`, so it uses GitHub's DEFAULT activity set, which omits \`${REQUIRED_TRIGGER_TYPE}\`. Retargeting a PR's base fires \`${REQUIRED_TRIGGER_TYPE}\` — measured on throwaway PR #1442, a feature branch retargeted develop→main re-dispatched nothing, kept the \`skipping\` conclusions it earned as a develop PR, and reported \`mergeStateStatus: CLEAN\`. An absent \`types:\` is the failing case, not a safe default.`,
+          `[R7] \`${workflow}\`'s \`${trigger.kind}\` trigger declares no \`types:\`, so it uses GitHub's DEFAULT activity set, which omits \`${REQUIRED_TRIGGER_TYPE}\`. Retargeting a PR's base fires \`${REQUIRED_TRIGGER_TYPE}\` — measured on throwaway PR #1442, a feature branch retargeted develop→main re-dispatched nothing, kept the \`skipping\` conclusions it earned as a develop PR, and reported \`mergeStateStatus: CLEAN\`. An absent \`types:\` is the failing case, not a safe default.`,
         );
       } else if (!trigger.types.includes(REQUIRED_TRIGGER_TYPE)) {
         report(
-          `[R7] \`${workflow}\`'s \`pull_request\` \`types:\` (${trigger.types.join(', ')}) omits \`${REQUIRED_TRIGGER_TYPE}\`, so a base retarget re-dispatches nothing and this required context keeps whatever conclusion it earned against the OLD base — \`skipping\`, which branch protection accepts (PR #1442).`,
+          `[R7] \`${workflow}\`'s \`${trigger.kind}\` \`types:\` (${trigger.types.join(', ')}) omits \`${REQUIRED_TRIGGER_TYPE}\`, so a base retarget re-dispatches nothing and this required context keeps whatever conclusion it earned against the OLD base — \`skipping\`, which branch protection accepts (PR #1442).`,
         );
       }
     }

--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -739,6 +739,11 @@ export function annotateNotMirrored(
   const evaluate = (key) => {
     if (key === 'manifest-or-lockfile') return touchesManifest;
     if (key === 'code') return productChanged;
+    // A workflow edit is not `code` — the `changes` classifier reports infrastructure-only work as
+    // N/A — so `workflow provenance` would have been marked irrelevant on exactly the diffs it
+    // exists to judge. Its own subject is the file list, so its relevance is a file-list question.
+    if (key === 'guarded-workflow')
+      return changedFiles.some((file) => file.startsWith('.github/workflows/'));
     // An unknown key must SHOUT rather than be ignored: the alternative is a required check
     // quietly demoted to a footnote by a relevance rule nobody implemented.
     return true;


### PR DESCRIPTION
Closes #1719

## What this is

Issue #1719's fifth and last plan step — making `workflow provenance` a required context. The item held it as the owner's because it needs a live-ruleset edit; the owner has assigned it.

This PR is the **file half**. The ruleset half is sequenced with `ARCH - robota`, who is the single writer on `protect-main` — see "Sequencing" below.

## The prerequisites the item did not name

Each was found by trying to do the step, not by reading about it.

### The gate was inert for two hours and nothing said so

`workflow-provenance-gate.yml` reached `develop` at **01:11 UTC**. GitHub registered the workflow at **03:21:51 UTC — two seconds after the promotion that carried it to `main` merged.** A `pull_request_target` workflow is not registered until it lands on the **default** branch.

Measured through `gh api .../actions/workflows/workflow-provenance-gate.yml/runs`: `total_count` was 2, both after registration. Pull requests #2010, #2011, #2012 and #2013 — every PR open in that window — got **no run at all**, while pull request #2015, opened at 03:28, got one four seconds later.

Requiring the context before that moment would have left every open PR with a permanently pending check and no way to satisfy it: the issue #1436 shape this repository already rolled back once.

### R7 was unsatisfied — the retarget hole

The trigger declared `types: [opened, synchronize, reopened]`. `edited` is the only activity a base retarget fires and GitHub's default set omits it, so a branch moved `develop`→`main` keeps the conclusion it earned against the **old** base while branch protection reports the context satisfied. That is PR #1442's measured shape, on the other plane. Added, with the reason in the file.

### R2 refused the fix as if it were the defect

`scan-main-required-checks` read only `^  pull_request:`. So the one workflow whose plane is the entire point of INFRA-097 reported:

> `[R2] ... declares no `pull_request:` trigger this scan can read.`

R2 exists to establish that a required context can **fail** — which is plane-independent. It now accepts `pull_request` or `pull_request_target`, and names which one it found in every message. A guard whose vocabulary predates the mechanism it must admit rejects the correct answer with a confident-sounding message.

### The self-guarding test was inverted, with its reasoning corrected

A case asserted the gate must **not** be in the guarded set, reasoning that a change editing it "would be judged by the edited version". That is true of a `pull_request` workflow and **false** of this one — `pull_request_target` loads its definition from the base, which is why the plane was split at all.

So once the gate provides a required context it *should* guard itself: an edit to the control plane's own control plane is exactly the change that must not pass unnoticed. The case now asserts the inclusion **plus the two properties that make it safe** (the target plane, and checking out no head ref), so the assertion cannot survive a regression in either.

`scan-workflow-provenance`'s own cases move with it: the guarded set is 3 files and 2 of them are PR-loaded. The previous case said "if this ever shrinks, a trusted-provenance design landed and INFRA-097 should be revisited." It has.

## Also here

- `workflow provenance` registered under **both** branches in `.github/required-status-checks.json`.
- A `guarded-workflow` relevance key in `ci-mirror-map` / `verify-like-ci`. A workflow edit is not `code` to the `changes` classifier, so the context would have been marked irrelevant on exactly the diffs it judges.

## Sequencing, and a live drift this closes

`workflow provenance` is **already required on the live `protect-develop`** (changed 03:50:04 UTC, version `v47293037`) and absent from the declaration file, whose own instruction is *"Change a ruleset and this file in the same change."* This PR is that half.

I did not issue that PUT — every ruleset call from this session was a GET — and `ARCH - robota` confirmed by timestamp that it was not theirs either. Worth stating plainly: **every session on this machine authenticates as `woojubb`, so the API's actor field cannot attribute a write between sessions.** An attribution field that could not have shown otherwise is not evidence.

Agreed order with ARCH, one writer per ruleset, each write preceded by a read and followed by a read-back:

1. this PR lands;
2. ARCH does one PUT on `protect-main` adding `promotion closes` (issue #1980) and `workflow provenance` together;
3. I confirm `protect-develop` is consistent, then ARCH adds `regression-red-proof` (INFRA-046).

`scan-main-required-checks.mjs --live` is the only reconciler and it runs from a `workflow_dispatch:`-only workflow, so it is run **by hand** as the last step of each write rather than trusted to fire.

## Verification

- `pnpm harness:scan` — 134 passed, 2 skipped
- `pnpm harness:verify-like-ci` — **PASS, all 12 stages**
- `scan-main-required-checks` now reports 5 required contexts on `main`, all of which run and can fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jk88JE5EUEaBTPM3LnGN5
