### PR TITLE
fix(ci): the provenance gate checked out the default branch, not the base (INFRA-097)

### DIFF
--- a/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/INFRA-097-trusted-required-workflow-provenance.md
@@ -81,6 +81,46 @@ registry state something untrue. The same held-membership shape `regression-red-
 
 ## Progress
 
+### 2026-08-22 — red-proved live, and the proof found a defect
+
+The Test Plan's _"live throwaway PR proof"_ ran as pull request #2034: three inert comment lines added
+to `.github/workflows/ci.yml`, with the expected refusal written into the pull request body **before**
+any check reported.
+
+**The context can fail.** `workflow provenance` reported `fail`, named `ci.yml`, enumerated all twelve
+required contexts that edit could move, and the pull request went `BLOCKED`. Everything established
+before this was evidence about the gate's SHAPE — it exists, it runs, `branches:` covers `main`, no
+job-level `if:`, `--live` reconciles. A context that has only ever reported success is
+indistinguishable from one that cannot fail, which is the exact case promotion pull request #1427 merged on.
+
+**The fourth prediction failed, and that is where the defect was.** The advisory was predicted to read
+`2 of 3` and read `2 of 2`. The gate had checked out the wrong tree:
+
+```
+git checkout --progress --force -B main refs/remotes/origin/main
+```
+
+`actions/checkout` with no `ref:` resolves to the repository's DEFAULT branch, not the pull request's
+base — while the file's own comment asserted the opposite. `BASE_SHA` was already passed to the scan,
+so the DIFF came from `develop` and the REGISTRY and SCAN CODE came from `main`. Two silent
+consequences: a context newly required on `develop` sat outside the guarded set until the next
+promotion, and a fix to `scan-workflow-provenance.mjs` did not reach `develop` pull requests until it
+reached `main`. Not a security hole — `main` is not attacker-controlled — but the gate judged by rules
+that could lag its base indefinitely.
+
+Fixed by naming the ref: `ref: ${{ github.event.pull_request.base.sha }}` — still the base, never the
+head — with a case asserting that exact spelling.
+
+**Recorded because of how it surfaced.** `2 of 2` reads as a healthy line and invites no second look.
+It was a finding only because `3` was on record beforehand. The same instrument as asserting a
+mutation applied before trusting the experiment that follows it.
+
+**Paths validated:** code (pull request #2030), docs-only (pull requests #2028 and #2031),
+genuine-finding (pull request #2034).
+**Paths declared but not exercised:** fork, retarget, cancellation. `edited` is now declared so a
+retarget re-dispatches, and the concurrency group is declared so a superseded run cancels; neither has
+been observed on a live pull request, and this record says so rather than implying coverage.
+
 ### 2026-08-22 — the requireable half, owner-assigned
 
 The owner assigned the fifth step, which the item had held as theirs. Making the context REQUIRED has

--- a/.github/workflows/workflow-provenance-gate.yml
+++ b/.github/workflows/workflow-provenance-gate.yml
@@ -60,12 +60,26 @@ jobs:
     name: workflow provenance
     runs-on: ubuntu-latest
     steps:
-      # The BASE, which is what `pull_request_target` checks out when no ref is named. Adding one
-      # that points at the pull request's head is the single line that would turn this file into the
-      # vulnerability it exists to avoid — a test refuses that spelling, and refuses it here in the
-      # comment too, which is why the shape is described rather than written out.
+      # THE PULL REQUEST'S OWN BASE, named explicitly. An earlier revision named no ref and its
+      # comment claimed that was the base; measured on throwaway PR #2034, `actions/checkout` with no
+      # `ref:` resolved to the repository's DEFAULT branch instead:
+      #
+      #     git checkout --progress --force -B main refs/remotes/origin/main
+      #
+      # For a pull request to `develop` that is not the base. `BASE_SHA` was already passed to the
+      # scan, so the DIFF was computed against `develop` while the REGISTRY and the SCAN CODE came
+      # from `main` — diff from the base, rules from the default branch. Two silent consequences: a
+      # context newly required on `develop` sat outside the guarded set until the next promotion, and
+      # a fix to the scan did not reach `develop` pull requests until it reached `main`. The gate read
+      # `::examined:: 2` where its base had 3, which is how it was caught.
+      #
+      # `base.sha` is still the BASE and never the head. A ref pointing at the pull request's head is
+      # the single line that would turn this file into the vulnerability it exists to avoid — a test
+      # refuses that spelling, and refuses it here in the comment too, which is why the shape is
+      # described rather than written out.
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       - name: Use Node.js 22.x

--- a/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
+++ b/scripts/harness/__tests__/workflow-provenance-gate.test.mjs
@@ -55,7 +55,15 @@ describe('the gate loads its definition from a place the pull request cannot edi
 });
 
 describe('and never runs the pull request it is judging', () => {
-  it('checks out no explicit ref, so the base is what lands in the working tree', () => {
+  // Measured on throwaway PR #2034: naming NO ref did not check out the base. `actions/checkout`
+  // resolved to the repository's default branch, so a pull request to `develop` was judged with
+  // `main`'s registry and `main`'s copy of the scan while its diff came from `develop`. The ref is
+  // now named, and named as `base.sha` — the base, never the head.
+  it("checks out the pull request's OWN base by sha, not whatever the default branch is", () => {
+    expect(STEPS).toMatch(/ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/);
+  });
+
+  it('checks out no head ref, so the pull request never lands in the working tree', () => {
     // The single line that would breach this: `ref: ${{ github.event.pull_request.head.sha }}`.
     // Under `pull_request_target` that is PR code executing with write credentials against the base.
     expect(STEPS).not.toMatch(/ref:\s*\$\{\{\s*github\.event\.pull_request\.head/);


### PR DESCRIPTION
Found by the live red-proof issue #1719's Test Plan asks for. Throwaway pull request #2034 is closed; this is what it turned up.

## The gate checked out the wrong tree

```
[command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
```

`actions/checkout` with no `ref:` resolves to the repository's **default branch**, not the pull request's base — while the file's own comment asserted the opposite:

> The BASE, which is what `pull_request_target` checks out when no ref is named.

`BASE_SHA` (`github.event.pull_request.base.sha`) was already passed to the scan as `--base-ref`, so the **diff** was computed against `develop` correctly. The **registry and the scan code** came from `main`.

| tree | guarded workflows |
| --- | --- |
| `origin/develop` (the pull request's base) | `ci.yml`, `review-gate.yml`, `workflow-provenance-gate.yml` |
| `origin/main` (what was checked out) | `ci.yml`, `review-gate.yml` |

## Why it matters

Diff from the base, rules from the default branch. Two consequences, both silent:

1. **A context newly required on `develop` sits outside the guarded set until the next promotion.** That was live for `workflow-provenance-gate.yml` itself between PR #2030 merging and the next promotion — the gate would not have guarded its own workflow.
2. **A fix to `scan-workflow-provenance.mjs` does not reach `develop` pull requests until it reaches `main`.** The executed code is `main`'s copy.

Not a security hole — `main` is not attacker-controlled — but a gate that judges by rules which can lag its base indefinitely, with nothing saying so.

## The fix

`ref: ${{ github.event.pull_request.base.sha }}`. Still the base, never the head, so the property the file exists for is unchanged: a pull request cannot put its own content in the working tree. A case asserts that exact spelling, alongside the existing one that refuses a head ref.

## How it surfaced, which is the part worth keeping

The throwaway's body carried four predictions written **before** any check ran. Three held exactly — the context failed, named `ci.yml`, enumerated all twelve contexts the edit could move, and the pull request went `BLOCKED`. The fourth predicted `2 of 3 guarded workflow(s)` and observed `2 of 2`.

`2 of 2` reads as a perfectly healthy line. Nothing in it invites a second look, and without the prediction on record the red-proof would have been filed as a clean success with this defect underneath it.

## Verification

- `pnpm harness:scan` — 134 passed, 2 skipped
- `pnpm harness:verify-like-ci` — **PASS, all 12 stages**
- `workflow-provenance-gate` suite — 13 passed

After this merges I will re-run the throwaway and confirm the advisory reads `2 of 3` with `::examined:: 3`, then close issue #1719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jk88JE5EUEaBTPM3LnGN5
