### PR TITLE
fix(harness): patch-coverage stops charging a package that owns no tests (INFRA-046)

### DIFF
--- a/.agents/tasks/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/INFRA-046-promote-advisory-gates.md
@@ -456,3 +456,55 @@ evidence — is gone, and what remains is a decision plus the work it implies. *
 `patch-coverage` is either promoted on the same standard of evidence, or recorded as permanently
 advisory with the reason, in which case this item's title is wrong and should be narrowed rather than
 the record being marked complete over half its subject.**
+
+## 2026-08-22 (later) — blocker 1 is FIXED; blocker 2 is measured and still a decision
+
+**Blocker 1 was a code defect, not a decision, and I had said otherwise.** The record names it
+plainly — _"This is the issue #1344 defect and it is in `scripts/harness/check-patch-coverage.mjs`"_ —
+and an earlier entry of mine described both remaining blockers as decisions. That was wrong about
+this one, and the correction is the reason it is now fixed rather than deferred.
+
+A package with no test suite still emits an lcov report under `coverage.all: true`, every record
+zero-hit. Those lines were counted as MEASURED-and-uncovered and dragged the patch percentage
+BELOW-TARGET, charging a pull request for a package with no way to discharge the debt.
+
+Such a package is now NO-DATA (INCONCLUSIVE, advisory). Both conditions are required, and all three
+directions are pinned by tests and by an end-to-end fixture run:
+
+| package    | lcov             | verdict                                                         |
+| ---------- | ---------------- | --------------------------------------------------------------- |
+| owns tests | nothing covered  | `patch-coverage-below-target` — the defect this gate exists for |
+| no tests   | nothing covered  | `inconclusive-no-data` — issue #1344's false positive           |
+| no tests   | any line covered | `patch-coverage-below-target` — a hit is evidence something ran |
+
+The two existing red cases failed on this change and were right to: neither modelled whether the
+package owns tests, because that dimension did not exist. The red fixture is `LH:0` with no test
+file — **indistinguishable from the false positive being fixed**. Fixtures now declare their test
+files explicitly.
+
+**Blocker 3 is discharged** — `regression-red-proof` got its real verdicts and is promoted and
+required.
+
+### Blocker 2 remains, and it was measured rather than assumed
+
+The obvious hope was that the issue #1344 fix also discharges the React-UI tax, since a GUI package
+with no component tests would now be excused. **It does not.** Measured:
+
+```
+packages/agent-cli-web       tsx=1     test files=0    -> excused by the #1344 fix
+apps/agent-web               tsx=6     test files=1    -> owns tests, still charged
+apps/agent-app               tsx=3     test files=1    -> owns tests, still charged
+packages/agent-playground    tsx=184   test files=32   -> owns tests, still charged
+```
+
+A package that owns _some_ tests but no component-test infrastructure for its `.tsx` render surfaces
+is not excused by the new classification, and should not be — owning tests is exactly what makes an
+uncovered line a real hole under this gate's own logic. So the tax stands for three of the four.
+
+**This is a genuine decision and not a measurement:** either exclude `.tsx` render surfaces from the
+patch denominator, or stand up component-test infrastructure for the GUI packages. Nothing about the
+number itself settles it; it is a question of what the number should mean for a render surface.
+
+**Status stays `in-progress`.** Done when `patch-coverage` is promoted after that decision, or
+recorded as permanently advisory with the reason — in which case the item's title, which names two
+gates, is what should be narrowed.

--- a/scripts/harness/__tests__/check-patch-coverage.test.mjs
+++ b/scripts/harness/__tests__/check-patch-coverage.test.mjs
@@ -10,6 +10,8 @@ import {
   groupCoverableChanges,
   isCoverableSource,
   isTestFile,
+  lcovIsEntirelyUnexercised,
+  packageOwnsTests,
   packageRootOf,
   parseChangedNewLines,
   parseLcov,
@@ -174,6 +176,10 @@ describe('INFRA-041 orchestration (injected io)', () => {
       diffText,
       hasPkgJson: flatPkgJson,
       collectLcov: () => 'SF:src/adder.ts\nDA:2,0\nDA:3,0\nDA:6,0\nDA:7,0\nend_of_record\n',
+      // #1344: the package OWNS a test suite, so an all-zero report is a real hole rather than an
+      // uninstrumented package. Without this the case is indistinguishable from the false positive
+      // the classification exists to prevent, and it would be asserting the wrong thing.
+      listFiles: () => ['packages/fixture-pkg/src/__tests__/adder.test.ts'],
     });
     expect(verdict).toBe(VERDICT.BELOW_TARGET);
     expect(measured).toBe(4);
@@ -245,5 +251,78 @@ describe('INFRA-041 CLI red-proof (fixture end-to-end, exit-code contract)', () 
     expect(enforced.code).toBe(0);
     expect(enforced.stdout).toContain(VERDICT.OK);
     expect(enforced.stdout).toContain('4/4');
+  });
+});
+
+/**
+ * #1344 / INFRA-046 — a package with no tests must not be CHARGED for its own uncovered lines.
+ *
+ * `coverage.all: true` instruments a package's source whether or not anything exercises it, so a
+ * package that owns no test file still emits an lcov report — every record zero-hit. Folding those
+ * lines into the measured total makes the patch percentage BELOW-TARGET for a package that has no
+ * way to discharge the debt. That is a false positive, and INFRA-046's promotion criterion allows
+ * none.
+ *
+ * BOTH conditions are required. A package WITH tests whose report happens to be wholly uncovered is
+ * exactly the defect this gate exists to catch, and the cases below pin that it still fails.
+ */
+describe('an untested package is NO-DATA, not BELOW-TARGET (#1344)', () => {
+  const ZERO_HIT_LCOV = 'SF:src/a.ts\nDA:1,0\nDA:2,0\nend_of_record\n';
+  const COVERED_LCOV = 'SF:src/a.ts\nDA:1,1\nDA:2,0\nend_of_record\n';
+
+  /** One changed line in one package, with the lcov and file listing under test. */
+  const runWith = ({ lcov, files }) =>
+    runPatchCoverage({
+      target: 80,
+      diffText:
+        'diff --git a/packages/p/src/a.ts b/packages/p/src/a.ts\n' +
+        '--- a/packages/p/src/a.ts\n+++ b/packages/p/src/a.ts\n@@ -1,0 +1,2 @@\n+x\n+y\n',
+      hasPkgJson: (dir) => dir === 'packages/p',
+      collectLcov: () => lcov,
+      listFiles: () => files,
+      log: () => {},
+    });
+
+  it('reports INCONCLUSIVE when the package owns no test file and nothing is covered', async () => {
+    const result = await runWith({
+      lcov: ZERO_HIT_LCOV,
+      files: ['packages/p/src/a.ts', 'packages/p/package.json'],
+    });
+    expect(result.verdict).toBe('inconclusive-no-data');
+    // The decisive part: those lines are UNMEASURED, not measured-and-missed.
+    expect(result.measured).toBe(0);
+  });
+
+  it('still reports BELOW-TARGET when the package DOES own tests', async () => {
+    const result = await runWith({
+      lcov: ZERO_HIT_LCOV,
+      files: ['packages/p/src/a.ts', 'packages/p/src/__tests__/a.test.ts'],
+    });
+    expect(result.verdict).toBe('patch-coverage-below-target');
+    expect(result.measured).toBe(2);
+  });
+
+  it('does not excuse a testless package whose report has ANY hit', async () => {
+    // One covered line is evidence something ran, so the report is real data and 50% < 80% fails.
+    const result = await runWith({
+      lcov: COVERED_LCOV,
+      files: ['packages/p/src/a.ts', 'packages/p/package.json'],
+    });
+    expect(result.verdict).toBe('patch-coverage-below-target');
+    expect(result.measured).toBe(2);
+  });
+});
+
+describe('lcovIsEntirelyUnexercised', () => {
+  it('is false for an EMPTY report — no records is not the same as no hits', () => {
+    // The distinction matters: an empty parse means the collector produced nothing for these files,
+    // which the existing UNINSTRUMENTED path already handles. Claiming "unexercised" here would
+    // swallow that case under a different label.
+    expect(lcovIsEntirelyUnexercised(new Map())).toBe(false);
+  });
+
+  it('is true only when records exist and none has a hit', () => {
+    expect(lcovIsEntirelyUnexercised(new Map([['f', new Map([[1, 0]])]]))).toBe(true);
+    expect(lcovIsEntirelyUnexercised(new Map([['f', new Map([[1, 1]])]]))).toBe(false);
   });
 });

--- a/scripts/harness/__tests__/fixtures/patch-coverage/green/tests.txt
+++ b/scripts/harness/__tests__/fixtures/patch-coverage/green/tests.txt
@@ -1,0 +1,1 @@
+packages/fixture-pkg/src/__tests__/adder.test.ts

--- a/scripts/harness/__tests__/fixtures/patch-coverage/red/tests.txt
+++ b/scripts/harness/__tests__/fixtures/patch-coverage/red/tests.txt
@@ -1,0 +1,1 @@
+packages/fixture-pkg/src/__tests__/adder.test.ts

--- a/scripts/harness/check-patch-coverage.mjs
+++ b/scripts/harness/check-patch-coverage.mjs
@@ -153,6 +153,69 @@ export function parseLcov(lcovText, pkgRoot = '') {
 // ── Pure: patch-coverage computation ──────────────────────────────────────────────────────────────
 
 /**
+ * Does a package own any test file at all?
+ *
+ * #1344. A package with no tests can still emit an lcov report whose every record is zero-hit —
+ * `coverage.all: true` instruments the source whether or not anything exercises it. Those lines then
+ * arrive as MEASURED-and-uncovered and drag the patch percentage to BELOW-TARGET, so a pull request
+ * is charged for a package that has no way to discharge the debt. That is a false positive, and one
+ * is one more than the promotion criterion allows.
+ *
+ * Injectable (`listFiles`) so the classification is unit-testable without a real tree.
+ */
+export function packageOwnsTests(pkgRoot, listFiles = defaultListFiles) {
+  for (const rel of listFiles(pkgRoot)) {
+    if (isTestFile(rel)) return true;
+  }
+  return false;
+}
+
+/** Every file under a package root, repo-relative, skipping `node_modules` and build output. */
+function defaultListFiles(pkgRoot) {
+  const out = [];
+  const walk = (dirRel) => {
+    const abs = path.join(WORKSPACE_ROOT, dirRel);
+    let entries;
+    try {
+      entries = fs.readdirSync(abs, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const rel = path.posix.join(dirRel, entry.name);
+      if (entry.isSymbolicLink()) continue; // never follow: a pnpm workspace link reaches the store
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'coverage') {
+          continue;
+        }
+        walk(rel);
+      } else {
+        out.push(rel);
+      }
+    }
+  };
+  walk(pkgRoot);
+  return out;
+}
+
+/**
+ * Is this package's lcov entirely unexercised? True when it produced records and NOT ONE has a hit.
+ *
+ * Deliberately not "some records are zero": a package with real tests and one uncovered file is the
+ * defect this gate exists to catch. Only a report with no hits AT ALL is evidence that nothing ran.
+ */
+export function lcovIsEntirelyUnexercised(lcovByFileForPackage) {
+  let sawRecord = false;
+  for (const da of lcovByFileForPackage.values()) {
+    for (const hits of da.values()) {
+      sawRecord = true;
+      if (hits > 0) return false;
+    }
+  }
+  return sawRecord;
+}
+
+/**
  * Compute per-file and total patch coverage.
  *   changedLinesByFile — Map(file → Set(lines)) restricted to coverable files
  *   lcovByFile         — Map(file → Map(line → hits)) merged across packages
@@ -283,6 +346,7 @@ export async function runPatchCoverage(io = {}) {
   const diffText = io.diffText ?? git(['diff', '-U0', `${base}..HEAD`]);
   const hasPkgJson = io.hasPkgJson ?? defaultHasPkgJson;
   const collectLcov = io.collectLcov ?? defaultCollectLcov;
+  const listFiles = io.listFiles ?? defaultListFiles;
 
   const changedNewLines = parseChangedNewLines(diffText);
   const byPkg = groupCoverableChanges([...changedNewLines.keys()], hasPkgJson);
@@ -308,7 +372,24 @@ export async function runPatchCoverage(io = {}) {
       noDataPackages.push(pkgRoot);
       continue;
     }
-    for (const [file, da] of parseLcov(lcovText, pkgRoot)) {
+    const parsed = parseLcov(lcovText, pkgRoot);
+
+    // #1344. A package that owns NO test file can still emit an lcov report whose every record is
+    // zero-hit — `coverage.all: true` instruments the source whether or not anything exercises it.
+    // Folding those lines into the measured total charges a pull request for a package that has no
+    // way to discharge the debt, which is a false positive, and one is one more than the promotion
+    // criterion allows. Both conditions are required: a package WITH tests and a wholly-uncovered
+    // report is exactly the defect this gate exists to catch, and must still fail.
+    if (lcovIsEntirelyUnexercised(parsed) && !packageOwnsTests(pkgRoot, listFiles)) {
+      log(
+        `⚠︎  ${pkgRoot}: NO-DATA — lcov has no covered line and the package owns no test file, so ` +
+          `its changed lines are UNMEASURED rather than uncovered (#1344).`,
+      );
+      noDataPackages.push(pkgRoot);
+      continue;
+    }
+
+    for (const [file, da] of parsed) {
       const merged = lcovByFile.get(file) ?? new Map();
       for (const [line, hits] of da) merged.set(line, Math.max(merged.get(line) ?? 0, hits));
       lcovByFile.set(file, merged);
@@ -382,6 +463,14 @@ function fixtureIo(dir) {
     // fixture package roots are the two-segment `packages/<x>` / `apps/<x>` shape
     hasPkgJson: (dirRel) => dirRel.split('/').length === 2,
     collectLcov: () => fs.readFileSync(path.join(abs, 'lcov.info'), 'utf8'),
+    // #1344 needs to know whether the package OWNS tests, so the fixture has to be able to say. A
+    // `tests.txt` (one repo-relative path per line) is that statement; absent, the fixture declares
+    // no test files, which is the untested-package shape rather than an accident of the harness.
+    listFiles: () => {
+      const manifest = path.join(abs, 'tests.txt');
+      if (!existsSync(manifest)) return [];
+      return fs.readFileSync(manifest, 'utf8').split('\n').filter(Boolean);
+    },
   };
 }
 


### PR DESCRIPTION
## The blocker I had misclassified

INFRA-046 listed three blockers. I described the two remaining as *decisions*. **That was wrong about
one of them**, and the record said so in its own words:

> `patch-coverage` must not charge a PR for a package that has no test suite … **This is the issue
> #1344 defect and it is in `scripts/harness/check-patch-coverage.mjs`.**

A file, a named defect, and a described fix. Correcting the classification is what made it work
rather than a decision to wait for.

## The defect

`coverage.all: true` instruments a package's source whether or not anything exercises it, so a
package with **no test suite** still emits an lcov report — every record zero-hit. Those lines
arrived as MEASURED-and-uncovered, dragged the patch percentage BELOW-TARGET, and charged a pull
request for a package with no way to discharge the debt.

One confirmed false positive is one more than this item's promotion criterion allows.

## The fix, and all three directions pinned

| package | lcov | verdict |
| ------- | ---- | ------- |
| owns tests | nothing covered | `patch-coverage-below-target` — the defect this gate exists for |
| **no tests** | **nothing covered** | **`inconclusive-no-data`** — issue #1344's false positive |
| no tests | any line covered | `patch-coverage-below-target` — a hit is evidence something ran |

Both conditions are required. A package *with* tests whose report is wholly uncovered is precisely
what this gate is for, and must still fail.

`lcovIsEntirelyUnexercised` returns **false** for an empty report, deliberately: no records is not
the same as no hits, and the existing UNINSTRUMENTED path already owns that case. Pinned by its own
test.

## Two existing red cases broke, and were right to

Neither modelled whether the package owns tests — the dimension did not exist. The red fixture is
`LH:0` **with no test file**, which is indistinguishable from the very false positive being fixed.

That is the question I put to myself before touching them: *is the fixture describing a case that
should fail?* Per issue #1344's own definition, a testless package being charged is a false positive
— so the fixture was under-specified, not the change wrong. Fixtures now declare their test files
through a `tests.txt` manifest, and both say so explicitly.

Verified end to end, not just in units:

```
red fixture                        -> patch-coverage-below-target
red fixture minus its tests.txt    -> inconclusive-no-data
```

## What this does NOT do, measured rather than assumed

The obvious hope was that this also discharges the React-UI coverage tax (blocker 2), since a GUI
package with no component tests would now be excused. **It does not:**

```
packages/agent-cli-web       tsx=1     test files=0    -> excused
apps/agent-web               tsx=6     test files=1    -> owns tests, still charged
apps/agent-app               tsx=3     test files=1    -> owns tests, still charged
packages/agent-playground    tsx=184   test files=32   -> owns tests, still charged
```

Three of four still pay, and correctly so under the gate's own logic. Blocker 2 remains a genuine
decision — exclude `.tsx` render surfaces from the denominator, or stand up component-test
infrastructure — and nothing about the number settles it.

## Verification

19 tests in `scripts/harness/__tests__/check-patch-coverage.test.mjs`, 135 scans, 4668 tests across
the pre-push tiers.

**This does not close INFRA-046.** Blocker 3 is discharged (`regression-red-proof` is promoted and
required) and blocker 1 is fixed here; blocker 2 is a decision. The record states that and stays
`in-progress`.

ACTIONABLE FINDINGS: 0

Refs INFRA-046