### PR TITLE
docs(tasks): register SECURITY-001 foundational blockers

### DIFF
--- a/.agents/tasks/ARCH-042-public-sdk-project-authority-is-ambient.md
+++ b/.agents/tasks/ARCH-042-public-sdk-project-authority-is-ambient.md
@@ -1,0 +1,69 @@
+---
+title: 'ARCH-042: public SDK project authority is ambient'
+status: todo
+created: 2026-08-22
+priority: critical
+urgency: now
+area: packages/agent-framework, packages/agent-session, packages/agent-provider-replay
+depends_on: []
+---
+
+# ARCH-042: public SDK project authority is ambient
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2137.
+
+## Problem
+
+Public SDK project APIs still encode authority as a path, raw Node filesystem access, or an optional
+reader. Session persistence, memory, checkpoints, task context, prompt references, and provider
+settings repeat that shape. Securing one loader therefore leaves both existing bypasses and a contract
+that will recreate the same bypass in the next project-scoped API.
+
+This blocks `SECURITY-001`: its Restricted Mode claim cannot be true for direct SDK consumers while
+public project loaders silently fall back to ambient filesystem access.
+
+## Existing Evidence
+
+- `packages/agent-framework/src/interactive/session-persistence.ts` defaults a project session store
+  to raw Node I/O.
+- Project memory, checkpoint, task-context, prompt-reference, and provider-settings surfaces each
+  expose a capabilityless project path or raw-I/O fallback.
+- The SECURITY-001 architecture refresh classified the repeated published contract as FOUNDATIONAL,
+  not as a set of independent call-site bugs.
+
+## Directions Considered
+
+- Design one explicit public authority model separating host-owned content and generic filesystem
+  adapters from project-scoped operations.
+- Reject another optional-reader convention: absence has already acquired incompatible meanings.
+- Reject per-loader patches because they retain ambient authority as the public extension pattern.
+
+## Completion Criteria
+
+- [ ] Every public project-scoped SDK entry point requires authenticated workspace authority or
+      returns a documented restricted/refused result.
+- [ ] Host-owned prebuilt content and generic filesystem adapters remain possible through contracts
+      that do not imply workspace trust.
+- [ ] Package public-surface documentation and examples expose one authority model.
+- [ ] A mechanical or type-level guard prevents a new public project loader from adding an ambient
+      path/raw-I/O fallback.
+
+## Test Plan
+
+- Type-level contract tests for project APIs with and without workspace authority.
+- Runtime tests proving capabilityless calls cannot consume project settings, context, session logs,
+  memory, checkpoints, tasks, or prompt references.
+- Package builds, typechecks, tests, public-surface scans, and SDK documentation examples.
+
+## User Execution Test Scenarios
+
+### Scenario: a reader-less SDK session cannot consume project state
+
+- Prerequisites: build the affected packages; create an isolated Git project containing canary
+  settings, context, memory, and session data.
+- Exact steps: run the delivered public SDK example once without workspace authority and once after
+  obtaining authority through the supported trust service.
+- Expected observable result: the first run reports restricted project access and exposes none of
+  the canaries; the second run reads only the explicitly authorized project contributions.
+- Cleanup: remove the isolated project and trust grant.
+- Evidence:

--- a/.agents/tasks/ARCH-043-workspace-access-is-not-a-session-owned-policy.md
+++ b/.agents/tasks/ARCH-043-workspace-access-is-not-a-session-owned-policy.md
@@ -1,0 +1,69 @@
+---
+title: 'ARCH-043: workspace access is not a session-owned policy'
+status: todo
+created: 2026-08-22
+priority: critical
+urgency: now
+area: packages/agent-framework, packages/agent-command, packages/agent-cli
+depends_on: []
+---
+
+# ARCH-043: workspace access is not a session-owned policy
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2139.
+
+## Problem
+
+Workspace authority is copied through optional reader fields while Restricted Mode exists only as a
+CLI startup boolean. The session does not own one immutable workspace-access policy. Lazy provider
+switching, permission persistence, replay validation, and mode transitions can consequently lose the
+original authority or increase permissions after a restricted startup.
+
+This blocks `SECURITY-001`: patching the current transition sites would preserve the duplicated
+representation that caused them.
+
+## Existing Evidence
+
+- Provider switching does not preserve the session's trusted reader.
+- Project allow-tool persistence and replay validation reopen project state outside the initial
+  decision.
+- Mode and plan-approval transitions can raise a session that the CLI initialized in Restricted Mode.
+- The SECURITY-001 architecture refresh classified the repeated representation as FOUNDATIONAL.
+
+## Directions Considered
+
+- Design one immutable workspace-access policy owned by the session recipe/runtime and consumed by
+  every eager and lazy operation.
+- Reject a second set of CLI transition guards because non-CLI hosts and new lazy paths would bypass
+  them.
+- Preserve trusted sessions' reader capability while making authority-increasing restricted
+  transitions unrepresentable or explicitly refused.
+
+## Completion Criteria
+
+- [ ] Session construction has one workspace-access policy with explicit restricted, trusted, and
+      host-owned semantics.
+- [ ] Provider switching, replay, project permission persistence, context refresh, and future lazy
+      operations consume that same policy.
+- [ ] Restricted sessions cannot increase project or tool authority through mode/preset/approval
+      transitions.
+- [ ] Direct SDK and CLI composition use the same contract.
+
+## Test Plan
+
+- Red-first tests for every current lazy authority-loss path and permission-increasing transition.
+- Construction tests for CLI, direct SDK, replay, TUI, and headless hosts.
+- Framework/command/CLI builds, typechecks, tests, and scenario verification.
+
+## User Execution Test Scenarios
+
+### Scenario: Restricted Mode remains restricted for the whole session
+
+- Prerequisites: build the CLI; create an isolated untrusted Git project with project provider,
+  permission, and replay canaries; use the deterministic scripted provider.
+- Exact steps: start the delivered interactive CLI in the project, attempt `/mode`, plan approval,
+  provider switching, and replay operations that would increase or reopen project authority.
+- Expected observable result: each authority-increasing operation is refused with recovery guidance,
+  and no project canary is consumed; after an explicit trust grant a fresh session can use them.
+- Cleanup: revoke the grant and remove the isolated project.
+- Evidence:

--- a/.agents/tasks/ARCH-044-subagent-child-wire-reuses-live-runtime-contracts.md
+++ b/.agents/tasks/ARCH-044-subagent-child-wire-reuses-live-runtime-contracts.md
@@ -1,0 +1,64 @@
+---
+title: 'ARCH-044: subagent child wire reuses live runtime contracts'
+status: todo
+created: 2026-08-22
+priority: critical
+urgency: now
+area: packages/agent-subagent-runner, packages/agent-interface-transport, packages/agent-framework
+depends_on: []
+---
+
+# ARCH-044: subagent child wire reuses live runtime contracts
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2047.
+
+## Problem
+
+The child-process wire DTO reuses the in-process semantic spawn request and live framework types.
+Future fields therefore cross IPC by default. A nested provider profile can carry credentials and
+destinations, and nested agent-definition extras survive projections whose guards validate only a
+few required properties.
+
+This blocks `SECURITY-001`: top-level omission tests cannot establish a least-authority boundary while
+the wire contract structurally inherits new live fields.
+
+## Existing Evidence
+
+- The start payload embeds the complete semantic spawn request.
+- The request can contain a secret-bearing provider profile.
+- Agent-definition projection uses object spread, and its guard neither validates every allowed field
+  nor rejects unknown keys.
+- Issue #2047 independently recorded the missing total JSON-safe DTO before this finding.
+
+## Directions Considered
+
+- Define a runner-owned, minimal, JSON-safe child DTO and explicit encoder/total decoder.
+- Reject omission-only guards on reused framework objects.
+- Require field-coverage tests so adding a wire field without codec and canary coverage fails.
+
+## Completion Criteria
+
+- [ ] The child wire DTO references no live in-process dependency bag or semantic request type.
+- [ ] Encoding is field-by-field and decoding rejects unknown, missing, malformed, and non-JSON values.
+- [ ] Credentials, raw endpoints, provider options, callbacks, tools, terminals, and capabilities are
+      absent from the generic wire.
+- [ ] Codec round-trip and nested canary tests cover every allowed field.
+
+## Test Plan
+
+- Red-first encoder/decoder tests, including nested secret and unknown-field canaries.
+- Real child-process round trips through IPC-equivalent serialization.
+- Runner/framework builds, typechecks, unit tests, and a real self-fork integration scenario.
+
+## User Execution Test Scenarios
+
+### Scenario: a real child receives only the declared safe request
+
+- Prerequisites: build the CLI and subagent runner; use an isolated project and deterministic scripted
+  provider; enable a child-process subagent.
+- Exact steps: invoke the delivered CLI scenario that spawns the child with canary fields present on
+  the parent semantic request and capture the child's decoded diagnostic projection.
+- Expected observable result: the child completes the safe request, while every undeclared canary is
+  absent or rejected before worker construction.
+- Cleanup: remove the isolated project and captured diagnostic output.
+- Evidence:

--- a/.agents/tasks/ARCH-045-child-provider-credentials-and-destinations-have-separate-owners.md
+++ b/.agents/tasks/ARCH-045-child-provider-credentials-and-destinations-have-separate-owners.md
@@ -1,0 +1,67 @@
+---
+title: 'ARCH-045: child provider credentials and destinations have separate owners'
+status: todo
+created: 2026-08-22
+priority: critical
+urgency: now
+area: packages/agent-subagent-runner, packages/agent-framework, packages/agent-core
+depends_on: []
+---
+
+# ARCH-045: child provider credentials and destinations have separate owners
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2138.
+
+## Problem
+
+Child-process composition selects destination and provider options from child-local configuration but
+may select credential provenance from a parent environment reference or literal-credential broker.
+There is no single bound connection-profile identity. A parent credential can therefore be paired
+with a different child-selected endpoint, including provider-specific destination options.
+
+This blocks `SECURITY-001`: comparing provider type or patching one provider source does not make
+credential and destination ownership atomic.
+
+## Existing Evidence
+
+- The child validates provider type rather than a complete connection identity.
+- Parent credential references can be combined with child-local `baseURL` and `options`.
+- Literal-credential broker enforcement does not inspect every effective provider source.
+- Related issue #2044 covers reproducible product provider recipes, but not this credential/destination
+  security invariant.
+
+## Directions Considered
+
+- Resolve credentials and all destination-affecting values as one owner-bound child-local profile.
+- If selection must cross IPC, carry a non-secret canonical digest and require the child to recompute
+  an exact match before it can obtain credentials.
+- Reject provider-type-only comparison and independent credential fallback.
+
+## Completion Criteria
+
+- [ ] Credential provenance, endpoint, and provider-specific destination options have one owner-bound
+      connection identity.
+- [ ] Broker and environment-reference paths validate the same effective provider source.
+- [ ] Any destination mismatch fails before a credential is read or released.
+- [ ] Provider-specific alternate endpoints have credential-redirection canary coverage.
+
+## Test Plan
+
+- Red-first tests for same-type/different-destination profiles, alternate endpoint options, and every
+  effective provider source.
+- Broker tests proving literal credentials are never released before exact binding succeeds.
+- Real child-process integration tests plus core/framework/runner build, typecheck, and test gates.
+
+## User Execution Test Scenarios
+
+### Scenario: a child cannot redirect a parent credential
+
+- Prerequisites: build the CLI; use an isolated trusted project, a loopback capture server, a dummy
+  credential, and a deterministic parent flow that spawns a child.
+- Exact steps: configure the parent-owned profile for a safe unreachable destination, configure the
+  child project profile with the same provider type and the capture-server destination, then spawn the
+  child through the delivered CLI scenario.
+- Expected observable result: child startup fails with a destination-binding error before credential
+  release, and the capture server receives no request or authorization value.
+- Cleanup: stop the server, revoke trust, and remove the isolated project.
+- Evidence:

--- a/.agents/tasks/ARCH-046-workspace-contribution-inventory-duplicates-loader-ownership.md
+++ b/.agents/tasks/ARCH-046-workspace-contribution-inventory-duplicates-loader-ownership.md
@@ -1,0 +1,64 @@
+---
+title: 'ARCH-046: workspace contribution inventory duplicates loader ownership'
+status: todo
+created: 2026-08-22
+priority: high
+urgency: now
+area: packages/agent-framework, packages/agent-cli
+depends_on: []
+---
+
+# ARCH-046: workspace contribution inventory duplicates loader ownership
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2140.
+
+## Problem
+
+The pre-trust contribution inventory maintains a separate hand-written path list rather than deriving
+categories from contribution owners. It already omits active project skills, agents, memory, logs, and
+checkpoints, so the consent prompt can under-report what granting trust enables. Adding the five paths
+alone would preserve the design that guarantees future omissions.
+
+This blocks `SECURITY-001`: informed consent requires the fixed content-blind inventory and the loaders
+to share ownership of contribution categories.
+
+## Existing Evidence
+
+- `.robota/skills`, `.agents/agents`, `.robota/memory`, `.robota/logs`, and
+  `.robota/checkpoints` are active inputs but absent from the inventory.
+- The inventory reports `.agents/memory`, which is not the runtime project-memory owner.
+- No owner registry or mechanical coverage connects loader changes to inventory changes.
+
+## Directions Considered
+
+- Establish an owner-controlled contribution-source registry or equivalent SSOT from which loaders and
+  the content-blind inventory derive categories.
+- Preserve pre-trust no-follow/no-content inspection.
+- Reject another synchronized path list or a test that merely copies the same duplicate list.
+
+## Completion Criteria
+
+- [ ] Every active project contribution family has one owner declaration consumed by both loading and
+      inventory projection.
+- [ ] Adding a project contribution source without inventory coverage fails mechanically.
+- [ ] Pre-trust inspection remains fixed-depth, no-follow, and content-blind.
+- [ ] Trust prompt, status, diagnose, package docs, and architecture maps use the same categories.
+
+## Test Plan
+
+- Registry ownership and exhaustiveness tests across all contribution loaders.
+- Adversarial inventory tests for symlinks, deep trees, missing paths, and unreadable entries.
+- Framework/CLI build, typecheck, test, harness scan, and trust lifecycle scenario.
+
+## User Execution Test Scenarios
+
+### Scenario: trust inventory reports every enabled project contribution family
+
+- Prerequisites: build the CLI; create an isolated Git project with one canary entry in each declared
+  contribution family and with no trust grant.
+- Exact command: run `robota trust status`, then `robota trust --yes`, then `robota diagnose`, using an
+  isolated user home.
+- Expected observable result: status reports every family without reading canary content; after the
+  grant, diagnose reports the same categories and their trusted provenance.
+- Cleanup: run `robota trust revoke` and remove the isolated project and user home.
+- Evidence:

--- a/.agents/tasks/SECURITY-001-untrusted-workspace-configuration-crosses-the-user-trust-boundary.md
+++ b/.agents/tasks/SECURITY-001-untrusted-workspace-configuration-crosses-the-user-trust-boundary.md
@@ -1,11 +1,11 @@
 ---
 title: 'SECURITY-001: untrusted workspace configuration crosses the user trust boundary'
-status: todo
+status: blocked
 created: 2026-08-22
 priority: critical
 urgency: now
 area: packages/agent-framework, packages/agent-session, packages/agent-core, packages/agent-cli
-depends_on: []
+depends_on: [ARCH-042, ARCH-043, ARCH-044, ARCH-045, ARCH-046]
 ---
 
 # SECURITY-001: untrusted workspace configuration crosses the user trust boundary


### PR DESCRIPTION
## Summary

- register ARCH-042 through ARCH-046 as the five foundational blockers found by the SECURITY-001 architecture refresh
- link every Task to its live GitHub issue and make each issue title claim the Task ID
- mark SECURITY-001 blocked on those five root items instead of merging a locally patched trust boundary

## Depth disposition

The SECURITY-001 architecture refresh returned FOUNDATIONAL for these five causes. The chosen disposition is re-plan, not containment. The halted implementation is preserved separately and is not part of this diff.

## Verification

- `pnpm harness:scan` — PASS, 134 scans
- `pnpm build` — PASS (refreshed stale local dist artifacts)
- `pnpm harness:verify-like-ci` — PASS, all 12 stages
- harness contract tests — 163 files / 3,529 tests passed
- local review — 0 findings, foundational IDs ARCH-042 through ARCH-046 recorded

## Issue registration

- ARCH-042: #2137
- ARCH-043: #2139
- ARCH-044: #2047
- ARCH-045: #2138
- ARCH-046: #2140
