### PR TITLE
fix(agent-tool-mcp): an MCP tool can be registered as an agent tool (TOOL-006)

### DIFF
--- a/packages/agent-tool-mcp/src/__tests__/tool-006-registrable.test.ts
+++ b/packages/agent-tool-mcp/src/__tests__/tool-006-registrable.test.ts
@@ -1,0 +1,78 @@
+/**
+ * TOOL-006 — an MCP tool can actually be registered as an agent tool.
+ *
+ * The package existed to register MCP tools with the runtime and could not: `MCPTool` and
+ * `RelayMcpTool` implemented the narrow `ITool` and lacked `getName()` and `setEventService()`, while
+ * the runtime's tool slot is `IToolWithEventService` and registration calls `setEventService`
+ * UNCONDITIONALLY. So the failure was not only a type error a caller could cast past — casting
+ * produced a `TypeError` at registration.
+ *
+ * These rows therefore assert the CONTRACT rather than the types. A compile-time check would have
+ * passed the moment the methods existed, including if `setEventService` had been a no-op that
+ * discarded the service — which satisfies the signature and defeats the reason the runtime calls it.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { MCPTool } from '../mcp-tool';
+import { RelayMcpTool } from '../relay-mcp-tool';
+
+const schema = {
+  name: 'mcp__probe__read',
+  description: 'a probe tool',
+  parameters: { type: 'object' as const, properties: {}, required: [] },
+};
+
+/** The two methods the runtime's tool intake requires beyond the narrow `ITool`. */
+const REQUIRED = ['getName', 'setEventService'] as const;
+
+function mcpTool(): MCPTool {
+  return new MCPTool({ isConnected: () => true } as never, schema as never);
+}
+
+function relayTool(): RelayMcpTool {
+  return new RelayMcpTool({
+    schema: schema as never,
+    targetToolName: 'read',
+    ownerPath: [],
+  } as never);
+}
+
+describe('an MCP tool satisfies the runtime tool slot', () => {
+  for (const [label, make] of [
+    ['MCPTool', mcpTool],
+    ['RelayMcpTool', relayTool],
+  ] as const) {
+    describe(label, () => {
+      for (const method of REQUIRED) {
+        it(`implements ${method}, which registration calls unconditionally`, () => {
+          expect(typeof (make() as unknown as Record<string, unknown>)[method]).toBe('function');
+        });
+      }
+
+      it('reports the schema name from getName, not a placeholder', () => {
+        // The runtime addresses a tool by this name — permission rules, event payloads and the
+        // model's own tool list all key on it. A getName returning anything else would register
+        // successfully and then be unreachable by rule.
+        expect(make().getName()).toBe(schema.name);
+      });
+
+      it('RETAINS the event service it is given, rather than accepting and discarding it', () => {
+        // The signature is satisfied by a no-op. The contract is not: the runtime injects the
+        // service so tool lifecycle events can be emitted, and a tool that drops it registers
+        // cleanly while emitting nothing. This is the assertion a types-only fix would pass.
+        const tool = make();
+        const service = { emit: () => undefined } as never;
+        tool.setEventService(service);
+        expect((tool as unknown as { eventService?: unknown }).eventService).toBe(service);
+      });
+
+      it('accepts undefined, which is how the runtime clears the injection', () => {
+        const tool = make();
+        tool.setEventService({ emit: () => undefined } as never);
+        tool.setEventService(undefined);
+        expect((tool as unknown as { eventService?: unknown }).eventService).toBeUndefined();
+      });
+    });
+  }
+});

--- a/packages/agent-tool-mcp/src/mcp-tool.ts
+++ b/packages/agent-tool-mcp/src/mcp-tool.ts
@@ -12,6 +12,8 @@ import {
 import { ThirdPartySchemaValidator, type TUnenforceableSchemaReporter } from './third-party-schema';
 
 import type {
+  IEventService,
+  IToolWithEventService,
   ITool,
   IToolResult,
   IToolExecutionContext,
@@ -31,8 +33,11 @@ const CONNECTION_CHECK_INTERVAL_MS = 100;
  * Implements ITool without extending AbstractTool to avoid
  * circular runtime dependency (tool-mcp → agents → tools → agents).
  */
-export class MCPTool implements ITool {
+export class MCPTool implements IToolWithEventService {
   readonly schema: IToolSchema;
+
+  /** Held for the runtime's benefit; see `setEventService`. */
+  private eventService: IEventService | undefined;
   private readonly mcpConfig: IMCPConfig;
   private connectionStatus: TMCPConnectionStatus = 'disconnected';
   private sessionId: string | undefined;
@@ -149,6 +154,26 @@ export class MCPTool implements ITool {
    */
   getDescription(): string {
     return this.schema.description;
+  }
+
+  /**
+   * TOOL-006. The runtime's tool slot is `IToolWithEventService`, and registration calls
+   * `setEventService` unconditionally — so a tool without it is a `TypeError` at registration, not a
+   * type error a caller can work around by casting. Both methods exist for that contract.
+   */
+  getName(): string {
+    return this.schema.name;
+  }
+
+  /**
+   * Accepts the runtime's event service so tool lifecycle events are emitted.
+   *
+   * Stored and not otherwise used here: this class emits nothing of its own, and the point of the
+   * method is that the runtime can call it. Refusing to hold the reference would satisfy the type
+   * and break the contract's purpose, which is the shape this package was already in.
+   */
+  setEventService(eventService: IEventService | undefined): void {
+    this.eventService = eventService;
   }
 
   /**

--- a/packages/agent-tool-mcp/src/relay-mcp-tool.ts
+++ b/packages/agent-tool-mcp/src/relay-mcp-tool.ts
@@ -3,13 +3,15 @@ import { ToolExecutionError } from '@robota-sdk/agent-core';
 import { ThirdPartySchemaValidator, type TUnenforceableSchemaReporter } from './third-party-schema';
 
 import type {
+  IEventService,
+  IToolWithEventService,
   TToolParameters,
   IToolResult,
   IToolExecutionContext,
   IParameterValidationResult,
 } from '@robota-sdk/agent-core';
 import type { IToolSchema } from '@robota-sdk/agent-core';
-import type { IEventService, IOwnerPathSegment } from '@robota-sdk/agent-core';
+import type { IOwnerPathSegment } from '@robota-sdk/agent-core';
 
 const ID_RADIX = 36;
 const ID_SUBSTR_END = 8;
@@ -51,8 +53,11 @@ export interface IRelayMcpOptions {
  *
  * Implements ITool without extending AbstractTool to avoid circular runtime dependency.
  */
-export class RelayMcpTool {
+export class RelayMcpTool implements IToolWithEventService {
   readonly schema: IToolSchema;
+
+  /** Held for the runtime's benefit; see `setEventService`. */
+  private eventService: IEventService | undefined;
   private readonly runImpl: IRelayMcpOptions['run'];
   private readonly onUnenforceableSchema?: TUnenforceableSchemaReporter;
   /** CORE-040: built on first use and reused — narrowing is a property of the schema, not the call. */
@@ -130,5 +135,25 @@ export class RelayMcpTool {
 
   getDescription(): string {
     return this.schema.description;
+  }
+
+  /**
+   * TOOL-006. The runtime's tool slot is `IToolWithEventService`, and registration calls
+   * `setEventService` unconditionally — so a tool without it is a `TypeError` at registration, not a
+   * type error a caller can work around by casting. Both methods exist for that contract.
+   */
+  getName(): string {
+    return this.schema.name;
+  }
+
+  /**
+   * Accepts the runtime's event service so tool lifecycle events are emitted.
+   *
+   * Stored and not otherwise used here: this class emits nothing of its own, and the point of the
+   * method is that the runtime can call it. Refusing to hold the reference would satisfy the type
+   * and break the contract's purpose, which is the shape this package was already in.
+   */
+  setEventService(eventService: IEventService | undefined): void {
+    this.eventService = eventService;
   }
 }


### PR DESCRIPTION
Resolves TOOL-006. **First increment of issue #1985, not a fix for it** — see Scope below.

## The blocker

`@robota-sdk/agent-tool-mcp` exists to register MCP tools with the runtime and **could not**.
`MCPTool` and `RelayMcpTool` implemented the narrow `ITool` and lacked `getName()` and
`setEventService()`, while the runtime's tool slot is `IToolWithEventService` and registration calls
`setEventService` **unconditionally**.

So this was not a type error a caller could cast past — casting produced a `TypeError` at
registration.

Both methods added to both classes, and both now declare the interface they satisfy rather than the
narrower one they happened to match. **No new dependency:** `@robota-sdk/agent-core` is already a
peer dependency and both files already import from it.

## The tests assert the contract, not the types

This is the part worth reviewing. **A types-only fix passes the moment the methods exist** —
including if `setEventService` were a no-op that discards the service, which satisfies the signature
and defeats the reason the runtime calls it.

So the rows assert behaviour a signature check cannot see:

| row | what a types-only fix would do |
| --- | --- |
| the service is **retained**, not accepted and dropped | pass with a no-op body |
| `undefined` **clears** it, the way the runtime clears an injection | pass with a no-op body |
| `getName()` returns the **schema name**, not any string | pass returning `''` |

The `getName` row matters more than it looks: the runtime addresses a tool by that name, and
permission rules, event payloads and the model's own tool list all key on it. A wrong name
**registers cleanly and is then unreachable by rule** — which is a worse failure than not
registering, because it looks like it worked.

## RED→GREEN, proven rather than assumed

Checked the two source files out at `origin/develop`, re-ran, restored:

```
pre-fix:   10 failed | 0 passed
after:     10 passed
```

The restore was verified by **reading the files back**, not by trusting the copy.

## Scope

Issue #1985's gate checklist is a full MCP client — three installation scopes with a precedence rule,
four transports, reconnection backoff, a timeout hierarchy, permission addressing, OAuth. **None of
it can land while an MCP tool cannot be registered at all**, which is why this went first and why
this PR does not claim the issue.

## Verification

- 53 package tests pass (`@robota-sdk/agent-tool-mcp`), typecheck clean
- `pnpm harness:scan` — **134 passed, 2 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc8Cy57xP1AyHj8LsDGqcx
