### PR TITLE
docs(harness): the issue-link header's split is 2/2, not 3/1

### DIFF
--- a/scripts/harness/task-record-issue-link.mjs
+++ b/scripts/harness/task-record-issue-link.mjs
@@ -12,9 +12,18 @@
  * the 48 IDs claimed by BOTH a record and an issue title:
  *
  *   44  the record names that issue's own number
- *    3  the record names a DIFFERENT issue (`ARCH-037`→#1805 cites 1764/1773; `ARCH-039`→#1828
- *       cites 1764; `HARNESS-074`→#1619 cites 1615)
- *    1  the record names none at all (`HARNESS-058`→#1571)
+ *    2  the record names a DIFFERENT issue — `ARCH-037`→issue #1805 and `ARCH-039`→issue #1828,
+ *       both citing issue #1764
+ *    2  the record names no issue at all — `HARNESS-074`→issue #1619 cites only PR #1615, and
+ *       `HARNESS-058`→issue #1571 cites nothing
+ *
+ * The split was published as 3/1 and is 2/2. PR #1615 (the only reference `HARNESS-074` carries) and
+ * PR #1773 (a second reference in `ARCH-037`) are PULL REQUESTS, not issues, and counting either as
+ * "names a different issue" reads a bare `#N` as an issue reference — which is the
+ * one thing `ISSUE_LINK_PATTERNS` deliberately does not do. A predicate that accepted `#N` would move
+ * `HARNESS-074` into the linked column on the strength of a pull request, while it names nothing that
+ * could ever be compared against an issue title. It is the live case FOR the exclusion, which is why
+ * it is worth naming rather than dropping.
  *
  * So the gap is FOUR citation lines in four named files, not a wait for new records to accumulate.
  * A first cut of this header said 39, which was a frontmatter-only count carried over from the


### PR DESCRIPTION
## The split published in the module header is wrong

`task-record-issue-link.mjs` says three records name a DIFFERENT issue and one names none. Two of the three references it counts are **pull requests**, classified through the issues API rather than by shape:

| number | kind |
| --- | --- |
| `#1764` | issue |
| `#1773` | **PR** |
| `#1615` | **PR** |

- `HARNESS-074`'s only reference is PR #1615, so it names **no issue at all** and belongs in the fourth bucket.
- `ARCH-037` cites one different issue (issue #1764), not two.

Corrected: **44 name their own issue, 2 name a different issue, 2 name none.**

## Why this is worth a PR rather than a shrug

The header states it was measured *"with the predicates this module ships — `namesItsIssue` and `ISSUE_LINK_PATTERNS`"*, and those predicates disagree with what it published. Both require `issue #N` or an issues URL; a bare `#1615` matches neither. Counting it read a bare `#N` as an issue reference — which is the one thing the pattern set deliberately does not do.

That makes this the third re-derivation of this population to go wrong, in the paragraph that narrates the first two. The number is load-bearing: it is the one a future reader will take rather than re-measure.

`HARNESS-074` stays named rather than dropped, because it is the live case **for** the exclusion. A predicate accepting `#N` would move it into the linked column on the strength of a pull request, while it names nothing that could ever be compared against an issue title.

## Provenance

Raised as a MUST on PR #2016 before it merged; the merge landed at the reviewed head, so the finding went in unaddressed rather than being rejected. This is the fix, not a re-litigation.

## Verification

- `pnpm harness:scan` — 134 passed, 2 skipped
- `task-record-issue-link` suite — 27 passed
- Every number re-derived at this head, and every reference classified through `gh api repos/woojubb/robota/issues/<n>` rather than by its shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jk88JE5EUEaBTPM3LnGN5
