### PR TITLE
test(ci): THROWAWAY — red-proof that workflow provenance refuses a self-edit (INFRA-097)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1204,3 +1204,6 @@ jobs:
       - name: Skip (no coverable src changes)
         if: steps.detect.outputs.affected != 'true'
         run: echo "No package/app src lines changed — patch coverage is a no-op for this PR."
+
+# INFRA-097 throwaway: a deliberately inert edit, made to prove the `workflow provenance` gate
+# FAILS on a self-edit of the control plane. This branch is never merged.


### PR DESCRIPTION
## THROWAWAY — do not merge, do not review. This pull request exists to be REFUSED.

Issue #1719's Test Plan asks for a *"live throwaway PR proof"* that the control plane cannot be edited invisibly. Until PR #2030 merged, the gate's own workflow was not in the guarded set and `workflow provenance` was not a required context, so the experiment was not possible. It is now.

**I will close this without merging as soon as the result is recorded.**

## The prediction, written before any check ran

The single commit adds **three comment lines** to `.github/workflows/ci.yml` — deliberately inert, changing no job, step, condition or trigger.

1. The **`workflow provenance`** check MUST report **failure**.
2. Its log MUST name `.github/workflows/ci.yml` and MUST enumerate the required contexts that edit could move. Predicted list, derived from `.github/required-status-checks.json` at this base:
   - develop: `build`, `quality`, `scans`, `dependency audit`, `commitlint`, `tui-e2e`, `examples-typecheck`, `windows-shell`
   - main: `promotion ancestry`, `main PR source guard`, `promotion closes`, `release-grade verification`
3. The pull request MUST become unmergeable on that context — `workflow provenance` is required on `protect-develop` as of today.
4. The advisory line MUST read `2 of 3 guarded workflow(s) load their definition from the pull request`, naming `ci.yml` and `review-gate.yml` — the gate itself is the third and is NOT self-loading, because it runs on `pull_request_target`.

**A green `workflow provenance` here is a FINDING, not a relief.** It would mean either the gate cannot fail, or my edit never reached the diff the gate reads.

## That second failure mode already happened once, locally

The first local run of `scan-workflow-provenance.mjs --base-ref origin/develop --head-ref HEAD` exited **0** and printed only the advisory. The edit was in the working tree and not committed, so it was absent from `origin/develop...HEAD` — the scan ran correctly against a diff that did not contain the intervention, and reported the answer that means "clean".

After committing, the same command exits **1** with the full context list. Recorded because a no-op experiment and a passing experiment are indistinguishable in the output, and the direction of that silence is always toward reassurance. `ARCH - robota` hit the same shape twenty minutes earlier with a `.replace` that silently did not match, and the fix there is one line: assert the intervention changed something before drawing any conclusion from the result.

## What this proves and what it does not

Proves: the required context **can fail**, on a real pull request, for the reason it exists.

Does not prove: that the control plane is *trusted*. `ci.yml` still loads its definition from the pull request under test. The gate makes a self-edit unmergeable-without-notice; it does not make an edit impossible. That distinction is INFRA-097's own, and it is why the advisory in item 4 is expected rather than a defect.

## Related

- Issue #1719 / INFRA-097 — the item this closes the last step of
- PR #2030 — the change that made the context requireable
