### PR TITLE
fix(harness): verify a merged branch by its PR merge commit (PROC-012)

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -386,15 +386,39 @@ judgement conditions above govern, and when one of them holds the branch stays a
 **Never** use `gh pr merge --delete-branch` (see the ban above) — delete explicitly, only after confirming
 the branch is merged:
 
-- **Local:** `git branch -d <branch>` (the `-d` form refuses an unmerged branch — a built-in guard).
-- **Remote:** confirm merged, then `gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<branch>`.
-- **Verify before remote deletion:** `git merge-base --is-ancestor origin/<branch> origin/main` (or
-  `origin/develop` for non-release merges) must succeed. If it does not, the branch carries commits the
-  target does not have — do not delete it; surface it.
+- **Verify first, and verify the MERGE COMMIT — never the branch.** This repository squash-merges: a
+  squash merge writes a NEW commit on the target, so a merged branch's own commits are ancestors of
+  nothing there. Ancestry of the branch therefore answers a question nobody asked. Ask instead whether
+  the branch's pull request LANDED on the target:
+
+  ```bash
+  MC=$(gh pr list --state merged --head "<branch>" --json mergeCommit --jq '.[0].mergeCommit.oid')
+  [ -n "$MC" ] && git merge-base --is-ancestor "$MC" origin/main   # or origin/develop
+  ```
+
+  **Both halves are required.** A merged pull request must exist for the branch, AND its merge commit
+  must be an ancestor of the target you name. A branch can carry a merged pull request whose base was
+  another feature branch, leaving its work on neither standing branch — so "it was merged" alone does
+  not authorize deletion. **If either half fails, do not delete it; surface it.**
+
+- **Name the target deliberately.** `main` trails `develop` between promotions, so a branch merged to
+  `develop` is legitimately absent from `main`. Check against the branch it was merged INTO.
+- **Local:** `git branch -D <branch>`, after the same verification. `-d` is not a usable guard here: it
+  applies the same ancestry test and so refuses every squash-merged branch. The verification above is
+  the guard; `-D` without it is not.
+- **Remote:** `gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/<branch>`.
 
 **Never delete `develop` or `main`.**
 
 **Why:** stale merged branches obscure the active set; the confirmed per-branch delete (never merge-time `--delete-branch`) is the form that cannot take an integration branch or an unmerged PR with it.
+
+**Why the merge commit and not the branch.** Ancestry of the branch encodes the merge METHOD — it is
+true only where merges leave the branch's own commits on the target. Encoding a contingent fact about
+tooling as if it were a property of merged branches makes the rule unsatisfiable the moment the method
+changes, and this failure is silent: a check that refuses a correct action produces no contradiction,
+only a growing pile of undeletable branches that nothing prompts anyone to look at. The measured
+before-and-after is recorded in
+[PROC-012](../tasks/completed/PROC-012-verify-a-merged-branch-by-its-pull-request-merge-commit-not-by-branch-ancestry.md).
 
 ### Post-Merge Branch Cycle (mandatory)
 

--- a/.agents/spec-docs/done/PROC-012-verify-a-merged-branch-by-its-pull-request-merge-commit.md
+++ b/.agents/spec-docs/done/PROC-012-verify-a-merged-branch-by-its-pull-request-merge-commit.md
@@ -1,0 +1,117 @@
+---
+status: done
+type: RULE
+tags: [harness]
+---
+
+# PROC-012: verify a merged branch by its pull request merge commit
+
+Paired with
+`.agents/tasks/PROC-012-verify-a-merged-branch-by-its-pull-request-merge-commit-not-by-branch-ancestry.md`.
+Converted from [issue #2135](https://github.com/woojubb/robota/issues/2135).
+
+## Problem
+
+`git-branch.md` § "Delete Merged Branches" mandates that a merged branch not be left standing, then
+requires `git merge-base --is-ancestor origin/<branch> origin/main` before deleting it. This
+repository squash-merges, so a merged branch's own commits are ancestors of nothing on the target and
+that check fails for every one of them. The rule's two halves are each correct and jointly
+unsatisfiable.
+
+The same wrong question appears a second time in `.claude/hooks/branch-guard.sh`, which blocks branch
+creation while a local branch looks unmerged. That path already knew about squash merges — it matched
+candidates against `gh pr list --state merged --limit 500` — but the list is saturated at 500 in this
+repository, so merged pull requests older than the window fall out and their branches are reported
+unmerged. The hook printed a NOTE saying the list came back full and blocked anyway.
+
+Both sites ask whether the BRANCH's commits are reachable on the target. The property they need is
+whether the branch's PULL REQUEST landed there.
+
+## Prior Art Research
+
+Waived: the correct check is stated in full in the source issue, and it is a two-command composition
+over `gh` and `git` with no external product analog to survey. The waiver is recorded rather than the
+section left empty, per [research.md](../../rules/research.md).
+
+The one external fact the design rests on is verified rather than assumed: GitHub's pull-request
+object exposes `mergeCommit.oid` for a squash merge, and it is the commit written on the base branch.
+Confirmed against this repository's own merged pull requests — see the Evidence Log.
+
+## Architecture Review
+
+**Alternatives considered.**
+
+1. **Ancestry of the merged head (`headRefOid`) against the target.** Rejected: that is the same
+   question in different clothing. A squash discards the head commit, so it is on the target under no
+   merge method that squashes.
+2. **"A merged pull request exists for this branch" alone.** Rejected on measurement, not taste. Four
+   branches on `origin` carry a merged pull request whose base was a feature branch that has since
+   been deleted, so their work is on neither `develop` nor `main`. This alternative clears all four
+   for deletion and the work is unrecoverable afterwards. This is the rebuttal that decided the
+   design.
+3. **Ancestry of the pull request's merge commit against the named target.** Chosen. It answers the
+   question the original check was reaching for, under both merge methods, and it keeps the guard's
+   real value: no merged pull request, or a merge commit absent from the target, still refuses.
+
+**Reachability.** Both consumers of the check — the rule's prose procedure and the hook's creation
+guard — can run it: `gh` and `git` are already required by both, and the hook already routes `gh`
+through its bounded helper.
+
+**Capability preservation.** The replaced check protected two things, and both survive. Unmerged work
+still blocks (no merged pull request → refused). Branch-name reuse still blocks: the decision requires
+the local branch to still point at the exact commit the pull request merged, so stacking new work on a
+merged name is not cleared. Both are covered by fixtures rather than asserted.
+
+**Blast radius.** The hook trades one global query for one query per branch that is actually ahead of
+the integration ref. That count is small by construction — the rule this very change unblocks is the
+one that deletes the others — and the per-branch form removes the saturation window entirely.
+
+## Completion Criteria
+
+- **TC-01** The rule's verification step tests the pull request's merge commit against a named target,
+  and states that both halves are required.
+- **TC-02** The rule text carries no case narrative: the measurement lives in the paired Task, reached
+  by a resolving link (`rule-case-narrative` green).
+- **TC-03** The hook clears a squash-merged branch whose merge commit is on the integration ref.
+- **TC-04** The hook refuses a branch whose pull request merged somewhere other than the integration
+  ref.
+- **TC-05** The hook refuses a merged branch name carrying new commits, and refuses when no merged
+  pull request exists.
+- **TC-06** A failed or stalled query still refuses, names the by-hand verification, and stays bounded.
+- **TC-07** `pnpm harness:scan` green; the branch-guard suites green.
+
+## Test Plan
+
+`scripts/harness/__tests__/branch-guard-unmerged.test.mjs` — one fixture per TC-03…TC-06, with `gh`
+stubbed per-branch so the assertions are about the DECISION rather than about a transcript. The
+scratch repository advances `develop` by a commit to stand in for the squash, so merge-commit
+ancestry is a real git question in the fixture and not a mocked boolean.
+
+## Evidence Log
+
+| Claim                                                            | Verified at                                                                                                                                                                                                                                                                                                                        |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The rule's current check fails for every squash-merged branch    | 14 of 14 non-default `origin` branches FAIL `--is-ancestor`, including all 8 fully merged into `develop` — table in the paired Task                                                                                                                                                                                                |
+| A merged PR's `mergeCommit.oid` is the commit on the base branch | `gh pr list --state merged --head <branch> --json mergeCommit` over PRs #2133, #2141–#2147, #2150; each oid is an ancestor of `origin/develop`                                                                                                                                                                                     |
+| "Merged PR exists" alone is insufficient                         | PRs #1723–#1726 merged into `feat/arch-dag-runtime-completion`, which no longer exists on `origin`; their merge commits are ancestors of neither `origin/develop` nor `origin/main`                                                                                                                                                |
+| The hook's 500-item window is saturated, not theoretical         | The hook's own `MERGED_TRUNCATED` NOTE fired in this clone, and the four branches it named were merged as PRs #2143, #2147, #2133, #2144                                                                                                                                                                                           |
+| The defect blocks live work, not just cleanup                    | Branch creation refused in two of four active clones within ten minutes; one `BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1` override resulted                                                                                                                                                                                                |
+| `-d` is not a fallback guard                                     | `git branch -d` applies the same ancestry test; all four stale local branches here required `-D`                                                                                                                                                                                                                                   |
+| GATE-APPROVAL                                                    | The repository owner, in the current conversation, was shown the measured block and asked whether to pull issue #2135 forward; they selected "지금 큐 앞으로 당김" (pull it forward now). This is a direct instruction naming this issue, not a standing delegation, so the delegated-class question does not arise for this item. |
+| The rule change is a policy-file edit                            | Disclosed to the owner in the same exchange: `backlog-execution.md` reserves repository-wide policy files, and the owner's instruction to prioritize this issue is what authorizes it. Scope is limited to the one section and the one hook path.                                                                                  |
+
+## Non-goals
+
+Deleting the branches this unblocks. A bulk remote deletion is irreversible and outward-facing; the
+rule already permits a branch to stay with a recorded reason, so the sweep asks its holder. The four
+`feat/arch-dag-runtime-completion` branches need a disposition decision this change surfaces rather
+than makes.
+
+## User Execution Test Scenarios
+
+**Not applicable.** This change delivers rule text and a repository hook, not runnable user-facing
+product behavior — no CLI command, TUI action, browser flow, or public SDK surface changes. Per
+`.agents/tasks/README.md`, a documentation/rule-only change must record the not-applicable with its
+reason rather than invent a product scenario, and the developer-workflow observable it does change
+(a branch creation that no longer needs an override) belongs in the Test Plan, where it is recorded
+with its evidence.

--- a/.agents/tasks/completed/PROC-012-verify-a-merged-branch-by-its-pull-request-merge-commit-not-by-branch-ancestry.md
+++ b/.agents/tasks/completed/PROC-012-verify-a-merged-branch-by-its-pull-request-merge-commit-not-by-branch-ancestry.md
@@ -1,0 +1,152 @@
+---
+title: 'PROC-012: verify a merged branch by its pull request merge commit, not by branch ancestry'
+issue: https://github.com/woojubb/robota/issues/2135
+status: done
+created: 2026-08-23
+completed: 2026-08-23
+priority: high
+urgency: now
+area: .agents/rules/git-branch.md, .claude/hooks/branch-guard.sh
+depends_on: []
+---
+
+# PROC-012: verify a merged branch by its pull request merge commit, not by branch ancestry
+
+## Problem
+
+`.agents/rules/git-branch.md` § "Delete Merged Branches (mandatory)" mandates that a merged branch
+must not be left standing, and then requires this before deleting it:
+
+> `git merge-base --is-ancestor origin/<branch> origin/main` (or `origin/develop` for non-release
+> merges) must succeed. If it does not, the branch carries commits the target does not have — **do
+> not delete it; surface it**.
+
+This repository squash-merges. A squash merge writes a NEW commit on the target; the branch's own
+commits become ancestors of nothing on that target. So the verification step fails for every
+squash-merged branch, and an agent following the rule honestly reaches "do not delete it; surface
+it" every time — for branches that are genuinely, fully merged.
+
+The rule's two halves are each correct and jointly unsatisfiable. They became incompatible when the
+merge method changed, and the ancestry check encodes a contingent fact — _we merge with merge
+commits_ — as if it were a property of merged branches.
+
+## Evidence
+
+Measured 2026-08-23 in `/home/ubunutu/dev/robota` against `origin`, one row per non-default remote
+branch. `anc(dev)`/`anc(main)` are the rule's current check; `mc(dev)`/`mc(main)` are the proposed
+merge-commit check.
+
+| remote branch                               | anc(dev) | anc(main) | merged PR → base                              | mc(dev) | mc(main) |
+| ------------------------------------------- | -------- | --------- | --------------------------------------------- | ------- | -------- |
+| `chore/complete-infra-129-records`          | FAIL     | FAIL      | PR #2143 → develop                            | PASS    | FAIL     |
+| `docs/cli-082-output-styles-research`       | FAIL     | FAIL      | PR #2142 → develop                            | PASS    | FAIL     |
+| `docs/register-security-foundations`        | FAIL     | FAIL      | PR #2141 → develop                            | PASS    | FAIL     |
+| `feat/architecture-audit-refresh`           | FAIL     | FAIL      | PR #2150 → develop                            | PASS    | FAIL     |
+| `fix/dependency-review-license-exemptions`  | FAIL     | FAIL      | PR #2147 → develop                            | PASS    | FAIL     |
+| `fix/infra-126-burn-down`                   | FAIL     | FAIL      | PR #2146 → develop                            | PASS    | FAIL     |
+| `fix/work-item-id-allocator`                | FAIL     | FAIL      | PR #2133 → develop                            | PASS    | FAIL     |
+| `task/dependency-review-license-exemptions` | FAIL     | FAIL      | PR #2144 → develop                            | PASS    | FAIL     |
+| `feat/arch-012-session-capabilities`        | FAIL     | FAIL      | PR #1724 → `feat/arch-dag-runtime-completion` | FAIL    | FAIL     |
+| `feat/arch-019-honest-session-double`       | FAIL     | FAIL      | PR #1723 → `feat/arch-dag-runtime-completion` | FAIL    | FAIL     |
+| `fix/infra-099-completion-archive`          | FAIL     | FAIL      | PR #1726 → `feat/arch-dag-runtime-completion` | FAIL    | FAIL     |
+| `fix/infra-099-stage-verification-receipts` | FAIL     | FAIL      | PR #1725 → `feat/arch-dag-runtime-completion` | FAIL    | FAIL     |
+| `fix/glob-import-spellings`                 | FAIL     | FAIL      | none                                          | —       | —        |
+| `spec/arch-042-project-authority`           | FAIL     | FAIL      | none (PR #2160 OPEN)                          | —       | —        |
+
+Three groups, and the proposed check separates them where the current one cannot:
+
+1. **Eight genuinely merged into `develop`.** The current check refuses deletion for all eight; the
+   merge-commit check clears all eight. Ancestry-of-branch passes for **0 of 14** branches — a 100%
+   false-negative rate over the set it is supposed to clear.
+2. **Four merged into a FEATURE branch** (`feat/arch-dag-runtime-completion`, PRs #1723–#1726) that
+   no longer exists on `origin`. Their work is on neither `develop` nor `main`. This is the genuine
+   "surface it, do not delete" case, and the merge-commit check still refuses them — the guard keeps
+   its real value. `gh pr list --state merged --head <branch>` alone would have cleared these four,
+   so the base of the merged PR is not sufficient on its own; the merge commit must be tested for
+   ancestry on the actual target.
+3. **Two with no merged pull request**, one of which has an OPEN PR. Both correctly retained under
+   either check.
+
+`main` trails `develop` by 50 commits, so a merge commit on `develop` is on `main` for none of these
+rows. The target the check names is therefore load-bearing, not incidental.
+
+### The same wrong question in the branch-creation guard
+
+`.claude/hooks/branch-guard.sh` blocks new branch creation when a local branch has commits not on the
+integration branch. It already knows about squash merges and matches candidates against a merged-PR
+list — but it fetches that list as `gh pr list --state merged --limit 500` over ALL merged PRs and
+matches by `headRefName + headRefOid`. The list is saturated: it returns a full 500, so merged PRs
+older than the window fall out and their branches are reported as unmerged. The hook prints a NOTE
+saying the list came back full and blocks anyway.
+
+Measured 2026-08-23: this blocked branch creation in two of four active clones within ten minutes.
+In this clone all four reported branches (`chore/complete-infra-129-records`,
+`fix/dependency-review-license-exemptions`, `fix/work-item-id-allocator`,
+`task/dependency-review-license-exemptions`) were fully merged via PRs #2143, #2147, #2133, #2144. In
+another clone it produced a `BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1` override on a branch whose work had
+already landed as PR #2146.
+
+This is the same cause, not a second one: both sites ask whether the BRANCH's commits are reachable
+on the target, when the property they need is whether the branch's PULL REQUEST landed there. The
+per-branch query the rule change adopts (`--head <branch>`) also removes the 500-item window,
+because it never enumerates the global list.
+
+## Non-goals
+
+- Deleting the remote branches this unblocks. The rule already allows a branch to stay with a
+  recorded reason, so the sweep asks its holder rather than assumes; a bulk remote deletion is an
+  irreversible outward-facing action and is not authorized by this Task.
+- Branch attribution. Issue #2135 notes that 28 of the branches it measured carry no
+  `Claude-Session` trailer and cannot be attributed. That is a separate observation.
+- The four `feat/arch-dag-runtime-completion` branches. They need a disposition decision from their
+  holder, which this Task surfaces rather than makes.
+
+## Plan
+
+- [x] Rewrite `git-branch.md` § "Delete Merged Branches" verification to test the merge commit of the
+      branch's merged pull request for ancestry on the stated target, under both merge methods.
+- [x] State the retained refusal explicitly: no merged PR, or a merge commit absent from the target,
+      still means surface it and do not delete.
+- [x] Replace the branch-guard creation check's global 500-item merged-PR list with the per-branch
+      merge-commit query, so the window cannot saturate.
+- [x] Add a regression fixture covering all three groups above.
+
+## Test Plan
+
+- Hook fixture: a merged-and-squashed branch is cleared; a branch merged into a third branch that is
+  not the target is refused; a branch with no merged PR is refused; a branch whose name matches a
+  merged PR but whose HEAD has moved on is refused (the name-reuse case the delete guard already
+  documents).
+- `pnpm harness:scan` green, including `hook-override-declarations` and `conflict-markers`.
+- Re-run the measurement table above and confirm the three groups separate as predicted.
+- Confirm branch creation succeeds in a clone holding a squash-merged local branch WITHOUT an
+  override, which is the observable that made this Task urgent.
+
+## User Execution Test Scenarios
+
+Not applicable — rule text and a repository hook, delivering no runnable user-facing product
+behavior. The observable is a developer-workflow check and is covered in the Test Plan, per
+`.agents/tasks/README.md` (documentation/rule-only changes must not invent a product scenario).
+
+## Verification Evidence
+
+Recorded after implementation, per `.agents/tasks/README.md`.
+
+- `npx vitest run scripts/harness/__tests__/branch-guard-*.test.mjs` → **113 passed, 5 files**,
+  including the six new/rewritten decision fixtures in `branch-guard-unmerged.test.mjs`.
+- The rewritten suite fails against the pre-change hook: the per-branch stub answers a query the old
+  code never makes, so a stale implementation reads an unanswered world rather than silently agreeing.
+- `pnpm harness:scan` green, including `rule-case-narrative` (the amendment carries no case narrative —
+  the measurement lives here and is reached from the rule by a resolving link) and
+  `reference-kind-qualified` (every `#NNNN` above says which kind it is).
+- The block that motivated this Task is gone in practice: after deleting the four verified-merged
+  stale local branches, `git checkout -b fix/proc-012-…` succeeded with **no override**. The four had
+  landed as PRs #2143, #2147, #2133 and #2144, and `git branch -d` refused all four — `-D` plus the
+  merge-commit verification is what cleared them.
+
+## Follow-ups filed rather than absorbed
+
+- The 14 remote branches are left standing. Eight are safely deletable under the new check; four
+  (PRs #1723–#1726, merged into the since-deleted `feat/arch-dag-runtime-completion`) need a
+  disposition decision from their holder; two have no merged pull request, one of them with an open
+  pull request. The sweep asks rather than assumes, per the rule's own judgement conditions.

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1338,30 +1338,25 @@ while read -r STMT_START STMT_LEN; do
     # — silently disabling the very rule this check enforces. The delete-guard below already carries that
     # lesson ("a merged PR earlier in this branch's history does not make deletion safe"); this path was
     # written without it.
-    MERGED_REFS=""
-    MERGED_REFS_READ=false
+    # Asked PER BRANCH, not as one global list (PROC-012, issue #2135). The previous form pulled
+    # `pr list --state merged --limit 500` once and matched candidates against it. That list is
+    # SATURATED — it returns a full 500 — so every merged PR older than the window fell out and its
+    # branch was reported unmerged. The hook printed a NOTE saying the list came back full and blocked
+    # anyway, which is a guard announcing its own false positive and refusing regardless. Measured
+    # 2026-08-23: it blocked branch creation in two of four active clones inside ten minutes, on four
+    # branches merged as #2143, #2147, #2133 and #2144, and produced one reflex override.
     #
-    # Bounded, because this runs on every branch creation. This path was once entirely local; it makes
-    # a network call now, and a SLOW response is not a failed one — unbounded, a stalled connection
-    # holds the branch creation open instead of taking the fallback below.
+    # `--head <branch>` has no window to saturate. It costs one call per branch that is actually ahead
+    # of the integration ref — the branches already deleted after their merge cost nothing, which is
+    # the direction the rule pushes anyway.
     #
-    # The bound comes from the shared helper, which is where the deadline and every hard-won detail of
-    # enforcing it lives. That helper's original was written HERE, for this one query, while ten other
-    # calls in this directory had no bound at all — which is how a convention ends up applied once.
-    MERGED_LIMIT=500
-    if MERGED_REFS=$(bounded_gh pr list --state merged --limit "$MERGED_LIMIT" \
-      --json headRefName,headRefOid --jq '.[] | "\(.headRefName) \(.headRefOid)"'); then
-      MERGED_REFS_READ=true
-    fi
-
-    # A full page may mean the list was truncated, so older merged branches would be missing and the
-    # check would over-report again — without the notice that explains why. Say it rather than let the
-    # list quietly grow back.
-    MERGED_TRUNCATED=false
-    if [[ "$MERGED_REFS_READ" == "true" ]] &&
-      [[ "$(printf '%s\n' "$MERGED_REFS" | grep -c .)" -ge "$MERGED_LIMIT" ]]; then
-      MERGED_TRUNCATED=true
-    fi
+    # Still bounded, and for the reason the global form was: this path was once entirely local, it now
+    # makes a network call, and it runs on every branch creation. A SLOW response is not a failed one —
+    # unbounded, a stalled connection holds the branch creation open instead of taking the fallback
+    # below. The bound comes from the shared helper, which owns the deadline and every hard-won detail
+    # of enforcing it. Per-branch makes that bound MORE load-bearing, not less: the deadline is now
+    # paid per candidate rather than once, which is the cost of asking a question that has an answer.
+    MERGED_QUERY_FAILED=false
 
     UNMERGED_BRANCHES=()
     SKIP_PATTERNS="^(main|master|develop|gh-pages)$"
@@ -1373,12 +1368,28 @@ while read -r STMT_START STMT_LEN; do
       [[ -z "$candidate" ]] && continue
       ahead=$(hook_git_in "$PROJECT_DIR" rev-list --count "$INTEGRATION_REF..$candidate" 2>/dev/null || echo 0)
       [[ "$ahead" -gt 0 ]] || continue
-      # A merged PR settles it — for the COMMIT that was merged, not for the name.
-      if [[ "$MERGED_REFS_READ" == "true" ]]; then
-        candidate_sha=$(hook_git_in "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
-        if [[ -n "$candidate_sha" ]] &&
-          printf '%s\n' "$MERGED_REFS" | grep -Fxq -- "$candidate $candidate_sha"; then
-          continue
+      # A merged PR settles it — for the COMMIT that was merged, not for the name, and only when the
+      # merge actually LANDED on the integration ref.
+      #
+      # Three conditions, all required. A merged PR must exist for this branch name; the local branch
+      # must still point at the exact commit that PR merged (a reused name with new work stacked on it
+      # is NOT settled — the delete-guard below carries the same lesson); and the PR's merge commit
+      # must be an ancestor of the integration ref. That last one is not redundant: measured
+      # 2026-08-23, four branches on `origin` had a merged PR whose base was a since-deleted FEATURE
+      # branch, so their work is on neither `develop` nor `main`. Asking only "was it merged" clears
+      # all four.
+      candidate_sha=$(hook_git_in "$PROJECT_DIR" rev-parse "$candidate" 2>/dev/null || echo "")
+      if [[ -n "$candidate_sha" ]]; then
+        if MERGED_PR=$(bounded_gh pr list --state merged --head "$candidate" \
+          --json headRefOid,mergeCommit --jq '.[0] | "\(.headRefOid) \(.mergeCommit.oid)"'); then
+          merged_head="${MERGED_PR%% *}"
+          merged_commit="${MERGED_PR##* }"
+          if [[ "$merged_head" == "$candidate_sha" && -n "$merged_commit" && "$merged_commit" != "null" ]] &&
+            hook_git_in "$PROJECT_DIR" merge-base --is-ancestor "$merged_commit" "$INTEGRATION_REF" 2>/dev/null; then
+            continue
+          fi
+        else
+          MERGED_QUERY_FAILED=true
         fi
       fi
       UNMERGED_BRANCHES+=("$candidate ($ahead commits ahead of $INTEGRATION_REF)")
@@ -1392,12 +1403,10 @@ while read -r STMT_START STMT_LEN; do
       done
       echo "[branch-guard] Branch cleanup after a merge is governed by .agents/rules/git-branch.md" >&2
       echo "[branch-guard] (see 'Delete Merged Branches') — read it there, it is the only copy." >&2
-      if [[ "$MERGED_REFS_READ" != "true" ]]; then
-        echo "[branch-guard] NOTE: merged PRs could not be read, so squash-merged branches are listed" >&2
-        echo "[branch-guard] here as unmerged. The list is longer than the real backlog." >&2
-      elif [[ "$MERGED_TRUNCATED" == "true" ]]; then
-        echo "[branch-guard] NOTE: the merged-PR list came back full ($MERGED_LIMIT), so older merged" >&2
-        echo "[branch-guard] branches may be missing from it and listed here as unmerged." >&2
+      if [[ "$MERGED_QUERY_FAILED" == "true" ]]; then
+        echo "[branch-guard] NOTE: at least one merged-PR query failed (gh unavailable / timed out), so a" >&2
+        echo "[branch-guard] squash-merged branch may be listed here as unmerged. Verify by hand before" >&2
+        echo "[branch-guard] overriding: gh pr list --state merged --head <branch> --json mergeCommit" >&2
       fi
       echo "[branch-guard] To override: set BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1" >&2
       exit 2

--- a/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
+++ b/scripts/harness/__tests__/branch-guard-unmerged.test.mjs
@@ -19,7 +19,17 @@ const HOOK = path.join(WORKSPACE_ROOT, '.claude/hooks/branch-guard.sh');
  * session. The check's own failure message already told people to delete squash-merged branches;
  * it simply never used what the message knew.
  *
- * So the assertions below are about the DECISION, and `gh` is stubbed to state the world.
+ * PROC-012 (issue #2135) then found the same question asked with the wrong DATA. The check pulled
+ * one global `pr list --state merged --limit 500` and matched candidates against it. That list is
+ * saturated in this repository, so every merged PR older than the window fell out and its branch was
+ * reported unmerged again — with a NOTE saying the list came back full, printed by a guard that then
+ * blocked anyway. Measured 2026-08-23: it blocked branch creation in two of four active clones inside
+ * ten minutes, on branches merged as #2143, #2147, #2133 and #2144.
+ *
+ * So the query is now per-branch (`--head`, which has no window to saturate) and the decision needs
+ * three things: a merged PR for the name, the branch still at the commit that PR merged, and that
+ * PR's MERGE COMMIT present on the integration ref. The assertions below are about that DECISION,
+ * and `gh` is stubbed to state the world.
  */
 const scratch = [];
 
@@ -49,16 +59,36 @@ function scratchRepo(branches) {
   return dir;
 }
 
+function sha(dir, rev) {
+  return spawnSync('git', ['-C', dir, 'rev-parse', rev], { encoding: 'utf8' }).stdout.trim();
+}
+
+/** Advance develop by one commit, so it has a commit a branch's "merge" can point at. */
+function squashOnto(dir, label) {
+  const git = (...args) => spawnSync('git', ['-C', dir, ...args], { encoding: 'utf8' });
+  git('checkout', '--quiet', 'develop');
+  writeFileSync(path.join(dir, `squashed-${label}`), 'm\n');
+  git('add', '-A');
+  git('commit', '--quiet', '-m', `feat: squashed ${label}`);
+  return sha(dir, 'develop');
+}
+
 /**
- * A PATH whose `gh` reports exactly the merged head refs given.
+ * A PATH whose `gh` answers the per-branch merged-PR query.
  *
- * `--state merged` is the only query the hook makes here; anything else exits non-zero so a change
- * in what the hook asks for shows up as an unread answer rather than a silently different verdict.
+ * `merges` maps a branch name to `"<headRefOid> <mergeCommitOid>"` — exactly the two fields the
+ * decision needs. A branch absent from the map has no merged PR. Any query the hook makes other than
+ * `--state merged` exits non-zero, so a change in what the hook ASKS FOR shows up as an unread answer
+ * rather than a silently different verdict.
  */
-function stubbedPath(mergedRefs, { broken = false, hangs = false } = {}) {
+function stubbedPath(merges, { broken = false, hangs = false } = {}) {
   const dir = makeTemp('gh-stub-');
   scratch.push(dir);
   const gh = path.join(dir, 'gh');
+  const cases = Object.entries(merges).map(
+    ([branch, line]) =>
+      `  *"--state merged"*"--head ${branch}"*) echo ${JSON.stringify(line)}; exit 0 ;;`,
+  );
   writeFileSync(
     gh,
     [
@@ -66,9 +96,9 @@ function stubbedPath(mergedRefs, { broken = false, hangs = false } = {}) {
       broken ? 'exit 1' : '',
       hangs ? 'sleep 120' : '',
       'case "$*" in',
-      '  *"--state merged"*)',
-      mergedRefs.map((r) => `    echo ${JSON.stringify(r)}`).join('\n'),
-      '    exit 0 ;;',
+      ...cases,
+      // A branch with no merged PR: the real gh prints nothing and exits 0.
+      '  *"--state merged"*) exit 0 ;;',
       'esac',
       'exit 1',
     ]
@@ -79,15 +109,7 @@ function stubbedPath(mergedRefs, { broken = false, hangs = false } = {}) {
   return `${dir}:${process.env.PATH}`;
 }
 
-/** The line gh returns for a merged PR: the branch name and the commit that was merged. */
-function mergedRef(dir, branch) {
-  const oid = spawnSync('git', ['-C', dir, 'rev-parse', branch], {
-    encoding: 'utf8',
-  }).stdout.trim();
-  return `${branch} ${oid}`;
-}
-
-function judge(cwd, mergedRefs, options) {
+function judge(cwd, merges, options) {
   const result = spawnSync('bash', [HOOK], {
     input: JSON.stringify({
       tool_name: 'Bash',
@@ -97,7 +119,7 @@ function judge(cwd, mergedRefs, options) {
     encoding: 'utf8',
     env: {
       ...process.env,
-      PATH: stubbedPath(mergedRefs, options),
+      PATH: stubbedPath(merges, options),
       CLAUDE_PROJECT_DIR: cwd,
     },
   });
@@ -105,9 +127,17 @@ function judge(cwd, mergedRefs, options) {
 }
 
 describe('branch-guard counts only branches that are really still open', () => {
-  it('allows a new branch when every open-looking branch has a merged PR', () => {
+  it('allows a new branch when every open-looking branch landed on the integration ref', () => {
     const cwd = scratchRepo(['feat/a', 'feat/b']);
-    const verdict = judge(cwd, [mergedRef(cwd, 'feat/a'), mergedRef(cwd, 'feat/b')]);
+    const headA = sha(cwd, 'feat/a');
+    const headB = sha(cwd, 'feat/b');
+    const mergeA = squashOnto(cwd, 'a');
+    const mergeB = squashOnto(cwd, 'b');
+
+    const verdict = judge(cwd, {
+      'feat/a': `${headA} ${mergeA}`,
+      'feat/b': `${headB} ${mergeB}`,
+    });
 
     expect(
       verdict.status,
@@ -119,11 +149,37 @@ describe('branch-guard counts only branches that are really still open', () => {
   it('still refuses while a branch has no merged PR', () => {
     // The rule itself is unchanged: real unmerged work still blocks a new branch.
     const cwd = scratchRepo(['feat/a', 'feat/open']);
-    const verdict = judge(cwd, [mergedRef(cwd, 'feat/a')]);
+    const headA = sha(cwd, 'feat/a');
+    const mergeA = squashOnto(cwd, 'a');
+
+    const verdict = judge(cwd, { 'feat/a': `${headA} ${mergeA}` });
 
     expect(verdict.status, 'genuinely unmerged work stopped blocking').toBe(2);
     expect(verdict.output).toMatch(/feat\/open/);
     expect(verdict.output, 'a merged branch was named as unmerged').not.toMatch(/- feat\/a /);
+  });
+
+  it('refuses a branch whose PR merged somewhere other than the integration ref', () => {
+    // PROC-012's second half, and the reason "was it merged" is not the whole question. Measured
+    // 2026-08-23 on `origin`: four branches carried a merged PR whose base was a FEATURE branch that
+    // has since been deleted, so their work is on neither develop nor main. A check that stops at
+    // "a merged PR exists" clears all four and the work is gone.
+    const cwd = scratchRepo(['feat/a', 'feat/elsewhere']);
+    const headA = sha(cwd, 'feat/a');
+    const mergeA = squashOnto(cwd, 'a');
+    // Merged, but onto a branch that is not develop — so its merge commit is not reachable from it.
+    const headElsewhere = sha(cwd, 'feat/elsewhere');
+
+    const verdict = judge(cwd, {
+      'feat/a': `${headA} ${mergeA}`,
+      'feat/elsewhere': `${headElsewhere} ${headElsewhere}`,
+    });
+
+    expect(
+      verdict.status,
+      'a branch merged into a third branch was cleared as if it had landed on the integration ref',
+    ).toBe(2);
+    expect(verdict.output).toMatch(/feat\/elsewhere/);
   });
 
   it('does not accept a merged name carrying new commits', () => {
@@ -131,7 +187,8 @@ describe('branch-guard counts only branches that are really still open', () => {
     // the NAME alone waves those commits through and disables the rule this check enforces. The
     // delete-guard in the same file already carries that lesson; this path was written without it.
     const cwd = scratchRepo(['feat/a']);
-    const mergedAt = mergedRef(cwd, 'feat/a');
+    const headA = sha(cwd, 'feat/a');
+    const mergeA = squashOnto(cwd, 'a');
 
     const git = (...args) => spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
     git('checkout', '--quiet', 'feat/a');
@@ -140,7 +197,7 @@ describe('branch-guard counts only branches that are really still open', () => {
     git('commit', '--quiet', '-m', 'feat: work stacked after the merge');
     git('checkout', '--quiet', 'develop');
 
-    const verdict = judge(cwd, [mergedAt]);
+    const verdict = judge(cwd, { 'feat/a': `${headA} ${mergeA}` });
 
     expect(verdict.status, 'new commits on a merged branch name were counted as merged').toBe(2);
     expect(verdict.output).toMatch(/feat\/a/);
@@ -153,8 +210,10 @@ describe('branch-guard counts only branches that are really still open', () => {
     // command substitution's pipe — which does not close until every process holding it is gone —
     // so a successful query still waited the full ten seconds, worse than what it replaced.
     const cwd = scratchRepo(['feat/a']);
+    const headA = sha(cwd, 'feat/a');
+    const mergeA = squashOnto(cwd, 'a');
     const started = Date.now();
-    const verdict = judge(cwd, [mergedRef(cwd, 'feat/a')]);
+    const verdict = judge(cwd, { 'feat/a': `${headA} ${mergeA}` });
     const elapsed = Date.now() - started;
 
     expect(verdict.status, verdict.output).toBe(0);
@@ -170,7 +229,7 @@ describe('branch-guard counts only branches that are really still open', () => {
     // hook indefinitely rather than taking the fallback written for exactly this case.
     const cwd = scratchRepo(['feat/a']);
     const started = Date.now();
-    const verdict = judge(cwd, [], { hangs: true });
+    const verdict = judge(cwd, {}, { hangs: true });
     const elapsed = Date.now() - started;
 
     expect(elapsed, 'the hook waited on a stalled query instead of falling back').toBeLessThan(
@@ -178,20 +237,24 @@ describe('branch-guard counts only branches that are really still open', () => {
     );
     expect(verdict.status).toBe(2);
     expect(verdict.output, 'the fallback did not explain why the list is inflated').toMatch(
-      /merged PRs could not be read/,
+      /merged-PR query failed/,
     );
   });
 
-  it('says so when merged PRs could not be read', () => {
+  it('says so when the merged-PR query could not be read', () => {
     // Without gh the check falls back to ancestry, which over-reports. That is the safe direction,
     // but a list that is longer than the real backlog must say why — an unexplained wall of names
-    // is what gets overridden.
+    // is what gets overridden. It must also name the by-hand check, because the next thing a reader
+    // does with an unexplained block is reach for the override.
     const cwd = scratchRepo(['feat/a']);
-    const verdict = judge(cwd, [], { broken: true });
+    const verdict = judge(cwd, {}, { broken: true });
 
     expect(verdict.status).toBe(2);
     expect(verdict.output, 'the fallback did not explain that the list is inflated').toMatch(
-      /merged PRs could not be read/,
+      /merged-PR query failed/,
+    );
+    expect(verdict.output, 'the fallback did not name the by-hand verification').toMatch(
+      /--state merged --head/,
     );
   });
 });


### PR DESCRIPTION
Closes #2135.

## The rule forbade the action it mandated

`.agents/rules/git-branch.md` § "Delete Merged Branches" mandated that a merged branch not be left standing, then required `git merge-base --is-ancestor origin/<branch> <target>` before deleting it. This repository squash-merges: a squash writes a NEW commit on the target, so a merged branch's own commits are ancestors of nothing there. Both halves of the rule were correct; together they were unsatisfiable.

It failed toward **inaction**, which is why nothing ever reported it. A guard that returns a false verdict eventually contradicts something. A guard that refuses a correct action produces only a growing pile, and the pile is the sole evidence.

## The branch-creation guard asked the same question with the wrong data

`.claude/hooks/branch-guard.sh` already knew about squash merges — it matched candidates against `gh pr list --state merged --limit 500`. That list is **saturated** here, so merged PRs older than the window fall out and their branches are reported unmerged. The hook printed a NOTE saying the list came back full and blocked anyway.

This is not theoretical. While this change was being written, it blocked branch creation in **two of four active clones inside ten minutes**, on branches merged as #2143, #2147, #2133 and #2144, and produced one `BRANCH_GUARD_ALLOW_OPEN_BRANCHES=1` override on a branch whose work had already landed as #2146.

## The change

Both sites now ask whether the branch's pull request **landed on the target**. Three conditions, all required:

1. a merged PR exists for the branch name,
2. the branch still points at the commit that PR merged (a reused name with new work stacked on it is not settled), and
3. that PR's merge commit is an ancestor of the named target.

**Condition 3 is not redundant**, and this is the rebuttal that decided the design: four branches on `origin` carry a merged PR whose base was `feat/arch-dag-runtime-completion`, a feature branch since deleted. Their work is on neither `develop` nor `main`. A check that stops at "was it merged" clears all four and the work is gone.

Asking per-branch (`--head`) also removes the 500-item window entirely — there is no list to saturate.

## Measured, over the 14 non-default branches on `origin`

| group | count | current check | this change |
| --- | --- | --- | --- |
| fully merged into `develop` | 8 | **all 8 refused** | all 8 cleared |
| merged into a since-deleted feature branch | 4 | refused | refused (correctly) |
| no merged PR (one with an open PR) | 2 | refused | refused (correctly) |

Ancestry-of-branch passes for **0 of 14**, including every branch it exists to clear.

## Verification

- `npx vitest run scripts/harness/__tests__/branch-guard-*.test.mjs` → **113 passed** across 5 files, including six decision fixtures: cleared-on-landing, refused-when-merged-elsewhere, refused-on-name-reuse, refused-without-a-merged-PR, bounded-on-stall, and explained-on-query-failure.
- The rewritten suite fails against the pre-change hook — the per-branch stub answers a query the old code never makes, so a stale implementation reads an unanswered world rather than silently agreeing.
- `pnpm harness:scan` → **137 passed, 2 skipped, 0 failed**.
- The motivating block is gone in practice: after deleting the four verified-merged stale local branches, `git checkout -b` succeeded with **no override**. `git branch -d` refused all four — it applies the same ancestry test — so the rule now says `-D` *after the verification*, and says why.

## Scope

The 14 remote branches are **left standing**. Deleting them is irreversible and outward-facing, and the rule already permits a branch to stay with a recorded reason, so the sweep asks its holder. The four `feat/arch-dag-runtime-completion` branches need a disposition decision this change surfaces rather than makes.

Records: `.agents/tasks/completed/PROC-012-…` (measurement + evidence) and `.agents/spec-docs/done/PROC-012-…` (alternatives, rejected designs, gate log). The rule text itself carries no case narrative — it reaches the measurement by a resolving link, per `rule-case-narrative`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY