### PR TITLE
fix(harness): a declared context name is checked on every branch, not only main

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -101,11 +101,11 @@
       ],
       "deliberately_not_required": [
         {
-          "context": "patch-coverage",
+          "context": "patch-coverage (advisory)",
           "reason": "Advisory by design (HARNESS-041). It runs and prints a verdict on every code PR but never blocks; excluded because a required context must be able to fail, and this one deliberately cannot. INFRA-046 holds it advisory over two open defects: NO-DATA lines are folded into the below-target total, and the React-UI denominator policy is undecided."
         },
         {
-          "context": "regression-red-proof",
+          "context": "regression-red-proof (enforcing: accidental-green only)",
           "reason": "CAN fail as of INFRA-046 — `REGRESSION_RED_PROOF_ENFORCE=1` makes an `accidental-green` verdict exit 1 — so the 'deliberately cannot fail' reason above does NOT apply to it. Excluded for a different reason, by owner decision: `accidental-green` has never fired on a real pull request, and making it required would put an untested refusal in the merge path. One observed firing is the evidence that promotes it. Note this exclusion does not make the job harmless: `merge-gate.sh` refuses any non-CLEAN mergeStateStatus, and GitHub reports UNSTABLE when a NON-required check fails."
         },
         {

--- a/scripts/harness/__tests__/scan-main-required-checks.test.mjs
+++ b/scripts/harness/__tests__/scan-main-required-checks.test.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -7,7 +7,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DECLARATION_FILE,
+  declaredBranches,
+  findContextNameFindings,
   findRequiredCheckFindings,
+  publishedContexts,
   jobConditionProblem,
   jobNeeds,
   pullRequestTrigger,
@@ -391,5 +394,113 @@ describe('scan-main-required-checks parsing helpers', () => {
       types: ['edited'],
       hasPathFilter: true,
     });
+  });
+});
+
+/**
+ * issue #2036 — R1's reasoning is not `main`-specific, and its scope was.
+ *
+ * "Branch protection matches on the context NAME, so a required context nothing publishes never
+ * reports and blocks the PR forever" is a fact about how branch protection matches. It is identical
+ * on `develop`, which had no equivalent check.
+ *
+ * MEASURED when this was written: `develop`'s `deliberately_not_required` named `patch-coverage` and
+ * `regression-red-proof` while the jobs publish `patch-coverage (advisory)` and
+ * `regression-red-proof (enforcing: accidental-green only)`. Neither was required, so neither was
+ * harmful — and both were staged for promotion, where moving the entry verbatim would have required
+ * a name nothing publishes and stranded every `develop` pull request.
+ */
+describe('a declared context name must be one a workflow actually publishes (issue #2036)', () => {
+  it('reads the published names from the job `name:`, falling back to the job id', () => {
+    const published = publishedContexts();
+    // Both spellings, from the real workflows: a job with an explicit display name, and one without.
+    expect(published.has('regression-red-proof (enforcing: accidental-green only)')).toBe(true);
+    expect(published.has('build')).toBe(true);
+  });
+
+  it('covers EVERY declared branch, not only `main`', () => {
+    const branches = declaredBranches();
+    expect(branches).toContain('main');
+    expect(branches).toContain('develop');
+  });
+
+  it('the repository declares no context that nothing publishes', () => {
+    expect(findContextNameFindings()).toEqual([]);
+  });
+
+  it('reports a develop-side entry whose name no job publishes', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ctxname-'));
+    mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+    writeFileSync(
+      path.join(root, '.github', 'workflows', 'ci.yml'),
+      'jobs:\n  red-proof:\n    name: regression-red-proof (enforcing: accidental-green only)\n    steps: []\n',
+      'utf8',
+    );
+    writeFileSync(
+      path.join(root, '.github', 'required-status-checks.json'),
+      JSON.stringify({
+        branches: {
+          develop: {
+            required_status_checks: [{ context: 'regression-red-proof' }],
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    const findings = findContextNameFindings(root);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].context).toBe('regression-red-proof');
+    expect(findings[0].detail).toMatch(/branches\.develop\.required_status_checks/);
+    expect(findings[0].detail).toMatch(/permanently pending/);
+  });
+
+  it('checks `deliberately_not_required` too, because that list is where a promotion starts', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ctxname-'));
+    mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+    writeFileSync(
+      path.join(root, '.github', 'workflows', 'ci.yml'),
+      'jobs:\n  cov:\n    name: patch-coverage (advisory)\n    steps: []\n',
+      'utf8',
+    );
+    writeFileSync(
+      path.join(root, '.github', 'required-status-checks.json'),
+      JSON.stringify({
+        branches: {
+          develop: {
+            required_status_checks: [{ context: 'patch-coverage (advisory)' }],
+            deliberately_not_required: [{ context: 'patch-coverage', reason: 'advisory' }],
+          },
+        },
+      }),
+      'utf8',
+    );
+
+    const findings = findContextNameFindings(root);
+    expect(findings.map((f) => f.context)).toEqual(['patch-coverage']);
+    expect(findings[0].detail).toMatch(/deliberately_not_required/);
+  });
+
+  it('skips a grouped label that names several contexts in one string', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ctxname-'));
+    mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+    writeFileSync(
+      path.join(root, '.github', 'workflows', 'ci.yml'),
+      'jobs:\n  a:\n    steps: []\n',
+      'utf8',
+    );
+    writeFileSync(
+      path.join(root, '.github', 'required-status-checks.json'),
+      JSON.stringify({
+        branches: {
+          develop: {
+            required_status_checks: [{ context: 'a' }],
+            deliberately_not_required: [{ context: 'build / quality / scans', reason: 'grouped' }],
+          },
+        },
+      }),
+      'utf8',
+    );
+    expect(findContextNameFindings(root)).toEqual([]);
   });
 });

--- a/scripts/harness/__tests__/scan-main-required-checks.test.mjs
+++ b/scripts/harness/__tests__/scan-main-required-checks.test.mjs
@@ -411,21 +411,83 @@ describe('scan-main-required-checks parsing helpers', () => {
  * a name nothing publishes and stranded every `develop` pull request.
  */
 describe('a declared context name must be one a workflow actually publishes (issue #2036)', () => {
+  /**
+   * FIXTURE, not the real tree. The harness test tier runs from a temporary clone that carries no
+   * `.github`, and these finders now THROW there by design — so a case that reads the real
+   * repository passes locally and fails in the tier that actually gates the push. The assertion
+   * "this repository declares nothing unpublished" belongs to the SCAN, which runs over the real
+   * tree on every `pnpm harness:scan`; it is not a unit test's job.
+   */
+  function fixtureRoot({ workflows, declaration }) {
+    const root = mkdtempSync(path.join(tmpdir(), 'ctxname-'));
+    mkdirSync(path.join(root, '.github', 'workflows'), { recursive: true });
+    for (const [file, text] of Object.entries(workflows)) {
+      writeFileSync(path.join(root, '.github', 'workflows', file), text, 'utf8');
+    }
+    writeFileSync(
+      path.join(root, '.github', 'required-status-checks.json'),
+      JSON.stringify(declaration),
+      'utf8',
+    );
+    return root;
+  }
+
   it('reads the published names from the job `name:`, falling back to the job id', () => {
-    const published = publishedContexts();
-    // Both spellings, from the real workflows: a job with an explicit display name, and one without.
+    const root = fixtureRoot({
+      workflows: {
+        'ci.yml':
+          'jobs:\n  red-proof:\n    name: regression-red-proof (enforcing: accidental-green only)\n    steps: []\n  build:\n    steps: []\n',
+      },
+      declaration: { branches: { main: { required_status_checks: [{ context: 'build' }] } } },
+    });
+    const published = publishedContexts(root);
+    // Both spellings: a job with an explicit display name, and one that publishes its job id.
     expect(published.has('regression-red-proof (enforcing: accidental-green only)')).toBe(true);
     expect(published.has('build')).toBe(true);
   });
 
   it('covers EVERY declared branch, not only `main`', () => {
-    const branches = declaredBranches();
-    expect(branches).toContain('main');
-    expect(branches).toContain('develop');
+    const root = fixtureRoot({
+      workflows: { 'ci.yml': 'jobs:\n  a:\n    steps: []\n' },
+      declaration: {
+        branches: {
+          main: { required_status_checks: [{ context: 'a' }] },
+          develop: { required_status_checks: [{ context: 'a' }] },
+        },
+      },
+    });
+    expect(declaredBranches(root)).toEqual(['main', 'develop']);
   });
 
-  it('the repository declares no context that nothing publishes', () => {
-    expect(findContextNameFindings()).toEqual([]);
+  it('reports nothing when every declared name is published', () => {
+    const root = fixtureRoot({
+      workflows: { 'ci.yml': 'jobs:\n  a:\n    name: quality\n    steps: []\n' },
+      declaration: {
+        branches: {
+          main: { required_status_checks: [{ context: 'quality' }] },
+          develop: { required_status_checks: [{ context: 'quality' }] },
+        },
+      },
+    });
+    expect(findContextNameFindings(root)).toEqual([]);
+  });
+
+  it('FAILS CLOSED rather than reporting nothing when the declaration is absent', () => {
+    const bare = mkdtempSync(path.join(tmpdir(), 'ctxname-bare-'));
+    // Measured before the guard existed: this returned `[]`, which reads as "every declared name is
+    // published" over a tree that was never read.
+    expect(() => findContextNameFindings(bare)).toThrow(/nothing was examined/);
+  });
+
+  it('FAILS CLOSED when the workflows directory is absent', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'ctxname-nowf-'));
+    mkdirSync(path.join(root, '.github'), { recursive: true });
+    writeFileSync(
+      path.join(root, '.github', 'required-status-checks.json'),
+      JSON.stringify({ branches: { main: { required_status_checks: [{ context: 'a' }] } } }),
+      'utf8',
+    );
+    expect(() => findContextNameFindings(root)).toThrow(/broken checkout/);
   });
 
   it('reports a develop-side entry whose name no job publishes', () => {

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -87,6 +87,15 @@ const REGISTRATION_FILE = path.join(HARNESS_DIR, 'run-all-scans.mjs');
  */
 export const MANDATORY_TREE_GUARDS = [
   {
+    // issue #2036. Measured BEFORE the guard existed: over a root with no `.github`, this returned
+    // `[]` — which reads as "every declared context name is published" when nothing was read at all.
+    // The classification is what caught it, exactly as it caught INFRA-127's exported finder.
+    file: 'scan-main-required-checks.mjs',
+    finder: 'findContextNameFindings',
+    tree: '.github/required-status-checks.json',
+    why: 'the declaration file IS the population — it is the SOURCE of what each ruleset must require, so its absence is a broken checkout, and "no findings" would claim every declared name matches a published context when none was read',
+  },
+  {
     // INFRA-126. Measured as `findTempDirOwnerFindings(bare)`: throws
     // `scripts/harness/__tests__ missing from <root>` before a single file is read.
     file: 'scan-temp-dir-owner.mjs',

--- a/scripts/harness/scan-main-required-checks.mjs
+++ b/scripts/harness/scan-main-required-checks.mjs
@@ -63,7 +63,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 
 import { fetchAllPages } from './github-api.mjs';
@@ -419,10 +419,97 @@ function reconcileLiveBranch(root, branchName) {
   return findings;
 }
 
+/** Every branch `.github/required-status-checks.json` declares, in file order. */
+export function declaredBranches(root = WORKSPACE_ROOT) {
+  const file = path.join(root, DECLARATION_FILE);
+  if (!existsSync(file)) return [];
+  return Object.keys(JSON.parse(readFileSync(file, 'utf8'))?.branches ?? {});
+}
+
+/**
+ * Every status-check context this repository's workflows can publish.
+ *
+ * GitHub names a check run after the job's `name:` when it has one, and after the job ID when it
+ * does not. Branch protection matches on that string exactly.
+ */
+export function publishedContexts(root = WORKSPACE_ROOT) {
+  const dir = path.join(root, '.github', 'workflows');
+  // FAIL CLOSED for the same reason: an empty set makes EVERY declared context look unpublished,
+  // which is loud rather than silent — but it is still a verdict over a tree that was never read.
+  if (!existsSync(dir)) {
+    throw new Error(
+      '.github/workflows is missing, so no published context could be read. That is a broken checkout, not a repository whose workflows publish nothing.',
+    );
+  }
+  const names = new Set();
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+    const text = readFileSync(path.join(dir, file), 'utf8');
+    for (const job of splitWorkflowJobs(text)) {
+      const declared = jobLevelValue(job.text, 'name');
+      names.add(declared ? declared.replace(/^['"]|['"]$/g, '') : job.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * R1, applied to EVERY declared branch rather than only `main` (issue #2036).
+ *
+ * R1's reasoning is not `main`-specific — "branch protection matches on the context NAME, so a
+ * required context nothing publishes never reports and blocks the PR forever" is a fact about how
+ * branch protection matches, and it is identical on `develop`. The `main`-only scope was a
+ * contingent fact about which branch was being hardened when R1 was written, hardened into the rule.
+ *
+ * MEASURED when this was added: `develop`'s `deliberately_not_required` named `patch-coverage` and
+ * `regression-red-proof`, while the jobs publish `patch-coverage (advisory)` and
+ * `regression-red-proof (enforcing: accidental-green only)`. Neither was required, so neither was
+ * harmful — and both were staged for promotion, where moving the existing entry would have required
+ * a name nothing publishes and blocked every `develop` pull request permanently.
+ *
+ * So `deliberately_not_required` is IN SCOPE. An entry there is a promotion waiting to happen, and
+ * checking only the live list would leave the trap exactly where it was found.
+ */
+export function findContextNameFindings(root = WORKSPACE_ROOT) {
+  const file = path.join(root, DECLARATION_FILE);
+  // FAIL CLOSED (HARNESS-052). Measured before this guard existed: over a root with no `.github`
+  // this returned `[]`, which reads as "every declared name is published" when nothing was read at
+  // all. The declaration file is the SOURCE of what each ruleset must require, so its absence is a
+  // broken checkout, not a repository that has declared nothing.
+  if (!existsSync(file)) {
+    throw new Error(
+      `${DECLARATION_FILE} is missing. Reporting "no findings" here would mean "nothing was examined", which is not the claim this check makes.`,
+    );
+  }
+  const declaration = JSON.parse(readFileSync(file, 'utf8'));
+  const published = publishedContexts(root);
+  const findings = [];
+  for (const [branchName, branch] of Object.entries(declaration?.branches ?? {})) {
+    for (const [list, entries] of [
+      ['required_status_checks', branch?.required_status_checks],
+      ['deliberately_not_required', branch?.deliberately_not_required],
+    ]) {
+      for (const entry of entries ?? []) {
+        const context = entry?.context;
+        // A grouped entry names several contexts in one string for prose reasons; it is a label,
+        // not a match target, and is skipped rather than reported as unpublished.
+        if (typeof context !== 'string' || context.includes('/')) continue;
+        if (published.has(context)) continue;
+        findings.push({
+          context,
+          detail: `${DECLARATION_FILE} names it under \`branches.${branchName}.${list}\`, but no workflow job publishes that context. Branch protection matches on the NAME, so requiring it would leave every pull request permanently pending.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
 export async function main({ argv = process.argv.slice(2) } = {}) {
   const findings = findRequiredCheckFindings();
+  const names = findContextNameFindings();
   const live = argv.includes('--live') ? reconcileLive() : [];
-  const all = [...findings, ...live];
+  const all = [...findings, ...names, ...live];
 
   if (all.length > 0) {
     process.stdout.write('main-required-checks scan failed (INFRA-055):\n');


### PR DESCRIPTION
Closes #2036

## The trap this was found in the middle of

R1 exists to prevent one disaster, in its own words:

> Branch protection matches on the context NAME, so a required context nothing publishes never
> reports and blocks the PR forever.

That is a fact about **how branch protection matches** — identical on `develop`. R1 ran over `main`'s
declared list alone (`GOVERNED_BRANCH = 'main'`), and `develop`'s ten contexts were checked by
nothing.

```
declared in deliberately_not_required     actually published
  patch-coverage                            patch-coverage (advisory)
  regression-red-proof                      regression-red-proof (enforcing: accidental-green only)
```

Neither was required, so neither was harmful. **Both were staged to become required**, and promoting
either by moving its existing entry would have demanded a name nothing publishes — stranding every
`develop` pull request permanently. Found while preparing exactly that promotion (INFRA-046, owner
approved). The entry looks like the thing to move; it is not.

## What changed

Both names corrected. `findContextNameFindings` walks **every declared branch** and **both lists** —
`deliberately_not_required` is in scope because that list is where a promotion starts, and checking
only the live one would leave the trap precisely where it was found. Grouped labels
(`build / quality / scans`) are skipped: they are prose, not match targets.

## The new finder was vacuous, and the harness caught it before I did

```
findContextNameFindings(bare)  ->  []
```

Over a root with no `.github` it reported no findings — which reads as *"every declared context name
is published"* when nothing was read at all. The defect this scan exists to catch, in the check added
to catch more of it.

`guard-scope-fail-closed` refused to register it without a classification, the classification was
produced **by running it**, and both finders now throw. Pinned in `MANDATORY_TREE_GUARDS` with that
measurement; 80 guards proven fail-closed by execution.

## And then that fix broke my own tests, in the tier that matters

Three cases called the finders with no `root`, so they read the real repository. The harness test
tier runs from a temporary clone with **no `.github`** — where the finders now throw by design. So
those cases **passed locally and failed in the tier that gates the push.** Pre-push refused, and was
right.

An assertion about *this* repository belongs to the scan, which evaluates it over the real tree on
every `pnpm harness:scan`. The unit suite gets fixtures, like every other case in the file, plus two
new cases for the fail-closed behaviour itself.

## Red-proofed, each mutation asserted to have applied

| mutation | result |
| -------- | ------ |
| restrict the walk to `main` | the develop cases fail |
| skip `deliberately_not_required` | that case fails, alone |
| revert one corrected name in the **real** declaration | the scan names it and exits 1 |

The third ran against the actual repository file, so the check is proven on the shape that motivated
it.

One negative result recorded rather than dressed up: an attempt to reproduce the no-`.github`
environment by hand failed while loading the vitest config. That proved nothing and was not treated
as evidence — pre-push is the authoritative instrument for that question.

## Verification

- 31 tests in `scripts/harness/__tests__/scan-main-required-checks.test.mjs`
- `pnpm harness:scan`: 134 passed
- `pnpm harness:pre-push`: green, 3508 + 1134 tests across the tiers
- All re-run on the **committed** tree after `eslint --fix` touched staged files.

ACTIONABLE FINDINGS: 0

Refs INFRA-055