### PR TITLE
feat(ci): regression-red-proof is required on develop (INFRA-046)

### DIFF
--- a/.agents/tasks/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/INFRA-046-promote-advisory-gates.md
@@ -1,6 +1,6 @@
 ---
 title: 'INFRA-046: promote advisory CI gates (regression-red-proof, patch-coverage) to blocking'
-status: blocked
+status: in-progress
 created: 2026-07-25
 priority: high
 urgency: now
@@ -405,3 +405,54 @@ it.
 modified since 2026-07-26. Any required-list edit touches the same surface, and `robota-4-aa` has
 been assigned a separate required-context addition for issue #1719. Three edits to two rulesets by
 two agents is exactly how the issue #1980 half-application happened.
+
+## 2026-08-22 — `regression-red-proof` is PROMOTED; `patch-coverage` is not, and that is the whole remainder
+
+The block this item carried is discharged. It was stated exactly, which is what made it
+dischargeable:
+
+> `accidental-green` has never fired on a real pull request … **One observed firing is what
+> promotes it.**
+
+It fired twice on PR #1983 and caught a real defect — a registration hunk in
+`scripts/harness/run-all-scans.mjs` reversible with every changed test still passing. The author
+repaired it in three rounds without assistance. Three other verdicts in the same run reported
+`inconclusive` **with the reason**, which is the property that makes a refusal from this gate worth
+acting on. Owner approved the promotion on that evidence.
+
+**Applied, in the order the declaration file demands:**
+
+1. `.github/required-status-checks.json` — the entry moved from `deliberately_not_required` into
+   `branches.develop.required_status_checks`, carrying the context name the job actually
+   **publishes**: `regression-red-proof (enforcing: accidental-green only)`. The bare spelling it had
+   been recorded under matches nothing, and promoting that would have stranded every `develop` pull
+   request permanently. That trap is closed separately as issue #2036.
+2. The live `protect-develop` ruleset — read first, written once, read back:
+
+```
+before: 10 contexts        after: 11 contexts
+rules, conditions, enforcement, bypass_actors: byte-identical before and after
+scan-main-required-checks.mjs --live: REAL EXIT 0, "Live ruleset reconciled."
+```
+
+No `develop` pull request was open at the time, so no already-open PR inherited a permanently
+pending context.
+
+### Why this item is NOT done
+
+Its title names **two** gates. `patch-coverage` is still advisory, and the two defects that hold it
+there are unchanged and were re-read rather than assumed:
+
+- `inconclusive-no-data` lines are folded into the BELOW-TARGET total instead of being reported as
+  NO-DATA;
+- the React-UI denominator policy is undecided — the choice is to exclude those files, change the
+  denominator, or stand up component-test infrastructure for the GUI packages.
+
+Promotion is unsafe until one of those is settled, and neither is a measurement I can take: both are
+policy decisions about what the number should mean.
+
+So the status moves from `blocked` to `in-progress`, because the thing that blocked it — missing
+evidence — is gone, and what remains is a decision plus the work it implies. **Done when
+`patch-coverage` is either promoted on the same standard of evidence, or recorded as permanently
+advisory with the reason, in which case this item's title is wrong and should be narrowed rather than
+the record being marked complete over half its subject.**

--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -97,16 +97,21 @@
           "local": {
             "notRunnable": "ci-mirror-map NOT_MIRRORED"
           }
+        },
+        {
+          "context": "regression-red-proof (enforcing: accidental-green only)",
+          "workflow": ".github/workflows/ci.yml",
+          "job": "regression-red-proof",
+          "verifies": "INFRA-046 — a regression test must FAIL with its fix reversed. Only the `accidental-green` verdict blocks (`REGRESSION_RED_PROOF_ENFORCE=1`): a test that still passes against the pre-fix code guards nothing, and that is a defect whatever else the run found. `inconclusive`, `skipped` and `red-proof-unreached` all pass, so a verdict the checker could not reach never blocks a pull request — the property that makes this refusal trustworthy. PROMOTED 2026-08-22 on exactly the evidence its own exclusion demanded: `accidental-green` had never fired on a real pull request, and \"one observed firing is what promotes it\". It fired twice on PR #1983 and caught a real defect — a `run-all-scans.mjs` registration hunk reversible with every changed test still passing — which the author repaired in three rounds without assistance.",
+          "local": {
+            "notRunnable": "the checker RUNS locally and is useful there (`REGRESSION_RED_PROOF_ENFORCE=1 node scripts/harness/check-regression-red-proof.mjs`), but it cannot reproduce this context's VERDICT. The opt-out is read from `PR_BODY` joined with the commit subjects; off a pull request `PR_BODY` is empty, so an `allow-green-at-base: <reason>` declared in the body alone is invisible locally and the run reports `accidental-green` for a case CI legitimately excuses. A mirror that can disagree with the gate on the gate's own escape hatch is not a mirror."
+          }
         }
       ],
       "deliberately_not_required": [
         {
           "context": "patch-coverage (advisory)",
           "reason": "Advisory by design (HARNESS-041). It runs and prints a verdict on every code PR but never blocks; excluded because a required context must be able to fail, and this one deliberately cannot. INFRA-046 holds it advisory over two open defects: NO-DATA lines are folded into the below-target total, and the React-UI denominator policy is undecided."
-        },
-        {
-          "context": "regression-red-proof (enforcing: accidental-green only)",
-          "reason": "CAN fail as of INFRA-046 — `REGRESSION_RED_PROOF_ENFORCE=1` makes an `accidental-green` verdict exit 1 — so the 'deliberately cannot fail' reason above does NOT apply to it. Excluded for a different reason, by owner decision: `accidental-green` has never fired on a real pull request, and making it required would put an untested refusal in the merge path. One observed firing is the evidence that promotes it. Note this exclusion does not make the job harmless: `merge-gate.sh` refuses any non-CLEAN mergeStateStatus, and GitHub reports UNSTABLE when a NON-required check fails."
         },
         {
           "context": "promotion ancestry / promotion closes / main PR source guard / release-grade verification",

--- a/scripts/harness/__tests__/ci-mirror-map.test.mjs
+++ b/scripts/harness/__tests__/ci-mirror-map.test.mjs
@@ -274,7 +274,17 @@ describe('the ruleset declaration matches the workflow it names', () => {
       const source = readFileSync(workflowPath, 'utf8');
       expect(() => jobRunSteps(source, job)).not.toThrow();
       // The context string is the job's `name:`, which is what branch protection matches on.
-      expect(source).toContain(`name: ${context}`);
+      //
+      // Accept the quoted spellings. A raw `toContain` held only while every context happened to be
+      // a bare scalar; `regression-red-proof (enforcing: accidental-green only)` contains `: `, so
+      // YAML REQUIRES quoting it and the unquoted form the assertion looked for cannot legally
+      // exist. The property being checked is unchanged — the job's `name:` is the context string —
+      // and the assertion now recognises the only spellings that can express it.
+      const escaped = context.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      expect(
+        new RegExp(`^\\s*name:\\s*(['"]?)${escaped}\\1\\s*$`, 'm').test(source),
+        `no job in ${declared.workflow} declares \`name: ${context}\` (bare or quoted)`,
+      ).toBe(true);
     },
   );
 });

--- a/scripts/harness/ci-mirror-map.mjs
+++ b/scripts/harness/ci-mirror-map.mjs
@@ -193,6 +193,15 @@ export const CI_STAGES = [
  */
 export const NOT_MIRRORED = [
   {
+    context: 'regression-red-proof (enforcing: accidental-green only)',
+    reason:
+      "the checker RUNS locally and is useful there, but it cannot reproduce this context's VERDICT. The opt-out is read from `PR_BODY` joined with the commit subjects, and off a pull request `PR_BODY` is empty — so an `allow-green-at-base: <reason>` declared in the body ALONE is invisible locally and the run reports `accidental-green` for a case CI legitimately excuses. A mirror that can disagree with the gate on the gate's own escape hatch is worse than no mirror: it would report a blocking verdict the required check does not hold.",
+    relevance: 'code',
+    relevantWhen: 'the diff changes product code — ci.yml reports docs-only work as N/A',
+    manualCommand:
+      'REGRESSION_RED_PROOF_ENFORCE=1 node scripts/harness/check-regression-red-proof.mjs   (reads the opt-out from commit subjects only; a PR-body opt-out will NOT be seen, so a local `accidental-green` is a question to check against the pull request, not a verdict)',
+  },
+  {
     context: 'dependency audit',
     reason:
       'downloads the osv-scanner binary from GitHub and scans the lockfile against the OSV.dev database — it needs network access and an external toolchain, so a local run could not be made deterministic or offline.',

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -240,6 +240,12 @@
       "timestamp": "2026-08-21T16:36:24.601Z",
       "ratio": "84/100",
       "reason": "The message ACKNOWLEDGING the entry above committed the same violation, by quoting the offending fraction without the percentage while explaining that it lacked one. This file already records that exact shape three times (2026-08-15, 2026-08-17, 2026-08-19), which is the point: the habit is writing the fraction at all without its percentage, quotation included, and an intention to comply does not survive the very next message. Recorded as its own entry rather than folded into the first, because the repeat is the evidence."
+    },
+    {
+      "transcript": "e82cfba8-e0c6-4e4b-bf40-c54a5d248ee4.jsonl",
+      "timestamp": "2026-08-22T06:11:53.217Z",
+      "ratio": "81/84",
+      "reason": "A session-status table reported INFRA backlog completion as ‘81/84 완료’ with no percentage. It is 96%. The violation is the ordinary one this file exists for — a countable set summarised mid-work by its fraction alone — and it happened in the same message that itemised what remained, which is precisely where a reader needs the proportion to judge whether the remainder is a rounding error or a third of the work. Recorded rather than edited: the transcript is append-only, and the entry is the correction."
     }
   ]
 }


### PR DESCRIPTION
## The block is discharged, and it was discharged by evidence, not by argument

INFRA-046 named its condition exactly, which is what made it dischargeable:

> `accidental-green` has never fired on a real pull request, so requiring it would put an untested
> refusal in the merge path. **One observed firing is what promotes it.**

It fired twice on PR #1983 and caught a real defect — a registration hunk in
`scripts/harness/run-all-scans.mjs` that could be reversed with **every changed test still
passing**. The author repaired it in three rounds without assistance. Three other verdicts in the
same run reported `inconclusive` **with the reason** (*"the range added this file and never revised
it, so there is no earlier state to reverse to … which is not a verdict"*), which is the property
that makes a refusal from this gate worth acting on.

Owner approved the promotion on that evidence.

## Applied in the order the declaration file demands

1. **`.github/required-status-checks.json`** — the entry moves from `deliberately_not_required` into
   `branches.develop.required_status_checks`.
2. **The live `protect-develop` ruleset** — read first, written once, read back:

```
before: 10 contexts        after: 11 contexts
rules / conditions / enforcement / bypass_actors:  identical before and after
scan-main-required-checks.mjs --live:  REAL EXIT 0, "Live ruleset reconciled."
```

The declaration is the source and a ruleset ahead of it is the defect issue #1980 recorded, so the
order is not incidental.

**No `develop` pull request was open at write time**, so nothing inherited a permanently pending
context.

## It moves with the name the job PUBLISHES

`regression-red-proof (enforcing: accidental-green only)`, not the bare `regression-red-proof` it had
been recorded under. Promoting that spelling would have made branch protection match a name nothing
publishes and stranded every `develop` pull request. That trap was found while preparing this change
and closed separately as issue #2036.

## Three refusals from pre-push, all correct

- **The scan was the wrong instrument.** `scripts/harness/ci-mirror-map.mjs` exits 0; the contract
  lives in its **test suite**. I ran the cheaper one and stopped, which is the mistake this
  repository keeps catching.
- **`NOT_MIRRORED` is where the declaration belongs** — not `local.notRunnable` in the JSON, which is
  a different consumer. Declared with the precise reason: the checker *runs* locally and cannot
  reproduce the **verdict**, because an `allow-green-at-base` declared in the PR body alone is
  invisible off a pull request. A mirror that can disagree with the gate on the gate's own escape
  hatch is worse than none.
- **One assertion could not express this context.** It searched the workflow for a bare
  `name: <context>`. This name contains `: `, so **YAML requires quoting it** — the assertion rejected
  the only spelling that can legally exist. It held until now because every context happened to be a
  bare scalar. The property checked is unchanged; the assertion now recognises either form.

I was careful with that last one: earlier today I nearly talked myself into calling a different rule
"over-broad" to license my own change, and was wrong. The test here is different — it asks whether
the job's `name:` equals the matched context, and that property is quoting-independent.

## Red-proofed, mutations asserted to have applied

Naming the unpublished spelling in `NOT_MIRRORED` fails three cases. 51 mirror-map tests, 135 scans,
4645 tests across the pre-push tiers.

## This does NOT close INFRA-046

The item's title names **two** gates. `patch-coverage` is still advisory over two unchanged defects —
`inconclusive-no-data` folded into the BELOW-TARGET total, and an undecided React-UI denominator
policy. Both were re-read rather than assumed, and neither is a measurement: they are decisions about
what the number should mean. The record moves `blocked` → `in-progress` and states the terminal
condition rather than claiming half a subject as a whole.

ACTIONABLE FINDINGS: 0

Refs INFRA-046