### PR TITLE
docs(tasks): INFRA-104 is done — TC-10 observed on a real promotion

### DIFF
--- a/.agents/memory/reference-kind-is-named.md
+++ b/.agents/memory/reference-kind-is-named.md
@@ -37,7 +37,7 @@ different enforcement shapes, and the write surface is always the cheap one.
 ## The exemption that is load-bearing
 
 `Closes #N` is exempt because GitHub parses that exact shape, and
-[INFRA-104](../tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md) built the promotion
+[INFRA-104](../tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md) built the promotion
 machinery that carries those keywords to the default branch so a finished issue closes itself.
 Requiring a qualifier there would have traded a readability gain for a broken automation — the kind
 of trade a new rule makes silently when its author only looks at the surface being improved.

--- a/.agents/rules/publish.md
+++ b/.agents/rules/publish.md
@@ -104,7 +104,7 @@ anything, and every keyword written on a feature pull request is prose.
 Enforced by: `scripts/harness/scan-promotion-closes.mjs`, run as the `promotion closes` job in
 `.github/workflows/ci.yml` and required on `protect-main`. It re-derives the requirement from the
 live pull request and blocks a body that omits any of it. Record:
-[INFRA-104](../tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md).
+[INFRA-104](../tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md).
 
 ### CI Failure Triage
 

--- a/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -261,3 +261,98 @@ What has never been exercised is GitHub's half, and this record now says why tha
 - issue #1984 — the lint ratchet's only CI execution path is the promotion job.
 - issue #2014 — the dependency-review licence exemption names 2 of this repository's 56
   dual-licensed packages.
+
+### 2026-08-22 (third entry) — TC-10 OBSERVED
+
+The second promotion of the day, PR #2041, merged at `05:23:35Z`. The three conditions fixed in
+writing **before** the branch was pushed were executed against it.
+
+| #   | condition, fixed in advance                                  | outcome                                           |
+| --- | ------------------------------------------------------------ | ------------------------------------------------- |
+| 1   | the body carries a non-empty block naming all three subjects | **MET** — 3 closing lines                         |
+| 2   | `promotion closes` passes                                    | **MET** — `pass`, and REQUIRED for the first time |
+| 3   | each subject is closed by GITHUB, attributed to the merge    | **MET** — see below                               |
+
+```
+issue #1980  closedAt 05:23:36Z  closer = PullRequest #2041
+issue #2018  closedAt 05:23:37Z  closer = PullRequest #2041
+issue #1719  closedAt 05:23:37Z  closer = PullRequest #2041
+promotion merged 05:23:35Z
+```
+
+**Three subjects, three closures, one to two seconds after the merge, every one attributed by GitHub
+to the promotion itself.** No partial result: the bar written in advance was that three subjects
+closing two issues is not "mostly observed", and it did not have to be invoked.
+
+### The instrument was wrong, and saying so is the point
+
+Condition 3 was written as _"the timeline event carries a `commit_id`, and `closed_by` is not a
+person"_. Executed literally, all three read:
+
+```
+closed_by=woojubb  commit_id=NONE
+```
+
+which, taken at face value, says a person closed them by hand — the failure branch, for the sixth
+time. **That reading would have been wrong.** `commit_id` is populated when a commit MESSAGE closes
+an issue; a closing keyword in a pull-request BODY is recorded differently, and `closed_by` names
+whoever merged rather than distinguishing mechanism from hand.
+
+The field that actually answers the question is `ClosedEvent.closer`, and it names `PullRequest
+#2041` for all three.
+
+So the condition was right and its **operationalisation** was wrong: I had picked a field that
+cannot distinguish the two cases the condition is about. That is the same defect this item has spent
+the day cataloguing, committed by the person checking for it — and it is why the correction was made
+by querying a different field rather than by softening the condition to fit what the first query
+returned.
+
+Fixing the reading afterwards is only legitimate because the direction was against interest: the
+literal reading said FAIL and the corrected one says PASS. The check on that is whether the new
+field would have been chosen had the first result read PASS. It would: `closer` is the field that
+names the mechanism, and the first one never did.
+
+**And the corrected field was validated against a known negative rather than trusted.** Issue #1965
+was closed BY HAND earlier the same day, by the same account, on the same repository:
+
+```
+CONTROL  issue #1965  closedAt 01:42:25Z  closer = NULL              actor = woojubb
+TEST     issue #1980  closedAt 05:23:36Z  closer = PullRequest #2041  actor = woojubb
+TEST     issue #2018  closedAt 05:23:37Z  closer = PullRequest #2041  actor = woojubb
+TEST     issue #1719  closedAt 05:23:37Z  closer = PullRequest #2041  actor = woojubb
+```
+
+`actor` is identical across all four and carries no information — every session on this machine
+authenticates as that account. `closer` separates them cleanly: null for the hand-close, the
+promotion for all three mechanism-closes. A discriminator that had matched the control too would
+have proved nothing, which is why it was run.
+
+A second session reached the same verdict independently through a different field — a `referenced`
+timeline event carrying the promotion's merge commit `68fc0490e` at the close timestamp on all
+three. Two fields, two observers, same conclusion.
+
+### What made this run different from the five failures
+
+Every earlier attempt lost its subject in the window between a fix merging and a promotion running —
+five times, once seventeen minutes after the merge. This time the window was held deliberately:
+`robota-4-aa` was told the promotion would close issue #1719 and confirmed they would not close it by
+hand, and issue #2018 was left alone for the same reason.
+
+That is worth recording plainly, because it qualifies the result. **TC-10 was observed under a
+protected window, not under ordinary operation.** The structural finding from the previous entry
+stands: nothing in the workflow protects that window, the open issue still reads as an oversight to
+anyone tidying, and the next observation depends on someone again being told not to tidy.
+
+So this proves the mechanism WORKS. It does not prove the mechanism is RELIABLE, and the item should
+not be read as though it did.
+
+### The gate's own half, also exercised for the first time
+
+`promotion closes` had passed before, but always over an EMPTY requirement — correct and vacuous. On
+this run it derived three subjects, confirmed each is an open issue through the API, verified the
+body carried a keyword for every one, and passed **as a required context** whose failure would have
+blocked the merge. Before today it was declared required and was not (issue #1980, fixed in the same
+session and closed by this very promotion).
+
+Provenance was checked rather than assumed: the `Closes #1719` line originates in PR #2030, inside
+the promotion's range. PR #2038 merged after the branch was cut and is not in this promotion.

--- a/.agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-104: a merged Closes #N never reaches main, so finished issues stay open'
-status: in-progress
+status: done
 created: 2026-08-18
+completed: 2026-08-22
 priority: high
 urgency: now
 area: scripts/harness, .github/workflows, .github/required-status-checks.json
@@ -39,8 +40,12 @@ and guard the promotion PR against omitting one.
 - [x] TC-08: `pnpm harness:scan` and the harness unit tier are green.
 - [x] TC-09: `scan-main-required-checks.mjs` exits 0 with the new required context declared under
       `branches.main`.
-- [ ] TC-10 (user-execution): the next promotion PR carries the block and GitHub — not a person —
-      closes the issues it names. `#1722` is the first case.
+- [x] TC-10 (user-execution): the next promotion PR carries the block and GitHub — not a person —
+      closes the issues it names. OBSERVED 2026-08-22 on promotion PR #2041: three subjects
+      (issues #1980, #2018, #1719), all three closed 1-2s after the merge with
+      `ClosedEvent.closer = PullRequest #2041`. Validated against a hand-closed control
+      (issue #1965, `closer = NULL`). NOT `#1722` — that subject was consumed by hand long
+      before, as were four others; see the dated entries below.
 
 ## Test Plan
 

--- a/scripts/harness/reference-kind-baseline.json
+++ b/scripts/harness/reference-kind-baseline.json
@@ -132,7 +132,7 @@
   ".agents/tasks/HARNESS-108-barrel-parameter-types-covers-two-of-fifty-five-barrels.md": 2,
   ".agents/tasks/INFRA-046-promote-advisory-gates.md": 64,
   ".agents/tasks/INFRA-054-fast-forward-promotion-end-state.md": 5,
-  ".agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md": 5,
+  ".agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md": 5,
   ".agents/tasks/PEER-003-peer-input-coalescing-loses-conversation-turns.md": 1,
   ".agents/tasks/REL-023-changeset-reconciliation.md": 1,
   ".agents/tasks/RUNTIME-002-headless-only-bun-runtime-entry.md": 2,


### PR DESCRIPTION
## TC-10 was the last unmet criterion, and it is observed

TC-01 through TC-09 were already met. TC-10 asked for the one thing no local run can produce: a real
promotion whose derived block causes **GitHub, not a person**, to close the issues it names.

It went unobserved **five times** this session — each time the subject was closed by hand in the
window between its fix merging and a promotion running, once seventeen minutes after.

Observed on promotion PR #2041:

```
promotion merged                  05:23:35Z
issue #1980  closedAt 05:23:36Z   closer = PullRequest #2041
issue #2018  closedAt 05:23:37Z   closer = PullRequest #2041
issue #1719  closedAt 05:23:37Z   closer = PullRequest #2041
```

Three subjects, three closures, each attributed by GitHub to the promotion. The bar written in
advance — *a partial result is a failure* — did not have to be invoked.

## The scoring instrument was wrong, and the record says so

Condition 3 was fixed in writing beforehand as *"the timeline event carries a `commit_id`, and
`closed_by` is not a person"*. Run literally it returned `closed_by=woojubb commit_id=NONE` for all
three — **the failure branch, for the sixth time**.

That reading would have been wrong. `commit_id` is populated when a commit **message** closes an
issue; a closing keyword in a pull-request **body** is recorded differently. The field that answers
the question is `ClosedEvent.closer`.

So the condition was right and the field chosen to operationalise it could not distinguish the two
cases it was about — the same defect this item spent the day cataloguing, in the scoring rule of the
test built to catch it.

**The correction is legitimate only because of how it was made:** by querying a *different field*,
not by softening the condition; and because `closer` would have been chosen had the first result read
PASS. Loosening a threshold until the result flips looks identical in the diff and is the opposite
act.

## The corrected field was validated against a known negative

```
CONTROL  issue #1965 (closed BY HAND the same day)  closer = NULL              actor = woojubb
TEST     issue #1980 / #2018 / #1719                 closer = PullRequest #2041  actor = woojubb
```

`actor` is identical across all four and carries no information — every session on this machine
authenticates as the same account. `closer` separates them cleanly. A discriminator that had matched
the control too would have proved nothing, which is why it was run first.

A second session reached the same verdict independently through a different field — a `referenced`
event carrying the promotion's merge commit on all three.

## Qualified, not overclaimed

The window was held **deliberately**: another session was asked not to close issue #1719 by hand and
did not. Nothing in the workflow protects that window, and the open issue still reads as an oversight
to anyone tidying.

**This proves the mechanism works. It does not prove the mechanism is reliable.** The record says so
in those words, and the structural finding from the previous entry stands.

## Housekeeping

Status `done`, `completed` dated, record archived. Two inbound links and the `reference-kind`
baseline entry repointed in the same change — the five unqualified references are the frozen count
moving with the file, not new debt. 134 scans pass.

ACTIONABLE FINDINGS: 0

Refs INFRA-104