### PR TITLE
feat(harness): allocate a work-item id and its record in one operation (INFRA-129)

### DIFF
--- a/.agents/loop-runs/automated-review-convergence.jsonl
+++ b/.agents/loop-runs/automated-review-convergence.jsonl
@@ -1,0 +1,1 @@
+{"runId":"r20260822082610","opened":"2026-08-22T08:26:10.630Z","closed":null,"roundFindings":[1],"terminal":null,"ref":null}

--- a/.agents/loop-runs/pr-finding-resolution-loop.jsonl
+++ b/.agents/loop-runs/pr-finding-resolution-loop.jsonl
@@ -1,0 +1,1 @@
+{"runId":"r20260822082505","opened":"2026-08-22T08:25:05.942Z","closed":null,"roundFindings":[1],"terminal":null,"ref":null}

--- a/.agents/loop-runs/user-request-gate.jsonl
+++ b/.agents/loop-runs/user-request-gate.jsonl
@@ -1,2 +1,3 @@
 {"runId":"r20260822021745","opened":"2026-08-22T02:17:45.854Z","closed":"2026-08-22T02:18:14.379Z","roundFindings":[0],"terminal":"halted-for-user","ref":null}
 {"runId":"r20260822040747","opened":"2026-08-22T04:07:47.842Z","closed":"2026-08-22T04:15:29.286Z","roundFindings":[0],"terminal":"converged","ref":null}
+{"runId":"r20260822082505","opened":"2026-08-22T08:25:05.916Z","closed":"2026-08-22T08:25:11.573Z","roundFindings":[0],"terminal":"converged","ref":null}

--- a/.agents/tasks/INFRA-129-allocate-a-work-item-id-and-its-record-in-one-operation.md
+++ b/.agents/tasks/INFRA-129-allocate-a-work-item-id-and-its-record-in-one-operation.md
@@ -1,0 +1,73 @@
+---
+title: 'INFRA-129: allocate a work-item id and its record in one operation'
+issue: https://github.com/woojubb/robota/issues/1916
+status: in-progress
+created: 2026-08-22
+priority: medium
+urgency: soon
+area: scripts/harness, .agents/tasks
+depends_on: []
+---
+
+# INFRA-129: allocate a work-item id and its record in one operation
+
+## Objective
+
+A work-item ID is allocated by reading the current highest number and adding one. Nothing owns the
+allocation, so the collision is created **between the read and the write** — which is precisely
+where no scan can stand. `scan-work-item-id-collision` closes the half a clone can judge offline
+(one ID, two tracked records); this closes the half that actually bit.
+
+Option 2 of issue #1916: make the read and the claim the same operation.
+
+## Plan
+
+- [x] Compute the claimed set from records, tree citations, and issue titles.
+- [x] Report an unread source explicitly rather than treating it as empty.
+- [x] Write the record stub in the same step that takes the number.
+- [x] Register as `pnpm harness:task:allocate` and replace the survey step in the tasks README.
+
+## What "claimed" actually means, measured
+
+The record filenames are not the claimed set. On 2026-08-22: **867** IDs have a record file and
+**63 more are claimed by a tracked file that is not a record** — a rule citing the item that
+introduced it, a scan header, a hook comment, an archived breakdown.
+
+`INFRA-127` is one of the 63. `scan-task-frontmatter-fields.mjs` and `scan-rule-table-shape.mjs`
+both cite it, no `.agents/tasks/INFRA-127-*.md` exists, and so `ls .agents/tasks | grep INFRA`
+reported `INFRA-126` as the highest. The sibling task INFRA-128 was numbered 127 on that reading and
+renumbered by hand. This item exists because that happened while its own sibling was being written.
+
+## Why counting up, and why not into the 900s
+
+The next ID is one above the highest claimed number, never the lowest free one. A gap is usually a
+number claimed by something the tool cannot see — an unpushed branch, an issue not yet opened — and
+handing it out is the same collision with more confidence behind it.
+
+The first run of the script returned `INFRA-1000`, because `INFRA-999` is a fixture in the collision
+scan's own test. Measured before fixing it: of the 867 IDs with a record file, **zero** are at or
+above 900, and all 18 citations that are, are either fixtures or not work-item IDs at all
+(`CVE-2024`, `ISO-8601`, `RFC-7807`). So `SENTINEL_FLOOR = 900` is a measurement, not a convention.
+
+## `null` is not an empty set
+
+`idsFromIssueTitles` returns `null` when the source could not be read, and the run prints that it
+allocated from a smaller set than the one that matters. The three collisions issue #1916 opens with
+were all between a record and an issue title, so a run that silently skipped that source would be
+green in exactly the case it was built for.
+
+## Two defects the tool found in itself
+
+- **`INFRA-1000`**, above.
+- **`--issue 1916` put `1916` in the slug.** Filtering arguments on a leading `--` removes the flag
+  and leaves its value behind, so the number became part of the title. Found by running the script
+  on this record — the file was first written as
+  `INFRA-129-…-in-one-operation-1916.md`. Both are pinned as cases.
+
+## What this does not close
+
+Two sessions can still allocate the same number in the same minute: each reads a set that does not
+yet contain the other's unpushed record. The window is now the push interval rather than the
+authoring interval, and `scan-work-item-id-collision` refuses the second one at pre-push. Removing
+the class rather than guarding it is option 3 of the issue — non-sequential IDs — and is not
+attempted here.

--- a/.agents/tasks/README.md
+++ b/.agents/tasks/README.md
@@ -82,7 +82,22 @@ record's ID".
 
 ## Process
 
-1. Create a new `.md` file in this directory with the required frontmatter (see File Format below).
+1. Allocate the ID and create the record in ONE step:
+
+   ```
+   pnpm harness:task:allocate INFRA "the problem, as a sentence" --issue 1916
+   ```
+
+   Do **not** read the highest number and add one. That read has a shelf life measured in minutes
+   when more than one session is working, and the number is claimed by more than the filenames in
+   this directory: on 2026-08-22, 63 IDs were claimed by a tracked file that is not a record — a
+   rule citing the item that introduced it, a scan header, a hook comment. `INFRA-127` was one of
+   them, and a survey of this directory reported `INFRA-126` as the highest.
+
+   The allocator reads the records, every citation in the tree, and the issue titles, and says so:
+   when it cannot reach the issue list it prints that it allocated from a smaller set rather than
+   passing quietly. Add `--dry-run` to see the ID without writing the file.
+
 2. Set `status: todo` (not yet started) or `status: in-progress` (underway) in frontmatter.
 3. When implementation is complete and all gates pass (see
    [backlog-execution.md](../rules/backlog-execution.md)):

--- a/.agents/tasks/completed/INFRA-128-pull-request-target-promotion-lag.md
+++ b/.agents/tasks/completed/INFRA-128-pull-request-target-promotion-lag.md
@@ -1,8 +1,9 @@
 ---
 title: 'INFRA-128: report the promotion lag of every pull_request_target gate'
 issue: https://github.com/woojubb/robota/issues/2039
-status: in-progress
+status: done
 created: 2026-08-22
+completed: 2026-08-22
 priority: medium
 urgency: soon
 area: scripts/harness, .github/workflows

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "test:mutation": "stryker run",
     "proof:external": "node scripts/external-proof/run-external-proof.mjs",
     "typecheck:compare": "node scripts/perf/compare-typecheck.mjs",
-    "harness:review:record": "node scripts/harness/record-local-review.mjs"
+    "harness:review:record": "node scripts/harness/record-local-review.mjs",
+    "harness:task:allocate": "node scripts/harness/allocate-work-item-id.mjs"
   },
   "keywords": [
     "ai",

--- a/scripts/harness/__tests__/allocate-work-item-id.test.mjs
+++ b/scripts/harness/__tests__/allocate-work-item-id.test.mjs
@@ -1,0 +1,176 @@
+/*
+ * The allocator must go RED on the condition it exists for: a number that no record file holds but
+ * something in the tree already claims. That is the case that happened (INFRA-127), and it is the
+ * one a survey of `.agents/tasks` cannot see.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SENTINEL_FLOOR,
+  collectClaimed,
+  idsFromIssueTitles,
+  idsFromRecords,
+  nextFreeId,
+  positionalArgs,
+  readExamined,
+  recordStub,
+} from '../allocate-work-item-id.mjs';
+import { makeTemp } from './make-temp.mjs';
+
+function repoWith({ records = [], files = {} }) {
+  const dir = makeTemp('robota-alloc-');
+  const run = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  run('init', '-q', '-b', 'main');
+  run('config', 'user.email', 'probe@example.invalid');
+  run('config', 'user.name', 'probe');
+  mkdirSync(path.join(dir, '.agents/tasks/completed'), { recursive: true });
+  for (const name of records) writeFileSync(path.join(dir, '.agents/tasks', name), 'x');
+  for (const [name, text] of Object.entries(files)) {
+    mkdirSync(path.join(dir, path.dirname(name)), { recursive: true });
+    writeFileSync(path.join(dir, name), text);
+  }
+  run('add', '-A');
+  run('commit', '-qm', 'fixture');
+  return dir;
+}
+
+describe('the claimed set is wider than the record filenames', () => {
+  it('reads an ID out of a record filename, live or completed', () => {
+    const dir = repoWith({ records: ['INFRA-126-a.md', 'ARCH-FIX-020-b.md'] });
+    expect(idsFromRecords(dir)).toEqual(new Set(['INFRA-126', 'ARCH-FIX-020']));
+  });
+
+  it('THE CASE THIS EXISTS FOR: a number claimed only by a citation is not free', () => {
+    // Exactly what happened. `.agents/tasks` holds 126 as the highest, so counting from records
+    // alone hands out 127 — which two scans already cite and no record file holds.
+    const claimedFromRecordsOnly = new Set(['INFRA-125', 'INFRA-126']);
+    expect(nextFreeId('INFRA', claimedFromRecordsOnly)).toBe('INFRA-127');
+
+    const claimedIncludingCitations = new Set([...claimedFromRecordsOnly, 'INFRA-127']);
+    expect(nextFreeId('INFRA', claimedIncludingCitations)).toBe('INFRA-128');
+  });
+
+  it('counts up from the highest rather than filling a gap', () => {
+    // A gap is usually a number claimed by something not visible here — an unpushed branch, an
+    // issue not yet opened. Handing it out is the collision again with more confidence.
+    expect(nextFreeId('INFRA', new Set(['INFRA-001', 'INFRA-005']))).toBe('INFRA-006');
+  });
+
+  it('skips the fixture band instead of continuing the sequence into it', () => {
+    expect(nextFreeId('INFRA', new Set(['INFRA-126', 'INFRA-999']))).toBe('INFRA-127');
+    expect(SENTINEL_FLOOR).toBe(900);
+  });
+
+  it('keeps the width already in use rather than padding wider', () => {
+    expect(nextFreeId('INFRA', new Set(['INFRA-099']))).toBe('INFRA-100');
+    expect(nextFreeId('INFRA', new Set(['INFRA-0099']))).toBe('INFRA-0100');
+  });
+
+  it('starts a prefix nobody has used at 001', () => {
+    expect(nextFreeId('BRANDNEW', new Set(['INFRA-126']))).toBe('BRANDNEW-001');
+  });
+
+  it('does not let one prefix advance another', () => {
+    expect(nextFreeId('PEER', new Set(['INFRA-126', 'PEER-007']))).toBe('PEER-008');
+  });
+});
+
+describe('the issue-title source', () => {
+  it('reads every ID a title names', () => {
+    expect(
+      idsFromIssueTitles({ run: () => ['INFRA-126 something', 'fix ARCH-FIX-020 too'] }),
+    ).toEqual(new Set(['INFRA-126', 'ARCH-FIX-020']));
+  });
+
+  it('returns null — NOT an empty set — when the source could not be read', () => {
+    // The distinction the whole script turns on. An empty set says no issue claims an ID; null says
+    // nobody asked. Conflating them makes an unreachable network read as a clean allocation, which
+    // is the exact failure the three original collisions were.
+    expect(idsFromIssueTitles({ run: () => null })).toBeNull();
+  });
+});
+
+describe('the record it writes', () => {
+  const stub = recordStub({ id: 'INFRA-129', title: 'a thing', today: '2026-08-22', issue: 1916 });
+
+  it('carries every field .agents/tasks/README.md declares required', () => {
+    for (const field of [
+      'title:',
+      'status:',
+      'created:',
+      'priority:',
+      'urgency:',
+      'area:',
+      'depends_on:',
+    ]) {
+      expect(stub).toContain(field);
+    }
+  });
+
+  it('links the issue when one is given, and omits the key when none is', () => {
+    expect(stub).toContain('issue: https://github.com/woojubb/robota/issues/1916');
+    expect(recordStub({ id: 'INFRA-129', title: 'a thing', today: '2026-08-22' })).not.toContain(
+      'issue:',
+    );
+  });
+
+  it('opens at a non-terminal status, so nothing reads it as finished work', () => {
+    expect(stub).toContain('status: todo');
+    expect(stub).not.toContain('completed:');
+  });
+});
+
+describe('the arguments it reads', () => {
+  it("does not let a flag's VALUE become part of the title", () => {
+    // Found by running this script on its own record: `--issue 1916` put `1916` in the slug,
+    // because filtering on a leading `--` removes the flag and leaves the number behind it.
+    expect(positionalArgs(['INFRA', 'a thing', '--issue', '1916'])).toEqual(['INFRA', 'a thing']);
+  });
+
+  it('still drops a valueless flag wherever it appears', () => {
+    expect(positionalArgs(['INFRA', '--dry-run', 'a thing'])).toEqual(['INFRA', 'a thing']);
+  });
+
+  it('keeps a positional that merely looks like a number', () => {
+    expect(positionalArgs(['INFRA', '2026', 'plan'])).toEqual(['INFRA', '2026', 'plan']);
+  });
+});
+
+describe('the reported size', () => {
+  /*
+   * The `::examined::` number is this script's coverage claim, so it is asserted as an output: an
+   * exact value against sources of known size, again after a second union, and once where every
+   * source is empty. `claimed.size` would have been the size of a Set, which swallows exactly the
+   * overlap between the three sources.
+   */
+  const RECORDS = new Set(['INFRA-126', 'INFRA-127']);
+  const CITATIONS = new Set(['INFRA-127', 'ARCH-FIX-020']); // one OVERLAPS records on purpose
+  const ISSUES = new Set(['PEER-007']);
+
+  it('counts each distinct id once across the three sources', () => {
+    collectClaimed(RECORDS, CITATIONS, ISSUES);
+    expect(readExamined()).toBe(4);
+  });
+
+  it('starts from zero on a second union rather than accumulating', () => {
+    collectClaimed(RECORDS, CITATIONS, ISSUES);
+    collectClaimed(RECORDS, CITATIONS, ISSUES);
+    expect(readExamined()).toBe(4);
+  });
+
+  it('reports zero, not the previous union, when every source is empty', () => {
+    collectClaimed(RECORDS, CITATIONS, ISSUES);
+    collectClaimed(new Set(), new Set(), new Set());
+    expect(readExamined()).toBe(0);
+  });
+
+  it('counts an unread source as contributing nothing, without dropping the others', () => {
+    collectClaimed(RECORDS, CITATIONS, null);
+    expect(readExamined()).toBe(3);
+  });
+});

--- a/scripts/harness/__tests__/allocate-work-item-id.test.mjs
+++ b/scripts/harness/__tests__/allocate-work-item-id.test.mjs
@@ -4,7 +4,7 @@
  * one a survey of `.agents/tasks` cannot see.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -144,6 +144,18 @@ describe('the arguments it reads', () => {
 
   it('keeps a positional that merely looks like a number', () => {
     expect(positionalArgs(['INFRA', '2026', 'plan'])).toEqual(['INFRA', '2026', 'plan']);
+  });
+
+  it('rejects --issue when no value follows it', () => {
+    const script = path.join(import.meta.dirname, '../allocate-work-item-id.mjs');
+    for (const argv of [
+      ['INFRA', 'a thing', '--dry-run', '--issue'],
+      ['INFRA', 'a thing', '--issue', '--dry-run'],
+    ]) {
+      const result = spawnSync(process.execPath, [script, ...argv], { encoding: 'utf8' });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('--issue requires a value');
+    }
   });
 });
 

--- a/scripts/harness/__tests__/allocate-work-item-id.test.mjs
+++ b/scripts/harness/__tests__/allocate-work-item-id.test.mjs
@@ -5,12 +5,13 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 import {
+  RECORD_ID_WIDTH,
   SENTINEL_FLOOR,
   collectClaimed,
   idsFromIssueTitles,
@@ -66,9 +67,14 @@ describe('the claimed set is wider than the record filenames', () => {
     expect(SENTINEL_FLOOR).toBe(900);
   });
 
-  it('keeps the width already in use rather than padding wider', () => {
+  it('pads to the measured record width, and a wider CITATION does not change it', () => {
     expect(nextFreeId('INFRA', new Set(['INFRA-099']))).toBe('INFRA-100');
-    expect(nextFreeId('INFRA', new Set(['INFRA-0099']))).toBe('INFRA-0100');
+    // Inferring the width from the claimed set let prose set it: `idsFromCitations` reads the
+    // working tree of every tracked file, so a comment mentioning a four-digit form became the
+    // highest claim and the next allocation came back four digits wide. The number is honoured;
+    // the style it appears to imply is not.
+    expect(nextFreeId('INFRA', new Set(['INFRA-0126']))).toBe('INFRA-127');
+    expect(RECORD_ID_WIDTH).toBe(3);
   });
 
   it('starts a prefix nobody has used at 001', () => {
@@ -172,5 +178,21 @@ describe('the reported size', () => {
   it('counts an unread source as contributing nothing, without dropping the others', () => {
     collectClaimed(RECORDS, CITATIONS, null);
     expect(readExamined()).toBe(3);
+  });
+});
+
+describe('the write itself', () => {
+  it('creates or fails in one syscall, never checks-then-writes', () => {
+    // CodeQL reported `js/file-system-race` on the first push of this script: an `existsSync`
+    // followed by a write is a check and a claim with a gap between them, which is the exact shape
+    // the script exists to remove one level up. Asserted on the source because the property is
+    // which flag the call uses, and a functional test of "it refuses an existing file" passes
+    // equally well for the racy version.
+    const source = readFileSync(
+      path.join(import.meta.dirname, '../allocate-work-item-id.mjs'),
+      'utf8',
+    );
+    expect(source).toContain("{ flag: 'wx' }");
+    expect(source).not.toMatch(/if \(existsSync\(absolute\)\)/);
   });
 });

--- a/scripts/harness/allocate-work-item-id.mjs
+++ b/scripts/harness/allocate-work-item-id.mjs
@@ -258,6 +258,10 @@ function main(argv) {
   const dryRun = argv.includes('--dry-run');
   const issueAt = argv.indexOf('--issue');
   const issue = issueAt === -1 ? null : argv[issueAt + 1];
+  if (issueAt !== -1 && (issue === undefined || issue.startsWith('--'))) {
+    console.error('allocate-work-item-id: --issue requires a value');
+    return 2;
+  }
 
   const records = idsFromRecords();
   const citations = idsFromCitations();

--- a/scripts/harness/allocate-work-item-id.mjs
+++ b/scripts/harness/allocate-work-item-id.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+
+/**
+ * Allocate a work-item ID and write its record in ONE operation (issue #1916, option 2).
+ *
+ * ## The gap this closes
+ *
+ * `scan-work-item-id-collision` refuses an ID held by two tracked RECORDS. That is the half a clone
+ * can judge offline, and it is not the half that bites. An ID is allocated by reading the current
+ * highest number and adding one, and the read has a shelf life measured in minutes when more than
+ * one session is working — so the collision is created between the read and the write, which is
+ * exactly where no scan can stand.
+ *
+ * Making the read and the claim the same operation is what removes that window. This script does
+ * not survey and advise; it takes the number and writes the file.
+ *
+ * ## What "claimed" means here, measured
+ *
+ * The record filenames are NOT the claimed set. Measured on 2026-08-22: 867 IDs have a record file
+ * and **63 more are claimed by a tracked file that is not a record** — a rule citing the item that
+ * introduced it, a scan header, a hook comment, an archived breakdown. `INFRA-127` was one of them:
+ * `scan-task-frontmatter-fields.mjs` and `scan-rule-table-shape.mjs` both cite it and no
+ * `.agents/tasks/INFRA-127-*.md` exists, so `ls .agents/tasks | grep INFRA` reported 126 as the
+ * highest and the next allocation walked straight into a live number. That happened while writing
+ * this file's own sibling, which is why the citation half is here rather than deferred.
+ *
+ * Issue titles are the third source and the one the original three collisions came from. They are
+ * read when the network and `gh` are both available, and their ABSENCE is reported rather than
+ * assumed away — an allocator that quietly skips a source allocates from a smaller set than it
+ * claims to, which is the failure it exists to prevent.
+ *
+ * ## Why it never reuses a gap
+ *
+ * The next ID is one above the highest CLAIMED number, not the lowest free one. A gap in the
+ * sequence is usually a number that was claimed by something this script cannot see — a branch not
+ * yet pushed, an issue in a session that has not opened it yet — and handing it out is the collision
+ * again with extra confidence. Counting up is monotone and cheap.
+ *
+ * Usage:
+ *   node scripts/harness/allocate-work-item-id.mjs INFRA "the slug of the problem"
+ *   node scripts/harness/allocate-work-item-id.mjs INFRA "…" --issue 1916
+ *   node scripts/harness/allocate-work-item-id.mjs INFRA --dry-run     # print the ID, write nothing
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const TASKS_DIR = '.agents/tasks';
+
+/** A work-item ID: one or more uppercase segments, then a number. `ARCH-FIX-020` is one. */
+export const WORK_ITEM_ID = /\b([A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*)-(\d{3,})\b/g;
+
+/**
+ * Every ID that has a record file, live or completed.
+ *
+ * `completed/` counts. An archived item's number is still cited by the commits and pull requests
+ * that delivered it, so handing it out again points every one of those citations at new work.
+ */
+export function idsFromRecords(root = WORKSPACE_ROOT) {
+  const dirs = [path.join(root, TASKS_DIR), path.join(root, TASKS_DIR, 'completed')];
+  const ids = new Set();
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith('.md')) continue;
+      const match = /^([A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\d{3,})/.exec(name);
+      if (match) ids.add(match[1]);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Every ID cited by a tracked file, whether or not a record exists for it.
+ *
+ * Deliberately unfiltered: a fixture ID like `CLI-999` costs one skipped number and a missed real
+ * claim costs a collision. The asymmetry decides it.
+ */
+export function idsFromCitations(root = WORKSPACE_ROOT) {
+  const grep = spawnSync(
+    'git',
+    ['grep', '-hoIE', '\\b[A-Z][A-Z0-9]*(-[A-Z][A-Z0-9]*)*-[0-9]{3,}\\b'],
+    { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  // Exit 1 is "no match", which is a legitimate empty result; anything else means the tree was not
+  // read, and an allocator that treats "could not read" as "nothing is claimed" hands out live IDs.
+  if (grep.status !== 0 && grep.status !== 1) {
+    throw new Error(
+      `allocate-work-item-id: could not read tracked files (git grep exited ${grep.status}). ` +
+        'Refusing rather than allocating from a set that was never read.\n' +
+        `${grep.stderr ?? ''}`,
+    );
+  }
+  const ids = new Set();
+  for (const line of (grep.stdout ?? '').split('\n')) {
+    const trimmed = line.trim();
+    if (/^[A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\d{3,}$/.test(trimmed)) ids.add(trimmed);
+  }
+  return ids;
+}
+
+/**
+ * Every ID named by an issue title, or `null` when the source could not be read.
+ *
+ * `null` is not an empty set and the two must not be conflated: an empty set says no issue claims
+ * an ID, and `null` says nobody asked. The caller reports which one it got.
+ */
+export function idsFromIssueTitles({ run = defaultGh } = {}) {
+  const result = run();
+  if (result === null) return null;
+  const ids = new Set();
+  for (const title of result) {
+    for (const match of title.matchAll(WORK_ITEM_ID)) ids.add(match[0]);
+  }
+  return ids;
+}
+
+function defaultGh() {
+  const listed = spawnSync(
+    'gh',
+    ['issue', 'list', '--state', 'all', '--limit', '1000', '--json', 'title', '-q', '.[].title'],
+    { cwd: WORKSPACE_ROOT, encoding: 'utf8', timeout: 30_000, maxBuffer: 16 * 1024 * 1024 },
+  );
+  if (listed.status !== 0) return null;
+  return (listed.stdout ?? '').split('\n').filter((line) => line.trim() !== '');
+}
+
+/**
+ * RESET per union, so a run that reads nothing cannot report the previous run's number.
+ *
+ * Incremented as the union is built rather than taken from `claimed.size` afterwards: a size read
+ * off a collection is the size of the collection, and a Set additionally swallows every duplicate —
+ * which is precisely where the three sources overlap most.
+ */
+let examinedCount = 0;
+
+export function readExamined() {
+  return examinedCount;
+}
+
+/** The union of every source that could be read. `null` from a source contributes nothing. */
+export function collectClaimed(records, citations, issues) {
+  examinedCount = 0;
+  const claimed = new Set();
+  for (const source of [records, citations, issues]) {
+    if (source === null) continue;
+    for (const id of source) {
+      if (claimed.has(id)) continue;
+      claimed.add(id);
+      examinedCount += 1;
+    }
+  }
+  return claimed;
+}
+
+/**
+ * Numbers at or above this are fixture space, not allocations, and are skipped when counting up.
+ *
+ * MEASURED, not assumed. Of the 867 IDs with a record file on 2026-08-22, **zero** are at or above
+ * 900. Of the 18 citations that are, every one is either a test fixture (`NOSUCH-999`, `CLI-996`
+ * through `CLI-999`, `INFRA-900` through `INFRA-902`) or not a work-item ID at all (`CVE-2024`,
+ * `ISO-8601`, `RFC-7807` — the pattern cannot tell them apart and does not need to, since nothing
+ * allocates under those prefixes).
+ *
+ * Without this the first run of this script returned `INFRA-1000`, because `INFRA-999` is a fixture
+ * in the collision scan's own test. Counting up from a sentinel is how a deliberately out-of-band
+ * number becomes the sequence.
+ */
+export const SENTINEL_FLOOR = 900;
+
+/**
+ * The next ID for `prefix`: one above the highest number any source claims for it.
+ *
+ * Width follows the widest claim already in use, so a repository at `INFRA-099` moves to
+ * `INFRA-100` rather than to `INFRA-0100`.
+ */
+export function nextFreeId(prefix, claimed, sentinelFloor = SENTINEL_FLOOR) {
+  let highest = 0;
+  let width = 3;
+  for (const id of claimed) {
+    const match = new RegExp(`^${prefix}-(\\d{3,})$`).exec(id);
+    if (!match) continue;
+    const number = Number(match[1]);
+    if (number >= sentinelFloor) continue;
+    highest = Math.max(highest, number);
+    width = Math.max(width, match[1].length);
+  }
+  const next = highest + 1;
+  return `${prefix}-${String(next).padStart(width, '0')}`;
+}
+
+/** The stub a fresh record starts as — every field `.agents/tasks/README.md` declares required. */
+export function recordStub({ id, title, today, issue = null }) {
+  return `---
+title: '${id}: ${title}'
+${issue === null ? '' : `issue: https://github.com/woojubb/robota/issues/${issue}\n`}status: todo
+created: ${today}
+priority: medium
+urgency: soon
+area: TODO
+depends_on: []
+---
+
+# ${id}: ${title}
+
+## Objective
+
+TODO
+
+## Plan
+
+- [ ] TODO
+`;
+}
+
+/**
+ * Positional arguments only: flags AND the values they take.
+ *
+ * Filtering on `startsWith('--')` alone leaves `--issue`'s number behind, and the number becomes
+ * part of the title and the slug. Caught by running this script on its own record, which produced
+ * `INFRA-129-…-in-one-operation-1916.md`.
+ */
+export function positionalArgs(argv, flagsTakingValue = ['--issue']) {
+  const positional = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (flagsTakingValue.includes(token)) {
+      index += 1;
+      continue;
+    }
+    if (token.startsWith('--')) continue;
+    positional.push(token);
+  }
+  return positional;
+}
+
+function main(argv) {
+  const args = positionalArgs(argv);
+  const prefix = args[0];
+  if (!prefix || !/^[A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*$/.test(prefix)) {
+    console.error('usage: allocate-work-item-id.mjs <PREFIX> "<title>" [--issue N] [--dry-run]');
+    return 2;
+  }
+  const title = args.slice(1).join(' ');
+  const dryRun = argv.includes('--dry-run');
+  const issueAt = argv.indexOf('--issue');
+  const issue = issueAt === -1 ? null : argv[issueAt + 1];
+
+  const records = idsFromRecords();
+  const citations = idsFromCitations();
+  const issues = idsFromIssueTitles();
+
+  const claimed = collectClaimed(records, citations, issues);
+  const id = nextFreeId(prefix, claimed);
+
+  console.log(
+    `::examined:: ${readExamined()} claimed work-item id(s); ` +
+      `${records.size} from records, ${citations.size} from citations, ` +
+      (issues === null ? 'issue titles UNREAD' : `${issues.size} from issue titles`),
+  );
+  if (issues === null) {
+    console.log(
+      '  issue titles could not be read (no `gh`, no network, or not authenticated). The three ' +
+        'collisions this allocator exists for were all between a record and an issue title, so ' +
+        'this run allocated from a SMALLER set than the one that matters. Re-check before pushing.',
+    );
+  }
+
+  if (dryRun || title === '') {
+    console.log(id);
+    return 0;
+  }
+
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 80);
+  const file = path.join(TASKS_DIR, `${id}-${slug}.md`);
+  const absolute = path.join(WORKSPACE_ROOT, file);
+  if (existsSync(absolute)) {
+    console.error(`${file} already exists — refusing to overwrite a record.`);
+    return 1;
+  }
+  const today = new Date().toISOString().slice(0, 10);
+  writeFileSync(absolute, recordStub({ id, title, today, issue }));
+  console.log(`${id}\n${file}`);
+  return 0;
+}
+
+// Compared as resolved PATHS, not as a `file://` string: the string form is false whenever the path
+// holds a character a URL escapes — a space, a `#`, anything non-ASCII — and it fails toward
+// silence, exiting 0 without running `main`.
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/harness/allocate-work-item-id.mjs
+++ b/scripts/harness/allocate-work-item-id.mjs
@@ -171,6 +171,20 @@ export function collectClaimed(records, citations, issues) {
 export const SENTINEL_FLOOR = 900;
 
 /**
+ * Digits in an allocated number. MEASURED: all 916 record filenames use exactly three.
+ *
+ * Fixed rather than inferred from the claimed set, and that is the second attempt. Inferring it let
+ * PROSE set the padding: `idsFromCitations` reads the working-tree content of every tracked file, so
+ * a comment in this module that mentioned a four-digit form made that form the highest claim, and
+ * the next allocation came back four digits wide. The number a citation claims is worth honouring;
+ * the house style it appears to imply is not.
+ *
+ * A prefix that legitimately passes 999 needs this widened deliberately, which is the right amount
+ * of friction for a decision that renames a convention.
+ */
+export const RECORD_ID_WIDTH = 3;
+
+/**
  * The next ID for `prefix`: one above the highest number any source claims for it.
  *
  * Width follows the widest claim already in use, so a repository at `INFRA-099` moves to
@@ -178,17 +192,14 @@ export const SENTINEL_FLOOR = 900;
  */
 export function nextFreeId(prefix, claimed, sentinelFloor = SENTINEL_FLOOR) {
   let highest = 0;
-  let width = 3;
   for (const id of claimed) {
     const match = new RegExp(`^${prefix}-(\\d{3,})$`).exec(id);
     if (!match) continue;
     const number = Number(match[1]);
     if (number >= sentinelFloor) continue;
     highest = Math.max(highest, number);
-    width = Math.max(width, match[1].length);
   }
-  const next = highest + 1;
-  return `${prefix}-${String(next).padStart(width, '0')}`;
+  return `${prefix}-${String(highest + 1).padStart(RECORD_ID_WIDTH, '0')}`;
 }
 
 /** The stub a fresh record starts as — every field `.agents/tasks/README.md` declares required. */
@@ -280,12 +291,20 @@ function main(argv) {
     .slice(0, 80);
   const file = path.join(TASKS_DIR, `${id}-${slug}.md`);
   const absolute = path.join(WORKSPACE_ROOT, file);
-  if (existsSync(absolute)) {
-    console.error(`${file} already exists — refusing to overwrite a record.`);
-    return 1;
-  }
   const today = new Date().toISOString().slice(0, 10);
-  writeFileSync(absolute, recordStub({ id, title, today, issue }));
+  try {
+    // `wx` — create-or-fail, in ONE syscall. An `existsSync` followed by a write is a check and a
+    // claim with a gap between them, which is the exact shape this script exists to remove one
+    // level up; writing it here would be the defect reproduced inside its own fix. Reported as
+    // `js/file-system-race` by CodeQL on the first push, which is how it came out.
+    writeFileSync(absolute, recordStub({ id, title, today, issue }), { flag: 'wx' });
+  } catch (error) {
+    if (error?.code === 'EEXIST') {
+      console.error(`${file} already exists — refusing to overwrite a record.`);
+      return 1;
+    }
+    throw error;
+  }
   console.log(`${id}\n${file}`);
   return 0;
 }

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -2,6 +2,7 @@
   "item": "HARNESS-087",
   "reason": "Every harness module carrying the declaration marker is classified here. `covered` meets the floor and is re-measured each run, so losing coverage is a regression finding rather than a quiet move to the debt list. `pending` was recorded unmet when the floor was adopted \u2014 the counter is not exported, or nothing asserts its value \u2014 and an entry that comes to meet the floor is itself a finding.",
   "covered": [
+    "scripts/harness/allocate-work-item-id.mjs",
     "scripts/harness/check-contract-disposition.mjs",
     "scripts/harness/check-fixture-floor.mjs",
     "scripts/harness/check-sdk-public-surface.mjs",


### PR DESCRIPTION
## The half a scan cannot close

`scan-work-item-id-collision` already refuses an ID held by two tracked records. That is the half a
clone can judge offline, and it is not the half that bit. An ID is allocated by reading the highest
number and adding one, so the collision is created **between the read and the write** — which is
exactly where no scan can stand. Issue #1916 names this: re-deriving at the moment of use narrows
the window, it does not close it.

This is option 2 from the issue: make the read and the claim one operation.

```
pnpm harness:task:allocate INFRA "the problem, as a sentence" --issue 1916
```

## The record filenames are not the claimed set — measured

- **867** IDs have a record file.
- **63 more** are claimed by a tracked file that is not a record: a rule citing the item that
  introduced it, a scan header, a hook comment, an archived breakdown.

`INFRA-127` is one of the 63. `scan-task-frontmatter-fields.mjs` and `scan-rule-table-shape.mjs`
both cite it and no `.agents/tasks/INFRA-127-*.md` exists, so `ls .agents/tasks | grep INFRA`
reports `INFRA-126` as the highest. **That is not hypothetical: it happened in this session.** The
sibling task now merged as INFRA-128 was numbered 127 on that reading and renumbered by hand. This
PR exists because writing its sibling walked into the defect.

The allocator's claimed set is records ∪ every citation in the tree ∪ issue titles.

## `null` is not an empty set

`idsFromIssueTitles` returns `null` when the source cannot be read, and the run says so:

> issue titles could not be read … this run allocated from a SMALLER set than the one that matters.

The three collisions issue #1916 opens with were *all* between a record and an issue title. A run
that silently skipped that source would print a clean allocation in precisely the case the tool was
built for. That distinction is pinned as a case.

## Counting up, and the sentinel band

The next ID is one above the highest claimed number, never the lowest free one — a gap is usually a
number claimed by something the tool cannot see (an unpushed branch, an issue not yet opened), and
handing it out is the same collision with more confidence.

The first run returned **`INFRA-1000`**, because `INFRA-999` is a fixture in the collision scan's
own test. Measured before fixing it: of the 867 IDs with a record file, **zero** are at or above
900, and all 18 citations that are, are fixtures or not work-item IDs at all (`CVE-2024`,
`ISO-8601`, `RFC-7807`). So `SENTINEL_FLOOR = 900` is a measurement, not a convention.

## Two defects the tool found in itself, and one the harness found

- **`INFRA-1000`**, above.
- **`--issue 1916` put `1916` in the slug.** Filtering arguments on a leading `--` drops the flag
  and leaves its value, so the number became part of the title. Found by running the script to
  create this PR's own record, which first landed as `INFRA-129-…-in-one-operation-1916.md`.
- **`harness-script-import-safety`** rejected `import.meta.url === \`file://${process.argv[1]}\``:
  false whenever the path holds a character a URL escapes, and it fails toward silence — `main()`
  does not run and the script exits 0, which reads as a pass. Now compared as resolved paths.
- **`measurement-provenance`** rejected `claimed.size` as the reported number. A Set swallows every
  duplicate, which is exactly where the three sources overlap. The counter now increments as the
  union is built, and is asserted exact against sources of known size, after a second union, over
  empty sources, and with one source unread.

## What this does not close, stated rather than implied

Two sessions can still choose the same number in the same minute, each reading a set that does not
yet contain the other's unpushed record. The window is now the **push** interval rather than the
**authoring** interval, and `scan-work-item-id-collision` refuses the second one at pre-push.
Removing the class rather than guarding it is option 3 of the issue — non-sequential IDs — and is
not attempted here.

Closes #1916

Task record: `.agents/tasks/INFRA-129-allocate-a-work-item-id-and-its-record-in-one-operation.md`
