### PR TITLE
docs(harness): record why guarded-workflow relevance is a directory test, not a registry lookup

### DIFF
--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -742,6 +742,20 @@ export function annotateNotMirrored(
     // A workflow edit is not `code` — the `changes` classifier reports infrastructure-only work as
     // N/A — so `workflow provenance` would have been marked irrelevant on exactly the diffs it
     // exists to judge. Its own subject is the file list, so its relevance is a file-list question.
+    //
+    // A DIRECTORY test, not a registry lookup, and the imprecision is deliberate. Asking
+    // `readGuardedWorkflows()` which files actually provide a required context is more precise, and
+    // it was tried: it makes relevance depend on a file THE CHANGE CAN EDIT. A change that edits a
+    // workflow and drops its context from the registry in the same commit would compute its own
+    // relevance as false — which is the shape `workflow-provenance-gate` exists to refuse,
+    // reproduced inside the relevance calculation. The gate reads the registry from the BASE for
+    // exactly this reason; `annotateNotMirrored` runs locally against the working tree and has no
+    // base to read from.
+    //
+    // The imprecision costs one advisory line on a diff already touching CI, where someone is
+    // already looking. Under-reporting hides a required check nobody will run by hand. If the noise
+    // ever matters, the fix is to read the registry from the merge base — which needs a base ref
+    // this function does not take.
     if (key === 'guarded-workflow')
       return changedFiles.some((file) => file.startsWith('.github/workflows/'));
     // An unknown key must SHOUT rather than be ignored: the alternative is a required check


### PR DESCRIPTION
Refs #1719. **Does not close it** — PR #2038 carries the task record, and it is right that it does.

## What this branch became

It started as INFRA-097's fifth step and it is now one comment. Everything else either landed in parallel or was argued out of it, and both are worth recording.

**The live ruleset edit is the part that is not in any diff.** My user authorised it and I made it: `protect-develop` requires ten contexts now, `workflow provenance` being the tenth. A ruleset is not a file, so nothing here shows it — and no observer could attribute the write either, because the API authenticates every session as the same user. It was settled by saying so.

## The argument I lost, recorded because it is a good argument

This branch carried a registry-driven `guarded-workflow` evaluator. `.github/workflows/` holds files that provide no required context, so the shipped directory test marks those relevant when they are not; asking `readGuardedWorkflows()` is more precise.

The author of the shipped line objected, and the objection is decisive: **reading the registry makes relevance depend on a file the change can edit.** A change that edits a workflow *and* drops its context from the registry in the same commit computes its own relevance as false — the exact shape `workflow-provenance-gate` exists to refuse, reproduced inside the relevance calculation. The gate reads the registry from the **base** for that reason; `annotateNotMirrored` runs locally against the working tree and has no base to read from.

The fail direction settles the rest. Over-reporting costs one advisory line on a diff already touching CI. Under-reporting hides a required check nobody will run by hand — and the unknown-key branch two lines down already returns `true` on that grain.

So the shipped version stays, and this records **why**, with the exit named: read the registry from the merge base, which needs a base ref the function does not take. Without the note the next person makes the same argument, and it is a good one — it is just answered.

## What was dropped, and why the record is not mine to carry

The task record moves in PR #2038, which ticks **four** of five criteria, not five as this branch did. Code, docs-only and genuine-finding are validated by observation; **fork, retarget and cancellation are not.**

And issue #2039 makes "done" narrower than either of us had written: a `pull_request_target` workflow runs the **default branch's** copy of its own YAML. `develop` has the base-pinned checkout; `main` does not; the run received no `ref:` input, so it executed `main`'s copy. **Both of today's gate fixes are inert until a promotion carries them**, and the retarget hole is live on `main` right now. A record ticking all five would read as though the gate were fully fixed today.

## One finding from the rebase that no scan caught

Both branches added a `workflow provenance` entry to `NOT_MIRRORED`; the rebase kept **both**. `required-check-local-reachability` asks whether an entry *exists* per context — two satisfy that as well as one. **136 scans passed over a list with a duplicated member**, found by reading the rebase result rather than from the suite.

The check answers its own question correctly; the question is the wrong shape — existential where the property is uniqueness. And merges are what produce duplicates, so it arrives through the one operation the check is least likely to be re-run after.

`verify-like-ci` 12/12 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uvyAk1oL2RmY2LCXJSq9s