### PR TITLE
feat(harness): a pull_request_target gate is inert until promotion, so report the lag (INFRA-128)

### DIFF
--- a/.agents/tasks/INFRA-128-pull-request-target-promotion-lag.md
+++ b/.agents/tasks/INFRA-128-pull-request-target-promotion-lag.md
@@ -1,0 +1,69 @@
+---
+title: 'INFRA-128: report the promotion lag of every pull_request_target gate'
+issue: https://github.com/woojubb/robota/issues/2039
+status: in-progress
+created: 2026-08-22
+priority: medium
+urgency: soon
+area: scripts/harness, .github/workflows
+depends_on: [INFRA-097]
+---
+
+# INFRA-128: report the promotion lag of every `pull_request_target` gate
+
+## Objective
+
+A `pull_request_target` workflow loads its YAML from the repository's DEFAULT branch, not from the
+PR and not from the PR's base. So a fix to such a gate is **inert on the branch that carries it**,
+and stays inert until that branch is promoted to `main`. Nothing in the harness said so, and the
+cost was paid twice in one session on issue #1719's gate: two defects were found, fixed, reviewed
+and merged to `develop`, and neither changed what actually ran.
+
+Report that gap, per workflow, on every scan run.
+
+## Plan
+
+- [x] Compare each `pull_request_target` workflow between `HEAD` and the promotion ref.
+- [x] Distinguish `absent` (never promoted) from `lagging` (promoted, then diverged).
+- [x] Refuse rather than report "no delta" when a ref cannot be read.
+- [x] Register the scan in `scripts/harness/run-all-scans.mjs`.
+- [x] Split `scan-workflow-provenance`'s finding by trigger, since the two triggers fail in
+      opposite directions.
+
+## Why whole-file comparison, not a curated field list
+
+Comparing only the fields that "matter" needs a list of what matters, and that list rots silently:
+the day a `pull_request_target` gate grows a field nobody listed, the check reports a match over a
+real difference. Whole-file comparison over-reports instead — a reworded comment is not a behaviour
+change, so comments and blank lines are stripped, and what remains can still differ for reasons that
+do not affect execution. That direction is the safe one: the failure mode is one advisory line on a
+diff already touching CI, where someone is already looking.
+
+## The state at authoring, stated so it cannot be mistaken for a measurement of nothing
+
+`git diff origin/main origin/develop -- .github/workflows/workflow-provenance-gate.yml` is **empty**
+as this lands: the promotion that carried both of issue #1719's gate fixes went through first. The check
+therefore ships with **no live subject** — it reports `1 pull_request_target workflow(s); 1 match
+origin/main, 0 do not`. Recorded here because a green line from a check with nothing to find and a
+green line from a check that found nothing are indistinguishable at a glance, and only the first one
+means the check is unproven against a real delta.
+
+The `lagging`, `absent` and unreadable-ref cases are therefore proven against throwaway git
+repositories with real refs, not against this tree.
+
+## The false start, kept because it is the point
+
+The first cut of those three cases used a stub helper that returned a fixed `promoted` verdict for
+every fixture. Two of the three passed. They proved nothing: the assertion could not observe what
+the code under test computed, and one case failed only because the stub disagreed with the fixture
+it served — which is the ONLY reason the stub was noticed at all.
+
+That is the same defect one layer up from this check's subject. A check that cannot fail installed
+in the slot where a check belongs reads exactly like a check that passes. Replaced with temporary
+repositories, which is I/O in a test and worth it: `git show <ref>:<path>` is the behaviour under
+test, so anything that stands in for git is asserting the stand-in.
+
+The refusal case then found a real defect in the implementation. `readAtRef` returned `null` for two
+different facts — "this ref has no such file" and "there is no such ref" — and `findPromotionLagAt`
+read both as `absent`. An unfetched `origin/main` would have reported every workflow as never
+promoted: a loud wrong answer, and one built out of exactly the collapse this check exists to name.

--- a/scripts/harness/__tests__/scan-pull-request-target-promotion-lag.test.mjs
+++ b/scripts/harness/__tests__/scan-pull-request-target-promotion-lag.test.mjs
@@ -1,0 +1,212 @@
+/**
+ * A `pull_request_target` workflow runs the default branch's copy of itself (issue #2039).
+ *
+ * The tree has NO delta as this lands — the promotion carried both fixes minutes before. So every
+ * case here CONSTRUCTS one rather than reading the tree, which is also the honest way round: a case
+ * that passed because the tree happened to differ would stop testing anything the moment it agreed.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { makeTemp } from './make-temp.mjs';
+
+import {
+  comparableBody,
+  findPromotionLagAt,
+  readExamined,
+  triggersFromPullRequestTarget,
+} from '../scan-pull-request-target-promotion-lag.mjs';
+
+describe('which workflows are in scope', () => {
+  it.each([
+    ['on:\n  pull_request_target:\n    branches: [main]\n', true],
+    ['on:\n  pull_request:\n    branches: [main]\n', false],
+    ['on:\n  schedule:\n    - cron: "0 0 * * *"\n', false],
+  ])('reads the trigger off the `on:` block', (text, expected) => {
+    expect(triggersFromPullRequestTarget(text)).toBe(expected);
+  });
+
+  it('does not match a mention of the string outside the `on:` block', () => {
+    // The same trap `scan-workflow-provenance` documents: a job step or a comment naming the trigger
+    // is not the trigger, and a substring search would call every file that discusses this one a
+    // member of the set.
+    expect(
+      triggersFromPullRequestTarget(
+        'on:\n  push:\n\njobs:\n  x:\n    steps:\n      - run: echo pull_request_target:\n',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('what counts as a difference', () => {
+  it('ignores a reworded comment — a rationale change is not a behaviour change', () => {
+    const a = '# one reason\non:\n  pull_request_target:\n';
+    const b = '# a different reason entirely\non:\n  pull_request_target:\n';
+    expect(comparableBody(a)).toBe(comparableBody(b));
+  });
+
+  it('ignores blank lines and trailing whitespace', () => {
+    expect(comparableBody('on:\n\n  pull_request_target:   \n\n')).toBe(
+      comparableBody('on:\n  pull_request_target:\n'),
+    );
+  });
+
+  it('SEES a trailing comment removed from a line that also has code', () => {
+    // The half that matters: `types: [a]  # why` and `types: [a, b]  # why` differ in the code, and
+    // stripping the comment must not take the code with it.
+    expect(comparableBody('types: [a]  # why')).not.toBe(comparableBody('types: [a, b]  # why'));
+  });
+
+  it.each([
+    ['a trigger type added', 'types: [opened]', 'types: [opened, edited]'],
+    ['a checkout ref pinned', 'with:\n  x: 1', 'with:\n  ref: ${{ base.sha }}\n  x: 1'],
+    ['a permission narrowed', 'permissions:\n  contents: write', 'permissions:\n  contents: read'],
+    ['the run line changed', 'run: node a.mjs', 'run: node a.mjs --base-ref x'],
+  ])('SEES %s', (_label, before, after) => {
+    // Four kinds, and only the first two are what today's fixes touched. The comparison is whole-file
+    // on purpose: a curated list of load-bearing fields would encode today's two changes as the
+    // definition of load-bearing, and the next inert fix would print a delta and pass.
+    expect(comparableBody(before)).not.toBe(comparableBody(after));
+  });
+});
+
+describe('the verdict for one workflow, against a real git repository', () => {
+  /*
+   * A temporary repository with two real refs, because `promotionLag` shells out to git and the
+   * property under test is what `git show <ref>:<path>` returns. A stub would be asserting the stub.
+   *
+   * The first cut of these three cases used a fake that returned a fixed value — it passed, proved
+   * nothing, and one of them failed only because the fixture disagreed with itself. Replaced rather
+   * than deleted: the cases are the right cases, the harness was the wrong one.
+   */
+  const TARGET = 'on:\n  pull_request_target:\n    branches: [main]\n';
+
+  function makeRepo({ head, promotion }) {
+    const dir = makeTemp('robota-prt-lag-');
+    const run = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    run('init', '-q', '-b', 'main');
+    run('config', 'user.email', 'probe@example.invalid');
+    run('config', 'user.name', 'probe');
+    mkdirSync(path.join(dir, '.github/workflows'), { recursive: true });
+    const write = (text) => writeFileSync(path.join(dir, '.github/workflows/w.yml'), text);
+
+    if (promotion !== null) {
+      write(promotion);
+      run('add', '-A');
+      run('commit', '-qm', 'promotion state');
+    } else {
+      writeFileSync(path.join(dir, 'placeholder'), 'x');
+      run('add', '-A');
+      run('commit', '-qm', 'no workflow yet');
+    }
+    run('branch', '-f', 'promotion-ref');
+
+    write(head);
+    // An unrelated file so the second commit exists even when `head` and `promotion` are identical
+    // — which is the `promoted` case, and the one where "no change to commit" would fail the setup
+    // rather than the assertion.
+    writeFileSync(path.join(dir, 'head-marker'), 'x');
+    run('add', '-A');
+    run('commit', '-qm', 'head state');
+    return dir;
+  }
+
+  function lagIn(fixture) {
+    // No `chdir`: the root is a parameter, which is the whole reason it was made one. An earlier
+    // cut changed the process directory instead and passed alone, then failed under the suite —
+    // vitest runs it in a worker, where `process.chdir` throws.
+    return findPromotionLagAt(makeRepo(fixture), 'HEAD', 'promotion-ref');
+  }
+
+  it('reports `promoted` when the two copies agree', () => {
+    expect(lagIn({ head: TARGET, promotion: TARGET })).toEqual([
+      { file: '.github/workflows/w.yml', state: 'promoted' },
+    ]);
+  });
+
+  it('reports `lagging` when they differ', () => {
+    expect(
+      lagIn({
+        head: TARGET,
+        promotion: 'on:\n  pull_request_target:\n    branches: [develop]\n',
+      }),
+    ).toEqual([{ file: '.github/workflows/w.yml', state: 'lagging' }]);
+  });
+
+  it('reports `absent` when the promotion ref does not carry the file at all', () => {
+    // Its own state, not a delta: never promoted is a stronger statement than differs, and folding
+    // them together would let "none of this is live" read as "some of this is old".
+    expect(lagIn({ head: TARGET, promotion: null })).toEqual([
+      { file: '.github/workflows/w.yml', state: 'absent' },
+    ]);
+  });
+
+  it('REFUSES an unreadable promotion ref rather than reporting no delta', () => {
+    // The distinction this whole session has been about: "could not compare" is not "nothing to
+    // compare". Building that confusion into the check whose subject is exactly this would be its
+    // own instance.
+    const dir = makeRepo({ head: TARGET, promotion: TARGET });
+    expect(() => findPromotionLagAt(dir, 'HEAD', 'no-such-ref')).toThrow(/could not/i);
+  });
+});
+
+describe('the reported size', () => {
+  /*
+   * The `::examined::` number is the only part of this check's coverage claim a reader can act on,
+   * so it is asserted as an output: an EXACT value against a fixture of known size, and again after
+   * a second walk. A bound would be met by an over-count, and a counter that accumulates rises
+   * monotonically while reading like growing coverage.
+   */
+  const TARGET = 'on:\n  pull_request_target:\n    branches: [main]\n';
+  const NOT_TARGET = 'on:\n  pull_request:\n    branches: [main]\n';
+
+  function repoWith(files) {
+    const dir = makeTemp('robota-prt-size-');
+    const run = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    run('init', '-q', '-b', 'main');
+    run('config', 'user.email', 'probe@example.invalid');
+    run('config', 'user.name', 'probe');
+    mkdirSync(path.join(dir, '.github/workflows'), { recursive: true });
+    for (const [name, text] of Object.entries(files)) {
+      writeFileSync(path.join(dir, '.github/workflows', name), text);
+    }
+    run('add', '-A');
+    run('commit', '-qm', 'fixture');
+    run('branch', '-f', 'promotion-ref');
+    return dir;
+  }
+
+  // THREE of the five trigger from `pull_request_target`; the number must be the subject's size,
+  // not the directory's, so the two non-subjects are what make this fixture able to fail.
+  const dir = repoWith({
+    'a.yml': TARGET,
+    'b.yml': TARGET,
+    'c.yml': TARGET,
+    'd.yml': NOT_TARGET,
+    'e.yml': NOT_TARGET,
+  });
+
+  it('counts the workflows the walk actually visited', () => {
+    findPromotionLagAt(dir, 'HEAD', 'promotion-ref');
+    expect(readExamined()).toBe(3);
+  });
+
+  it('starts from zero on a second walk rather than accumulating', () => {
+    findPromotionLagAt(dir, 'HEAD', 'promotion-ref');
+    findPromotionLagAt(dir, 'HEAD', 'promotion-ref');
+    expect(readExamined()).toBe(3);
+  });
+
+  it('reports zero, not the previous walk, when a tree holds no such workflow', () => {
+    // The direction the rule names: a number that survives a walk which read nothing is the one
+    // that reads steadier than the coverage it stands for.
+    const empty = repoWith({ 'only.yml': NOT_TARGET });
+    findPromotionLagAt(dir, 'HEAD', 'promotion-ref');
+    findPromotionLagAt(empty, 'HEAD', 'promotion-ref');
+    expect(readExamined()).toBe(0);
+  });
+});

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -49,6 +49,7 @@
     "product-identity",
     "progress-report-quantification",
     "publish-registry",
+    "pull-request-target-promotion-lag",
     "reference-kind-qualified",
     "release-sweep-coverage",
     "remote-stream-route-spelling",

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -1,6 +1,6 @@
 {
   "item": "HARNESS-087",
-  "reason": "Every harness module carrying the declaration marker is classified here. `covered` meets the floor and is re-measured each run, so losing coverage is a regression finding rather than a quiet move to the debt list. `pending` was recorded unmet when the floor was adopted — the counter is not exported, or nothing asserts its value — and an entry that comes to meet the floor is itself a finding.",
+  "reason": "Every harness module carrying the declaration marker is classified here. `covered` meets the floor and is re-measured each run, so losing coverage is a regression finding rather than a quiet move to the debt list. `pending` was recorded unmet when the floor was adopted \u2014 the counter is not exported, or nothing asserts its value \u2014 and an entry that comes to meet the floor is itself a finding.",
   "covered": [
     "scripts/harness/check-contract-disposition.mjs",
     "scripts/harness/check-fixture-floor.mjs",
@@ -27,6 +27,7 @@
     "scripts/harness/scan-preset-projection.mjs",
     "scripts/harness/scan-product-identity.mjs",
     "scripts/harness/scan-promotion-closes.mjs",
+    "scripts/harness/scan-pull-request-target-promotion-lag.mjs",
     "scripts/harness/scan-reference-kind-qualified.mjs",
     "scripts/harness/scan-remote-stream-route-spelling.mjs",
     "scripts/harness/scan-role-port-optionals.mjs",

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -522,6 +522,13 @@ export const SCAN_COMMANDS = [
     name: 'workflow-provenance',
     command: ['node', 'scripts/harness/scan-workflow-provenance.mjs'],
   },
+  // Issue #2039. The sibling above makes a `pull_request` gate's edit VISIBLE; a `pull_request_target`
+  // gate fails the opposite way — it loads its YAML from the default branch, so a fix to it is inert
+  // on the branch that carries it and stays inert until promotion. This reports that gap.
+  {
+    name: 'pull-request-target-promotion-lag',
+    command: ['node', 'scripts/harness/scan-pull-request-target-promotion-lag.mjs'],
+  },
   {
     name: 'new-rule-declares-enforcement',
     command: ['node', 'scripts/harness/scan-new-rule-declares-enforcement.mjs'],

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -113,6 +113,17 @@ export const MANDATORY_TREE_GUARDS = [
     why: 'the catalogue IS the subject — over a root without it there is no row to shape-check, and a silent zero would read as "every row fills its columns" while the file it governs had vanished',
   },
   {
+    // INFRA-128. Measured as `findPromotionLagAt(bare, 'HEAD', 'origin/main')`: throws
+    // `could not resolve the promotion ref \`origin/main\`` before any workflow is read. The
+    // classification is what fixed it — the first cut resolved nothing up front, so `readAtRef`
+    // returned null for both "this ref has no such file" and "there is no such ref", and every
+    // workflow came back `absent` over a root that was never a repository.
+    file: 'scan-pull-request-target-promotion-lag.mjs',
+    finder: 'findPromotionLagAt',
+    tree: '.github/workflows',
+    why: 'the comparison IS the check — over a root without the promotion ref there is nothing to compare against, and "0 do not match" would read as "every gate is promoted" when neither side was ever read',
+  },
+  {
     // Measured as `findLoopProofFindings(bare)`: throws `.agents/skills missing from <root>` before it
     // reads a baseline or a ledger.
     file: 'scan-loop-proof.mjs',

--- a/scripts/harness/scan-pull-request-target-promotion-lag.mjs
+++ b/scripts/harness/scan-pull-request-target-promotion-lag.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+/**
+ * A `pull_request_target` workflow runs the DEFAULT branch's copy of itself (issue #2039).
+ *
+ * Measured on three runs the day this landed. `workflow-provenance-gate.yml` executed `main`'s
+ * version of its own YAML on pull requests whose base was `develop`: the checkout step received no
+ * `ref:` input and resolved to `main`, and the gate's advisory printed the count `main`'s registry
+ * produces rather than `develop`'s.
+ *
+ * THE CONSEQUENCE, which is the whole reason this file exists: **a fix to such a workflow is inert
+ * until it is promoted.** Two landed on `develop` that day — adding `edited` to the trigger, and
+ * pinning the checkout to the pull request's base — and neither was active. Both were verified
+ * locally, both landed green, and both did nothing.
+ *
+ * The security property is unaffected and arguably stronger: `main` is further from a pull request's
+ * reach than `develop` is. What does not hold is the assumption that fixing the gate fixes the gate.
+ *
+ * ## Why it compares whole files rather than the fields that matter
+ *
+ * The first cut failed only when the delta touched `types:` or the checkout `ref:` — the two fields
+ * today's fixes happened to change. That is a contingent fact hardened into a rule, and the next
+ * inert fix would be a `permissions:` narrowing, a `concurrency` group, or the `run:` line the gate
+ * actually executes; the check would print a delta, pass, and read as though it had judged.
+ *
+ * So the comparison is mechanical: the file's content with comments and blank lines stripped. Any
+ * semantic difference means THE GATE THAT RUNS IS NOT THE GATE THAT WAS REVIEWED, which is the true
+ * property. No key list to maintain and no judgement about which lines matter.
+ *
+ * ## Why it reports rather than refuses
+ *
+ * A delta is the NORMAL state between promotions. A check red for most of a release cycle is one
+ * that gets switched off, and this repository has measured that failure mode more than once. So the
+ * standing state goes in the `::examined::` line, where it is visible without blocking.
+ *
+ * The moment that CAN be acted on is different: someone editing such a workflow and believing the
+ * edit takes effect. `scan-workflow-provenance` already speaks at exactly that moment, so the
+ * warning lives there rather than as a second red gate here.
+ *
+ * ## The subject was live when this was written and is EMPTY as it lands
+ *
+ * Measured while authoring: one `pull_request_target` workflow existed and it differed from `main`
+ * on two counts — `types:` (`edited` present on `develop`, absent on `main`) and the checkout `ref:`.
+ * Two fixes deep, exactly the state the issue describes.
+ *
+ * Then the promotion carried both, and the delta is now ZERO. So this scan lands with nothing to
+ * report, and says so rather than letting a green line be read as a measurement. The evidence that
+ * it ever had a subject is the paragraph above; the evidence that it can still find one is its
+ * tests, which construct a delta rather than relying on the tree having one.
+ *
+ * That distinction is the reason this paragraph exists. A guard whose population empties and does
+ * not announce it is indistinguishable from a guard that works, and this repository has measured
+ * that shape more than once.
+ *
+ * Usage:
+ *   node scripts/harness/scan-pull-request-target-promotion-lag.mjs
+ *   node scripts/harness/scan-pull-request-target-promotion-lag.mjs --promotion-ref origin/main
+ */
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const WORKFLOWS_PREFIX = '.github/workflows/';
+
+/** Where a promoted workflow runs FROM — the repository's default branch. */
+export const DEFAULT_PROMOTION_REF = 'origin/main';
+
+function git(args, root = WORKSPACE_ROOT) {
+  return spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+}
+
+/**
+ * Read one path at one ref, or null when the path does not exist there.
+ *
+ * A MISSING PATH and an UNREADABLE REF are different answers and this returns only the first as
+ * null — the caller refuses on the second. That distinction is the subject of half this repository's
+ * findings, and building it wrong into the check whose subject is exactly this would be its own
+ * instance.
+ */
+export function readAtRef(ref, relativePath, root = WORKSPACE_ROOT) {
+  const result = git(['show', `${ref}:${relativePath}`], root);
+  if (result.status === 0) return result.stdout;
+  const stderr = result.stderr ?? '';
+  if (
+    /does not exist|exists on disk, but not in|unknown revision|invalid object name/i.test(stderr)
+  )
+    return null;
+  throw new Error(
+    `pull-request-target-promotion-lag: could not read \`${ref}:${relativePath}\` — the ` +
+      `measurement FAILED, so no verdict can be reported from it.\n${stderr}`,
+  );
+}
+
+/** Does this workflow text trigger on `pull_request_target`? Read off the `on:` block only. */
+export function triggersFromPullRequestTarget(workflowText) {
+  let inOn = false;
+  for (const line of workflowText.split('\n')) {
+    if (/^on:\s*$/.test(line)) {
+      inOn = true;
+      continue;
+    }
+    if (inOn && /^\S/.test(line)) break;
+    if (inOn && /^\s{2}pull_request_target:\s*$/.test(line)) return true;
+  }
+  return false;
+}
+
+/**
+ * The comparable body: content with comments and blank lines removed.
+ *
+ * Comments are stripped because a reworded rationale is not a behaviour change, and a check that
+ * reported one would be noise on the day someone improves a comment. A `#` inside a quoted string
+ * would be over-stripped — accepted, because the failure direction is a FALSE DELTA (reported,
+ * never a refusal) rather than a missed one.
+ */
+export function comparableBody(workflowText) {
+  return workflowText
+    .split('\n')
+    .map((line) => line.replace(/\s+#\s.*$/, '').trimEnd())
+    .filter((line) => line.trim() !== '' && !/^\s*#/.test(line))
+    .join('\n');
+}
+
+/** Every `pull_request_target` workflow tracked at `ref`. */
+export function targetWorkflowsAt(ref, root = WORKSPACE_ROOT) {
+  const listing = git(['ls-tree', '-r', '--name-only', ref, '--', WORKFLOWS_PREFIX], root);
+  if (listing.status !== 0) {
+    throw new Error(
+      `pull-request-target-promotion-lag: could not list workflows at \`${ref}\`. ` +
+        'Refusing rather than reporting "no delta" over a tree that was never read.\n' +
+        `${listing.stderr ?? ''}`,
+    );
+  }
+  const files = (listing.stdout ?? '').split('\n').filter((f) => f.endsWith('.yml'));
+  return files.filter((file) => {
+    const text = readAtRef(ref, file, root);
+    return text !== null && triggersFromPullRequestTarget(text);
+  });
+}
+
+/**
+ * What each `pull_request_target` workflow on `headRef` looks like against `promotionRef`.
+ *
+ * `absent` is its own state rather than a delta: a workflow that does not exist on the promotion ref
+ * has not been promoted at all, which is a stronger statement than "differs".
+ */
+/**
+ * RESET per walk, so a run that reads nothing cannot report the previous run's number.
+ *
+ * Incremented inside the walk rather than taken from the returned array's `.length`: the array is a
+ * second source that resembles the subject, and the two agree right up to the run where a workflow
+ * is dropped between the walk and the result — which is the run the number was needed for.
+ */
+let examinedCount = 0;
+
+export function readExamined() {
+  return examinedCount;
+}
+
+export function findPromotionLagAt(root, headRef = 'HEAD', promotionRef = DEFAULT_PROMOTION_REF) {
+  examinedCount = 0;
+  // Resolve the promotion ref BEFORE reading anything through it. `readAtRef` returns null for two
+  // different facts — "this ref has no such file" and "there is no such ref" — and only the first is
+  // `absent`. Without this line an unfetched `origin/main` reports every workflow as never-promoted,
+  // which is a loud wrong answer; a nearby variant of the same collapse (see the `git show` path)
+  // would have reported "no delta" over a tree that was never read. That confusion IS this check's
+  // subject, so building it into the check would be its own instance of the bug.
+  if (git(['rev-parse', '--verify', '--quiet', `${promotionRef}^{commit}`], root).status !== 0) {
+    throw new Error(
+      `pull-request-target-promotion-lag: could not resolve the promotion ref \`${promotionRef}\`. ` +
+        'Refusing rather than reporting every workflow as unpromoted over a ref that does not exist. ' +
+        'Check out with `fetch-depth: 0` and fetch the promotion branch.',
+    );
+  }
+  return targetWorkflowsAt(headRef, root).map((file) => {
+    examinedCount += 1;
+    const here = readAtRef(headRef, file, root);
+    const there = readAtRef(promotionRef, file, root);
+    if (there === null) return { file, state: 'absent' };
+    return {
+      file,
+      state: comparableBody(here) === comparableBody(there) ? 'promoted' : 'lagging',
+    };
+  });
+}
+
+/** This repository, which is what the CLI asks about. `findPromotionLagAt` takes the root for a test. */
+export function promotionLag(headRef = 'HEAD', promotionRef = DEFAULT_PROMOTION_REF) {
+  return findPromotionLagAt(WORKSPACE_ROOT, headRef, promotionRef);
+}
+
+function main() {
+  const at = process.argv.indexOf('--promotion-ref');
+  const promotionRef = at === -1 ? DEFAULT_PROMOTION_REF : process.argv[at + 1];
+  const lag = promotionLag('HEAD', promotionRef);
+
+  const lagging = lag.filter((w) => w.state !== 'promoted');
+  console.log(
+    `::examined:: ${readExamined()} pull_request_target workflow(s); ` +
+      `${readExamined() - lagging.length} match ${promotionRef}, ${lagging.length} do not`,
+  );
+
+  for (const w of lagging) {
+    console.log(
+      w.state === 'absent'
+        ? `  ${w.file}: not on ${promotionRef} at all — nothing of it is live yet`
+        : `  ${w.file}: differs from ${promotionRef} — the version that RUNS is ${promotionRef}'s, ` +
+            'so edits here are not in effect until a promotion carries them',
+    );
+  }
+  if (lagging.length > 0) {
+    console.log(
+      'This is a report, not a refusal: a delta is the normal state between promotions. It is ' +
+        'printed because two fixes to such a workflow were once verified locally, landed green, ' +
+        'and did nothing (issue #2039).',
+    );
+  } else if (lag.length > 0) {
+    // Said out loud. "0 do not" and "there is nothing here to look at" print the same number, and a
+    // guard that goes quiet when its subject empties is the shape this repository keeps finding.
+    console.log(
+      `  every pull_request_target workflow matches ${promotionRef}, so what runs is what was ` +
+        'reviewed. This line is the measurement, not the absence of one.',
+    );
+  }
+  console.log('pull-request-target-promotion-lag scan passed.');
+  return 0;
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  process.exit(main());
+}

--- a/scripts/harness/scan-workflow-provenance.mjs
+++ b/scripts/harness/scan-workflow-provenance.mjs
@@ -35,6 +35,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 import { requireGovernedTree } from './governed-tree.mjs';
+import { triggersFromPullRequestTarget } from './scan-pull-request-target-promotion-lag.mjs';
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 const REGISTRY_RELATIVE = '.github/required-status-checks.json';
@@ -130,14 +131,27 @@ export function findWorkflowProvenanceFindings(root = WORKSPACE_ROOT, baseRef, h
     const touched = changedFiles(root, baseRef, headRef).filter((f) => workflows.includes(f));
     for (const file of touched) {
       const contexts = contextsByWorkflow.get(file) ?? [];
+      const full = path.join(root, file);
+      // The two triggers fail in OPPOSITE directions, so one message would be wrong for one of them.
+      // `pull_request` loads the edited definition and judges this change with it — the edit is too
+      // powerful. `pull_request_target` loads the DEFAULT branch's copy — the edit does nothing at
+      // all until a promotion carries it (issue #2039), which is how two verified, green fixes to
+      // this repository's own gate were both inert.
+      const promoted =
+        existsSync(full) && triggersFromPullRequestTarget(readFileSync(full, 'utf8'));
       findings.push({
         file,
-        problem:
-          `is edited by this change AND provides required check(s): ${contexts.join(', ')}. ` +
-          `Because it is triggered by \`pull_request\`, the edited definition is what will judge ` +
-          `this pull request — the change can move its own gate. This is not a refusal to make the ` +
-          `edit; it is a refusal to make it INVISIBLY. State in the pull request why the control ` +
-          `plane changes, and have a reviewer read the job that reports each context above.`,
+        problem: promoted
+          ? `is edited by this change AND provides required check(s): ${contexts.join(', ')}. ` +
+            `Because it is triggered by \`pull_request_target\`, THIS EDIT DOES NOT TAKE EFFECT ` +
+            `until a promotion carries it — the version that runs is the default branch's copy of ` +
+            `this file, whatever this change says. Verify the fix against the promoted copy, not ` +
+            `against this branch, and say in the pull request that it is not yet live.`
+          : `is edited by this change AND provides required check(s): ${contexts.join(', ')}. ` +
+            `Because it is triggered by \`pull_request\`, the edited definition is what will judge ` +
+            `this pull request — the change can move its own gate. This is not a refusal to make the ` +
+            `edit; it is a refusal to make it INVISIBLY. State in the pull request why the control ` +
+            `plane changes, and have a reviewer read the job that reports each context above.`,
       });
     }
   }


### PR DESCRIPTION
## The gap

A `pull_request_target` workflow loads its YAML from the repository's **default branch** — not from
the pull request, and not from the pull request's base. So a fix to such a gate is inert on the
branch that carries it, and stays inert until that branch is promoted to `main`.

The harness said nothing about this, and the cost was paid twice in one session on issue #1719's
gate: two real defects were found, fixed, reviewed and merged to `develop`, and neither changed
what actually ran. Both were discovered by hand, on a throwaway pull request.

## What this adds

`scans` → `pull-request-target-promotion-lag`. For every `pull_request_target` workflow on `HEAD`,
compare it against the promotion ref and report the verdict per workflow:

- `promoted` — the copies agree, so what runs is what was reviewed;
- `lagging` — promoted once, then diverged;
- `absent` — not on the promotion ref at all, which is a stronger statement than "differs" and is
  kept as its own state rather than folded into the delta.

It reports; it does not refuse. Lag is a normal state between a merge and a promotion, and a check
that failed on it would be red for the whole window it exists to describe.

`scan-workflow-provenance`'s finding now branches on trigger, because the two triggers fail in
**opposite** directions: a `pull_request` gate's edit is too powerful (the change carries the control
plane that judges it), while a `pull_request_target` gate's edit is inert. One sentence could not be
true of both.

## Whole-file comparison, deliberately imprecise

Comparing only the fields that "matter" needs a list of what matters, and that list rots silently —
the day a gate grows a field nobody listed, the check reports a match over a real difference.
Whole-file comparison over-reports instead. Comments and blank lines are stripped, since a reworded
rationale is not a behaviour change; a `#` inside a quoted string would be over-stripped, which is
accepted because that failure direction is a false delta, never a missed one.

## The state at authoring, said out loud

`git diff origin/main origin/develop -- .github/workflows/workflow-provenance-gate.yml` is **empty**
as this lands — the promotion carrying both of issue #1719's gate fixes went through first. So the
check ships with no live subject and prints:

```
::examined:: 1 pull_request_target workflow(s); 1 match origin/main, 0 do not
  every pull_request_target workflow matches origin/main, so what runs is what was reviewed.
  This line is the measurement, not the absence of one.
```

Recorded in the check's own header and in the task record, because a green line from a check with
nothing to find and a green line from a check that found nothing look identical, and only the
second one means anything.

## What the harness caught that I did not

Three of this branch's fixes came from checks rather than from me, and each is worth naming:

- **`guard-scope-fail-closed`** made me run the finder against a root with no governed tree. It
  returned every workflow as `absent`. `readAtRef` collapsed two different facts — "this ref has no
  such file" and "there is no such ref" — into one `null`, so an unfetched `origin/main` would have
  reported every gate as never promoted. That is a loud wrong answer built out of exactly the
  confusion this check exists to name. Now it resolves the ref up front and refuses.
- **`measurement-provenance`** rejected `lag.length` as the reported size. The counter now
  increments inside the walk, and is asserted as an output: an exact value against a five-workflow
  fixture where only three are subjects, again after a second walk, and once more against a tree
  with no subject at all.
- **`fixture-floor` and `temp-dir-owner`** named the test file's location and its temp-directory
  owner. Both were mine to get right and neither was.

The three verdict cases originally ran against a stub that returned a fixed `promoted` for every
fixture. Two of the three passed while proving nothing — the only reason the stub was noticed is
that the third case disagreed with it. They now run against throwaway git repositories with real
refs, because `git show <ref>:<path>` is the behaviour under test and anything standing in for git
is asserting the stand-in.

Closes #2039

Task record: `.agents/tasks/INFRA-128-pull-request-target-promotion-lag.md`
