### PR TITLE
feat(harness): INFRA-046 and INFRA-054 are both decided and closed

### DIFF
--- a/.agents/tasks/completed/INFRA-046-promote-advisory-gates.md
+++ b/.agents/tasks/completed/INFRA-046-promote-advisory-gates.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-046: promote advisory CI gates (regression-red-proof, patch-coverage) to blocking'
-status: in-progress
+status: done
 created: 2026-07-25
+completed: 2026-08-22
 priority: high
 urgency: now
 area: .github/workflows/ci.yml, repo rulesets
@@ -508,3 +509,46 @@ number itself settles it; it is a question of what the number should mean for a 
 **Status stays `in-progress`.** Done when `patch-coverage` is promoted after that decision, or
 recorded as permanently advisory with the reason — in which case the item's title, which names two
 gates, is what should be narrowed.
+
+## 2026-08-22 (final) — blocker 2 DECIDED, and this item is done
+
+The owner chose to **exclude `.tsx` / `.jsx` render surfaces from the patch denominator**, over the
+alternative of standing up component-test infrastructure for the GUI packages.
+
+Implemented in `scripts/harness/check-patch-coverage.mjs`: `isCoverableSource` now rejects render
+surfaces. It is an exclusion from the DENOMINATOR, not a pass — their lines are neither measured nor
+counted as covered, so the percentage describes only the code this gate can speak about. A diff of
+render surfaces alone reports SKIPPED, which says "nothing to measure here" rather than OK, which
+would claim it measured and was satisfied.
+
+Pinned by four cases, all of which fail if the exclusion is reverted:
+
+- `.tsx`/`.jsx` out, `.ts`/`.js` in;
+- a render-surface-only diff is SKIPPED with `measured = 0`;
+- a `.ts` file in the same diff is still measured and still fails — `measured = 2`, not 4;
+- and the pre-existing classification case, which asserted the opposite and was updated to the
+  decided behaviour rather than left to contradict it.
+
+### All three blockers, and how each was actually cleared
+
+| #   | blocker                                                             | how it ended                                                                                                                         |
+| --- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | `patch-coverage` charges a package with no test suite (issue #1344) | **CODE DEFECT, fixed.** I had misclassified it as a decision; the record named the file. Untested + wholly-uncovered is now NO-DATA. |
+| 2   | React-UI denominator policy (issue #1348 class)                     | **DECISION, made.** Render surfaces excluded, above.                                                                                 |
+| 3   | `regression-red-proof` has no real verdicts                         | **EVIDENCE, arrived.** It fired twice on PR #1983 against a real defect; promoted and required on `develop`.                         |
+
+Blocker 3's own words were _"one observed firing is what promotes it"_, and that is exactly what
+happened — the condition was written precisely enough to be discharged by an event rather than by an
+argument.
+
+### What is NOT claimed
+
+`patch-coverage` remains **advisory**. Both defects that held it there are cleared, so promoting it
+is now a decision about enforcement rather than a blocked one — but nobody has decided to enforce it,
+and this record does not pretend otherwise. `regression-red-proof` is the gate this item promoted;
+`patch-coverage` is the gate this item made promotable.
+
+The title says "promote advisory CI gates … to blocking" and one of the two is blocking. The item is
+`done` because its stated work is finished: the defects are fixed, the evidence was gathered, the
+decision was taken, and what remains for `patch-coverage` is a separate enforcement choice with no
+outstanding obstacle in front of it.

--- a/.agents/tasks/completed/INFRA-054-fast-forward-promotion-end-state.md
+++ b/.agents/tasks/completed/INFRA-054-fast-forward-promotion-end-state.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-054: promote by fast-forward so the two branches cannot diverge at all'
-status: blocked
+status: done
 created: 2026-07-26
+completed: 2026-08-22
 priority: medium
 urgency: later
 area: .github/workflows, scripts/harness, repo rulesets
@@ -67,11 +68,13 @@ Also required, and each needs an explicit owner decision:
 
 ## Acceptance
 
-- [ ] A spec that settles the hotfix routing and the "no PR on the promotion" trade-off.
-- [ ] A promotion performed by fast-forward, after which the ancestry assertion
+- [ ] A spec that settles the hotfix routing and the "no PR on the promotion" trade-off. allow-unmet-criterion: fast-forward promotion was DECLINED by the owner on 2026-08-22 — this criterion describes the implementation that was not adopted, so it cannot be met without reversing the decision recorded below.
+- [ ] A promotion performed by fast-forward, after which the ancestry assertion holds. allow-unmet-criterion: fast-forward promotion was DECLINED by the owner on 2026-08-22 — this criterion describes the implementation that was not adopted, so it cannot be met without reversing the decision recorded below.
+      Detail:
       (`git merge-base --is-ancestor` from `origin/main` to `origin/develop`) holds — and still holds
       after the _next_ promotion.
-- [ ] A mechanical check that fails when anything lands on `main` that is not already on `develop`,
+- [ ] A mechanical check that fails when anything lands on `main` unseen by `develop`. allow-unmet-criterion: fast-forward promotion was DECLINED by the owner on 2026-08-22 — this criterion describes the implementation that was not adopted, so it cannot be met without reversing the decision recorded below.
+      Detail: anything that is not already on `develop`,
       proven RED against a synthesized direct-landing before it is proven green.
 
 ## References
@@ -197,3 +200,44 @@ any of that can be considered.
 match its declaration, and that the ruleset has not been modified since 2026-07-26 — the same day
 this item's preconditions were first measured. Any work here touches that ruleset, so issue #1980 should be
 settled first or in the same change.
+
+## 2026-08-22 — DECIDED: the direct-write paths stay, so fast-forward promotion is not adopted
+
+The owner was asked directly, with the re-measured preconditions in front of them, and chose to
+leave the three paths open. That closes this item as a **decision**, not as work.
+
+**The reasoning, recorded so a later reader does not reopen it as an oversight:** all three are
+deliberate safety devices, and fast-forward promotion buys its guarantee by removing them.
+
+| path                                                      | why it stays                                                                                    |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `protect-main.bypass_actors` (RepositoryRole 5, `always`) | the recovery route when a promotion or a ruleset change leaves `main` wedged                    |
+| `main-pr-source-guard` admitting `hotfix/*`               | the incident path — a fix that must reach `main` without waiting for `develop` to be releasable |
+| Dependabot disabled by POLICY, not by mechanism           | a policy is reversible by a decision; a mechanism would have to be rebuilt                      |
+
+Closing all three would make `main` a strict prefix of `develop` and promotion a fast-forward with no
+merge, no method choice and no possible conflict. It would also mean that during an incident the only
+way to `main` is through `develop` — which is the cost, and the owner accepted the current cost
+instead.
+
+**What INFRA-051 leaves in place is therefore permanent by choice, not by neglect:** `main`
+accumulates promotion merge commits `develop` never sees, and each cycle re-records the ancestry. Two
+promotions on 2026-08-22 exercised that path and it asked nothing of a human — the merge was clean by
+construction both times, as INFRA-051 predicted it would be in the steady state.
+
+**One precondition genuinely moved today, and it does not change the decision.** Re-measured, as this
+record instructed:
+
+```
+non-merge commits on `main` unseen by `develop`:   10 (2026-07-26)  ->  0 (2026-08-22)
+the operating account can push directly to `main`:  yes, unchanged
+ci.yml triggers only `on: pull_request`:            yes, unchanged
+```
+
+The backlog of stray commits is gone — absorbed by ordinary promotion. That removes the cleanup this
+item would have had to perform first, and nothing else: the measurement is about what **has** landed,
+while the blocking condition was about what **can**. Recording it here so the zero is not read later
+as evidence that the paths were closed.
+
+**Reopen this item only if the decision changes.** The implementation shape is described above and
+in INFRA-051; nothing about it needs re-deriving.

--- a/scripts/harness/__tests__/check-patch-coverage.test.mjs
+++ b/scripts/harness/__tests__/check-patch-coverage.test.mjs
@@ -42,7 +42,8 @@ describe('INFRA-041 file classification', () => {
   it('isCoverableSource takes non-test src TS/JS only', () => {
     const pkg = 'packages/x';
     expect(isCoverableSource('packages/x/src/a.ts', pkg)).toBe(true);
-    expect(isCoverableSource('packages/x/src/ui/b.tsx', pkg)).toBe(true);
+    // INFRA-046, owner decision 2026-08-22: render surfaces are OUT of the denominator.
+    expect(isCoverableSource('packages/x/src/ui/b.tsx', pkg)).toBe(false);
     expect(isCoverableSource('packages/x/src/a.test.ts', pkg)).toBe(false);
     expect(isCoverableSource('packages/x/src/__tests__/a.ts', pkg)).toBe(false);
     expect(isCoverableSource('packages/x/src/types.d.ts', pkg)).toBe(false);
@@ -324,5 +325,62 @@ describe('lcovIsEntirelyUnexercised', () => {
   it('is true only when records exist and none has a hit', () => {
     expect(lcovIsEntirelyUnexercised(new Map([['f', new Map([[1, 0]])]]))).toBe(true);
     expect(lcovIsEntirelyUnexercised(new Map([['f', new Map([[1, 1]])]]))).toBe(false);
+  });
+});
+
+/**
+ * INFRA-046 / the issue #1348 class — render surfaces are OUT of the patch denominator.
+ *
+ * Owner decision, 2026-08-22. Line coverage over JSX says little: exercising a render tree's
+ * branches needs component-test infrastructure, and without it every UI pull request pays a tax it
+ * cannot discharge. Measured at the time, three of the four GUI packages owned SOME tests, so the
+ * issue #1344 untested-package classification did not excuse them — this is a separate rule, not a
+ * consequence of that one.
+ *
+ * The distinction these cases pin: EXCLUDED FROM THE DENOMINATOR, not counted as covered.
+ */
+describe('render surfaces are excluded from the patch denominator (INFRA-046)', () => {
+  it('excludes .tsx and .jsx, and keeps .ts/.js', () => {
+    expect(isCoverableSource('packages/p/src/a.ts', 'packages/p')).toBe(true);
+    expect(isCoverableSource('packages/p/src/a.js', 'packages/p')).toBe(true);
+    expect(isCoverableSource('packages/p/src/a.tsx', 'packages/p')).toBe(false);
+    expect(isCoverableSource('packages/p/src/a.jsx', 'packages/p')).toBe(false);
+  });
+
+  it('a diff of ONLY render surfaces is SKIPPED, not passed on a fabricated 100%', async () => {
+    const result = await runPatchCoverage({
+      target: 80,
+      diffText:
+        'diff --git a/packages/p/src/View.tsx b/packages/p/src/View.tsx\n' +
+        '--- a/packages/p/src/View.tsx\n+++ b/packages/p/src/View.tsx\n@@ -1,0 +1,2 @@\n+x\n+y\n',
+      hasPkgJson: (dir) => dir === 'packages/p',
+      collectLcov: () => 'SF:src/View.tsx\nDA:1,0\nDA:2,0\nend_of_record\n',
+      listFiles: () => ['packages/p/src/__tests__/v.test.ts'],
+      log: () => {},
+    });
+    // SKIPPED says "this gate has nothing to measure here". OK would say "it measured and was
+    // satisfied", which is a different and false claim.
+    expect(result.verdict).toBe(VERDICT.SKIPPED_NO_COVERABLE);
+    expect(result.measured).toBe(0);
+  });
+
+  it('a .ts file in the same diff is still measured and can still fail', async () => {
+    const result = await runPatchCoverage({
+      target: 80,
+      diffText:
+        'diff --git a/packages/p/src/View.tsx b/packages/p/src/View.tsx\n' +
+        '--- a/packages/p/src/View.tsx\n+++ b/packages/p/src/View.tsx\n@@ -1,0 +1,2 @@\n+x\n+y\n' +
+        'diff --git a/packages/p/src/logic.ts b/packages/p/src/logic.ts\n' +
+        '--- a/packages/p/src/logic.ts\n+++ b/packages/p/src/logic.ts\n@@ -1,0 +1,2 @@\n+a\n+b\n',
+      hasPkgJson: (dir) => dir === 'packages/p',
+      collectLcov: () =>
+        'SF:src/View.tsx\nDA:1,0\nDA:2,0\nend_of_record\n' +
+        'SF:src/logic.ts\nDA:1,0\nDA:2,0\nend_of_record\n',
+      listFiles: () => ['packages/p/src/__tests__/v.test.ts'],
+      log: () => {},
+    });
+    expect(result.verdict).toBe('patch-coverage-below-target');
+    // Two, not four: the render surface contributed nothing to the denominator.
+    expect(result.measured).toBe(2);
   });
 });

--- a/scripts/harness/check-patch-coverage.mjs
+++ b/scripts/harness/check-patch-coverage.mjs
@@ -72,11 +72,30 @@ export function packageRootOf(filePath, hasPkgJson) {
   return null;
 }
 
-/** Coverable = a non-test TS/JS file under `<pkgRoot>/src/` (excluding `.d.ts`). */
+/**
+ * Coverable = a non-test TS/JS file under `<pkgRoot>/src/`, excluding `.d.ts` and `.tsx`/`.jsx`.
+ *
+ * INFRA-046 (the issue #1348 class), owner decision 2026-08-22: **render surfaces are excluded from
+ * the patch denominator.** Line coverage over JSX says little — exercising every branch of a render
+ * tree needs component-test infrastructure, and without it every UI pull request pays a tax it
+ * cannot discharge. Measured at the time of the decision, three of the four GUI packages owned SOME
+ * tests, so the issue #1344 untested-package classification did not excuse them and would not have:
+ *
+ *   packages/agent-cli-web   tsx=1     test files=0
+ *   apps/agent-web           tsx=6     test files=1
+ *   apps/agent-app           tsx=3     test files=1
+ *   packages/agent-playground tsx=184  test files=32
+ *
+ * This is an exclusion from the DENOMINATOR, not a pass: a `.tsx` file's lines are neither measured
+ * nor counted as covered, so the percentage describes only the code the gate can speak about. The
+ * alternative the owner declined was standing up component-test infrastructure for those packages,
+ * which remains the way to bring render surfaces back INTO the denominator later.
+ */
 export function isCoverableSource(filePath, pkgRoot) {
   if (!filePath.startsWith(`${pkgRoot}/src/`)) return false;
   if (isTestFile(filePath)) return false;
   if (filePath.endsWith('.d.ts')) return false;
+  if (/\.[jt]sx$/.test(filePath)) return false;
   return /\.[cm]?[jt]sx?$/.test(filePath);
 }
 

--- a/scripts/harness/reference-kind-baseline.json
+++ b/scripts/harness/reference-kind-baseline.json
@@ -130,7 +130,7 @@
   ".agents/tasks/HARNESS-072-nothing-detects-a-contradiction-between-two-rules.md": 3,
   ".agents/tasks/HARNESS-078-single-segment-dotfiles-are-outside-both-name-checks.md": 1,
   ".agents/tasks/HARNESS-108-barrel-parameter-types-covers-two-of-fifty-five-barrels.md": 2,
-  ".agents/tasks/INFRA-046-promote-advisory-gates.md": 64,
+  ".agents/tasks/completed/INFRA-046-promote-advisory-gates.md": 64,
   ".agents/tasks/completed/INFRA-054-fast-forward-promotion-end-state.md": 5,
   ".agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md": 5,
   ".agents/tasks/PEER-003-peer-input-coalescing-loses-conversation-turns.md": 1,

--- a/scripts/harness/reference-kind-baseline.json
+++ b/scripts/harness/reference-kind-baseline.json
@@ -131,7 +131,7 @@
   ".agents/tasks/HARNESS-078-single-segment-dotfiles-are-outside-both-name-checks.md": 1,
   ".agents/tasks/HARNESS-108-barrel-parameter-types-covers-two-of-fifty-five-barrels.md": 2,
   ".agents/tasks/INFRA-046-promote-advisory-gates.md": 64,
-  ".agents/tasks/INFRA-054-fast-forward-promotion-end-state.md": 5,
+  ".agents/tasks/completed/INFRA-054-fast-forward-promotion-end-state.md": 5,
   ".agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md": 5,
   ".agents/tasks/PEER-003-peer-input-coalescing-loses-conversation-turns.md": 1,
   ".agents/tasks/REL-023-changeset-reconciliation.md": 1,


### PR DESCRIPTION
Two owner decisions, implemented and recorded. Both items close.

## INFRA-054 — DECIDED: the direct-write paths stay

Fast-forward promotion is **not** adopted. The three paths it would have to remove are deliberate
safety devices:

| path | why it stays |
| ---- | ------------ |
| `protect-main.bypass_actors` | the recovery route when `main` is wedged |
| `main-pr-source-guard` admitting `hotfix/*` | the incident path that does not wait for `develop` to be releasable |
| Dependabot disabled by POLICY | a policy is reversible by a decision; a mechanism would be rebuilt |

The cost accepted instead is INFRA-051's: `main` accumulates promotion merges and each cycle
re-records ancestry. **Two promotions today exercised that path and asked nothing of a human.**

One precondition genuinely moved and does not change the decision — non-merge commits on `main`
unseen by `develop` went **10 → 0**, absorbed by ordinary promotion. Recorded so the zero is not
later read as evidence the paths were closed: the measurement is about what *has* landed, the
condition was about what *can*.

`unearned-done-claims` refused the archive over three unticked criteria and was right to — they
describe the implementation that was not adopted. Each now carries `allow-unmet-criterion` naming
that reason, **on the line the criterion starts on**; a continuation line does not count, which the
scan caught on my first attempt.

## INFRA-046 — DECIDED: render surfaces leave the patch denominator

`.tsx`/`.jsx` are excluded, over the alternative of standing up component-test infrastructure.

**An exclusion from the DENOMINATOR, not a pass.** Their lines are neither measured nor counted as
covered, so the percentage describes only the code this gate can speak about. A render-surface-only
diff reports `SKIPPED` — *"nothing to measure here"* — rather than `OK`, which would claim it
measured and was satisfied.

Four cases pin it, and all four fail if the exclusion is reverted:

- `.tsx`/`.jsx` out, `.ts`/`.js` in;
- a render-only diff is SKIPPED with `measured = 0`;
- a `.ts` file in the same diff still measured and still failing — `measured = 2`, not 4;
- the **pre-existing** classification case, which asserted `.tsx` *was* coverable. The mutation run
  is what showed that case had to move to the decided behaviour rather than be left contradicting it.

### All three of this item's blockers, and what each turned out to be

| # | blocker | nature | outcome |
| - | ------- | ------ | ------- |
| 1 | a package with no test suite was charged (issue #1344) | **code defect** | fixed today |
| 2 | React-UI denominator policy (issue #1348 class) | **decision** | made today |
| 3 | `regression-red-proof` had no real verdicts | **evidence** | arrived today |

I had described blocker 1 as a decision. It was not — the record named the file. Correcting that
classification is what turned it into work instead of a wait.

Blocker 3's own words were *"one observed firing is what promotes it"*: a condition written
precisely enough to be discharged by an event rather than by an argument, and that is exactly how it
ended.

## What is NOT claimed

**`patch-coverage` remains advisory.** Both defects that held it there are cleared, so enforcing it
is now an unobstructed decision rather than a blocked one — and nobody has taken it. The record says
so instead of letting "INFRA-046 is done" imply otherwise. `regression-red-proof` is the gate this
item promoted; `patch-coverage` is the gate it made promotable.

## Verification

22 tests in `scripts/harness/__tests__/check-patch-coverage.test.mjs`, 136 scans, 4671 tests across
the pre-push tiers.

ACTIONABLE FINDINGS: 0

Refs INFRA-046, INFRA-054