### PR TITLE
docs(tasks): INFRA-097's gate fixes are live, and TC-10 was observed

### DIFF
--- a/.agents/tasks/completed/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/completed/INFRA-097-trusted-required-workflow-provenance.md
@@ -91,7 +91,19 @@ base-pinned checkout, so from this merge onward the gate that runs is the gate t
 The measurement is this pull request's own `workflow provenance` run: with the checkout pinned to the
 pull request's base, the advisory must read **`2 of 3 guarded workflow(s)`** and `::examined:: 3`.
 Before the promotion the same line read `2 of 2`, because the job was checking out `main` and reading
-`main`'s registry. RESULT: recorded below, before merge.
+`main`'s registry.
+
+**Observed on run `32554628933`:**
+
+```
+⚑ 2 of 3 guarded workflow(s) load their definition from the pull request (`on: pull_request`):
+  .github/workflows/ci.yml, .github/workflows/review-gate.yml
+::examined:: 3 guarded workflow(s)
+```
+
+Three, and the one that is NOT self-loading is the gate itself. That is the first observation that any
+of the day's gate work actually executes, and it closes the loop the fourth prediction opened: the
+number that was wrong is now right, for the reason issue #2039 gave.
 
 Also observed at that merge, and it belongs here because this item's closing keyword produced it:
 issues #1719, #1980 and #2018 were closed by **GitHub**, not by a person — `ClosedEvent.closer` names

--- a/.agents/tasks/completed/INFRA-097-trusted-required-workflow-provenance.md
+++ b/.agents/tasks/completed/INFRA-097-trusted-required-workflow-provenance.md
@@ -82,6 +82,24 @@ registry state something untrue. The same held-membership shape `regression-red-
 
 ## Progress
 
+### 2026-08-22 — first observation that the fixes execute
+
+Promotion pull request #2041 merged at `05:23:35Z` as `68fc0490e`, carrying both of the day's gate
+fixes to `main`. `main` now declares `types: [opened, synchronize, reopened, edited]` and the
+base-pinned checkout, so from this merge onward the gate that runs is the gate that was reviewed.
+
+The measurement is this pull request's own `workflow provenance` run: with the checkout pinned to the
+pull request's base, the advisory must read **`2 of 3 guarded workflow(s)`** and `::examined:: 3`.
+Before the promotion the same line read `2 of 2`, because the job was checking out `main` and reading
+`main`'s registry. RESULT: recorded below, before merge.
+
+Also observed at that merge, and it belongs here because this item's closing keyword produced it:
+issues #1719, #1980 and #2018 were closed by **GitHub**, not by a person — `ClosedEvent.closer` names
+pull request #2041 on all three, against a control (issue #1965, closed by hand) where the same field
+is `null`. That is INFRA-104's TC-10 observed for the first time, and it was observed only because the
+window was held deliberately: the issue was left open on purpose rather than tidied closed. The
+mechanism works; nothing yet makes it reliable.
+
 ### 2026-08-22 — the fixes are landed and INERT until promotion (issue #2039)
 
 The completion pull request was used as the last verification: with the base-pinned checkout on


### PR DESCRIPTION
Records two observations made after promotion pull request #2041 merged as `68fc0490e`.

**This pull request's own `workflow provenance` run is the measurement.** With the base-pinned checkout live on `main`, the advisory must read `2 of 3 guarded workflow(s)` and `::examined:: 3`. Before the promotion the same line read `2 of 2`, because the job checked out `main` and read `main`'s registry (issue #2039). I am reading the log before merging; if it reads `2`, the diagnosis in issue #2039 is wrong and this does not merge.

**TC-10 was observed for the first time.** Issues #1719, #1980 and #2018 were closed by GitHub, not by a person: `ClosedEvent.closer` names pull request #2041 on all three, against a control — issue #1965, closed by hand — where the same field is `null`. `actor` is the shared account on all four and carries no information, which is why the discriminator had to be a different field and why it was run against a known negative first.

Recorded qualified, in the record's own words: the window was held deliberately, nothing in the workflow protects it, so the mechanism **works** and is not yet shown to be **reliable**.

## Verification

- `pnpm harness:scan` — 134 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jk88JE5EUEaBTPM3LnGN5