### PR TITLE
fix(harness): the ruleset reconciliation has a place that actually runs

### DIFF
--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -378,17 +378,16 @@ describe('promote.mjs reconciles the rulesets before the PR exists (issue #1980)
 
   it('reports the reconciliation when the declarations match', async () => {
     const root = await promotable();
-    const { code, output } = await ready(root, () => ({ code: 0, output: '' }));
+    const { code, output } = await ready(root, () => []);
     expect(code).toBe(0);
     expect(output).toMatch(/declarations reconcile against the live rulesets/);
   });
 
   it('WARNS with the finding when a ruleset does not match, and still promotes', async () => {
     const root = await promotable();
-    const { code, output } = await ready(root, () => ({
-      code: 1,
-      output: '  - promotion closes: the LIVE ruleset does not require it\n',
-    }));
+    const { code, output } = await ready(root, () => [
+      { context: 'promotion closes', detail: 'the LIVE ruleset does not require it' },
+    ]);
     // The branch is still built: a stale required list is not a reason to discard an
     // ancestry-verified promotion, and refusing here would put a GitHub read in the promotion's path.
     expect(code).toBe(0);
@@ -435,10 +434,9 @@ describe('promote.mjs --dry-run carries the reconciliation too (issue #1980)', (
         'develop',
       ],
       fetch: false,
-      reconcileRulesets: () => ({
-        code: 1,
-        output: '  - promotion closes: the LIVE ruleset does not require it\n',
-      }),
+      reconcileRulesets: () => [
+        { context: 'promotion closes', detail: 'the LIVE ruleset does not require it' },
+      ],
     });
 
     expect(code).toBe(0);

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -412,3 +412,38 @@ describe('promote.mjs reconciles the rulesets before the PR exists (issue #1980)
     expect(output).not.toMatch(/declarations reconcile against the live rulesets/);
   });
 });
+
+/**
+ * issue #1980 — `--dry-run` is the CHEAP pre-check, so it is the path most likely to be the only one
+ * anyone runs before deciding a promotion is fine. A reconciliation that reports only on the
+ * expensive path is a warning delivered after the decision it should have informed.
+ */
+describe('promote.mjs --dry-run carries the reconciliation too (issue #1980)', () => {
+  it('a mismatch is reported on the dry run, not only on the real build', async () => {
+    const { root, git } = await newRepo();
+    git(['checkout', '--quiet', 'develop']);
+    commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+
+    const { code, output } = await runWithOptions(root, {
+      argv: [
+        '--dry-run',
+        '--main-ref',
+        'main',
+        '--develop-ref',
+        'develop',
+        '--baseline',
+        'develop',
+      ],
+      fetch: false,
+      reconcileRulesets: () => ({
+        code: 1,
+        output: '  - promotion closes: the LIVE ruleset does not require it\n',
+      }),
+    });
+
+    expect(code).toBe(0);
+    expect(output).toMatch(/--dry-run — the merge is clean/);
+    expect(output).toMatch(/WARNING — a live ruleset does NOT match its declaration/);
+    expect(output).toMatch(/promotion closes: the LIVE ruleset does not require it/);
+  });
+});

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -346,3 +346,69 @@ describe('promote.mjs — closing keywords for the promotion body (INFRA-104)', 
     expect(output).toMatch(/scan-promotion-closes/);
   });
 });
+
+/**
+ * issue #1980 — the reconciliation has a home, and it is this tool.
+ *
+ * `.github/required-status-checks.json` declares what each ruleset must require; the OFFLINE half of
+ * `scan-main-required-checks.mjs` proves every declared context can fail. Neither half can see the
+ * ruleset move underneath it. That is `--live`'s job, and `--live` ran only from a workflow whose
+ * `schedule:` was removed — so `protect-main` declared four contexts and required three for four
+ * weeks, and nothing said so.
+ *
+ * These cases pin the three verdicts a promotion can get, and the third is the one that matters: an
+ * UNREACHABLE reconciliation must never render as a clean one. "No answer" reading as "they match"
+ * is the defect itself, one layer up.
+ */
+describe('promote.mjs reconciles the rulesets before the PR exists (issue #1980)', () => {
+  const ready = async (root, reconcileRulesets) =>
+    runWithOptions(root, {
+      argv: ['--main-ref', 'main', '--develop-ref', 'develop', '--baseline', 'develop'],
+      fetch: false,
+      reconcileRulesets,
+    });
+
+  /** A promotable repository: develop ahead of main, nothing unmerged on main. */
+  async function promotable() {
+    const { root, git } = await newRepo();
+    git(['checkout', '--quiet', 'develop']);
+    commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+    return root;
+  }
+
+  it('reports the reconciliation when the declarations match', async () => {
+    const root = await promotable();
+    const { code, output } = await ready(root, () => ({ code: 0, output: '' }));
+    expect(code).toBe(0);
+    expect(output).toMatch(/declarations reconcile against the live rulesets/);
+  });
+
+  it('WARNS with the finding when a ruleset does not match, and still promotes', async () => {
+    const root = await promotable();
+    const { code, output } = await ready(root, () => ({
+      code: 1,
+      output: '  - promotion closes: the LIVE ruleset does not require it\n',
+    }));
+    // The branch is still built: a stale required list is not a reason to discard an
+    // ancestry-verified promotion, and refusing here would put a GitHub read in the promotion's path.
+    expect(code).toBe(0);
+    expect(output).toMatch(/WARNING — a live ruleset does NOT match its declaration/);
+    expect(output).toMatch(/promotion closes: the LIVE ruleset does not require it/);
+    expect(output).toMatch(/does not block the promotion/);
+    expect(output).toMatch(/is ready — A1\/A2\/A3 hold/);
+  });
+
+  it('an unreachable reconciliation is reported as unreachable, NOT as a match', async () => {
+    const root = await promotable();
+    const { code, output } = await ready(root, () => {
+      throw new Error('getaddrinfo ENOTFOUND api.github.com');
+    });
+    expect(code).toBe(0);
+    expect(output).toMatch(/could NOT reconcile the rulesets/);
+    expect(output).toMatch(/ENOTFOUND/);
+    expect(output).toMatch(/this is NOT "they match"/);
+    // The discriminating assertion: the clean wording must be ABSENT. Without this the case passes
+    // on a build that prints both, which is the shape a future refactor would produce.
+    expect(output).not.toMatch(/declarations reconcile against the live rulesets/);
+  });
+});

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -59,6 +59,16 @@ async function newRepo() {
  */
 const NO_CLOSES = () => '';
 
+/**
+ * issue #1980 — the ruleset reconciliation reads GitHub, so it is INJECTED for the same reason
+ * `NO_CLOSES` is. `newRepo()` usually creates no `origin`, which makes `originSlug` return nothing
+ * and the reconciliation return early — but the fetch case below adds a REAL local bare repo as
+ * `origin`, and `originSlug` parses `/tmp/…/robota-promote-origin-XXXX` into the plausible-looking
+ * slug `tmp/robota-promote-origin-XXXX`. That reaches `gh api` and the network, in a case whose own
+ * comment promises none is needed.
+ */
+const NO_RECONCILE = () => [];
+
 async function run(root, extraArgv = [], options = {}) {
   let output = '';
   // extraArgv first: `flag()` reads the FIRST occurrence, so a test override must precede the defaults.
@@ -70,6 +80,7 @@ async function run(root, extraArgv = [], options = {}) {
     },
     fetch: false,
     closesBlock: NO_CLOSES,
+    reconcileRulesets: NO_RECONCILE,
     ...options,
   });
   return { code, output };
@@ -83,6 +94,7 @@ async function runWithOptions(root, options) {
       output += text;
     },
     closesBlock: NO_CLOSES,
+    reconcileRulesets: NO_RECONCILE,
     ...options,
   });
   return { code, output };
@@ -443,5 +455,42 @@ describe('promote.mjs --dry-run carries the reconciliation too (issue #1980)', (
     expect(output).toMatch(/--dry-run — the merge is clean/);
     expect(output).toMatch(/WARNING — a live ruleset does NOT match its declaration/);
     expect(output).toMatch(/promotion closes: the LIVE ruleset does not require it/);
+  });
+});
+
+/**
+ * issue #1980 — the hermetic promise, pinned.
+ *
+ * `newRepo()` usually has no `origin`, so the reconciliation returns early and nothing reaches the
+ * network by accident. The fetch case adds a REAL local bare repository as `origin`, and
+ * `originSlug` parses that path into a plausible-looking `owner/repo`. Without the injection in the
+ * shared helpers, the default implementation runs `gh api` against it.
+ *
+ * This asserts the outcome that distinguishes the two: an injected reconciliation reports nothing,
+ * while a real one against a slug derived from a temp path reports a finding. Remove
+ * `reconcileRulesets: NO_RECONCILE` from the helpers and this fails.
+ */
+describe('the promote suite stays hermetic when a local origin exists (issue #1980)', () => {
+  it('a repository with a real local origin produces no reconciliation output at all', async () => {
+    const { root, git } = await newRepo();
+    commit(root, git, 'feature.txt', 'work\n', 'feat: work');
+    const remote = await mkdtemp(path.join(tmpdir(), 'robota-promote-origin-'));
+    roots.push(remote);
+    makeGit(remote)(['init', '--bare', '--quiet']);
+    git(['remote', 'add', 'origin', remote]);
+    git(['push', '--quiet', 'origin', 'main', 'develop']);
+
+    const { code, output } = await runWithOptions(root, {
+      argv: ['--dry-run', '--baseline', 'origin/develop'],
+    });
+
+    expect(code).toBe(0);
+    // The injected reconciliation returns no findings, so the CLEAN line is the correct output.
+    expect(output).toMatch(/declarations reconcile against the live rulesets/);
+    // These two are the discriminators. Either one means the real implementation ran: a WARNING
+    // because `gh api` judged a slug invented from a temp path, or the unreachable notice because
+    // it tried and could not. Both require the network this case promises not to need.
+    expect(output).not.toMatch(/WARNING — a live ruleset/);
+    expect(output).not.toMatch(/could NOT reconcile the rulesets/);
   });
 });

--- a/scripts/harness/__tests__/promote.test.mjs
+++ b/scripts/harness/__tests__/promote.test.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { main } from '../promote.mjs';
+import { RECONCILED_BRANCHES, reconcileLive } from '../scan-main-required-checks.mjs';
 
 /**
  * `git-branch.md` makes `promote.mjs` the ONLY sanctioned way to build a promotion branch ("never by
@@ -409,18 +410,52 @@ describe('promote.mjs reconciles the rulesets before the PR exists (issue #1980)
     expect(output).toMatch(/is ready — A1\/A2\/A3 hold/);
   });
 
-  it('an unreachable reconciliation is reported as unreachable, NOT as a match', async () => {
+  /**
+   * The shape a FAILED READ actually has, which is not a thrown error.
+   *
+   * `reconcileLiveBranch` catches its own read failures and returns `{ context: '(live)', detail }`
+   * — the same shape a real drift finding has. An earlier cut of this case made the mock THROW,
+   * which the real implementation cannot do, so it passed while a genuine outage rendered as
+   * "the ruleset disagrees with its declaration". A report stating a verdict it never obtained is
+   * this issue's own defect one layer up.
+   */
+  it('an UNREADABLE ruleset is reported as unreachable, NOT as a mismatch', async () => {
     const root = await promotable();
-    const { code, output } = await ready(root, () => {
-      throw new Error('getaddrinfo ENOTFOUND api.github.com');
-    });
+    const { code, output } = await ready(root, () => [
+      { context: '(live)', detail: 'getaddrinfo ENOTFOUND api.github.com' },
+    ]);
     expect(code).toBe(0);
     expect(output).toMatch(/could NOT reconcile the rulesets/);
     expect(output).toMatch(/ENOTFOUND/);
     expect(output).toMatch(/this is NOT "they match"/);
-    // The discriminating assertion: the clean wording must be ABSENT. Without this the case passes
-    // on a build that prints both, which is the shape a future refactor would produce.
+    // Both discriminators: neither the clean verdict nor the MISMATCH verdict may appear.
     expect(output).not.toMatch(/declarations reconcile against the live rulesets/);
+    expect(output).not.toMatch(/WARNING — a live ruleset does NOT match/);
+  });
+
+  it('a thrown error is still reported as unreachable', async () => {
+    const root = await promotable();
+    const { code, output } = await ready(root, () => {
+      throw new Error('spawn ENOENT');
+    });
+    expect(code).toBe(0);
+    expect(output).toMatch(/could NOT reconcile the rulesets \(spawn ENOENT\)/);
+    expect(output).not.toMatch(/WARNING — a live ruleset does NOT match/);
+  });
+
+  /**
+   * Binds the rendering above to the REAL contract, offline. A repository with no `origin` makes
+   * `originSlug` return nothing, and `reconcileLive` returns the `(live)` sentinel without any
+   * network call — so this proves the shape the mock uses is the shape the implementation produces,
+   * which is exactly what the earlier throwing mock did not.
+   */
+  it('reconcileLive really does return the `(live)` sentinel rather than throwing', async () => {
+    const { root } = await newRepo();
+    const findings = reconcileLive(root);
+    // One per reconciled branch, and EVERY one carries the sentinel context rather than throwing.
+    expect(findings).toHaveLength(RECONCILED_BRANCHES.length);
+    expect(findings.every((f) => f.context === '(live)')).toBe(true);
+    expect(findings.every((f) => /origin/.test(f.detail))).toBe(true);
   });
 });
 

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -205,18 +205,37 @@ export async function main({
 
     // issue #1980. WARNS, never refuses: a GitHub outage must not discard an ancestry-verified
     // promotion branch, the same reason the closing-block derivation below is allow-fallback.
-    // Unreachable is reported as unreachable — this path never prints a clean verdict it did not
-    // obtain, because "no answer" reading as "they match" is the defect itself, one layer up.
+    //
+    // UNREACHABLE IS NOT MISMATCH, and the two arrive the same way. `reconcileLiveBranch` does not
+    // throw on a failed read — it returns `{ context: '(live)', detail }`, the same shape a real
+    // drift finding has. Rendering the list without separating them turns "could not read the
+    // ruleset" into "the ruleset disagrees with its declaration", which is this issue's own defect
+    // one layer up: a report that states a verdict it never obtained.
+    //
+    // The `catch` below is kept for a genuine throw, and is deliberately NOT the path a network
+    // failure takes. An earlier cut relied on it, and its test passed only because the mock threw —
+    // a shape the real implementation cannot produce.
+    const LIVE_UNREADABLE = '(live)';
     let rulesetSection = '';
     try {
       const findings = reconcileRulesets({ cwd });
-      rulesetSection =
-        findings.length === 0
-          ? '\npromote: required-status-check declarations reconcile against the live rulesets.\n'
-          : '\npromote: WARNING — a live ruleset does NOT match its declaration:\n' +
-            findings.map((f) => `  - ${f.context}: ${f.detail}\n`).join('') +
-            'promote: this does not block the promotion. Fix the ruleset AND\n' +
-            'promote: `.github/required-status-checks.json` in the same change (issue #1980).\n';
+      const unreadable = findings.filter((f) => f.context === LIVE_UNREADABLE);
+      const drift = findings.filter((f) => f.context !== LIVE_UNREADABLE);
+      if (unreadable.length > 0) {
+        rulesetSection =
+          '\npromote: could NOT reconcile the rulesets:\n' +
+          unreadable.map((f) => `  - ${f.detail}\n`).join('') +
+          'promote: this is NOT "they match". Run `node scripts/harness/scan-main-required-checks.mjs --live`.\n';
+      } else if (drift.length > 0) {
+        rulesetSection =
+          '\npromote: WARNING — a live ruleset does NOT match its declaration:\n' +
+          drift.map((f) => `  - ${f.context}: ${f.detail}\n`).join('') +
+          'promote: this does not block the promotion. Fix the ruleset AND\n' +
+          'promote: `.github/required-status-checks.json` in the same change (issue #1980).\n';
+      } else {
+        rulesetSection =
+          '\npromote: required-status-check declarations reconcile against the live rulesets.\n';
+      }
     } catch (error) {
       rulesetSection =
         `\npromote: could NOT reconcile the rulesets (${error.message}).\n` +

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -208,9 +208,29 @@ export async function main({
       );
     }
 
+    // issue #1980. WARNS, never refuses: a GitHub outage must not discard an ancestry-verified
+    // promotion branch, which is the same reason the closing-block derivation below is
+    // allow-fallback. Unreachable is reported as unreachable — this path never prints a clean
+    // verdict it did not obtain, because "no answer" reading as "they match" is the defect itself.
+    let rulesetSection = '';
+    try {
+      const live = reconcileRulesets({ cwd });
+      rulesetSection =
+        live.code === 0
+          ? '\npromote: required-status-check declarations reconcile against the live rulesets.\n'
+          : `\npromote: WARNING — a live ruleset does NOT match its declaration:\n${live.output}` +
+            'promote: this does not block the promotion. Fix the ruleset AND\n' +
+            'promote: `.github/required-status-checks.json` in the same change (issue #1980).\n';
+    } catch (error) {
+      rulesetSection =
+        `\npromote: could NOT reconcile the rulesets (${error.message}).\n` +
+        'promote: this is NOT "they match". Run `node scripts/harness/scan-main-required-checks.mjs --live`.\n';
+    }
+
     if (dryRun) {
       out(
-        `promote: --dry-run — the merge is clean and promotes develop's tree unchanged (${mergedTree.slice(0, 9)}).\n`,
+        `promote: --dry-run — the merge is clean and promotes develop's tree unchanged (${mergedTree.slice(0, 9)}).\n` +
+          rulesetSection,
       );
       return 0;
     }
@@ -277,25 +297,6 @@ export async function main({
         'promote: this is NOT "nothing to close". Run `node scripts/harness/promotion-closes.mjs ' +
         '--base origin/main --head origin/develop` and paste its output into the PR body — the ' +
         'required `scan-promotion-closes` check will refuse the promotion until you do.\n';
-    }
-
-    // issue #1980. WARNS, never refuses: a GitHub outage must not discard an ancestry-verified
-    // promotion branch, which is the same reason the closing-block derivation below is
-    // allow-fallback. Unreachable is reported as unreachable — this path never prints a clean
-    // verdict it did not obtain, because "no answer" reading as "they match" is the defect itself.
-    let rulesetSection = '';
-    try {
-      const live = reconcileRulesets({ cwd });
-      rulesetSection =
-        live.code === 0
-          ? '\npromote: required-status-check declarations reconcile against the live rulesets.\n'
-          : `\npromote: WARNING — a live ruleset does NOT match its declaration:\n${live.output}` +
-            'promote: this does not block the promotion. Fix the ruleset AND\n' +
-            'promote: `.github/required-status-checks.json` in the same change (issue #1980).\n';
-    } catch (error) {
-      rulesetSection =
-        `\npromote: could NOT reconcile the rulesets (${error.message}).\n` +
-        'promote: this is NOT "they match". Run `node scripts/harness/scan-main-required-checks.mjs --live`.\n';
     }
 
     out(

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -30,6 +30,7 @@
  * requires explicit user approval (`.agents/rules/git-branch.md`). It prints the exact next commands.
  */
 
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 import { ADOPTION_BASELINE, evaluatePromotion, runGit } from './scan-promotion-ancestry.mjs';
@@ -46,6 +47,34 @@ export const DEFAULT_BRANCH = 'release/promote-develop-to-main';
 
 /** Thrown for a handled, explained failure. `main()` turns it into a non-zero exit code. */
 class PromoteError extends Error {}
+
+/**
+ * Reconcile the DECLARED required status checks against the live rulesets.
+ *
+ * issue #1980. `.github/required-status-checks.json` is the SOURCE of what each ruleset must
+ * require, and `scan-main-required-checks.mjs` proves OFFLINE that every declared context can fail.
+ * What that half cannot see is the ruleset moving underneath it: measured 2026-08-22, `protect-main`
+ * had been declaring four contexts and requiring three for four weeks, because the reconciling
+ * `--live` half runs only from `.github/workflows/ruleset-drift.yml`, whose `schedule:` trigger was
+ * removed and never replaced. A declaration nobody re-derives is a claim about the day it was
+ * written.
+ *
+ * That workflow's own comment names the moment this belongs at — it surfaces drift "BEFORE a
+ * promotion pull request is opened rather than while one is waiting" — which is here, building the
+ * branch, not in the protected CI that judges it afterwards.
+ *
+ * INJECTED, like `closesBlock`, because it reads GitHub: a hermetic suite must not reach the network
+ * to assert an ancestry invariant.
+ */
+export function defaultReconcileRulesets({ cwd }) {
+  const result = spawnSync(
+    process.execPath,
+    ['scripts/harness/scan-main-required-checks.mjs', '--live'],
+    { cwd, encoding: 'utf8' },
+  );
+  if (result.error) throw result.error;
+  return { code: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+}
 
 function flag(argv, name, fallback) {
   const index = argv.indexOf(name);
@@ -88,6 +117,7 @@ export async function main({
   fetch: shouldFetch = true,
   runGitImpl = runGit,
   closesBlock = defaultClosesBlock,
+  reconcileRulesets = defaultReconcileRulesets,
 } = {}) {
   const git = (args) => runGitImpl(args, cwd);
   const branch = flag(argv, '--branch', DEFAULT_BRANCH);
@@ -249,10 +279,30 @@ export async function main({
         'required `scan-promotion-closes` check will refuse the promotion until you do.\n';
     }
 
+    // issue #1980. WARNS, never refuses: a GitHub outage must not discard an ancestry-verified
+    // promotion branch, which is the same reason the closing-block derivation below is
+    // allow-fallback. Unreachable is reported as unreachable — this path never prints a clean
+    // verdict it did not obtain, because "no answer" reading as "they match" is the defect itself.
+    let rulesetSection = '';
+    try {
+      const live = reconcileRulesets({ cwd });
+      rulesetSection =
+        live.code === 0
+          ? '\npromote: required-status-check declarations reconcile against the live rulesets.\n'
+          : `\npromote: WARNING — a live ruleset does NOT match its declaration:\n${live.output}` +
+            'promote: this does not block the promotion. Fix the ruleset AND\n' +
+            'promote: `.github/required-status-checks.json` in the same change (issue #1980).\n';
+    } catch (error) {
+      rulesetSection =
+        `\npromote: could NOT reconcile the rulesets (${error.message}).\n` +
+        'promote: this is NOT "they match". Run `node scripts/harness/scan-main-required-checks.mjs --live`.\n';
+    }
+
     out(
       `\npromote: ${branch} is ready — A1/A2/A3 hold (non-merge debt on main: ${currentDebt}).` +
         '\npromote: `release-grade verification` runs once in protected CI on the promotion PR.\n' +
         'promote: optional diagnostic before push: `pnpm harness:verify:release`.\n' +
+        rulesetSection +
         closesSection +
         `\nNext (promoting to \`main\` is a release-level action needing explicit user approval):\n` +
         `  git push -u origin ${branch}\n` +

--- a/scripts/harness/promote.mjs
+++ b/scripts/harness/promote.mjs
@@ -30,10 +30,10 @@
  * requires explicit user approval (`.agents/rules/git-branch.md`). It prints the exact next commands.
  */
 
-import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 import { ADOPTION_BASELINE, evaluatePromotion, runGit } from './scan-promotion-ancestry.mjs';
+import { reconcileLive } from './scan-main-required-checks.mjs';
 import {
   collectClosingLines,
   createGitHubReaders,
@@ -53,27 +53,22 @@ class PromoteError extends Error {}
  *
  * issue #1980. `.github/required-status-checks.json` is the SOURCE of what each ruleset must
  * require, and `scan-main-required-checks.mjs` proves OFFLINE that every declared context can fail.
- * What that half cannot see is the ruleset moving underneath it: measured 2026-08-22, `protect-main`
- * had been declaring four contexts and requiring three for four weeks, because the reconciling
- * `--live` half runs only from `.github/workflows/ruleset-drift.yml`, whose `schedule:` trigger was
- * removed and never replaced. A declaration nobody re-derives is a claim about the day it was
- * written.
+ * Neither half can see the ruleset move underneath it. That is `reconcileLive`'s job, and it ran
+ * only from `.github/workflows/ruleset-drift.yml`, whose `schedule:` trigger was removed and never
+ * replaced — so `protect-main` declared four contexts and required three for four weeks, and nothing
+ * said so. A declaration nobody re-derives is a claim about the day it was written.
  *
- * That workflow's own comment names the moment this belongs at — it surfaces drift "BEFORE a
- * promotion pull request is opened rather than while one is waiting" — which is here, building the
- * branch, not in the protected CI that judges it afterwards.
+ * That workflow's own comment names the moment this belongs at: it surfaces drift "BEFORE a
+ * promotion pull request is opened rather than while one is waiting", which is here, building the
+ * branch.
  *
- * INJECTED, like `closesBlock`, because it reads GitHub: a hermetic suite must not reach the network
- * to assert an ancestry invariant.
+ * IMPORTED, not spawned. `promotion-preflight-parity` pins that this file starts no subprocess, so
+ * the full release sweep cannot quietly become a local prerequisite of assembling a promotion; the
+ * ancestry gate beside it is reached the same way. INJECTED like `closesBlock` because it reads
+ * GitHub, and a hermetic suite must not reach the network to assert an ancestry invariant.
  */
 export function defaultReconcileRulesets({ cwd }) {
-  const result = spawnSync(
-    process.execPath,
-    ['scripts/harness/scan-main-required-checks.mjs', '--live'],
-    { cwd, encoding: 'utf8' },
-  );
-  if (result.error) throw result.error;
-  return { code: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
+  return reconcileLive(cwd);
 }
 
 function flag(argv, name, fallback) {
@@ -209,16 +204,17 @@ export async function main({
     }
 
     // issue #1980. WARNS, never refuses: a GitHub outage must not discard an ancestry-verified
-    // promotion branch, which is the same reason the closing-block derivation below is
-    // allow-fallback. Unreachable is reported as unreachable — this path never prints a clean
-    // verdict it did not obtain, because "no answer" reading as "they match" is the defect itself.
+    // promotion branch, the same reason the closing-block derivation below is allow-fallback.
+    // Unreachable is reported as unreachable — this path never prints a clean verdict it did not
+    // obtain, because "no answer" reading as "they match" is the defect itself, one layer up.
     let rulesetSection = '';
     try {
-      const live = reconcileRulesets({ cwd });
+      const findings = reconcileRulesets({ cwd });
       rulesetSection =
-        live.code === 0
+        findings.length === 0
           ? '\npromote: required-status-check declarations reconcile against the live rulesets.\n'
-          : `\npromote: WARNING — a live ruleset does NOT match its declaration:\n${live.output}` +
+          : '\npromote: WARNING — a live ruleset does NOT match its declaration:\n' +
+            findings.map((f) => `  - ${f.context}: ${f.detail}\n`).join('') +
             'promote: this does not block the promotion. Fix the ruleset AND\n' +
             'promote: `.github/required-status-checks.json` in the same change (issue #1980).\n';
     } catch (error) {


### PR DESCRIPTION
Closes #1980

## The gap

`.github/required-status-checks.json` is the source of what each ruleset must require.
`scripts/harness/scan-main-required-checks.mjs` proves **offline** that every declared context can
fail. Neither half can see the ruleset move underneath it — that is `reconcileLive`'s job, and it ran
only from `.github/workflows/ruleset-drift.yml`, whose `schedule:` trigger was removed and never
replaced.

Measured consequence: `protect-main` **declared four contexts and required three for four weeks**,
and nothing reported it. A declaration nobody re-derives is a claim about the day it was written.

## Where it runs, and why there

`scripts/harness/promote.mjs`, while building the promotion branch. Not an invented location — it is
the drift workflow's own stated intent:

> It also surfaces drift **BEFORE a promotion PR is opened** rather than while one is waiting.

It **warns and never refuses**: a GitHub outage must not discard an ancestry-verified promotion
branch, the same reason the closing-block derivation beside it is `allow-fallback`. It runs **above**
the `--dry-run` early return, because the dry run is the cheap pre-check and therefore the path most
likely to be the only one anyone runs; a warning that appears only on the expensive path arrives
after the decision it should have informed.

## The invariant this change first broke, and what it taught

The first cut **spawned** the scan as a subprocess.
`scripts/harness/__tests__/promotion-preflight-parity.test.mjs` pins that `promote.mjs` starts no
subprocess, so the full release sweep cannot quietly become a local prerequisite of assembling a
promotion. **Pre-push refused the push and was right to.**

I had begun to reason that the assertion was over-broad — a contingent fact hardened into a rule, and
my spawn a legitimate exception. It was not. The rule's stated purpose covered this case exactly, and
the repository already offered the better path: the scan **already exports** `reconcileLive`, and
`promote.mjs` already reaches the ancestry gate by import. Findings now arrive as **data** instead of
text to parse, with no `node:child_process` anywhere.

*A rule that inconveniences you is not thereby over-broad.*

## Red-proofed, one mutation per case, each asserted to have applied

| mutation | cases that failed |
| -------- | ----------------- |
| unreachable rendered as a clean reconciliation | 1 |
| a mismatch rendered as silence | 2 |
| the reconciliation never invoked | 3 |
| the dry run drops the warning | 1 |

**An earlier attempt at the fourth proof proved nothing**, and that is worth recording: the
`.replace` building the mutant did not match the prettier-formatted indentation, so the file was
untouched and the suite stayed green — indistinguishable from a test that cannot fail. Every mutation
here now carries `assert s != before`.

*An experiment that cannot distinguish "the intervention was applied and survived" from "the
intervention never happened" has not run.*

The unreachable case asserts the clean wording is **absent**, not merely that the error wording is
present — otherwise it passes on a build printing both, and "no answer" rendering as "they match" is
this issue's own defect one layer up.

## Verified against the live repository

Before the ruleset fixes landed, the tool reported the real, then-current mismatch:

```
promote: WARNING — a live ruleset does NOT match its declaration:
  - workflow provenance: the LIVE `develop` ruleset requires it, but
    .github/required-status-checks.json does not declare it under `branches.develop`
```

Both rulesets now reconcile — `protect-main` requires all five declared contexts, `protect-develop`
all ten — each applied by a single writer, read back, and confirmed independently by a second
session.

## Verification

- 23 tests across `scripts/harness/__tests__/promote.test.mjs` and
  `scripts/harness/__tests__/promotion-preflight-parity.test.mjs`, run on the **committed** tree.
- `pnpm harness:scan`: 134 passed.

ACTIONABLE FINDINGS: 0

Refs INFRA-055