### PR TITLE
feat(session): decode the persisted session record instead of casting it (TRANS-005)

### DIFF
--- a/.agents/spec-docs/done/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md
+++ b/.agents/spec-docs/done/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md
@@ -1,0 +1,928 @@
+---
+status: done
+type: DATA
+tags: [session, persistence, codec, contract, decoder]
+---
+
+# TRANS-005: the persisted interactive-session record has no total runtime decoder
+
+Design for Task
+[`.agents/tasks/completed/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`](../../tasks/completed/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md),
+the execution leaf [issue #2081](https://github.com/woojubb/robota/issues/2081) under tracker
+[issue #2067](https://github.com/woojubb/robota/issues/2067).
+
+## Problem
+
+`IInteractiveSessionRecord` (`packages/agent-interface-transport/src/session-contracts.ts:447`) is a
+persisted and transferred shape that exists only at compile time. Every ingress casts into it instead
+of decoding it.
+
+**Symptom 1 — a cast produces a value whose runtime type contradicts its declared type.**
+`NodeSessionStore.load` is `JSON.parse(raw) as IInteractiveSessionRecord`
+(`packages/agent-session/src/session-store.ts:91`). The contract declares
+`messages[].timestamp: Date` and `history[].timestamp: Date` (`IBaseMessage` / `IHistoryEntry`,
+`packages/agent-core/src/interfaces/messages.ts:66,120`), but JSON has no date type, so a loaded
+record carries **strings** in both. No revival step exists anywhere on the load path:
+`WorkspaceSessionStore.load` forwards the store result unchanged
+(`packages/agent-framework/src/interactive/workspace-session-store.ts:55-63`), and the only
+`new Date(...)` calls on that path re-parse `updatedAt` for sorting — never the message or history
+timestamps.
+
+Reproduction condition: resume any persisted session (`--resume` / `--continue`) and reach a consumer
+that treats the declared type as true. `createMainThreadDetailPage` calls
+`entry.timestamp.toISOString()`
+(`packages/agent-framework/src/background-tasks/execution-workspace-detail.ts:19`) and
+`interactive-session-workspace.ts:51` calls `history.at(-1)?.timestamp.toISOString()`. On a resumed
+record `entry.timestamp` is a `string`, and `String.prototype.toISOString` does not exist — a
+`TypeError` at the render, not at the load.
+
+**Symptom 2 — corruption is indistinguishable from absence.** `NodeSessionStore.load` catches every
+failure and returns `undefined` (`session-store.ts:92-95`, carrying an explicit
+`// allow-fallback:` marker), and `NodeSessionStore.list` skips unreadable files silently
+(`session-store.ts:114`). `WorkspaceSessionStore.load` falls through to log replay when the parse fails
+(`workspace-session-store.ts:63`), which reconstructs a _partial_ record —
+`skillActivationEvents: []`, no `goal`, no `plan`, no `activeBranch`, no `toolSchemas`
+(`workspace-session-store.ts:106-107`). A truncated session file therefore resumes as a silently
+field-stripped session rather than as an error.
+
+**Symptom 3 — a parseable wrong shape is accepted everywhere.** The artifact decoder validates the
+envelope version and then only that the record is a non-array object with a string `id`
+(`packages/agent-session/src/session-artifact.ts:69-81`); every nested field is unchecked. The
+handoff destination verifies byte integrity and then casts
+(`packages/agent-framework/src/handoff/handoff-destination.ts:82-111`) — integrity is not schema
+validity.
+
+No component owns "is this a valid record?", so four ingresses answer it four different ways and
+none of them answers it completely.
+
+## Prior Art Research
+
+**Question.** When a product persists a rich, nested session/checkpoint state and reads it back later,
+how does it (a) version the persisted shape, (b) decide what to do with data it cannot decode, and
+(c) tell the caller _where_ the decode failed?
+
+**Zod — field-path diagnostics are a path array, not a message string.**
+[Zod's error-formatting documentation](https://zod.dev/error-formatting) specifies that every issue
+carries a `path` array locating the failure inside the validated structure: an error at index 1 of
+`favoriteNumbers` reports `path: ['favoriteNumbers', 1]`, and a top-level error reports `path: []`.
+Zod additionally ships three _renderings_ over that one structure — `z.treeifyError()` (a nested
+object mirroring the schema), `z.prettifyError()` (a human string, `→ at favoriteNumbers[1]`), and
+`z.flattenError()` (shallow `formErrors` / `fieldErrors`). **Constraint that applies to Robota:** the
+machine-readable location and its human rendering are separate concerns; a decoder should emit a
+structured path and let a consumer render it. A decoder that returns only a prose message cannot be
+consumed by a store that must classify the failure.
+
+**LangGraph checkpointers — serde is a named protocol, and the fallback is opt-in.**
+[LangChain's checkpointer documentation](https://docs.langchain.com/oss/python/langgraph/checkpointers)
+defines a `SerializerProtocol` whose `dumps_typed` returns a **type identifier plus** the binary blob,
+so the persisted bytes never travel without a declaration of what they are. Support for types outside
+the serializer's own vocabulary is not implicit: it requires the explicit `pickle_fallback` argument
+of `JsonPlusSerializer`. **Constraint that applies to Robota:** the version/type tag belongs _with_
+the persisted bytes rather than being inferred by the reader, and a permissive path must be something
+a caller opts into by name — which is the opposite of `session-store.ts`'s unconditional
+`catch { return undefined }`.
+
+**Protocol Buffers — a version boundary is what makes "unknown" recoverable.**
+[The proto3 language guide's schema-update rules](https://protobuf.dev/programming-guides/proto3/#updating)
+make additive change safe _because_ the wire format is versioned by field number and readers preserve
+unknown fields; the same document is explicit that renumbering fields and reusing deleted field
+numbers produce "ambiguous" decoding, and that unknown fields are **lost** when serializing to JSON.
+**Constraint that applies to Robota:** the persisted format here _is_ JSON, so the forward-compatible
+"preserve what you do not understand" property protobuf relies on is not available. With no
+compatibility requirement (the audited API is prerelease, per issue #2079), the correct reading of that
+constraint is the strict one — reject a shape this build does not understand and say so, rather than
+decode what is recognised and silently drop the rest, which is exactly Symptom 2.
+
+**No comparable reference found** for the specific case of a _TypeScript-interface-only_ persisted
+contract regaining a runtime decoder without adopting a schema library; the three references above
+constrain the design, they do not supply it.
+
+## Architecture Review
+
+### Affected Scope
+
+- **Type owner:** `packages/agent-interface-transport` declares `IInteractiveSessionRecord` and every
+  nested contract except `TUniversalMessage` / `IHistoryEntry` / `IToolSchema` (`agent-core`). It is
+  **not** written by this leaf — see the amendment in Decision below.
+- **Codec owner (this leaf's package):** `packages/agent-session`, which already owns the persistence
+  paths that will consume the decoder and already depends on both contract packages.
+- **Files this leaf writes:** a new `src/session-record-codec/` module directory under
+  `packages/agent-session`, one export block in that package's `src/index.ts`, one new test file
+  under its `src/__tests__/`, and its `docs/SPEC.md`.
+- **Files this leaf does NOT write:** every consumer, and the contract package. `session-store.ts`,
+  `session-artifact.ts`, `handoff-destination.ts`, and `workspace-session-store.ts` are migrated by
+  issue #2096, issue #2097 and issue #2098 and are untouched here, per issue #2081's scope boundary.
+  `packages/agent-interface-transport/` is byte-identical to the integration branch.
+- **Lane boundary:** issue #2080 (robota-2) owns `.agents/project-structure.md`, the architecture map,
+  and the dependency-direction docs, and states "No production TypeScript is moved in this issue".
+  After the amendment this leaf does not enter that package at all. Within `agent-session`,
+  `src/__tests__/` is shared with the hooks leaf (issue #2083) by directory but not by file; no
+  `package.json` change is needed, because the dependencies this codec imports are already declared.
+- **Nested contracts that must be decoded totally:** `TUniversalMessage` (4 variants),
+  `TUniversalMessagePart` (3 variants), `IToolCall`, `IHistoryEntry`, `IToolSchema` /
+  `IObjectParameterSchema` / `IParameterSchema`, `IBackgroundTaskState` (+ `IBackgroundTaskResult`,
+  `IBackgroundTaskError`, `IBackgroundTaskSchedule`), `TBackgroundTaskEvent` (12 variants),
+  `IBackgroundJobGroupState` (+ `IBackgroundJobResultEnvelope`), `TBackgroundJobGroupEvent`
+  (3 variants), `ISkillActivationEvent`, `IMemoryEvent`, `IMemoryReference`, `IContextReferenceItem`,
+  `IGoalState` (+ `IGoalProgressEntry`), `IPlanArtifact` (+ `IPlanStep`), `IActiveBranchPointer`.
+
+### Alternatives Considered
+
+**A. Hand-written total decoder inside the contract package (chosen).**
+
+- Pro: no dependency edge added — the `deps` scan fails any `agent-interface-*` package whose
+  internal dependencies exceed `{agent-core}` (this package's SPEC, "Boundaries"), and a hand-written
+  decoder adds none.
+- Pro: the decoder sits with the type it decodes, so there is exactly one owner, which is the property
+  issue #2067 exists to establish.
+- Pro: precedent already exists in this package — `isTransportRunOutcome(value: unknown)`
+  (`transport-adapter.ts:101`), `isHandoffCommitted`, `sourceRetainsAuthority`, `isTurnNotRunError` —
+  so a pure, class-free, I/O-free runtime guard is an established member of its surface, not a new
+  kind of thing.
+- Con: the decoder must be maintained by hand alongside the interfaces; a field added to a contract
+  and not to its decoder is a silent gap. Mitigated by TC-09 (a key-parity test that fails when the
+  two disagree), not by discipline.
+- Con: volume. The record reaches ~20 nested contracts, which cannot fit the 300-line production file
+  limit (`scripts/harness/scan-file-size.mjs`, `MAX_LINES = 300`) in one file — it needs a module
+  directory, which is more structure than a one-file decoder.
+
+**B. Declare the shapes with Zod and derive the decoder.**
+
+- Pro: dramatically less code, and field-path diagnostics come free in exactly the form the research
+  above endorses.
+- Con: **mechanically refused.** It adds `zod` to an `agent-interface-*` package, which the `deps`
+  scan fails; zod today is a dependency of `agent-framework`, `agent-core`, `agent-cli`, `agent-tools`
+  and the dag packages — never of a contract package.
+- Con: it creates a second source of truth. The TypeScript interface and the Zod schema would both
+  describe the record, and nothing would force them to agree — the same class of drift as A's con,
+  but without A's key-parity test being possible, because the schema _is_ the type.
+
+**C. Put the decoder in `agent-session` instead.**
+
+- Pro: `agent-session` already depends on the contract package and already carries validation code
+  (`session-log-validation.ts`), so no interface-package question arises at all.
+- Pro: reachable by every currently-known consumer — `agent-framework` depends on `agent-session`.
+- Con: it splits the decoder from the type it decodes, which is the defect issue #2067 names, and
+  contradicts that tracker's stated direction ("the session contract owner provides
+  `decodeInteractiveSessionRecord`").
+- Con: it is not reachable by every consumer of the _type_. `agent-transport-protocol`,
+  `agent-session-analytics`, and `agent-transport-tui` all reference `IInteractiveSessionRecord`
+  without depending on `agent-session`; placing the decoder there would put the type in one package
+  and its only validator in a package they cannot import.
+
+**D. Generate decoders from the TypeScript types at build time.**
+
+- Pro: no hand-maintenance, no second source of truth — the interface stays authoritative.
+- Con: it introduces a code-generation step and a generator dependency into a package whose entire
+  contract is "contracts plus pure dependency-free accessors", and puts generated code in the
+  published surface. That is a practice this repository has not used before, which is explicitly a
+  stop-and-ask class under `backlog-execution.md`.
+
+### Decision
+
+**Alternative C, hand-written (the decoder shape of A, in the package of C).**
+
+> **AMENDMENT — 2026-08-23, after implementation and before the pull request.** This section
+> originally chose alternative A and was approved as such. That choice was WRONG, and the correction
+> is recorded here rather than quietly applied, because GATE-APPROVAL had already been recorded
+> against the superseded text. The superseded decision read: _"Alternative A. … Between A and C the
+> deciding fact is not style but reachability — three packages consume `IInteractiveSessionRecord`
+> without depending on `agent-session`, so C would ship a contract whose validator half its consumers
+> cannot reach."_
+>
+> **What refuted it.** `pnpm harness:scan` carries `scan-interface-runtime`, which freezes the number
+> of runtime MECHANISMS an `agent-interface-*` entry may publish (`agent-interface-transport`: 5,
+> `scripts/harness/interface-entry-baseline.json`). Its failure text states the rule and its remedy:
+> _"An agent-interface-\* package publishes contracts, its vocabulary and its discriminators — not
+> mechanisms. Move it to an owner package."_ A decoder is a mechanism. So the same class of
+> mechanical constraint that made alternative B unavailable makes alternative A unavailable, and the
+> Architecture Review missed it — the alternatives were checked against the `deps` scan and not
+> against this one.
+>
+> **The reasoning error, named.** The reachability argument that rejected C is true about the TYPE
+> and was allowed to stand for the DECODER without being re-tested. They are different populations:
+> `agent-transport-protocol`, `agent-session-analytics` and `agent-transport-tui` consume the record
+> TYPE without depending on `agent-session`, but none of them decodes one. Every actual and planned
+> consumer of the DECODER — issue #2096, issue #2097, issue #2098 — is in `agent-session` or in
+> `agent-framework`, which depends on it. C is reachable by all of them.
+>
+> **What was NOT done, deliberately.** The frozen allowance was not raised. A guard whose failure
+> text says "move it", answered by editing that guard's baseline, adopts exactly the debt the guard
+> exists to refuse; `rules/index.md` binds a rule until it is amended, and an argument against one is
+> the input to an amendment rather than an exemption from it.
+
+The decoder's SHAPE is alternative A's — hand-written, no schema library — and its PLACEMENT is
+alternative C's. The trade-off that decides the shape is dependency direction against authoring cost:
+B is the better _code_ and is unavailable, because it adds a dependency that `agent-session`'s own
+boundary does not want and that would make the schema a second source of truth beside the interface.
+A's maintenance con is answered mechanically by TC-09 rather than by care.
+
+Three things the corrected placement improves rather than merely satisfies: the codec lands beside
+`session-store.ts`, `session-artifact.ts` and `session-log-validation.ts` — the very files
+issue #2096/#2097/#2098 migrate; the contract package's published surface is untouched, so no
+`export *` and no barrel-size exemption are needed; and `packages/agent-interface-transport/` ends
+this leaf byte-identical to the integration branch.
+
+**Shape of the decision, and what each part answers:**
+
+1. **Outcome, not exception.** `decodeInteractiveSessionRecord(value: unknown)` returns a
+   discriminated outcome — `valid` / `corrupt` / `unsupported` — rather than throwing or returning
+   `undefined`. `missing` is deliberately **not** a member: absence is a property of a store, not of a
+   value, and issue #2096 composes the store's `missing` with these three. Returning `undefined` for a bad
+   value is what created Symptom 2, so the type makes that spelling unavailable.
+2. **Version travels with the bytes, not in the reader's head.** `INTERACTIVE_SESSION_RECORD_VERSION`
+   plus an `IVersionedInteractiveSessionRecord` envelope (`{ schemaVersion, record }`), and
+   `decodeVersionedInteractiveSessionRecord` returns `unsupported` — carrying the version it actually
+   saw — when the envelope names a version this build does not implement. This follows the LangGraph
+   constraint. The bare-record decoder stays exported for callers that have already unwrapped an
+   envelope.
+3. **`schemaVersion` is NOT added to `IInteractiveSessionRecord`.** Making it a required member would
+   force every producer to set it, and migrating producers is out of scope for this leaf by issue #2081's
+   own boundary; making it optional would mean absent-is-fine, which is the permissive reader issue #2067
+   rejects. The envelope keeps the version mandatory where it is checked without touching a single
+   consumer. **Nothing in this leaf changes what is written to disk** — the envelope is defined and
+   tested here and adopted by issue #2096 and issue #2097, which is where the on-disk format actually changes.
+4. **Dates are revived, because the contract says `Date`.** `messages[].timestamp` and
+   `history[].timestamp` decode from an ISO-8601 string **or** an existing `Date` into a `Date`, and
+   an unparseable value is an issue. This is what makes "returns only a fully validated record" true
+   rather than nominally true, and it is the direct answer to Symptom 1.
+5. **String timestamps are validated as timestamps.** `createdAt`, `updatedAt`, and the other
+   `…At` / `at` fields are declared `string` and stay `string`, but must parse as dates — because
+   `NodeSessionStore.list` sorts by `new Date(updatedAt).getTime()`
+   (`session-store.ts:119-120`, `workspace-session-store.ts:63`), and a non-date string yields `NaN` and an
+   unstable order rather than an error.
+6. **Unknown keys on a declared object are an issue.** A persisted record is written by this build's
+   own code at a known version, so an unrecognised key means the shape drifted — which is what the
+   envelope version exists to report. Genuinely open maps are exempt by contract and stay open:
+   `IHistoryEntry.data` (declared `T = unknown`), `TUniversalMessageMetadata`, `IMemoryEvent.data`,
+   `IBackgroundTask*.metadata`, and `IParameterSchema.properties`.
+7. **A limit stated rather than hidden.** `TUniversalValue` and `TUniversalMessageMetadata` both admit
+   `Date` as a member. Inside an open map a persisted date is an indistinguishable string, so the
+   decoder validates open-map contents as JSON values and does **not** revive dates there. Reviving
+   them would mean guessing from string shape, which converts any date-like user string into a `Date`.
+   This is a capability of the declared type that persistence cannot carry; it is recorded here rather
+   than left for a reader to discover.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료 — "Affected Scope" above; one package written, four consumer
+      packages explicitly out of scope, lane boundary against issue #2080 confirmed.
+- [x] Sibling scan 완료 — existing decode/validate siblings read before choosing the shape:
+      `decodeChannelFrame` (`agent-transport-protocol/src/channel-frames.ts`, magic + version header,
+      throws), `decodeDefinitionFile` (`dag-adapters-local/src/definition-files.ts`),
+      `validateSessionReplayLogEntries` (`agent-session/src/session-log-validation.ts`, returns
+      `{ ok, issues[] }` with a coded issue vocabulary), and the in-package pure guards
+      `isTransportRunOutcome` / `isHandoffCommitted` / `isTurnNotRunError`. The outcome-object shape
+      chosen here mirrors `session-log-validation.ts`'s `{ ok, issues }` rather than
+      `channel-frames.ts`'s throw, because the caller (issue #2096) must _classify_ the failure, not just
+      fail.
+- [x] 대안 최소 2개 검토 완료 — four alternatives with pro/con above.
+- [x] 결정 근거 문서화 완료 — Decision above states the deciding trade-off (dependency direction vs
+      authoring cost; reachability between A and C) and the seven shape decisions with their reasons.
+- [x] New-surface placement — **N/A: no new package, app, or presentation/interface surface, and no
+      layer or product-family reclassification.** This adds a module directory inside an existing
+      package, owned by the package that already declares the type.
+
+## Fallback & Degradation Declaration
+
+None.
+
+This change removes a fallback rather than adding one; the `// allow-fallback:` site it makes
+unnecessary (`session-store.ts:93`) is deleted by issue #2096, not here. The decoder itself has no
+degraded path: every input either decodes to a complete record or returns a classified failure.
+
+## Solution
+
+A new module directory, `packages/agent-session/src/session-record-codec/`, split to respect the
+300-line production file limit:
+
+| Module                              | Owns                                                                                                                         |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `decode-outcome.ts`                 | `ISessionRecordDecodeIssue`, `TSessionRecordDecodeOutcome`, and the issue-collecting helpers (path building, joining)        |
+| `scalars.ts`                        | required/optional string, number, boolean, literal-union, array, open-map, JSON-value, `Date`-revival and ISO-string helpers |
+| `message-decoders.ts`               | `TUniversalMessagePart`, `IToolCall`, the four `TUniversalMessage` variants, `IHistoryEntry`                                 |
+| `tool-schema-decoders.ts`           | `IParameterSchema`, `IObjectParameterSchema`, `IToolSchema`                                                                  |
+| `background-task-members.ts`        | the task literal unions, `IBackgroundTaskError`, `IBackgroundTaskResult` (+ token usage), `IBackgroundTaskSchedule`          |
+| `background-task-decoders.ts`       | `IBackgroundTaskState`, driven from key tables for its seventeen optional members                                            |
+| `background-task-event-decoders.ts` | the twelve-variant `TBackgroundTaskEvent` union, dispatched by a per-variant lookup rather than a ladder                     |
+| `background-group-decoders.ts`      | `IBackgroundJobGroupState`, `IBackgroundJobResultEnvelope`, `TBackgroundJobGroupEvent`                                       |
+| `event-decoders.ts`                 | `ISkillActivationEvent`, `IMemoryReference`, `IMemoryEvent`, `IContextReferenceItem`                                         |
+| `goal-plan-branch-decoders.ts`      | `IGoalState`, `IGoalProgressEntry`, `IPlanArtifact`, `IPlanStep`, `IActiveBranchPointer`                                     |
+| `record-decoder.ts`                 | `INTERACTIVE_SESSION_RECORD_VERSION`, the envelope, and the two decode entry points                                          |
+| `record-optional-members.ts`        | every optional member of the record, written out one at a time so each assignment is compiler-checked                        |
+| `index.ts`                          | the module barrel                                                                                                            |
+
+Public surface added to `packages/agent-session/src/index.ts`:
+
+```ts
+export {
+  INTERACTIVE_SESSION_RECORD_VERSION,
+  decodeInteractiveSessionRecord,
+  decodeVersionedInteractiveSessionRecord,
+} from './session-record-codec/index.js';
+export type {
+  ISessionRecordDecodeIssue,
+  IVersionedInteractiveSessionRecord,
+  TSessionRecordDecodeOutcome,
+} from './session-record-codec/index.js';
+```
+
+Outcome contract:
+
+```ts
+export interface ISessionRecordDecodeIssue {
+  /** Dotted/bracketed location of the failure, e.g. `messages[2].timestamp`. Empty for the root. */
+  readonly path: string;
+  /** What was required at that path, and what was found. */
+  readonly message: string;
+}
+
+export type TSessionRecordDecodeOutcome =
+  | { readonly status: 'valid'; readonly record: IInteractiveSessionRecord }
+  | { readonly status: 'corrupt'; readonly issues: readonly ISessionRecordDecodeIssue[] }
+  | { readonly status: 'unsupported'; readonly schemaVersion: number | undefined };
+```
+
+A decode collects **every** issue rather than stopping at the first, so one call reports the whole
+shape of the damage.
+
+## Affected Files
+
+| File                                                                | Change                                                                     |
+| ------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `packages/agent-session/src/session-record-codec/*.ts` (13 files)   | added                                                                      |
+| `packages/agent-session/src/index.ts`                               | export block added                                                         |
+| `packages/agent-session/src/__tests__/session-record-codec.test.ts` | added                                                                      |
+| `packages/agent-session/docs/SPEC.md`                               | Scope, Boundaries, Type Ownership, Public API Surface, and a codec section |
+| `.agents/tasks/TRANS-005-…​.md`                                     | status/plan                                                                |
+
+No file outside `packages/agent-session/` is written by this leaf. In particular
+`packages/agent-interface-transport/` is byte-identical to the integration branch, and
+`.agents/harness.config.json` is untouched — both were written under the superseded placement and
+both were reverted with it.
+
+## Completion Criteria
+
+- [x] TC-01: `decodeInteractiveSessionRecord(value)` accepts `unknown` and, for every non-record input
+      in the malformed corpus (`null`, `undefined`, `42`, `'{}'`, `[]`, `{}`), returns
+      `status: 'corrupt'` with at least one issue — never throws.
+- [x] TC-02: A complete record containing every optional field decodes to `status: 'valid'`, and the
+      returned `record` deep-equals the input except that `messages[].timestamp` and
+      `history[].timestamp` are `Date` instances.
+- [x] TC-03: For each of the 15 nested contract families listed in "Affected Scope", a record whose
+      only defect is inside that family returns `status: 'corrupt'` and reports an issue whose `path`
+      names the offending field (e.g. `backgroundTasks[0].depth`, `plan.steps[1].status`).
+- [x] TC-04: An ISO-8601 string, and an existing `Date`, both decode to an equal `Date` at
+      `messages[0].timestamp`; `'not-a-date'`, `''`, `0`, and `null` each produce an issue at that path.
+- [x] TC-05: A record whose `updatedAt` is a non-empty string that `Date.parse` rejects returns
+      `status: 'corrupt'` with an issue at `updatedAt`.
+- [x] TC-06: An unknown key on a declared object (root, a message, a background task) produces an
+      issue naming that key; an unknown key inside `history[].data`, `messages[].metadata`,
+      `memoryEvents[].data`, and `toolSchemas[].parameters.properties` produces none.
+- [x] TC-07: `decodeVersionedInteractiveSessionRecord({ schemaVersion: N, record })` returns
+      `status: 'unsupported'` with `schemaVersion: N` for any `N !== INTERACTIVE_SESSION_RECORD_VERSION`,
+      and for a missing/non-numeric `schemaVersion` returns `status: 'unsupported'` with
+      `schemaVersion: undefined` — in every case **without** reporting nested field issues.
+- [x] TC-08: A record with two independent defects returns both issues in one outcome (the decoder
+      does not stop at the first).
+- [x] TC-09: A key-parity test fails if a key of `IInteractiveSessionRecord` (and of each directly
+      nested interface) has no corresponding branch in its decoder — so a contract field added later
+      without a decoder branch breaks the build rather than passing silently.
+- [x] TC-10: `pnpm --filter @robota-sdk/agent-session build` succeeds and the package's declared
+      dependencies are unchanged (`@robota-sdk/agent-core` and `@robota-sdk/agent-interface-transport`),
+      verified by `pnpm harness:scan:deps`.
+- [x] TC-11: Every new production file is ≤ 300 lines, verified by `pnpm harness:scan:file-size`
+      reporting no new baseline entry.
+- [x] TC-12: `packages/agent-session/docs/SPEC.md` documents the new public exports under Public API
+      Surface and the codec's outcome vocabulary, and `pnpm harness:scan:spec-public-surface` passes.
+      `packages/agent-interface-transport/` is byte-identical to the integration branch, and
+      `scan-interface-runtime` passes.
+
+## Test Plan
+
+| TC-ID | Test Type         | Tool / Approach                                                                                     | Notes                                                                |
+| ----- | ----------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| TC-01 | Unit (corpus)     | vitest — table-driven over a shared malformed-input corpus                                          | Assert no throw via `expect(() => …).not.toThrow()` around each case |
+| TC-02 | Unit (round-trip) | vitest — a maximal fixture record built in the test, `JSON.parse(JSON.stringify(fixture))` as input | The stringify step is what reproduces the real persistence path      |
+| TC-03 | Unit (table)      | vitest — one mutation per nested family, asserting the reported `path`                              | 15 rows; the fixture from TC-02 is the unmutated base                |
+| TC-04 | Unit              | vitest — parameterised over accepted and rejected timestamp inputs                                  |                                                                      |
+| TC-05 | Unit              | vitest                                                                                              |                                                                      |
+| TC-06 | Unit              | vitest — paired assertions (strict site rejects / open site accepts)                                |                                                                      |
+| TC-07 | Unit              | vitest — versions `0`, `2`, `1.5`, `'1'`, absent                                                    | Asserts issues array is absent, so `unsupported` is not `corrupt`    |
+| TC-08 | Unit              | vitest                                                                                              |                                                                      |
+| TC-09 | Unit (parity)     | vitest — a `satisfies Record<keyof IInteractiveSessionRecord, true>` map beside the runtime key set | Compile-time exhaustiveness plus a runtime set comparison            |
+| TC-10 | Build / scan      | `pnpm --filter @robota-sdk/agent-session build` + `pnpm harness:scan:deps`                          |                                                                      |
+| TC-11 | Scan              | `pnpm harness:scan:file-size`                                                                       |                                                                      |
+| TC-12 | Scan + review     | `pnpm harness:scan:spec-public-surface`                                                             |                                                                      |
+
+Property testing (issue #2081, "malformed-record corpus and property tests") is covered by TC-01 and
+TC-03 running as table-driven mutations over one maximal fixture: every field of every nested contract
+is mutated in turn from a valid base, which is the property "no single-field mutation of a valid
+record decodes as valid".
+
+## User Execution Test Scenarios
+
+**Not applicable is NOT claimed here.** This leaf delivers no CLI, TUI or browser behaviour — no
+product surface routes through the decoder until issue #2096 — but `backlog-execution.md` names
+"public SDK/example usage for SDK-only features" as a product surface in its own right, and the codec
+is exported from a published package. So the scenario below drives the real public surface, and the
+library-seam "N/A" dodge the Capability Reachability rule forbids is not taken.
+
+The still-pending end-to-end verification is named rather than implied: the behaviour a USER
+experiences — a corrupt session file reported instead of silently replaced by a field-stripped replay
+— is not reachable until issue #2096 routes `NodeSessionStore.load` through this decoder, and that
+issue's own gate owns it. This slice's scenario proves the decoder itself, from outside the package,
+against its built artifact.
+
+### UES-01 — the published decoder decides all three outcomes on the real build
+
+- **Agent-executability:** `agent-executable`.
+- **Prerequisite state:** the package is built, so the scenario runs against `dist/` — the artifact a
+  consumer actually installs — and not against source:
+
+  ```bash
+  pnpm --filter @robota-sdk/agent-session build
+  ```
+
+- **Exact command:**
+
+  ```bash
+  node --input-type=module -e "
+  import { decodeInteractiveSessionRecord, decodeVersionedInteractiveSessionRecord, INTERACTIVE_SESSION_RECORD_VERSION } from './packages/agent-session/dist/node/index.js';
+  const record = { id: 's1', cwd: '/w', createdAt: '2026-08-01T00:00:00.000Z', updatedAt: '2026-08-01T00:00:00.000Z', messages: [{ id: 'm1', role: 'user', content: 'hi', timestamp: '2026-08-01T00:00:01.000Z', state: 'complete' }] };
+  const ok = decodeInteractiveSessionRecord(JSON.parse(JSON.stringify(record)));
+  console.log('1', ok.status, ok.status === 'valid' && ok.record.messages[0].timestamp instanceof Date);
+  const bad = decodeInteractiveSessionRecord({ ...record, messages: [{ ...record.messages[0], timestamp: 'not-a-date' }] });
+  console.log('2', bad.status, bad.status === 'corrupt' ? bad.issues.map(i => i.path).join(',') : '');
+  const old = decodeVersionedInteractiveSessionRecord({ schemaVersion: 99, record });
+  console.log('3', old.status, old.schemaVersion, 'issues' in old);
+  const cur = decodeVersionedInteractiveSessionRecord({ schemaVersion: INTERACTIVE_SESSION_RECORD_VERSION, record });
+  console.log('4', cur.status);
+  "
+  ```
+
+  The record is round-tripped through `JSON.parse(JSON.stringify(...))` on line 1 for the same reason
+  the unit fixture is: that is what persistence actually hands a reader, with the `Date` already
+  flattened to a string.
+
+- **Expected observable result** — exit code 0 and exactly these four lines:
+
+  ```
+  1 valid true
+  2 corrupt messages[0].timestamp
+  3 unsupported 99 false
+  4 valid
+  ```
+
+  Line 1 is the revival (a `Date` instance came back out of a string). Line 2 is a located failure,
+  not a boolean. Line 3 is the version gate reporting the version it saw AND carrying no nested field
+  issues, which is what makes `unsupported` distinguishable from `corrupt` by a caller. Line 4 is the
+  current version decoding through the envelope.
+
+- **Cleanup:** none — the scenario writes nothing and starts no process.
+- **Evidence field:** recorded in the Evidence Log under `[DONE-GATE-STAGE-2]`.
+
+## Tasks
+
+- [x] TRANS-005 — done — `.agents/tasks/completed/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** draft → review-ready
+
+- Frontmatter: opens with `---`; `status: draft`; `type: DATA` (member of the 11-prefix list);
+  `tags: [session, persistence, codec, contract, decoder]` present.
+- Problem — concrete symptom: three symptoms, each cited to a file and line
+  (`session-store.ts` bare cast; `execution-workspace-detail.ts:19`
+  `entry.timestamp.toISOString()` against a contract-declared `Date` that persistence delivers as a
+  string; the replay fallback reading corruption as absence). Line numbers and two class names in
+  this entry were written before ARCH-100 (PR #2176) renamed `SessionStore` to `NodeSessionStore` and
+  moved `session-persistence.ts` to `workspace-session-store.ts`; the Problem section above is
+  repointed at the current code, and this entry is left as written because an evidence record
+  describes the run that produced it.
+- Problem — reproduction condition: resume a persisted session and reach a consumer that calls a
+  `Date` method on `messages[]`/`history[]` `timestamp`. Verified by reading the whole load path —
+  `SessionStore.load` → `SessionPersistence.load` → consumer — and confirming no revival step exists
+  (`git grep "new Date(" ` over those files returns only `updatedAt` re-parses for sorting).
+- Problem — no "TBD"/"TODO"/vague text: `grep -nE "TBD|TODO|works correctly|no errors|displays correctly"` returns nothing.
+- Prior Art Research: substantiated with three product-documentation citations —
+  <https://zod.dev/error-formatting> (issue `path` array + three renderings),
+  <https://docs.langchain.com/oss/python/langgraph/checkpointers> (`SerializerProtocol.dumps_typed`
+  returns a type identifier with the blob; `pickle_fallback` is opt-in),
+  <https://protobuf.dev/programming-guides/proto3/#updating> (schema-update rules; unknown fields are
+  lost when serializing to JSON). Each is stated as a constraint that applies here, and the absence of
+  a comparable TypeScript-interface-only reference is stated explicitly rather than left blank. All
+  three feed Alternatives (B's diagnostics pro, the JSON-format constraint behind the strict reading)
+  and the Decision's points 1, 2 and 6. `node scripts/harness/scan-spec-research.mjs` — passed.
+- Architecture Review Checklist: all 4 items `[x]`. Sibling scan is `[x]` with named evidence — four
+  existing decode/validate siblings read (`channel-frames.ts`, `definition-files.ts`,
+  `session-log-validation.ts`, the in-package pure guards) and the outcome shape justified against
+  them. New-surface placement recorded as `N/A` with reason (no new package/app/surface; a module
+  directory inside the package that already declares the type).
+- Alternatives Considered: 4 entries (hand-written decoder / Zod / place in `agent-session` /
+  code-generation), each with explicit pro and con. Decision names the deciding trade-off
+  (dependency direction vs authoring cost; reachability between A and C — three packages consume the
+  type without depending on `agent-session`).
+- Completion Criteria: 12 items, every one `TC-N` prefixed (`grep -c '^- \[ \] TC-'` = 12). Each is a
+  command form or an observable-behaviour form; none uses banned vague language.
+- Test Plan: present; 12 rows (`grep -cE '^\| TC-[0-9]+ \|'` = 12), matching the 12 criteria
+  one-to-one. Every row has a non-empty Test Type and Tool/Approach; no row uses "manual", so the
+  manual-justification requirement does not apply.
+- Structure: `## Tasks` present; `## Evidence Log` present and empty before this entry (first
+  GATE-WRITE run); no `## Status` or `## Classification` section in the body.
+- `node scripts/harness/check-spec-doc-frontmatter.mjs` — passed (286 spec documents examined; the
+  four reported warnings are pre-existing duplicate IDs in other documents, none of them TRANS-005).
+
+**Recorded by:** this session, judged against the gate catalogue's GATE-WRITE criteria directly. The
+`backlog-gate-guard` subagent was not dispatched, because this session is operating under a
+user instruction not to invoke the Agent tool. Every criterion above was checked mechanically where a
+command exists and by reading the document where one does not.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** review-ready → approved
+
+**Prior gate:** GATE-WRITE shows PASS above; input status was `review-ready` in
+`.agents/spec-docs/backlog/`, as the prior-gate map requires.
+
+**Form of approval: a standing delegation, not a per-item sign-off.** Recorded here in the three parts
+`backlog-execution.md` § "Standing authorization" requires, and deliberately not claimed as anything
+stronger than it is.
+
+**(1) The delegation, verbatim.** The owner's session-opening instruction to the orchestrating session
+(`robota-a6`):
+
+> 지금부터 깃헙 이슈에 등록된 것들을 처리할 것인데, 이슈들은 순서를 잘 맞춰서 처리해야함. 그렇기 때문에
+> 너에게 오케스트레이션 권한을 줄테니 다른 세션들과 의사소통 하면서 이슈들을 나눠서 처리해줘.
+
+The orchestrating session then put the GATE-APPROVAL question to the owner explicitly, naming this
+rule and stating that a peer session cannot supply the sign-off. The owner **selected** the offered
+option `위임 선언 — 이슈 처리 전권`, whose text reads:
+
+> 「근거가 타당하면 스스로 승인하고 진행하라」는 취지의 표준 위임을 지금 선언해 주시면, 각 spec의
+> Evidence Log에 그 문장을 그대로 인용하고 + 근거 조건 충족을 입증하고 + 해당 항목이 위임 범위 안임을
+> 보여서 GATE-APPROVAL을 통과시킵니다.
+
+**Recorded precisely: the owner SELECTED that option; they did not type a fresh sentence.** The
+prior instance of the same delegation from the same owner is on record at
+`.agents/tasks/RULE-012-standing-delegation-must-not-be-reasked-as-ceremonial-approval.md`
+(2026-08-15): "내가 승인하는게 아니라 근거가 타당하면 너가 알아서 승인하고 넘어가야지".
+
+**Provenance, stated rather than smoothed over:** this delegation reached this session **relayed by
+the orchestrating session**, not typed into this conversation. A peer session cannot grant approval on
+the owner's behalf, and this entry does not claim it did — it records that the peer put the question
+to the owner and reports what the owner chose. The relay is surfaced to the owner in this session's
+own transcript, so the record can be corrected by the one person able to correct it.
+
+**(2) The evidence condition is satisfied for THIS item.** The delegation is conditional on 근거 —
+the reasoning being sound — not unconditional:
+
+- The problem is verified against the code, not asserted: every symptom cites a file and line, and the
+  central claim (no date revival exists on the load path) was established by reading the whole path
+  and by `git grep "new Date("` over those three files, which returns only `updatedAt` sort re-parses.
+- The design was checked for reachability before being chosen: alternative C was rejected on the
+  measured fact that `agent-transport-protocol`, `agent-session-analytics` and `agent-transport-tui`
+  reference `IInteractiveSessionRecord` without depending on `agent-session`.
+- The chosen placement was checked against the mechanical constraint that would have invalidated it:
+  the `deps` scan permits `agent-interface-*` no internal dependency beyond `agent-core`, which is why
+  alternative B is unavailable and why A adds no dependency edge.
+- The known cost of the choice is answered mechanically rather than by intention: A's
+  hand-maintenance con is bound by TC-09, a key-parity test that fails the build when a contract field
+  gains no decoder branch.
+- Four alternatives were considered with explicit pro/con, and three product-documentation sources
+  constrain the decision.
+
+**(3) The item sits inside the delegated class.** issue #2081 is an internal versioned decoder for an
+existing type, with a tracker (issue #2067), a stated acceptance list, and a scope boundary that forbids
+touching any consumer. Against the four exclusions a standing authorization never covers:
+
+- _Product direction / user-facing scope_ — none. No user-visible behaviour changes in this leaf; the
+  decoder has no caller until issue #2096.
+- _A published or externally visible contract_ — **checked, and this is the one worth stating.** The
+  new exports are additive to a prerelease package. Critically, this leaf **changes nothing that is
+  written to disk**: `schemaVersion` is deliberately kept out of `IInteractiveSessionRecord`
+  (Decision, point 3), the envelope is defined and tested but adopted by no producer here, and no
+  store, artifact, handoff, or replay path is migrated. The on-disk format actually changes in issue #2096;
+  that item is flagged to the orchestrating session as possibly leaving the delegated class, and this
+  entry does not pre-approve it.
+- _Business / legal / strategic judgement_ — none.
+- _A practice this repository has not used before_ — none; alternative D was rejected partly on
+  exactly that ground, and the chosen shape mirrors existing in-repo siblings
+  (`session-log-validation.ts`'s `{ ok, issues }`, the package's own pure type guards).
+- _Repository-wide policy files_ — untouched. No lint config, CI workflow, git hook, or workspace
+  topology file is in "Affected Files".
+
+**Independent architecture validation (conditional):** N/A — the spec introduces no new package, app,
+or presentation/interface surface, and reclassifies no layer or product-family boundary. It adds a
+module directory to the package that already declares the type.
+
+**No Architecture Review or frontmatter `type`/`tags` change is made after this entry.**
+
+### [GATE-IMPLEMENT] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** approved → in-progress
+
+**Prior gate:** GATE-APPROVAL shows PASS above; input status was `approved` in
+`.agents/spec-docs/todo/`.
+
+- Task file exists:
+  `.agents/tasks/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`,
+  allocated by `pnpm harness:task:allocate TRANS "…" --issue 2081`. The `--dry-run` was run first and
+  printed `TRANS-005` (1455 claimed ids examined — 877 from records, 1441 from citations, 87 from
+  issue titles), matching the orchestrating session's independent ledger read before the record was
+  written.
+- Task file path is recorded in this document's `## Tasks` section.
+- Task correspondence: the task file's `## Plan` has one entry per TC-N, TC-01 through TC-12 — twelve
+  entries against twelve completion criteria, each naming the module(s) that satisfy it.
+- Test Plan section: the task file carries `## Test Plan` at ~1,100 characters, naming the test file,
+  the runner command, the fixture strategy, and the five gate commands — well above the 50-character
+  floor the `test-plans` harness scan requires.
+
+**Evidence:** `.agents/tasks/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`
+— 12 plan tasks (TC-01…TC-12), `## Test Plan` present, `status: in-progress`,
+`area: packages/agent-interface-transport`.
+
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-23
+
+Scenario UES-01 is fully written: agent-executability decision (`agent-executable`), prerequisite
+build step, the exact command, the expected observable stated as four literal lines with what each
+one proves, cleanup, and the evidence field. Nothing is left unwritten, so the by-exception path does
+not apply.
+
+Executability was established BEFORE the scenario was written, by running the command — not asserted
+after. The Capability Reachability rule is answered rather than dodged: the surface used is public
+SDK usage of a published package, which `backlog-execution.md` names as a product surface, and the
+still-pending end-to-end verification (a user seeing a corrupt session reported instead of silently
+replaced) is named as belonging to issue #2096's gate rather than claimed here.
+
+### [GATE-VERIFY] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** in-progress → verifying (no folder change; `verifying` maps to `active/`)
+
+**Prior gate:** GATE-IMPLEMENT shows PASS above; input status was `in-progress` in `active/`.
+
+- All tasks in the task file are `[x]`: 12 of 12 (`grep -c '^- \[x\] TC-'` = 12,
+  `grep -c '^- \[ \]'` = 0). None blocked or pending.
+- Build passes: `pnpm --filter @robota-sdk/agent-interface-transport build` — clean, 12 files emitted.
+  `pnpm harness:verify` exited 0 over the affected scope (build, test, lint, typecheck for the owning
+  package; typecheck for all 21 dependents).
+- Tests pass: `pnpm --filter @robota-sdk/agent-interface-transport test` — **77 passed**.
+- Scans: `check-dependency-direction` (no violations; declared dependencies still `agent-core` only),
+  `scan-file-size`, `check-spec-public-surface`, `scan-spec-user-execution-section`,
+  `scan-doc-folder-status-agreement`, `check-spec-doc-frontmatter`, `scan-spec-research`,
+  `scan-test-plan` — all pass. `eslint src/session-record-codec` — 0 errors.
+
+**The tests were checked, not merely run.** Two mutation rounds, because a green suite proves nothing
+about whether it would go red:
+
+1. Breaking date revival and unknown-key rejection in `scalars.ts` turned **7 tests red**; restoring
+   returned 73 green.
+2. Collapsing `MESSAGE_KEYS_BY_ROLE` into one union of all four variants' keys turned **exactly the 4
+   new variant-key tests red**; restoring returned 77 green.
+
+The second round exists because of a gap found by review rather than by the suite: the original
+unknown-key coverage used an invented key (`surprise`), which a union implementation rejects
+identically — so it constrained "unknown keys are rejected" and not "the key set is per-variant",
+while `message-decoders.ts`'s own header claimed the latter. TC-06 now covers four members that only
+another variant declares.
+
+### [DONE-GATE-STAGE-2] — ✅ PASS | 2026-08-23
+
+Scenario UES-01 executed against the built artifact (`dist/node/index.js`), not against source.
+
+Command run: the `node --input-type=module -e …` block recorded verbatim in UES-01, after
+`pnpm --filter @robota-sdk/agent-interface-transport build`.
+
+Observed output — exit code 0, and identical to the expected result written before the run:
+
+```
+1 valid true
+2 corrupt messages[0].timestamp
+3 unsupported 99 false
+4 valid
+```
+
+Line 1 proves revival across the real package boundary: a record whose `Date` was flattened by
+`JSON.stringify` came back carrying a `Date` instance. Line 2 proves the failure is LOCATED rather
+than boolean. Line 3 proves the version gate reports the version it saw and carries no nested field
+issues, which is what lets a caller tell `unsupported` from `corrupt`. Line 4 proves the current
+version decodes through the envelope.
+
+The expected result was not rewritten after observation; it was authored from a pre-implementation
+executability run and matched on the gate run.
+
+**Durable artifacts backing this evidence:**
+`packages/agent-interface-transport/src/session-record-codec/` (12 modules) and
+`packages/agent-interface-transport/src/__tests__/session-record-codec.test.ts` (77 tests).
+
+---
+
+### [AMENDMENT — placement] — 🔴 recorded | 2026-08-23
+
+**What changed:** the Architecture Review's Decision. It chose alternative A (codec in
+`agent-interface-transport`); it now chooses alternative C's PLACEMENT with alternative A's SHAPE
+(codec in `agent-session`, hand-written). The full amendment, the guard that refuted the original,
+and the reasoning error behind it are recorded in-place in § Decision rather than only here.
+
+**Why it is recorded as an amendment and not applied quietly:** GATE-APPROVAL had already been
+recorded against the superseded text, and the gate catalogue's own criterion is "No Architecture
+Review or frontmatter type/tags modified after approval". Editing the Review therefore invalidates
+that approval. The entries below re-run every gate whose evidence was collected against the
+superseded placement.
+
+**Superseded by this amendment — do not read the following as current:**
+
+- `[GATE-APPROVAL] — ✅ PASS | 2026-08-23` (the first one): approved a Decision that no longer exists.
+- `[GATE-VERIFY] — ✅ PASS | 2026-08-23` (the first one): its build, test and scan evidence was
+  collected against `packages/agent-interface-transport`, which this leaf no longer writes.
+- `[DONE-GATE-STAGE-1]` and `[DONE-GATE-STAGE-2]` (the first ones): UES-01 named the
+  `agent-interface-transport` build and dist path.
+
+Nothing in those entries was false when written. They are superseded because the thing they measured
+moved, which is exactly the case where carrying a green forward is the defect.
+
+### [GATE-APPROVAL] — ✅ PASS (re-recorded against the amended Decision) | 2026-08-23
+
+**Status:** verifying (the document had already advanced; this re-establishes the approval the
+amendment invalidated, it does not re-run the status ladder).
+
+**(1) The delegation, verbatim** — unchanged, and reproduced rather than referenced so this entry
+stands on its own. The owner's session-opening instruction to the orchestrating session:
+
+> 지금부터 깃헙 이슈에 등록된 것들을 처리할 것인데, 이슈들은 순서를 잘 맞춰서 처리해야함. 그렇기 때문에
+> 너에게 오케스트레이션 권한을 줄테니 다른 세션들과 의사소통 하면서 이슈들을 나눠서 처리해줘.
+
+and, on the GATE-APPROVAL question put to them explicitly, the owner SELECTED the option
+`위임 선언 — 이슈 처리 전권`:
+
+> 「근거가 타당하면 스스로 승인하고 진행하라」는 취지의 표준 위임을 지금 선언해 주시면, 각 spec의
+> Evidence Log에 그 문장을 그대로 인용하고 + 근거 조건 충족을 입증하고 + 해당 항목이 위임 범위 안임을
+> 보여서 GATE-APPROVAL을 통과시킵니다.
+
+**Provenance, unchanged and still stated:** this reached the session RELAYED by the orchestrating
+session, not typed into its conversation. The owner selected an option rather than composing a
+sentence. A peer session cannot grant approval on the owner's behalf and this entry does not claim
+it did.
+
+**(2) The evidence condition, RE-TESTED against the amended Decision** — this is the half that had to
+be re-established, because the amendment changed what is being approved:
+
+- The placement is now the one the repository's own guard requires, rather than one it refuses:
+  `scan-interface-runtime` passes (`violations=0 scanned=27`), where the superseded placement failed
+  it at 9 mechanisms against a frozen 5.
+- The reachability claim that decided the original choice was re-tested rather than re-asserted, and
+  it did not survive: it is true of the record TYPE and false of the DECODER, whose every actual and
+  planned consumer (issue #2096, issue #2097, issue #2098) is in `agent-session` or in
+  `agent-framework`, which depends on it.
+- The correction was made in the direction the rule points, not the cheap one: the frozen allowance
+  in `scripts/harness/interface-entry-baseline.json` was NOT raised, and
+  `.agents/harness.config.json` was reverted to the integration branch — the amended placement needs
+  no exemption of any kind.
+- Every other decision the original approval rested on is unchanged and re-verified below.
+
+**(3) The item still sits inside the delegated class,** and the amendment narrows rather than widens
+it: the change now writes ONE package, adds no dependency edge, publishes no new contract, alters no
+shared configuration file, and leaves `packages/agent-interface-transport/` byte-identical to the
+integration branch. The four exclusions are untouched — no product direction, no externally visible
+contract (nothing this leaf ships changes a byte on disk), no business/legal judgement, no
+repository-wide policy file.
+
+### [GATE-VERIFY] — ✅ PASS (re-recorded after the move) | 2026-08-23
+
+**Prior gate:** GATE-IMPLEMENT shows PASS above; GATE-APPROVAL is re-recorded immediately above.
+
+- Task file: 12 of 12 `[x]`, none blocked or pending; `area:` corrected to `packages/agent-session`.
+- Build: `pnpm --filter @robota-sdk/agent-session build` — `Build complete`, dist emitted.
+- Tests: `pnpm --filter @robota-sdk/agent-session test` — **44 files, 308 tests, all passing**. That
+  is the package's WHOLE suite, not just the new file: the move put the codec into a package with
+  existing tests, so the number that matters is that none of them regressed.
+- Scans: `node scripts/harness/run-all-scans.mjs` — **138 passed, 1 skipped, 0 failed**. Named
+  individually because each was red at some point during this work and each is now green for a
+  reason rather than by luck: `interface-runtime` (violations=0 — the guard that forced the move),
+  `sdk-public-surface`, `orphan-exports`, `backlog-placement`, `resolving-claims`,
+  `reference-kind-qualified`, `file-size`, `deps` (no violations), `spec-public-surface`,
+  `spec-user-execution-section`, `doc-folder-status`.
+- `packages/agent-interface-transport/` is byte-identical to `origin/develop`
+  (`git diff origin/develop -- packages/agent-interface-transport/` is empty), and
+  `.agents/harness.config.json` is likewise reverted.
+
+**The tests were checked, not merely run** — two mutation rounds, unchanged by the move and re-run
+after it:
+
+1. Breaking date revival and unknown-key rejection in `scalars.ts` turned **7 tests red**.
+2. Collapsing `MESSAGE_KEYS_BY_ROLE` into one union of all four variants' keys turned **exactly the 4
+   variant-key tests red**.
+
+Both restored to green. The second round exists because review found a gap the suite could not:
+the original unknown-key coverage used an invented key, which a union implementation rejects
+identically — so it constrained "unknown keys are rejected" and not "the key set is per-variant",
+while the module's own header claimed the latter.
+
+### [DONE-GATE-STAGE-1] — ✅ PASS (re-recorded after the move) | 2026-08-23
+
+UES-01 is fully written and re-pointed at the new owner package: prerequisite
+`pnpm --filter @robota-sdk/agent-session build`, and the import under test is
+`./packages/agent-session/dist/node/index.js`. Agent-executability decision, exact command, expected
+observable as four literal lines with what each proves, cleanup, and evidence field are all present.
+Executability was re-established by running it after the move, before this entry was written.
+
+### [DONE-GATE-STAGE-2] — ✅ PASS (re-recorded after the move) | 2026-08-23
+
+UES-01 executed against `packages/agent-session/dist/node/index.js` — the built artifact of the
+package that now owns the codec, not source, and not the old package.
+
+Observed — exit code 0, identical to the expected result authored before the run:
+
+```
+1 valid true
+2 corrupt messages[0].timestamp
+3 unsupported 99 false
+4 valid
+```
+
+The expected result was not rewritten after observation. It was authored from a pre-implementation
+executability run, matched on the first gate run against `agent-interface-transport`, and matched
+again unchanged against `agent-session` — which is itself evidence that the move preserved behaviour
+rather than merely preserving the tests.
+
+**Durable artifacts:** `packages/agent-session/src/session-record-codec/` (13 modules) and
+`packages/agent-session/src/__tests__/session-record-codec.test.ts` (77 tests).
+
+### [GATE-COMPLETE] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** verifying → done
+
+Every criterion below was verified against the CURRENT placement (`packages/agent-session`). Test
+references name the file and the `describe` that owns each criterion:
+`packages/agent-session/src/__tests__/session-record-codec.test.ts`.
+
+- **[GATE-COMPLETE: TC-01]** Command: `pnpm --filter @robota-sdk/agent-session test`. Result: the
+  nine-case corpus (`null`, `undefined`, `42`, `'{}'`, `[]`, `{}`, `true`, a record missing every
+  required field, a record with no `messages`) each returns `corrupt` with ≥1 issue, and each case
+  asserts `not.toThrow()` around the call. Test: `> decodeInteractiveSessionRecord — TC-01 total over
+unknown input > reports %s as corrupt without throwing`. Exit code 0.
+- **[GATE-COMPLETE: TC-02]** A maximal record with every optional field populated, round-tripped
+  through `JSON.parse(JSON.stringify(...))`, decodes to `valid` and `toEqual`s the original — with
+  `messages[].timestamp` and `history[].timestamp` back as `Date` instances. Test: `> TC-02 a maximal
+record round-trips > decodes a persisted maximal record to valid` and `> revives the
+contract-declared Date members as Date instances`.
+- **[GATE-COMPLETE: TC-03]** 26 single-field mutations, one per nested contract family, each
+  asserting `corrupt` AND the exact reported `path` (`backgroundTasks[0].depth`,
+  `plan.steps[1].status`, `toolSchemas[0].parameters.properties.path.type`, …). Test: `> TC-03 every
+nested family reports its path > %s: a defect at %s is reported at that path`, plus `> reports a
+missing required nested field at its own path`.
+- **[GATE-COMPLETE: TC-04]** ISO-8601 string and live `Date` both decode to an equal `Date`;
+  `'not-a-date'`, `''`, `0`, `null` and `{}` each produce an issue at `messages[0].timestamp`. Test:
+  `> TC-04 date revival` (three cases plus a five-case table).
+- **[GATE-COMPLETE: TC-05]** `updatedAt: 'last thursday'` and `createdAt: ''` are both reported at
+  their own path; a valid string timestamp stays a `string` in the decoded record. Test: `> TC-05
+string timestamps must parse`.
+- **[GATE-COMPLETE: TC-06]** Unknown keys rejected on the root, a message, a background task and the
+  goal; permitted inside `history[].data`, message `metadata`, `memoryEvents[].data`, task
+  `metadata`, and a schema's `properties`. PLUS four members that only ANOTHER variant declares
+  (`toolCallId`/`toolCalls` on a user message, `name`/`toolCallId` on an assistant message), which is
+  what distinguishes per-variant key sets from one union. Test: `> TC-06 unknown keys`.
+- **[GATE-COMPLETE: TC-07]** Versions `0`, `2`, `1.5`, `-1` report `unsupported` carrying that
+  version; `'1'`, absent and `null` report `unsupported` with `schemaVersion: undefined`; an
+  unsupported version carries NO `issues` key; a non-envelope is `corrupt`, not `unsupported`; a
+  current-version envelope wrapping a corrupt record reports `corrupt` at `record.id`. Test: `>
+decodeVersionedInteractiveSessionRecord — TC-07 version gate`.
+- **[GATE-COMPLETE: TC-08]** Two independent defects (`id` and `cwd`) are both reported from one
+  call, and every issue carries a non-empty message. Test: `> TC-08 issues accumulate`.
+- **[GATE-COMPLETE: TC-09]** `INTERACTIVE_SESSION_RECORD_KEYS` is compared against an object literal
+  declared `satisfies Record<keyof IInteractiveSessionRecord, true>` — so a member added to the
+  contract without a decoder branch fails to COMPILE, and a runtime set comparison catches the
+  reverse. Test: `> TC-09 key parity between the contract and the decoder`.
+- **[GATE-COMPLETE: TC-10]** Command: `pnpm --filter @robota-sdk/agent-session build` → `Build
+complete`, dist emitted, exit 0. Command: `node scripts/harness/check-dependency-direction.mjs` →
+  `✅ No dependency direction violations found.` The package's declared dependencies are unchanged —
+  the codec imports only `@robota-sdk/agent-interface-transport` and `@robota-sdk/agent-core`, both
+  already declared, so no `package.json` was edited.
+- **[GATE-COMPLETE: TC-11]** Command: `node scripts/harness/scan-file-size.mjs` → `harness file-size
+scan passed (80 baselined burn-down entries)`. All 13 new production modules are ≤300 lines and
+  none was added to the baseline. Recorded because it drove a real design decision: the 300-line cap
+  is why the codec is a module directory rather than one file.
+- **[GATE-COMPLETE: TC-12]** Command: `node scripts/harness/check-spec-public-surface.mjs` → `spec
+public-surface scan passed`. `packages/agent-session/docs/SPEC.md` gained the Scope and Boundaries
+  statements of codec ownership, three Type Ownership rows, four Public API Surface rows, and § "The
+  Persisted Session Record Is Decoded, Never Cast (TRANS-005)". Command:
+  `node scripts/harness/scan-interface-runtime.mjs` → `violations=0 scanned=27`. Command:
+  `git diff origin/develop -- packages/agent-interface-transport/` → empty.
+
+**Test Plan coverage — every TC-N row addressed, none silently skipped:**
+
+TC-01 through TC-09 are automated in
+`packages/agent-session/src/__tests__/session-record-codec.test.ts` at the `describe` names quoted
+above. TC-10, TC-11 and TC-12 are scan/build rows rather than unit tests, and each names the exact
+command and its observed output above — no automated unit test is written for them because the
+harness scan IS the automated check, and duplicating it in vitest would assert the scan's result
+rather than the property.
+
+**Summary.** 12 of 12 completion criteria met and evidenced. 77 codec tests green inside a package
+suite of 308, all 44 files passing. 138 harness scans pass, 0 fail. The user-execution scenario ran
+against the built artifact and matched an expectation authored before implementation. The one
+architectural decision that was wrong — the placement — was caught by the repository's own guard,
+amended in the open, re-approved against the amended text, and re-verified end to end rather than
+carried forward on a stale green.

--- a/.agents/tasks/completed/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md
+++ b/.agents/tasks/completed/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md
@@ -1,0 +1,70 @@
+---
+title: 'TRANS-005: give the persisted interactive-session record one versioned total decoder'
+issue: https://github.com/woojubb/robota/issues/2081
+status: done
+created: 2026-08-22
+completed: 2026-08-23
+priority: high
+urgency: now
+area: packages/agent-session
+depends_on: []
+---
+
+# TRANS-005: give the persisted interactive-session record one versioned total decoder
+
+Execution leaf [issue #2081](https://github.com/woojubb/robota/issues/2081) under tracker
+[issue #2067](https://github.com/woojubb/robota/issues/2067). Plan:
+[`.agents/spec-docs/done/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`](../../spec-docs/done/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md).
+
+## Objective
+
+`IInteractiveSessionRecord` is persisted and transferred but exists only at compile time, so every
+ingress casts into it: the store `JSON.parse(...) as`, the artifact decoder checks an envelope
+version and a string `id`, and handoff verifies bytes and then casts. Two consequences are reachable
+today — a resumed record carries `string` where the contract declares `Date` (`messages[].timestamp`,
+`history[].timestamp`, with no revival anywhere on the load path), and a corrupt file is collapsed
+into "missing" and silently replaced by a field-stripped replay reconstruction.
+
+Add the single owner-owned runtime decoder for a complete persisted record. It lives in
+`agent-session`, beside the persistence paths that will consume it: the record TYPE is declared by
+`agent-interface-transport`, but an `agent-interface-*` package publishes contracts and
+discriminators rather than mechanisms (`scan-interface-runtime`), and a decoder is a mechanism. No store, artifact, handoff, or log consumer is migrated here — those are
+issue #2096, issue #2097 and issue #2098.
+
+## Plan
+
+- [x] TC-01 — `decode-outcome.ts`: the outcome/issue contract and issue-collecting helpers; every
+      non-record input returns `corrupt` and nothing throws.
+- [x] TC-02 — `scalars.ts` + `record-decoder.ts`: a maximal record round-trips through
+      `JSON.parse(JSON.stringify(...))` to `valid`, with revived `Date` timestamps.
+- [x] TC-03 — `message-decoders.ts`, `tool-schema-decoders.ts`, `background-decoders.ts`,
+      `event-decoders.ts`, `goal-plan-branch-decoders.ts`: all 15 nested contract families decoded
+      totally, each reporting a field-path on failure.
+- [x] TC-04 — date revival: ISO-8601 string or `Date` in, `Date` out; unparseable values are issues.
+- [x] TC-05 — string timestamp fields (`createdAt`, `updatedAt`, …) validated as parseable dates.
+- [x] TC-06 — unknown keys rejected on declared objects, permitted inside the five contract-open maps.
+- [x] TC-07 — `decodeVersionedInteractiveSessionRecord` reports `unsupported` with the version seen,
+      without nested field issues.
+- [x] TC-08 — issue accumulation: independent defects are reported together, not one at a time.
+- [x] TC-09 — key-parity test, so a contract field added without a decoder branch fails the build.
+- [x] TC-10 — package builds; declared dependencies unchanged (`agent-core` only).
+- [x] TC-11 — every new production file ≤ 300 lines; no new file-size baseline entry.
+- [x] TC-12 — `docs/SPEC.md` updated (Public API Surface, Type Ownership, codec section).
+
+## Test Plan
+
+Unit tests in `packages/agent-session/src/__tests__/session-record-codec.test.ts`, run by
+`pnpm --filter @robota-sdk/agent-session test`.
+
+One maximal fixture record — every optional field populated, every nested contract family present —
+is the base for two table-driven suites. The first feeds a malformed corpus (`null`, `undefined`,
+`42`, `'{}'`, `[]`, `{}`, and truncations) and asserts a `corrupt` outcome with no throw. The second
+mutates exactly one field per case from the valid base and asserts both the `corrupt` status and the
+reported `path`, which is the property "no single-field mutation of a valid record decodes as valid".
+Date handling, the unknown-key policy, version rejection, and issue accumulation each get their own
+focused cases; the key-parity test compares the runtime decoder's key set against
+`keyof IInteractiveSessionRecord` so a later contract field cannot be added silently.
+
+Gate commands: `pnpm --filter @robota-sdk/agent-session build`, `pnpm harness:scan:deps`,
+`pnpm harness:scan:file-size`, `pnpm harness:scan:spec-public-surface`, and `pnpm harness:verify`
+before the pull request.

--- a/packages/agent-session/docs/SPEC.md
+++ b/packages/agent-session/docs/SPEC.md
@@ -2,7 +2,11 @@
 
 ## Scope
 
-Owns the CLI session lifecycle for the Robota SDK. This package provides the `Session` class that wraps a `Robota` agent instance with permission-gated tool execution, hook-based lifecycle events, context window tracking, conversation compaction, and optional persistence through `IInteractiveSessionStore`. `NodeSessionStore` is the explicitly named host-filesystem adapter. The package is the primary runtime used by the CLI application (`agent-cli`) via the assembly layer (`agent-framework`).
+Owns the CLI session lifecycle for the Robota SDK. This package provides the `Session` class that wraps a `Robota` agent instance with permission-gated tool execution, hook-based lifecycle events, context window tracking, conversation compaction, and optional persistence through `IInteractiveSessionStore`. `NodeSessionStore` is the explicitly named host-filesystem adapter. The package is the primary runtime used by the CLI application (`agent-cli`) via the assembly layer (`agent-framework`). It also owns the **runtime codec for the
+persisted session record** (TRANS-005): the record's TYPE is owned by
+`@robota-sdk/agent-interface-transport`, but a decoder is a mechanism, and an `agent-interface-*`
+package publishes contracts, vocabulary and discriminators rather than mechanisms
+(`scan-interface-runtime`). The codec therefore lives beside the persistence paths that consume it.
 
 ## Boundaries
 
@@ -17,7 +21,8 @@ Owns the CLI session lifecycle for the Robota SDK. This package provides the `Se
 - Does not own the permission evaluation algorithm or hook execution engine. Those belong to `@robota-sdk/agent-core` (`evaluatePermission`, `runHooks`).
 - **Owns the file-persistence primitive, not the record or port shape.** `NodeSessionStore` owns atomic
   JSON file persistence and directly implements `IInteractiveSessionStore`; both that port and
-  `IInteractiveSessionRecord` are owned by `@robota-sdk/agent-interface-transport` (DATA-001 SSOT).
+  `IInteractiveSessionRecord` are owned by `@robota-sdk/agent-interface-transport` (DATA-001 SSOT). It also owns the record's runtime DECODER (TRANS-005) — the shape is
+  declared there, and the mechanism that validates a value against it lives here.
   The former local `ISessionRecord` and `ISessionStore` declarations were removed because they drifted
   from the canonical contract. Public compatibility names are renamed re-exports only. The store remains
   payload-agnostic in behavior (it never inspects persisted fields; `load`/`list` keep the honest
@@ -84,6 +89,9 @@ Types owned by this package (SSOT):
 
 | Type                                        | Kind      | File                                       | Description                                                                                           |
 | ------------------------------------------- | --------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `ISessionRecordDecodeIssue`                 | Interface | `session-record-codec/decode-outcome.ts`   | TRANS-005: one decode failure, located — a machine-readable `path` plus a human `message`             |
+| `TSessionRecordDecodeOutcome`               | Type      | `session-record-codec/decode-outcome.ts`   | TRANS-005: `valid` \| `corrupt` \| `unsupported` — deliberately no `missing` member                   |
+| `IVersionedInteractiveSessionRecord`        | Interface | `session-record-codec/record-decoder.ts`   | TRANS-005: `{ schemaVersion, record }` — how a persisted record's version travels with its bytes      |
 | `ISessionOptions`                           | Interface | `session-types.ts`                         | Constructor options for Session (tools, provider, systemMessage, providerTimeout, optional sessionId) |
 | `ISessionShutdownOptions`                   | Interface | `session-types.ts`                         | Graceful shutdown options, including Claude-compatible `reason`                                       |
 | `TPermissionHandler`                        | Type      | `permission-types.ts`                      | Async callback `(toolName, toolArgs) => Promise<TPermissionResult>`                                   |
@@ -145,6 +153,10 @@ Types consumed from other packages (not owned here):
 | `CompactionError`                           | Class                | Thrown when a compaction summary is invalid — history is preserved untouched (see Compaction Failure Contract)                            |
 | `DEFAULT_COMPACTION_PROMPT`                 | Constant             | Domain-neutral base template of the compaction summarization prompt; replaceable via `ISessionOptions.compactionBasePrompt`               |
 | `NodeSessionStore`                          | Class                | Explicit host-filesystem JSON persistence adapter for session records                                                                     |
+| `decodeInteractiveSessionRecord`            | Function             | TRANS-005: decode `unknown` into a fully validated `IInteractiveSessionRecord`, or report every place it failed                           |
+| `decodeVersionedInteractiveSessionRecord`   | Function             | TRANS-005: the same behind the schema-version gate — a version this build does not implement stops the decode                             |
+| `INTERACTIVE_SESSION_RECORD_VERSION`        | Constant             | TRANS-005: the persisted record shape this build reads and writes                                                                         |
+| `INTERACTIVE_SESSION_RECORD_KEYS`           | Constant             | TRANS-005: the record's declared key set, so a contract member added without a decoder branch is caught by test                           |
 | `isSafeSessionId`                           | Function             | SEC-006: whether a session id is safe to use as a single filesystem path component                                                        |
 | `assertSafeSessionId`                       | Function             | SEC-006: throws unless the session id is a safe path component — the guard `NodeSessionStore` applies to every id it joins into a path    |
 | `CheckpointTree`                            | Class                | SELFHOST-007 neutral, I/O-free branch tree over `{id,parentId}` checkpoint nodes (fork/switch/listBranches/ancestors/activeLeaf)          |
@@ -281,6 +293,56 @@ The repo-root `./scripts/migrate-session-history.mjs` backfills the `history` fi
 | `load`   | `(id: string) => IInteractiveSessionRecord \| undefined` | Load a session by ID. Returns undefined if not found.                                                                                                                  |
 | `list`   | `() => IInteractiveSessionRecord[]`                      | List all sessions, sorted by updatedAt descending.                                                                                                                     |
 | `delete` | `(id: string) => void`                                   | Delete a session file. No-ops if not found.                                                                                                                            |
+
+## The Persisted Session Record Is Decoded, Never Cast (TRANS-005)
+
+`IInteractiveSessionRecord` is persisted and transferred, so it needs a RUNTIME owner and not only a
+compile-time one. The TYPE is owned by `@robota-sdk/agent-interface-transport`; the DECODER is owned
+here, because an `agent-interface-*` package publishes contracts, vocabulary and discriminators and
+not mechanisms (`scan-interface-runtime`), and because every consumer that will route through it —
+the store, the artifact envelope, the handoff commit and the replay path — is in this package or in
+`agent-framework`, which depends on it. `decodeInteractiveSessionRecord(value: unknown)` is that owner: it returns a record
+every member of which was checked, or the list of every place the value failed — not the first place.
+
+The outcome has three members and deliberately not a fourth:
+
+| `status`      | Means                                                             | Carries                               |
+| ------------- | ----------------------------------------------------------------- | ------------------------------------- |
+| `valid`       | Every member decoded                                              | `record: IInteractiveSessionRecord`   |
+| `corrupt`     | The value is not a record of this shape                           | `issues: ISessionRecordDecodeIssue[]` |
+| `unsupported` | The envelope names a schema version this build does not implement | `schemaVersion: number \| undefined`  |
+
+`missing` is NOT a member. Absence is a property of a store, not of a value — a record that is not
+there never reaches a decoder — so a store composes its own `missing` with these three. Collapsing
+corruption into absence is what let a damaged file resume as a silently field-stripped session.
+
+An issue locates the failure with a `path` (`messages[2].timestamp`, empty at the root) separate from
+its human `message`, because a caller that must CLASSIFY a failure cannot do it by reading prose.
+
+Four decisions a consumer depends on:
+
+- **Dates are revived.** The contract declares `messages[].timestamp` and `history[].timestamp` as
+  `Date`, and JSON has no date type. The decoder accepts an ISO-8601 string or a live `Date` and
+  produces a `Date`, so a decoded record satisfies its declared type rather than merely resembling it.
+- **String timestamps stay strings, but must parse.** `createdAt`, `updatedAt` and the other `…At`
+  members are declared `string`. They are still checked as instants, because resume ordering sorts on
+  `new Date(updatedAt).getTime()` and an unparseable value sorts as `NaN` rather than failing.
+- **Unknown keys on a declared object are a defect.** A persisted record is written by this build's
+  own code at a known version, so an unrecognised member means the shape drifted — which is what the
+  version gate reports. Maps the contract leaves OPEN (`history[].data`, message `metadata`,
+  `memoryEvents[].data`, task `metadata`, a schema's `properties`) accept any key; only their values
+  are constrained.
+- **`TUniversalValue`'s `Date` member is unreachable through persistence.** Inside an open map a
+  persisted date is a string indistinguishable from any other string, and reviving by shape would
+  convert a user's date-like text into a `Date`. Open-map contents decode as JSON values.
+
+**Versioning.** `INTERACTIVE_SESSION_RECORD_VERSION` names the shape this build reads and writes, and
+`IVersionedInteractiveSessionRecord` (`{ schemaVersion, record }`) is how it travels with the bytes.
+The version is NOT a member of `IInteractiveSessionRecord`: required would oblige every producer to
+set it, and optional would mean absent-is-acceptable, which is the permissive reader this codec
+replaces. `decodeVersionedInteractiveSessionRecord` reads the version FIRST and returns `unsupported`
+without nested issues — field defects measured against another version's shape describe the reader's
+expectations, not the data's condition.
 
 ## Session Logging
 

--- a/packages/agent-session/src/__tests__/session-record-codec.test.ts
+++ b/packages/agent-session/src/__tests__/session-record-codec.test.ts
@@ -1,0 +1,612 @@
+/**
+ * TRANS-005 (#2081) — the versioned total decoder for a persisted interactive-session record.
+ *
+ * Two table-driven suites do most of the work, both built from ONE maximal fixture:
+ *   1. a malformed corpus, asserting `corrupt` and never a throw;
+ *   2. a single-field mutation per nested contract family, asserting the reported field PATH.
+ *
+ * The second is the property test the issue asks for, spelled as a table: no single-field mutation
+ * of a valid record decodes as valid.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  INTERACTIVE_SESSION_RECORD_KEYS,
+  INTERACTIVE_SESSION_RECORD_VERSION,
+  decodeInteractiveSessionRecord,
+  decodeVersionedInteractiveSessionRecord,
+} from '../session-record-codec/index.js';
+
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+import type { TSessionRecordDecodeOutcome } from '../session-record-codec/index.js';
+
+/** A record with every optional field populated and every nested contract family present. */
+function maximalRecord(): IInteractiveSessionRecord {
+  return {
+    id: 'session-1',
+    name: 'a named session',
+    cwd: '/work',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-02T00:00:00.000Z',
+    systemPrompt: 'be useful',
+    sandboxSnapshotId: 'snapshot-1',
+    messages: [
+      {
+        id: 'm1',
+        role: 'user',
+        content: 'hello',
+        timestamp: new Date('2026-08-01T00:00:01.000Z'),
+        state: 'complete',
+        name: 'someone',
+        metadata: { seen: true, count: 2, tag: 'x', tags: ['a'], scores: { a: 1 } },
+        parts: [
+          { type: 'text', text: 'hello' },
+          { type: 'image_inline', mimeType: 'image/png', data: 'AAA' },
+          { type: 'image_uri', uri: 'https://example.test/i.png', mimeType: 'image/png' },
+        ],
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: null,
+        timestamp: new Date('2026-08-01T00:00:02.000Z'),
+        state: 'complete',
+        toolCalls: [{ id: 'c1', type: 'function', function: { name: 'read', arguments: '{}' } }],
+      },
+      {
+        id: 'm3',
+        role: 'system',
+        content: 'system text',
+        timestamp: new Date('2026-08-01T00:00:03.000Z'),
+        state: 'interrupted',
+      },
+      {
+        id: 'm4',
+        role: 'tool',
+        content: 'tool output',
+        timestamp: new Date('2026-08-01T00:00:04.000Z'),
+        state: 'complete',
+        toolCallId: 'c1',
+        name: 'read',
+      },
+    ],
+    history: [
+      {
+        id: 'h1',
+        timestamp: new Date('2026-08-01T00:00:05.000Z'),
+        category: 'chat',
+        type: 'user',
+        data: { anything: { nested: [1, 'two', false, null] } },
+      },
+    ],
+    toolSchemas: [
+      {
+        name: 'read',
+        description: 'read a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'the path' },
+            depth: { type: 'integer', minimum: 0, maximum: 9, default: 1 },
+            mode: { enum: ['a', 'b'] },
+            either: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+            list: { type: 'array', items: { type: 'string' }, additionalProperties: false },
+          },
+          required: ['path'],
+        },
+        outputSchema: { type: 'string', pattern: '^.*$', format: 'uri' },
+      },
+    ],
+    backgroundTasks: [
+      {
+        id: 't1',
+        kind: 'agent',
+        label: 'a task',
+        agentType: 'general-purpose',
+        status: 'completed',
+        mode: 'background',
+        parentSessionId: 'session-1',
+        parentTaskId: 't0',
+        depth: 1,
+        cwd: '/work',
+        pid: 4242,
+        startedAt: '2026-08-01T00:01:00.000Z',
+        updatedAt: '2026-08-01T00:02:00.000Z',
+        lastActivityAt: '2026-08-01T00:01:30.000Z',
+        completedAt: '2026-08-01T00:02:00.000Z',
+        promptPreview: 'do the thing',
+        commandPreview: 'ls',
+        isolation: 'worktree',
+        currentAction: 'writing',
+        unread: false,
+        logPath: '/logs/t1.log',
+        transcriptPath: '/logs/t1.jsonl',
+        worktreePath: '/wt/t1',
+        branchName: 'feat/t1',
+        worktreeStatus: 'clean',
+        worktreeNextAction: 'none',
+        worktreeBaseRevision: 'abc1234',
+        parentWorktreeStatus: 'clean',
+        timeoutReason: 'idle',
+        nextFireAt: '2026-08-03T00:00:00.000Z',
+        metadata: { retries: 0, flagged: false, owner: 'me' },
+        schedule: {
+          cronExpression: '0 * * * *',
+          agentInstruction: 'wake up',
+          command: 'echo hi',
+          shell: '/bin/zsh',
+          env: { KEY: 'value' },
+        },
+        result: {
+          taskId: 't1',
+          kind: 'agent',
+          output: 'done',
+          exitCode: 0,
+          signalCode: 'SIGTERM',
+          metadata: { lines: 12 },
+          usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+        },
+        error: { category: 'timeout', message: 'too slow', recoverable: true },
+      },
+    ],
+    backgroundTaskEvents: [
+      { type: 'background_task_created', task: taskState() },
+      { type: 'background_task_started', task: taskState() },
+      { type: 'background_task_updated', task: taskState() },
+      { type: 'background_task_text_delta', taskId: 't1', delta: 'chunk' },
+      { type: 'background_task_tool_start', taskId: 't1', toolName: 'read', firstArg: 'a.ts' },
+      { type: 'background_task_tool_end', taskId: 't1', toolName: 'read', success: true },
+      {
+        type: 'background_task_permission_request',
+        taskId: 't1',
+        requestId: 'r1',
+        toolName: 'write',
+        toolArgs: { path: 'a.ts', force: false, retries: 1 },
+      },
+      { type: 'background_task_completed', task: taskState() },
+      { type: 'background_task_failed', task: taskState() },
+      { type: 'background_task_cancelled', task: taskState() },
+      { type: 'background_task_closed', taskId: 't1' },
+      { type: 'background_task_waking', taskId: 't1', instruction: 'continue' },
+    ],
+    backgroundJobGroups: [
+      {
+        id: 'g1',
+        parentSessionId: 'session-1',
+        waitPolicy: 'wait_all',
+        taskIds: ['t1'],
+        status: 'completed',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        updatedAt: '2026-08-01T00:03:00.000Z',
+        label: 'a group',
+        completedAt: '2026-08-01T00:03:00.000Z',
+        results: [
+          {
+            taskId: 't1',
+            label: 'a task',
+            status: 'completed',
+            summary: 'ok',
+            outputRef: '/logs/t1.log',
+            startedAt: '2026-08-01T00:01:00.000Z',
+            completedAt: '2026-08-01T00:02:00.000Z',
+            error: { category: 'runner', message: 'noted', recoverable: false },
+          },
+        ],
+      },
+    ],
+    backgroundJobGroupEvents: [
+      { type: 'background_job_group_created', group: jobGroupState() },
+      { type: 'background_job_group_updated', group: jobGroupState() },
+      { type: 'background_job_group_completed', group: jobGroupState() },
+    ],
+    skillActivationEvents: [
+      {
+        type: 'skill-activation',
+        skillName: 'a-skill',
+        source: 'plugin',
+        invocation: 'model-tool',
+        mode: 'fork',
+        status: 'failed',
+        timestamp: '2026-08-01T00:04:00.000Z',
+        qualifiedName: 'plugin:a-skill',
+        error: 'it failed',
+      },
+    ],
+    memoryEvents: [
+      {
+        type: 'memory_candidate_saved',
+        at: '2026-08-01T00:05:00.000Z',
+        candidateId: 'c1',
+        topic: 'a topic',
+        reason: 'because',
+        data: { nested: { ok: true }, list: [1, 2] },
+      },
+    ],
+    usedMemoryReferences: [{ topic: 'a topic', path: '/mem/a.md', score: 0.5, truncated: false }],
+    contextReferences: [
+      {
+        id: 'r1',
+        sourcePath: '/work/AGENTS.md',
+        relativePath: 'AGENTS.md',
+        originalReference: '@AGENTS.md',
+        loadType: 'prompt-reference',
+        status: 'active',
+        byteLength: 120,
+        loadedAt: '2026-08-01T00:06:00.000Z',
+        lastUsedAt: '2026-08-01T00:07:00.000Z',
+      },
+    ],
+    goal: {
+      id: 'goal-1',
+      objective: 'finish it',
+      status: 'stopped',
+      stopReason: 'no-progress',
+      iterations: 3,
+      maxIterations: 10,
+      startedAt: '2026-08-01T00:08:00.000Z',
+      progress: [{ iteration: 1, signal: 'continue', reason: 'more to do' }],
+    },
+    plan: {
+      id: 'plan-1',
+      objective: 'plan it',
+      steps: [{ id: 's1', description: 'first', status: 'done' }],
+      phase: 'executing',
+      createdAt: '2026-08-01T00:09:00.000Z',
+      approvedAt: '2026-08-01T00:10:00.000Z',
+    },
+    activeBranch: { branchId: 'b1', checkpointId: 'cp1' },
+  };
+}
+
+function taskState() {
+  return maximalRecordTask();
+}
+
+function maximalRecordTask() {
+  return {
+    id: 't1',
+    kind: 'agent' as const,
+    label: 'a task',
+    status: 'running' as const,
+    mode: 'background' as const,
+    parentSessionId: 'session-1',
+    depth: 0,
+    cwd: '/work',
+    updatedAt: '2026-08-01T00:02:00.000Z',
+    unread: true,
+  };
+}
+
+function jobGroupState() {
+  return {
+    id: 'g1',
+    parentSessionId: 'session-1',
+    waitPolicy: 'detached' as const,
+    taskIds: ['t1'],
+    status: 'running' as const,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:03:00.000Z',
+    results: [],
+  };
+}
+
+/** The record as it comes back off disk: JSON, so every `Date` has become a string. */
+function persisted(record: IInteractiveSessionRecord = maximalRecord()): unknown {
+  return JSON.parse(JSON.stringify(record)) as unknown;
+}
+
+/** Mutate one field, addressed by a dotted/bracketed path, on a fresh persisted copy. */
+function persistedWith(path: string, value: unknown): unknown {
+  const root = persisted() as Record<string, unknown>;
+  const steps = path.split(/\.|\[|\]\.?/).filter((step) => step.length > 0);
+  const last = steps.pop() as string;
+  let cursor: Record<string, unknown> = root;
+  for (const step of steps) {
+    cursor = cursor[step] as Record<string, unknown>;
+  }
+  if (value === undefined) delete cursor[last];
+  else cursor[last] = value;
+  return root;
+}
+
+function issuePaths(outcome: TSessionRecordDecodeOutcome): string[] {
+  return outcome.status === 'corrupt' ? outcome.issues.map((issue) => issue.path) : [];
+}
+
+describe('decodeInteractiveSessionRecord — TC-01 total over unknown input', () => {
+  const corpus: Array<[string, unknown]> = [
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['a JSON string', '{}'],
+    ['an array', []],
+    ['an empty object', {}],
+    ['a boolean', true],
+    ['a record missing every required field', { name: 'x' }],
+    [
+      'a record whose messages are absent',
+      {
+        id: 'a',
+        cwd: '/',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        updatedAt: '2026-08-01T00:00:00.000Z',
+      },
+    ],
+  ];
+
+  it.each(corpus)('reports %s as corrupt without throwing', (_label, value) => {
+    expect(() => decodeInteractiveSessionRecord(value)).not.toThrow();
+    const outcome = decodeInteractiveSessionRecord(value);
+    expect(outcome.status).toBe('corrupt');
+    if (outcome.status === 'corrupt') expect(outcome.issues.length).toBeGreaterThan(0);
+  });
+});
+
+describe('decodeInteractiveSessionRecord — TC-02 a maximal record round-trips', () => {
+  it('decodes a persisted maximal record to valid', () => {
+    const outcome = decodeInteractiveSessionRecord(persisted());
+    if (outcome.status !== 'valid') {
+      throw new Error(`expected valid, got ${outcome.status}: ${JSON.stringify(outcome, null, 2)}`);
+    }
+    expect(outcome.record).toEqual(maximalRecord());
+  });
+
+  it('revives the contract-declared Date members as Date instances', () => {
+    const outcome = decodeInteractiveSessionRecord(persisted());
+    if (outcome.status !== 'valid') throw new Error('expected valid');
+    for (const message of outcome.record.messages) {
+      expect(message.timestamp).toBeInstanceOf(Date);
+    }
+    for (const entry of outcome.record.history ?? []) {
+      expect(entry.timestamp).toBeInstanceOf(Date);
+    }
+    expect(outcome.record.messages[0]?.timestamp.toISOString()).toBe('2026-08-01T00:00:01.000Z');
+  });
+
+  it('accepts a record that is already in memory, with real Date members', () => {
+    const outcome = decodeInteractiveSessionRecord(maximalRecord());
+    expect(outcome.status).toBe('valid');
+  });
+});
+
+describe('decodeInteractiveSessionRecord — TC-03 every nested family reports its path', () => {
+  const mutations: Array<[string, string, unknown]> = [
+    ['root scalar', 'id', 42],
+    ['message base', 'messages[0].state', 'halfway'],
+    ['message variant', 'messages[1].content', 7],
+    ['message part', 'messages[0].parts[1].mimeType', null],
+    ['tool call', 'messages[1].toolCalls[0].function', 'read'],
+    ['history entry', 'history[0].category', 5],
+    ['tool schema', 'toolSchemas[0].name', null],
+    ['parameter schema', 'toolSchemas[0].parameters.properties.path.type', 'stringy'],
+    ['background task', 'backgroundTasks[0].depth', 'deep'],
+    ['background task result', 'backgroundTasks[0].result.output', 12],
+    ['background task error', 'backgroundTasks[0].error.category', 'nope'],
+    ['background task schedule', 'backgroundTasks[0].schedule.cronExpression', 3],
+    ['background task event', 'backgroundTaskEvents[3].delta', 9],
+    ['background task event payload', 'backgroundTaskEvents[0].task.id', null],
+    ['job group', 'backgroundJobGroups[0].waitPolicy', 'whenever'],
+    ['job group result', 'backgroundJobGroups[0].results[0].status', 'nearly'],
+    ['job group event', 'backgroundJobGroupEvents[0].group.taskIds', 't1'],
+    ['skill activation', 'skillActivationEvents[0].mode', 'sideways'],
+    ['memory event', 'memoryEvents[0].type', 'memory_candidate_eaten'],
+    ['memory reference', 'usedMemoryReferences[0].score', 'high'],
+    ['context reference', 'contextReferences[0].byteLength', '120'],
+    ['goal', 'goal.iterations', 'three'],
+    ['goal progress', 'goal.progress[0].signal', 'maybe'],
+    ['plan', 'plan.phase', 'pending'],
+    ['plan step', 'plan.steps[0].status', 'started'],
+    ['active branch', 'activeBranch.checkpointId', 12],
+  ];
+
+  it.each(mutations)('%s: a defect at %s is reported at that path', (_family, path, value) => {
+    const outcome = decodeInteractiveSessionRecord(persistedWith(path, value));
+    expect(outcome.status).toBe('corrupt');
+    expect(issuePaths(outcome)).toContain(path);
+  });
+
+  it('reports a missing required nested field at its own path', () => {
+    const outcome = decodeInteractiveSessionRecord(persistedWith('goal.objective', undefined));
+    expect(issuePaths(outcome)).toContain('goal.objective');
+  });
+});
+
+describe('decodeInteractiveSessionRecord — TC-04 date revival', () => {
+  it('accepts an ISO-8601 string', () => {
+    const outcome = decodeInteractiveSessionRecord(
+      persistedWith('messages[0].timestamp', '2026-08-01T00:00:09.000Z'),
+    );
+    if (outcome.status !== 'valid') throw new Error('expected valid');
+    expect(outcome.record.messages[0]?.timestamp.toISOString()).toBe('2026-08-01T00:00:09.000Z');
+  });
+
+  it('accepts a Date instance', () => {
+    const record = maximalRecord();
+    const outcome = decodeInteractiveSessionRecord(record);
+    if (outcome.status !== 'valid') throw new Error('expected valid');
+    expect(outcome.record.messages[0]?.timestamp.getTime()).toBe(
+      record.messages[0]?.timestamp.getTime(),
+    );
+  });
+
+  it.each([['not-a-date'], [''], [0], [null], [{}]])(
+    'rejects %s at messages[0].timestamp',
+    (value) => {
+      const outcome = decodeInteractiveSessionRecord(persistedWith('messages[0].timestamp', value));
+      expect(outcome.status).toBe('corrupt');
+      expect(issuePaths(outcome)).toContain('messages[0].timestamp');
+    },
+  );
+});
+
+describe('decodeInteractiveSessionRecord — TC-05 string timestamps must parse', () => {
+  it('rejects an updatedAt that Date.parse cannot read', () => {
+    const outcome = decodeInteractiveSessionRecord(persistedWith('updatedAt', 'last thursday'));
+    expect(outcome.status).toBe('corrupt');
+    expect(issuePaths(outcome)).toContain('updatedAt');
+  });
+
+  it('rejects an empty createdAt', () => {
+    expect(issuePaths(decodeInteractiveSessionRecord(persistedWith('createdAt', '')))).toContain(
+      'createdAt',
+    );
+  });
+
+  it('keeps a valid string timestamp a string', () => {
+    const outcome = decodeInteractiveSessionRecord(persisted());
+    if (outcome.status !== 'valid') throw new Error('expected valid');
+    expect(typeof outcome.record.updatedAt).toBe('string');
+  });
+});
+
+describe('decodeInteractiveSessionRecord — TC-06 unknown keys', () => {
+  it.each([
+    ['the root', 'surprise'],
+    ['a message', 'messages[0].surprise'],
+    ['a background task', 'backgroundTasks[0].surprise'],
+    ['the goal', 'goal.surprise'],
+  ])('rejects an unknown key on %s', (_where, path) => {
+    const outcome = decodeInteractiveSessionRecord(persistedWith(path, 'x'));
+    expect(outcome.status).toBe('corrupt');
+    expect(issuePaths(outcome)).toContain(path);
+  });
+
+  it.each([
+    ['history data', 'history[0].data.surprise'],
+    ['message metadata', 'messages[0].metadata.surprise'],
+    ['memory event data', 'memoryEvents[0].data.surprise'],
+    ['task metadata', 'backgroundTasks[0].metadata.surprise'],
+  ])('permits an unknown key inside %s', (_where, path) => {
+    const outcome = decodeInteractiveSessionRecord(persistedWith(path, 'x'));
+    expect(outcome.status).toBe('valid');
+  });
+
+  // A member ANOTHER variant declares is the case that separates per-variant key sets from one
+  // union of all four. An implementation using the union would accept every one of these, and every
+  // other unknown-key assertion in this file would stay green — so without these three the
+  // discriminated key set is correct by construction and verified by nothing.
+  it.each([
+    ['toolCallId on a user message', 'messages[0].toolCallId', 'c1'],
+    ['toolCalls on a user message', 'messages[0].toolCalls', []],
+    ['name on an assistant message', 'messages[1].name', 'someone'],
+    ['toolCallId on an assistant message', 'messages[1].toolCallId', 'c1'],
+  ])('rejects %s — a member only another variant declares', (_case, path, value) => {
+    const outcome = decodeInteractiveSessionRecord(persistedWith(path, value));
+    expect(outcome.status).toBe('corrupt');
+    expect(issuePaths(outcome)).toContain(path);
+  });
+
+  it('permits an unknown property name inside a tool schema properties map', () => {
+    const outcome = decodeInteractiveSessionRecord(
+      persistedWith('toolSchemas[0].parameters.properties.surprise', { type: 'string' }),
+    );
+    expect(outcome.status).toBe('valid');
+  });
+});
+
+describe('decodeVersionedInteractiveSessionRecord — TC-07 version gate', () => {
+  it('decodes an envelope at the current version', () => {
+    const outcome = decodeVersionedInteractiveSessionRecord({
+      schemaVersion: INTERACTIVE_SESSION_RECORD_VERSION,
+      record: persisted(),
+    });
+    expect(outcome.status).toBe('valid');
+  });
+
+  it.each([[0], [2], [1.5], [-1]])('reports version %s as unsupported', (version) => {
+    const outcome = decodeVersionedInteractiveSessionRecord({
+      schemaVersion: version,
+      record: persisted(),
+    });
+    expect(outcome).toEqual({ status: 'unsupported', schemaVersion: version });
+  });
+
+  it.each([
+    ['a string version', '1'],
+    ['an absent version', undefined],
+    ['a null version', null],
+  ])('reports %s as unsupported with schemaVersion undefined', (_label, version) => {
+    const envelope: Record<string, unknown> = { record: persisted() };
+    if (version !== undefined) envelope['schemaVersion'] = version;
+    expect(decodeVersionedInteractiveSessionRecord(envelope)).toEqual({
+      status: 'unsupported',
+      schemaVersion: undefined,
+    });
+  });
+
+  it('does not report nested field issues for an unsupported version', () => {
+    const outcome = decodeVersionedInteractiveSessionRecord({
+      schemaVersion: 99,
+      record: { total: 'garbage' },
+    });
+    expect(outcome.status).toBe('unsupported');
+    expect('issues' in outcome).toBe(false);
+  });
+
+  it('reports a non-envelope as corrupt rather than unsupported', () => {
+    expect(decodeVersionedInteractiveSessionRecord(null).status).toBe('corrupt');
+    expect(decodeVersionedInteractiveSessionRecord([]).status).toBe('corrupt');
+  });
+
+  it('reports a valid envelope carrying a corrupt record as corrupt', () => {
+    const outcome = decodeVersionedInteractiveSessionRecord({
+      schemaVersion: INTERACTIVE_SESSION_RECORD_VERSION,
+      record: persistedWith('id', 42),
+    });
+    expect(outcome.status).toBe('corrupt');
+    expect(issuePaths(outcome)).toContain('record.id');
+  });
+});
+
+describe('decodeInteractiveSessionRecord — TC-08 issues accumulate', () => {
+  it('reports every independent defect in one outcome', () => {
+    const broken = persisted() as Record<string, unknown>;
+    broken['id'] = 42;
+    broken['cwd'] = null;
+    const outcome = decodeInteractiveSessionRecord(broken);
+    expect(issuePaths(outcome)).toEqual(expect.arrayContaining(['id', 'cwd']));
+  });
+
+  it('carries a message on every issue', () => {
+    const outcome = decodeInteractiveSessionRecord({});
+    if (outcome.status !== 'corrupt') throw new Error('expected corrupt');
+    for (const issue of outcome.issues) {
+      expect(issue.message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('TC-09 key parity between the contract and the decoder', () => {
+  it('decodes every key the record contract declares', () => {
+    const declared = {
+      id: true,
+      name: true,
+      cwd: true,
+      createdAt: true,
+      updatedAt: true,
+      messages: true,
+      history: true,
+      systemPrompt: true,
+      toolSchemas: true,
+      backgroundTasks: true,
+      backgroundTaskEvents: true,
+      backgroundJobGroups: true,
+      backgroundJobGroupEvents: true,
+      skillActivationEvents: true,
+      memoryEvents: true,
+      usedMemoryReferences: true,
+      contextReferences: true,
+      sandboxSnapshotId: true,
+      goal: true,
+      plan: true,
+      activeBranch: true,
+    } satisfies Record<keyof IInteractiveSessionRecord, true>;
+
+    expect([...INTERACTIVE_SESSION_RECORD_KEYS].sort()).toEqual(Object.keys(declared).sort());
+  });
+
+  it('exports a schema version', () => {
+    expect(Number.isInteger(INTERACTIVE_SESSION_RECORD_VERSION)).toBe(true);
+  });
+});

--- a/packages/agent-session/src/index.ts
+++ b/packages/agent-session/src/index.ts
@@ -94,3 +94,19 @@ export type {
 // SELFHOST-007: neutral checkpoint tree (branching time-travel) — pure, I/O-free.
 export { CheckpointTree } from './checkpoint-tree.js';
 export type { ICheckpointNode } from './checkpoint-tree.js';
+
+// TRANS-005 (issue #2081): the total runtime decoder for a PERSISTED session record. It lives here,
+// beside the store and artifact paths that will consume it, rather than with the contract it decodes:
+// an `agent-interface-*` package publishes contracts, vocabulary and discriminators — not mechanisms
+// (`scan-interface-runtime`), and a decoder is a mechanism.
+export {
+  INTERACTIVE_SESSION_RECORD_KEYS,
+  INTERACTIVE_SESSION_RECORD_VERSION,
+  decodeInteractiveSessionRecord,
+  decodeVersionedInteractiveSessionRecord,
+} from './session-record-codec/index.js';
+export type {
+  ISessionRecordDecodeIssue,
+  IVersionedInteractiveSessionRecord,
+  TSessionRecordDecodeOutcome,
+} from './session-record-codec/index.js';

--- a/packages/agent-session/src/session-record-codec/background-group-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/background-group-decoders.ts
@@ -1,0 +1,178 @@
+/**
+ * TRANS-005 (#2081) — the job-group half of the persisted background state: a group, the per-task
+ * result envelopes it collects, and the three-variant group event union.
+ *
+ * A group's `results` are decoded even when the group is still `running`, because the array is
+ * present from creation and a half-filled one is normal rather than a defect.
+ */
+
+import { TASK_STATUSES, decodeBackgroundTaskError } from './background-task-members.js';
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeArray,
+  decodeDeclaredObject,
+  decodeLiteral,
+  decodeOptional,
+  decodeString,
+  decodeStringArray,
+  decodeTimestampString,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type {
+  IBackgroundJobGroupState,
+  IBackgroundJobResultEnvelope,
+  TBackgroundJobGroupEvent,
+  TBackgroundJobGroupStatus,
+  TBackgroundJobWaitPolicy,
+} from '@robota-sdk/agent-interface-transport';
+
+const WAIT_POLICIES = [
+  'detached',
+  'wait_all',
+  'wait_any',
+  'manual',
+] as const satisfies readonly TBackgroundJobWaitPolicy[];
+
+const GROUP_STATUSES = [
+  'running',
+  'completed',
+] as const satisfies readonly TBackgroundJobGroupStatus[];
+
+const GROUP_EVENT_TYPES = [
+  'background_job_group_created',
+  'background_job_group_updated',
+  'background_job_group_completed',
+] as const;
+
+function decodeJobResultEnvelope(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IBackgroundJobResultEnvelope | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'taskId',
+    'label',
+    'status',
+    'summary',
+    'outputRef',
+    'error',
+    'startedAt',
+    'completedAt',
+  ]);
+  if (raw === undefined) return undefined;
+  const taskId = decodeString(raw['taskId'], atKey(path, 'taskId'), issues);
+  const label = decodeString(raw['label'], atKey(path, 'label'), issues);
+  const status = decodeLiteral(raw['status'], TASK_STATUSES, atKey(path, 'status'), issues);
+  if (taskId === undefined || label === undefined || status === undefined) return undefined;
+  const envelope: IBackgroundJobResultEnvelope = { taskId, label, status };
+  for (const key of ['summary', 'outputRef'] as const) {
+    setOptional(envelope, key, decodeOptional(raw[key], atKey(path, key), issues, decodeString));
+  }
+  for (const key of ['startedAt', 'completedAt'] as const) {
+    setOptional(
+      envelope,
+      key,
+      decodeOptional(raw[key], atKey(path, key), issues, decodeTimestampString),
+    );
+  }
+  setOptional(
+    envelope,
+    'error',
+    decodeOptional(raw['error'], atKey(path, 'error'), issues, decodeBackgroundTaskError),
+  );
+  return envelope;
+}
+
+export function decodeJobGroupState(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IBackgroundJobGroupState | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'id',
+    'parentSessionId',
+    'waitPolicy',
+    'taskIds',
+    'status',
+    'createdAt',
+    'updatedAt',
+    'label',
+    'completedAt',
+    'results',
+  ]);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const parentSessionId = decodeString(
+    raw['parentSessionId'],
+    atKey(path, 'parentSessionId'),
+    issues,
+  );
+  const waitPolicy = decodeLiteral(
+    raw['waitPolicy'],
+    WAIT_POLICIES,
+    atKey(path, 'waitPolicy'),
+    issues,
+  );
+  const taskIds = decodeStringArray(raw['taskIds'], atKey(path, 'taskIds'), issues);
+  const status = decodeLiteral(raw['status'], GROUP_STATUSES, atKey(path, 'status'), issues);
+  const createdAt = decodeTimestampString(raw['createdAt'], atKey(path, 'createdAt'), issues);
+  const updatedAt = decodeTimestampString(raw['updatedAt'], atKey(path, 'updatedAt'), issues);
+  const results = decodeArray(
+    raw['results'],
+    atKey(path, 'results'),
+    issues,
+    decodeJobResultEnvelope,
+  );
+  if (
+    id === undefined ||
+    parentSessionId === undefined ||
+    waitPolicy === undefined ||
+    taskIds === undefined ||
+    status === undefined ||
+    createdAt === undefined ||
+    updatedAt === undefined ||
+    results === undefined
+  ) {
+    return undefined;
+  }
+  const group: IBackgroundJobGroupState = {
+    id,
+    parentSessionId,
+    waitPolicy,
+    taskIds,
+    status,
+    createdAt,
+    updatedAt,
+    results,
+  };
+  setOptional(
+    group,
+    'label',
+    decodeOptional(raw['label'], atKey(path, 'label'), issues, decodeString),
+  );
+  setOptional(
+    group,
+    'completedAt',
+    decodeOptional(raw['completedAt'], atKey(path, 'completedAt'), issues, decodeTimestampString),
+  );
+  return group;
+}
+
+export function decodeBackgroundJobGroupEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundJobGroupEvent | undefined {
+  const type = decodeLiteral(
+    (value as { type?: unknown } | null)?.type,
+    GROUP_EVENT_TYPES,
+    atKey(path, 'type'),
+    issues,
+  );
+  if (type === undefined) return undefined;
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'group']);
+  if (raw === undefined) return undefined;
+  const group = decodeJobGroupState(raw['group'], atKey(path, 'group'), issues);
+  return group === undefined ? undefined : { type, group };
+}

--- a/packages/agent-session/src/session-record-codec/background-task-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/background-task-decoders.ts
@@ -1,0 +1,177 @@
+/**
+ * TRANS-005 (#2081) — the background-task state decoder.
+ *
+ * The state carries thirteen optional plain-string members and four optional timestamp members.
+ * They are decoded from key tables rather than written out one call at a time: a table is checked
+ * against the contract by the key-parity test, whereas seventeen near-identical statements are
+ * checked by whoever reads them.
+ */
+
+import {
+  TASK_ISOLATIONS,
+  TASK_KINDS,
+  TASK_MODES,
+  TASK_STATUSES,
+  TASK_TIMEOUT_REASONS,
+  decodeBackgroundTaskError,
+  decodeBackgroundTaskResult,
+  decodeBackgroundTaskSchedule,
+  decodePrimitiveMap,
+} from './background-task-members.js';
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeBoolean,
+  decodeDeclaredObject,
+  decodeInteger,
+  decodeLiteral,
+  decodeOptional,
+  decodeString,
+  decodeTimestampString,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type { IBackgroundTaskState } from '@robota-sdk/agent-interface-transport';
+
+const OPTIONAL_STRING_KEYS = [
+  'agentType',
+  'parentTaskId',
+  'promptPreview',
+  'commandPreview',
+  'currentAction',
+  'logPath',
+  'transcriptPath',
+  'worktreePath',
+  'branchName',
+  'worktreeStatus',
+  'worktreeNextAction',
+  'worktreeBaseRevision',
+  'parentWorktreeStatus',
+] as const;
+
+const OPTIONAL_TIMESTAMP_KEYS = [
+  'startedAt',
+  'lastActivityAt',
+  'completedAt',
+  'nextFireAt',
+] as const;
+
+const TASK_STATE_KEYS: readonly string[] = [
+  'id',
+  'kind',
+  'label',
+  'status',
+  'mode',
+  'parentSessionId',
+  'depth',
+  'cwd',
+  'pid',
+  'updatedAt',
+  'isolation',
+  'unread',
+  'result',
+  'error',
+  'timeoutReason',
+  'schedule',
+  'metadata',
+  ...OPTIONAL_STRING_KEYS,
+  ...OPTIONAL_TIMESTAMP_KEYS,
+];
+
+export function decodeBackgroundTaskState(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IBackgroundTaskState | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, TASK_STATE_KEYS);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const kind = decodeLiteral(raw['kind'], TASK_KINDS, atKey(path, 'kind'), issues);
+  const label = decodeString(raw['label'], atKey(path, 'label'), issues);
+  const status = decodeLiteral(raw['status'], TASK_STATUSES, atKey(path, 'status'), issues);
+  const mode = decodeLiteral(raw['mode'], TASK_MODES, atKey(path, 'mode'), issues);
+  const parentSessionId = decodeString(
+    raw['parentSessionId'],
+    atKey(path, 'parentSessionId'),
+    issues,
+  );
+  const depth = decodeInteger(raw['depth'], atKey(path, 'depth'), issues);
+  const cwd = decodeString(raw['cwd'], atKey(path, 'cwd'), issues);
+  const updatedAt = decodeTimestampString(raw['updatedAt'], atKey(path, 'updatedAt'), issues);
+  const unread = decodeBoolean(raw['unread'], atKey(path, 'unread'), issues);
+  if (
+    id === undefined ||
+    kind === undefined ||
+    label === undefined ||
+    status === undefined ||
+    mode === undefined ||
+    parentSessionId === undefined ||
+    depth === undefined ||
+    cwd === undefined ||
+    updatedAt === undefined ||
+    unread === undefined
+  ) {
+    return undefined;
+  }
+
+  const task: IBackgroundTaskState = {
+    id,
+    kind,
+    label,
+    status,
+    mode,
+    parentSessionId,
+    depth,
+    cwd,
+    updatedAt,
+    unread,
+  };
+  for (const key of OPTIONAL_STRING_KEYS) {
+    setOptional(task, key, decodeOptional(raw[key], atKey(path, key), issues, decodeString));
+  }
+  for (const key of OPTIONAL_TIMESTAMP_KEYS) {
+    setOptional(
+      task,
+      key,
+      decodeOptional(raw[key], atKey(path, key), issues, decodeTimestampString),
+    );
+  }
+  setOptional(task, 'pid', decodeOptional(raw['pid'], atKey(path, 'pid'), issues, decodeInteger));
+  setOptional(
+    task,
+    'isolation',
+    decodeOptional(raw['isolation'], atKey(path, 'isolation'), issues, (member, memberPath, sink) =>
+      decodeLiteral(member, TASK_ISOLATIONS, memberPath, sink),
+    ),
+  );
+  setOptional(
+    task,
+    'timeoutReason',
+    decodeOptional(
+      raw['timeoutReason'],
+      atKey(path, 'timeoutReason'),
+      issues,
+      (member, memberPath, sink) => decodeLiteral(member, TASK_TIMEOUT_REASONS, memberPath, sink),
+    ),
+  );
+  setOptional(
+    task,
+    'result',
+    decodeOptional(raw['result'], atKey(path, 'result'), issues, decodeBackgroundTaskResult),
+  );
+  setOptional(
+    task,
+    'error',
+    decodeOptional(raw['error'], atKey(path, 'error'), issues, decodeBackgroundTaskError),
+  );
+  setOptional(
+    task,
+    'schedule',
+    decodeOptional(raw['schedule'], atKey(path, 'schedule'), issues, decodeBackgroundTaskSchedule),
+  );
+  setOptional(
+    task,
+    'metadata',
+    decodeOptional(raw['metadata'], atKey(path, 'metadata'), issues, decodePrimitiveMap),
+  );
+  return task;
+}

--- a/packages/agent-session/src/session-record-codec/background-task-event-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/background-task-event-decoders.ts
@@ -1,0 +1,220 @@
+/**
+ * TRANS-005 (#2081) — the twelve-variant persisted background-task event union.
+ *
+ * The union is discriminated by `type`, and the discriminant is read FIRST: it selects the key set
+ * the variant declares, so an event that names the wrong members fails on the members rather than on
+ * the union. An unrecognised `type` is reported once, at `type`, instead of as a pile of
+ * missing-member issues from whichever variant happened to be tried.
+ */
+
+import { decodeBackgroundTaskState } from './background-task-decoders.js';
+import { decodePrimitiveMap } from './background-task-members.js';
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeBoolean,
+  decodeDeclaredObject,
+  decodeLiteral,
+  decodeOptional,
+  decodeString,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type { TBackgroundTaskEvent } from '@robota-sdk/agent-interface-transport';
+
+/** The task-event variants whose entire payload is a task state. */
+const TASK_CARRYING_EVENTS = [
+  'background_task_created',
+  'background_task_started',
+  'background_task_updated',
+  'background_task_completed',
+  'background_task_failed',
+  'background_task_cancelled',
+] as const;
+
+const TASK_EVENT_TYPES = [
+  ...TASK_CARRYING_EVENTS,
+  'background_task_text_delta',
+  'background_task_tool_start',
+  'background_task_tool_end',
+  'background_task_permission_request',
+  'background_task_closed',
+  'background_task_waking',
+] as const;
+
+/** Every variant but the six task-carrying ones names the task by id rather than by value. */
+function taskIdOf(
+  raw: Record<string, unknown>,
+  path: string,
+  issues: TDecodeIssues,
+): string | undefined {
+  return decodeString(raw['taskId'], atKey(path, 'taskId'), issues);
+}
+
+type TTaskEventType = (typeof TASK_EVENT_TYPES)[number];
+
+function decodeTextDeltaEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'taskId', 'delta']);
+  if (raw === undefined) return undefined;
+  const taskId = taskIdOf(raw, path, issues);
+  const delta = decodeString(raw['delta'], atKey(path, 'delta'), issues);
+  if (taskId === undefined || delta === undefined) return undefined;
+  return { type: 'background_task_text_delta', taskId, delta };
+}
+
+function decodeToolStartEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'taskId', 'toolName', 'firstArg']);
+  if (raw === undefined) return undefined;
+  const taskId = taskIdOf(raw, path, issues);
+  const toolName = decodeString(raw['toolName'], atKey(path, 'toolName'), issues);
+  if (taskId === undefined || toolName === undefined) return undefined;
+  const event: TBackgroundTaskEvent = { type: 'background_task_tool_start', taskId, toolName };
+  setOptional(
+    event,
+    'firstArg',
+    decodeOptional(raw['firstArg'], atKey(path, 'firstArg'), issues, decodeString),
+  );
+  return event;
+}
+
+function decodeToolEndEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'type',
+    'taskId',
+    'toolName',
+    'success',
+    'error',
+  ]);
+  if (raw === undefined) return undefined;
+  const taskId = taskIdOf(raw, path, issues);
+  const toolName = decodeString(raw['toolName'], atKey(path, 'toolName'), issues);
+  const success = decodeBoolean(raw['success'], atKey(path, 'success'), issues);
+  if (taskId === undefined || toolName === undefined || success === undefined) return undefined;
+  const event: TBackgroundTaskEvent = {
+    type: 'background_task_tool_end',
+    taskId,
+    toolName,
+    success,
+  };
+  setOptional(
+    event,
+    'error',
+    decodeOptional(raw['error'], atKey(path, 'error'), issues, decodeString),
+  );
+  return event;
+}
+
+function decodePermissionRequestEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'type',
+    'taskId',
+    'requestId',
+    'toolName',
+    'toolArgs',
+  ]);
+  if (raw === undefined) return undefined;
+  const taskId = taskIdOf(raw, path, issues);
+  const requestId = decodeString(raw['requestId'], atKey(path, 'requestId'), issues);
+  const toolName = decodeString(raw['toolName'], atKey(path, 'toolName'), issues);
+  const toolArgs = decodePrimitiveMap(raw['toolArgs'], atKey(path, 'toolArgs'), issues);
+  if (
+    taskId === undefined ||
+    requestId === undefined ||
+    toolName === undefined ||
+    toolArgs === undefined
+  ) {
+    return undefined;
+  }
+  return { type: 'background_task_permission_request', taskId, requestId, toolName, toolArgs };
+}
+
+function decodeClosedEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'taskId']);
+  if (raw === undefined) return undefined;
+  const taskId = taskIdOf(raw, path, issues);
+  return taskId === undefined ? undefined : { type: 'background_task_closed', taskId };
+}
+
+function decodeWakingEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'taskId', 'instruction']);
+  if (raw === undefined) return undefined;
+  const taskId = taskIdOf(raw, path, issues);
+  if (taskId === undefined) return undefined;
+  const event: TBackgroundTaskEvent = { type: 'background_task_waking', taskId };
+  setOptional(
+    event,
+    'instruction',
+    decodeOptional(raw['instruction'], atKey(path, 'instruction'), issues, decodeString),
+  );
+  return event;
+}
+
+/** A task-carrying variant: `{ type, task }`, where `task` is a whole task state. */
+function decodeTaskCarryingEvent(
+  type: TTaskEventType,
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'task']);
+  if (raw === undefined) return undefined;
+  const task = decodeBackgroundTaskState(raw['task'], atKey(path, 'task'), issues);
+  if (task === undefined) return undefined;
+  return { type, task } as TBackgroundTaskEvent;
+}
+
+/** The variant decoders, keyed by discriminant — the dispatcher stays a lookup, not a ladder. */
+const VARIANT_DECODERS: Partial<
+  Record<
+    TTaskEventType,
+    (value: unknown, path: string, issues: TDecodeIssues) => TBackgroundTaskEvent | undefined
+  >
+> = {
+  background_task_text_delta: decodeTextDeltaEvent,
+  background_task_tool_start: decodeToolStartEvent,
+  background_task_tool_end: decodeToolEndEvent,
+  background_task_permission_request: decodePermissionRequestEvent,
+  background_task_closed: decodeClosedEvent,
+  background_task_waking: decodeWakingEvent,
+};
+
+export function decodeBackgroundTaskEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundTaskEvent | undefined {
+  const type = decodeLiteral(
+    (value as { type?: unknown } | null)?.type,
+    TASK_EVENT_TYPES,
+    atKey(path, 'type'),
+    issues,
+  );
+  if (type === undefined) return undefined;
+  const decodeVariant = VARIANT_DECODERS[type];
+  return decodeVariant === undefined
+    ? decodeTaskCarryingEvent(type, value, path, issues)
+    : decodeVariant(value, path, issues);
+}

--- a/packages/agent-session/src/session-record-codec/background-task-members.ts
+++ b/packages/agent-session/src/session-record-codec/background-task-members.ts
@@ -1,0 +1,205 @@
+/**
+ * TRANS-005 (#2081) — the member contracts a background-task state is built from: the literal
+ * unions it selects from, its error, its result (with token usage), and its schedule.
+ *
+ * They live beside the state decoder rather than inside it because the task EVENT union carries the
+ * same members, and one decoder per contract is the property this codec exists to establish.
+ */
+
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeBackgroundPrimitive,
+  decodeBoolean,
+  decodeDeclaredObject,
+  decodeInteger,
+  decodeLiteral,
+  decodeOpenMap,
+  decodeOptional,
+  decodeString,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type { ITokenUsage } from '@robota-sdk/agent-core';
+import type {
+  IBackgroundTaskError,
+  IBackgroundTaskResult,
+  IBackgroundTaskSchedule,
+  TBackgroundPrimitive,
+  TBackgroundTaskErrorCategory,
+  TBackgroundTaskIsolation,
+  TBackgroundTaskKind,
+  TBackgroundTaskMode,
+  TBackgroundTaskStatus,
+  TBackgroundTaskTimeoutReason,
+} from '@robota-sdk/agent-interface-transport';
+
+export const TASK_KINDS = [
+  'agent',
+  'process',
+  'scheduled',
+] as const satisfies readonly TBackgroundTaskKind[];
+export const TASK_MODES = [
+  'foreground',
+  'background',
+] as const satisfies readonly TBackgroundTaskMode[];
+export const TASK_ISOLATIONS = [
+  'none',
+  'worktree',
+] as const satisfies readonly TBackgroundTaskIsolation[];
+export const TASK_STATUSES = [
+  'queued',
+  'running',
+  'waiting_permission',
+  'sleeping',
+  'paused',
+  'completed',
+  'failed',
+  'cancelled',
+] as const satisfies readonly TBackgroundTaskStatus[];
+export const TASK_TIMEOUT_REASONS = [
+  'idle',
+  'max_runtime',
+  'output_limit',
+  'repetition',
+  'stale_worker',
+] as const satisfies readonly TBackgroundTaskTimeoutReason[];
+const TASK_ERROR_CATEGORIES = [
+  'validation',
+  'capacity',
+  'permission',
+  'timeout',
+  'runner',
+  'crash',
+  'provider',
+  'process',
+] as const satisfies readonly TBackgroundTaskErrorCategory[];
+
+export function decodePrimitiveMap(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): Record<string, TBackgroundPrimitive> | undefined {
+  return decodeOpenMap(value, path, issues, decodeBackgroundPrimitive);
+}
+
+function decodeStringMap(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): Record<string, string> | undefined {
+  return decodeOpenMap(value, path, issues, decodeString);
+}
+
+export function decodeBackgroundTaskError(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IBackgroundTaskError | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['category', 'message', 'recoverable']);
+  if (raw === undefined) return undefined;
+  const category = decodeLiteral(
+    raw['category'],
+    TASK_ERROR_CATEGORIES,
+    atKey(path, 'category'),
+    issues,
+  );
+  const message = decodeString(raw['message'], atKey(path, 'message'), issues);
+  const recoverable = decodeBoolean(raw['recoverable'], atKey(path, 'recoverable'), issues);
+  if (category === undefined || message === undefined || recoverable === undefined)
+    return undefined;
+  return { category, message, recoverable };
+}
+
+function decodeTokenUsage(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): ITokenUsage | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'promptTokens',
+    'completionTokens',
+    'totalTokens',
+  ]);
+  if (raw === undefined) return undefined;
+  const promptTokens = decodeInteger(raw['promptTokens'], atKey(path, 'promptTokens'), issues);
+  const completionTokens = decodeInteger(
+    raw['completionTokens'],
+    atKey(path, 'completionTokens'),
+    issues,
+  );
+  const totalTokens = decodeInteger(raw['totalTokens'], atKey(path, 'totalTokens'), issues);
+  if (promptTokens === undefined || completionTokens === undefined || totalTokens === undefined) {
+    return undefined;
+  }
+  return { promptTokens, completionTokens, totalTokens };
+}
+
+export function decodeBackgroundTaskResult(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IBackgroundTaskResult | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'taskId',
+    'kind',
+    'output',
+    'exitCode',
+    'signalCode',
+    'metadata',
+    'usage',
+  ]);
+  if (raw === undefined) return undefined;
+  const taskId = decodeString(raw['taskId'], atKey(path, 'taskId'), issues);
+  const kind = decodeLiteral(raw['kind'], TASK_KINDS, atKey(path, 'kind'), issues);
+  const output = decodeString(raw['output'], atKey(path, 'output'), issues);
+  if (taskId === undefined || kind === undefined || output === undefined) return undefined;
+  const result: IBackgroundTaskResult = { taskId, kind, output };
+  setOptional(
+    result,
+    'exitCode',
+    decodeOptional(raw['exitCode'], atKey(path, 'exitCode'), issues, decodeInteger),
+  );
+  setOptional(
+    result,
+    'signalCode',
+    decodeOptional(raw['signalCode'], atKey(path, 'signalCode'), issues, decodeString),
+  );
+  setOptional(
+    result,
+    'metadata',
+    decodeOptional(raw['metadata'], atKey(path, 'metadata'), issues, decodePrimitiveMap),
+  );
+  setOptional(
+    result,
+    'usage',
+    decodeOptional(raw['usage'], atKey(path, 'usage'), issues, decodeTokenUsage),
+  );
+  return result;
+}
+
+export function decodeBackgroundTaskSchedule(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IBackgroundTaskSchedule | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'cronExpression',
+    'agentInstruction',
+    'command',
+    'shell',
+    'env',
+  ]);
+  if (raw === undefined) return undefined;
+  const cronExpression = decodeString(raw['cronExpression'], atKey(path, 'cronExpression'), issues);
+  if (cronExpression === undefined) return undefined;
+  const schedule: IBackgroundTaskSchedule = { cronExpression };
+  for (const key of ['agentInstruction', 'command', 'shell'] as const) {
+    setOptional(schedule, key, decodeOptional(raw[key], atKey(path, key), issues, decodeString));
+  }
+  setOptional(
+    schedule,
+    'env',
+    decodeOptional(raw['env'], atKey(path, 'env'), issues, decodeStringMap),
+  );
+  return schedule;
+}

--- a/packages/agent-session/src/session-record-codec/decode-outcome.ts
+++ b/packages/agent-session/src/session-record-codec/decode-outcome.ts
@@ -1,0 +1,98 @@
+/**
+ * TRANS-005 (#2081) — the outcome vocabulary the session-record decoder answers in.
+ *
+ * ## Why an outcome and not an exception or `undefined`
+ *
+ * The defect this codec replaces is a store that answers "is this a valid record?" by returning
+ * `undefined`, which its caller then reads as "no such session" and repairs by replaying a partial
+ * reconstruction. Corruption and absence became the same answer, and the repair silently dropped
+ * fields. A type that cannot spell that confusion is the fix: this outcome distinguishes a value
+ * that failed to decode (`corrupt`) from one written by a build this one does not implement
+ * (`unsupported`), and deliberately has NO `missing` member.
+ *
+ * `missing` is a property of a STORE, not of a value — a file that is not there never reaches a
+ * decoder. The store composes its own `missing` with these three.
+ */
+
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * One decode failure, located.
+ *
+ * `path` is the machine-readable half and is kept separate from the human half on purpose: a caller
+ * that must CLASSIFY a failure cannot do it by reading prose. The rendering is dotted for object
+ * members and bracketed for array indices — `messages[2].timestamp` — and is empty at the root.
+ */
+export interface ISessionRecordDecodeIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+/** What a decode of a persisted session record can conclude. */
+export type TSessionRecordDecodeOutcome =
+  | { readonly status: 'valid'; readonly record: IInteractiveSessionRecord }
+  | { readonly status: 'corrupt'; readonly issues: readonly ISessionRecordDecodeIssue[] }
+  | { readonly status: 'unsupported'; readonly schemaVersion: number | undefined };
+
+/**
+ * The accumulator a decode pass writes into.
+ *
+ * Every decoder takes it and appends; none of them returns early on the first failure, so one call
+ * reports the whole shape of the damage rather than the first symptom of it.
+ */
+export type TDecodeIssues = ISessionRecordDecodeIssue[];
+
+/** `messages` + `id` → `messages.id`; a root-level key keeps its bare name. */
+export function atKey(parent: string, key: string): string {
+  return parent.length === 0 ? key : `${parent}.${key}`;
+}
+
+/** `messages` + `2` → `messages[2]`. */
+export function atIndex(parent: string, index: number): string {
+  return `${parent}[${index}]`;
+}
+
+export function addIssue(issues: TDecodeIssues, path: string, message: string): void {
+  issues.push({ path, message });
+}
+
+/**
+ * A short, non-throwing description of what was actually found, for the human half of an issue.
+ *
+ * It names the KIND rather than printing the value: a session record carries prompts and tool
+ * output, and an error string is exactly the kind of thing that ends up in a log.
+ */
+export function describeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  if (value instanceof Date) return 'a Date';
+  switch (typeof value) {
+    case 'undefined':
+      return 'nothing';
+    case 'string':
+      return 'a string';
+    case 'number':
+      return 'a number';
+    case 'boolean':
+      return 'a boolean';
+    case 'object':
+      return 'an object';
+    default:
+      return `a ${typeof value}`;
+  }
+}
+
+/**
+ * Assign an optional member only when it decoded to a value.
+ *
+ * Writing `undefined` instead would make an absent member present-and-undefined, which survives
+ * `JSON.stringify` as an omission but not as an identity — a decoded record must be the same shape
+ * as the one that was persisted, not a wider one.
+ */
+export function setOptional<TTarget extends object, TKey extends keyof TTarget>(
+  target: TTarget,
+  key: TKey,
+  value: TTarget[TKey] | undefined,
+): void {
+  if (value !== undefined) target[key] = value;
+}

--- a/packages/agent-session/src/session-record-codec/event-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/event-decoders.ts
@@ -1,0 +1,247 @@
+/**
+ * TRANS-005 (#2081) — decoders for the session-event payloads a record persists: skill activation,
+ * automatic-memory events and their references, and context references.
+ *
+ * These contracts spell their instants as `string`, not `Date`, so they stay strings here — but they
+ * are still checked as instants, because a member that reads as a timestamp and cannot be parsed as
+ * one is a defect that only surfaces later, as an ordering that is quietly wrong.
+ */
+
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeBoolean,
+  decodeDeclaredObject,
+  decodeInteger,
+  decodeLiteral,
+  decodeNumber,
+  decodeOpenMap,
+  decodeOptional,
+  decodeString,
+  decodeTimestampString,
+  decodeUniversalValue,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type {
+  IContextReferenceItem,
+  IMemoryEvent,
+  IMemoryReference,
+  ISkillActivationEvent,
+  TContextReferenceLoadType,
+  TContextReferenceStatus,
+  TSkillActivationInvocation,
+  TSkillActivationMode,
+  TSkillActivationSource,
+  TSkillActivationStatus,
+} from '@robota-sdk/agent-interface-transport';
+
+const SKILL_SOURCES = ['skill', 'plugin'] as const satisfies readonly TSkillActivationSource[];
+const SKILL_INVOCATIONS = [
+  'user-slash',
+  'model-tool',
+] as const satisfies readonly TSkillActivationInvocation[];
+const SKILL_MODES = ['inject', 'fork'] as const satisfies readonly TSkillActivationMode[];
+const SKILL_STATUSES = [
+  'started',
+  'completed',
+  'failed',
+] as const satisfies readonly TSkillActivationStatus[];
+
+const MEMORY_EVENT_TYPES = [
+  'memory_candidate_extracted',
+  'memory_candidate_queued',
+  'memory_candidate_saved',
+  'memory_candidate_skipped',
+  'memory_candidate_approved',
+  'memory_candidate_rejected',
+  'memory_retrieved',
+] as const satisfies readonly IMemoryEvent['type'][];
+
+const CONTEXT_LOAD_TYPES = [
+  'manual',
+  'prompt-reference',
+  'system',
+] as const satisfies readonly TContextReferenceLoadType[];
+
+const CONTEXT_STATUSES = [
+  'active',
+  'observed',
+] as const satisfies readonly TContextReferenceStatus[];
+
+export function decodeSkillActivationEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): ISkillActivationEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'type',
+    'skillName',
+    'source',
+    'invocation',
+    'mode',
+    'status',
+    'timestamp',
+    'qualifiedName',
+    'error',
+  ]);
+  if (raw === undefined) return undefined;
+  const type = decodeLiteral(raw['type'], ['skill-activation'], atKey(path, 'type'), issues);
+  const skillName = decodeString(raw['skillName'], atKey(path, 'skillName'), issues);
+  const source = decodeLiteral(raw['source'], SKILL_SOURCES, atKey(path, 'source'), issues);
+  const invocation = decodeLiteral(
+    raw['invocation'],
+    SKILL_INVOCATIONS,
+    atKey(path, 'invocation'),
+    issues,
+  );
+  const mode = decodeLiteral(raw['mode'], SKILL_MODES, atKey(path, 'mode'), issues);
+  const status = decodeLiteral(raw['status'], SKILL_STATUSES, atKey(path, 'status'), issues);
+  const timestamp = decodeTimestampString(raw['timestamp'], atKey(path, 'timestamp'), issues);
+  if (
+    type === undefined ||
+    skillName === undefined ||
+    source === undefined ||
+    invocation === undefined ||
+    mode === undefined ||
+    status === undefined ||
+    timestamp === undefined
+  ) {
+    return undefined;
+  }
+  const qualifiedName = decodeOptional(
+    raw['qualifiedName'],
+    atKey(path, 'qualifiedName'),
+    issues,
+    decodeString,
+  );
+  const error = decodeOptional(raw['error'], atKey(path, 'error'), issues, decodeString);
+  // Every member is `readonly`, so the optional ones are spread in rather than assigned after.
+  return {
+    type,
+    skillName,
+    source,
+    invocation,
+    mode,
+    status,
+    timestamp,
+    ...(qualifiedName === undefined ? {} : { qualifiedName }),
+    ...(error === undefined ? {} : { error }),
+  };
+}
+
+export function decodeMemoryReference(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IMemoryReference | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['topic', 'path', 'score', 'truncated']);
+  if (raw === undefined) return undefined;
+  const topic = decodeString(raw['topic'], atKey(path, 'topic'), issues);
+  const referencePath = decodeString(raw['path'], atKey(path, 'path'), issues);
+  const score = decodeNumber(raw['score'], atKey(path, 'score'), issues);
+  const truncated = decodeBoolean(raw['truncated'], atKey(path, 'truncated'), issues);
+  if (
+    topic === undefined ||
+    referencePath === undefined ||
+    score === undefined ||
+    truncated === undefined
+  ) {
+    return undefined;
+  }
+  return { topic, path: referencePath, score, truncated };
+}
+
+export function decodeMemoryEvent(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IMemoryEvent | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'type',
+    'at',
+    'candidateId',
+    'topic',
+    'reason',
+    'data',
+  ]);
+  if (raw === undefined) return undefined;
+  const type = decodeLiteral(raw['type'], MEMORY_EVENT_TYPES, atKey(path, 'type'), issues);
+  const at = decodeTimestampString(raw['at'], atKey(path, 'at'), issues);
+  if (type === undefined || at === undefined) return undefined;
+  const event: IMemoryEvent = { type, at };
+  for (const key of ['candidateId', 'topic', 'reason'] as const) {
+    setOptional(event, key, decodeOptional(raw[key], atKey(path, key), issues, decodeString));
+  }
+  setOptional(
+    event,
+    'data',
+    decodeOptional(raw['data'], atKey(path, 'data'), issues, (member, memberPath, sink) =>
+      decodeOpenMap(member, memberPath, sink, decodeUniversalValue),
+    ),
+  );
+  return event;
+}
+
+export function decodeContextReferenceItem(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IContextReferenceItem | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'id',
+    'sourcePath',
+    'relativePath',
+    'originalReference',
+    'loadType',
+    'status',
+    'byteLength',
+    'loadedAt',
+    'lastUsedAt',
+  ]);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const sourcePath = decodeString(raw['sourcePath'], atKey(path, 'sourcePath'), issues);
+  const relativePath = decodeString(raw['relativePath'], atKey(path, 'relativePath'), issues);
+  const originalReference = decodeString(
+    raw['originalReference'],
+    atKey(path, 'originalReference'),
+    issues,
+  );
+  const loadType = decodeLiteral(
+    raw['loadType'],
+    CONTEXT_LOAD_TYPES,
+    atKey(path, 'loadType'),
+    issues,
+  );
+  const status = decodeLiteral(raw['status'], CONTEXT_STATUSES, atKey(path, 'status'), issues);
+  const byteLength = decodeInteger(raw['byteLength'], atKey(path, 'byteLength'), issues);
+  const loadedAt = decodeTimestampString(raw['loadedAt'], atKey(path, 'loadedAt'), issues);
+  if (
+    id === undefined ||
+    sourcePath === undefined ||
+    relativePath === undefined ||
+    originalReference === undefined ||
+    loadType === undefined ||
+    status === undefined ||
+    byteLength === undefined ||
+    loadedAt === undefined
+  ) {
+    return undefined;
+  }
+  const item: IContextReferenceItem = {
+    id,
+    sourcePath,
+    relativePath,
+    originalReference,
+    loadType,
+    status,
+    byteLength,
+    loadedAt,
+  };
+  setOptional(
+    item,
+    'lastUsedAt',
+    decodeOptional(raw['lastUsedAt'], atKey(path, 'lastUsedAt'), issues, decodeTimestampString),
+  );
+  return item;
+}

--- a/packages/agent-session/src/session-record-codec/goal-plan-branch-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/goal-plan-branch-decoders.ts
@@ -1,0 +1,199 @@
+/**
+ * TRANS-005 (#2081) — decoders for the three in-flight artifacts a session record persists so they
+ * survive a resume: the autonomous goal, the plan artifact, and the active-branch pointer.
+ *
+ * The branch pointer is pure data by design — it names a `branchId`/`checkpointId` that live in a
+ * separate manifest store, and a pointer into a manifest that no longer holds them is a RESUME
+ * concern, not a decode one. This decoder therefore validates the pointer's shape and says nothing
+ * about whether it resolves.
+ */
+
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeArray,
+  decodeDeclaredObject,
+  decodeInteger,
+  decodeLiteral,
+  decodeOptional,
+  decodeString,
+  decodeTimestampString,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type {
+  IActiveBranchPointer,
+  IGoalProgressEntry,
+  IGoalState,
+  IPlanArtifact,
+  IPlanStep,
+  TGoalStatus,
+  TGoalStopReason,
+  TPlanPhase,
+  TPlanStepStatus,
+} from '@robota-sdk/agent-interface-transport';
+
+const GOAL_STATUSES = ['active', 'satisfied', 'stopped'] as const satisfies readonly TGoalStatus[];
+
+const GOAL_STOP_REASONS = [
+  'satisfied',
+  'max-iterations',
+  'cancelled',
+  'no-progress',
+] as const satisfies readonly TGoalStopReason[];
+
+const GOAL_SIGNALS = [
+  'continue',
+  'satisfied',
+] as const satisfies readonly IGoalProgressEntry['signal'][];
+
+const PLAN_STEP_STATUSES = [
+  'pending',
+  'in-progress',
+  'done',
+] as const satisfies readonly TPlanStepStatus[];
+
+const PLAN_PHASES = [
+  'planning',
+  'awaiting-approval',
+  'executing',
+  'completed',
+] as const satisfies readonly TPlanPhase[];
+
+function decodeGoalProgressEntry(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IGoalProgressEntry | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['iteration', 'signal', 'reason']);
+  if (raw === undefined) return undefined;
+  const iteration = decodeInteger(raw['iteration'], atKey(path, 'iteration'), issues);
+  const signal = decodeLiteral(raw['signal'], GOAL_SIGNALS, atKey(path, 'signal'), issues);
+  const reason = decodeString(raw['reason'], atKey(path, 'reason'), issues);
+  if (iteration === undefined || signal === undefined || reason === undefined) return undefined;
+  return { iteration, signal, reason };
+}
+
+export function decodeGoalState(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IGoalState | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'id',
+    'objective',
+    'status',
+    'stopReason',
+    'iterations',
+    'maxIterations',
+    'startedAt',
+    'progress',
+  ]);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const objective = decodeString(raw['objective'], atKey(path, 'objective'), issues);
+  const status = decodeLiteral(raw['status'], GOAL_STATUSES, atKey(path, 'status'), issues);
+  const iterations = decodeInteger(raw['iterations'], atKey(path, 'iterations'), issues);
+  const maxIterations = decodeInteger(raw['maxIterations'], atKey(path, 'maxIterations'), issues);
+  const startedAt = decodeTimestampString(raw['startedAt'], atKey(path, 'startedAt'), issues);
+  const progress = decodeArray(
+    raw['progress'],
+    atKey(path, 'progress'),
+    issues,
+    decodeGoalProgressEntry,
+  );
+  if (
+    id === undefined ||
+    objective === undefined ||
+    status === undefined ||
+    iterations === undefined ||
+    maxIterations === undefined ||
+    startedAt === undefined ||
+    progress === undefined
+  ) {
+    return undefined;
+  }
+  const goal: IGoalState = {
+    id,
+    objective,
+    status,
+    iterations,
+    maxIterations,
+    startedAt,
+    progress,
+  };
+  setOptional(
+    goal,
+    'stopReason',
+    decodeOptional(
+      raw['stopReason'],
+      atKey(path, 'stopReason'),
+      issues,
+      (member, memberPath, sink) => decodeLiteral(member, GOAL_STOP_REASONS, memberPath, sink),
+    ),
+  );
+  return goal;
+}
+
+function decodePlanStep(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IPlanStep | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['id', 'description', 'status']);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const description = decodeString(raw['description'], atKey(path, 'description'), issues);
+  const status = decodeLiteral(raw['status'], PLAN_STEP_STATUSES, atKey(path, 'status'), issues);
+  if (id === undefined || description === undefined || status === undefined) return undefined;
+  return { id, description, status };
+}
+
+export function decodePlanArtifact(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IPlanArtifact | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'id',
+    'objective',
+    'steps',
+    'phase',
+    'createdAt',
+    'approvedAt',
+  ]);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const objective = decodeString(raw['objective'], atKey(path, 'objective'), issues);
+  const steps = decodeArray(raw['steps'], atKey(path, 'steps'), issues, decodePlanStep);
+  const phase = decodeLiteral(raw['phase'], PLAN_PHASES, atKey(path, 'phase'), issues);
+  const createdAt = decodeTimestampString(raw['createdAt'], atKey(path, 'createdAt'), issues);
+  if (
+    id === undefined ||
+    objective === undefined ||
+    steps === undefined ||
+    phase === undefined ||
+    createdAt === undefined
+  ) {
+    return undefined;
+  }
+  const plan: IPlanArtifact = { id, objective, steps, phase, createdAt };
+  setOptional(
+    plan,
+    'approvedAt',
+    decodeOptional(raw['approvedAt'], atKey(path, 'approvedAt'), issues, decodeTimestampString),
+  );
+  return plan;
+}
+
+export function decodeActiveBranchPointer(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IActiveBranchPointer | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['branchId', 'checkpointId']);
+  if (raw === undefined) return undefined;
+  const branchId = decodeString(raw['branchId'], atKey(path, 'branchId'), issues);
+  const checkpointId = decodeString(raw['checkpointId'], atKey(path, 'checkpointId'), issues);
+  if (branchId === undefined || checkpointId === undefined) return undefined;
+  return { branchId, checkpointId };
+}

--- a/packages/agent-session/src/session-record-codec/index.ts
+++ b/packages/agent-session/src/session-record-codec/index.ts
@@ -1,0 +1,25 @@
+/**
+ * TRANS-005 (#2081) — the persisted interactive-session record codec.
+ *
+ * The single runtime owner of "is this a valid session record?", living beside the contract it
+ * decodes. Every store, artifact, handoff and replay ingress is meant to reach the record through
+ * here rather than through a cast of its own.
+ *
+ * ## Why it lives in a contract package
+ *
+ * Three packages consume `IInteractiveSessionRecord` without depending on the session runtime, so a
+ * decoder placed in that runtime would be a validator half the type's consumers cannot reach. This
+ * package's own rule is what makes the placement affordable: the codec is pure — no classes, no I/O,
+ * no dependency edge beyond the one this package already has — exactly like the type guards that
+ * already ship from it.
+ */
+
+export {
+  INTERACTIVE_SESSION_RECORD_KEYS,
+  INTERACTIVE_SESSION_RECORD_VERSION,
+  decodeInteractiveSessionRecord,
+  decodeVersionedInteractiveSessionRecord,
+} from './record-decoder.js';
+
+export type { IVersionedInteractiveSessionRecord } from './record-decoder.js';
+export type { ISessionRecordDecodeIssue, TSessionRecordDecodeOutcome } from './decode-outcome.js';

--- a/packages/agent-session/src/session-record-codec/message-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/message-decoders.ts
@@ -1,0 +1,282 @@
+/**
+ * TRANS-005 (#2081) — decoders for the conversation half of a persisted session record:
+ * message parts, tool calls, the four `TUniversalMessage` variants, and history entries.
+ *
+ * The message variants are discriminated by `role`, and each variant declares its OWN key set — a
+ * `toolCallId` on a user message is a defect, not a spare field, because only the tool variant
+ * declares one.
+ */
+
+import { addIssue, atKey, describeValue, setOptional } from './decode-outcome.js';
+import {
+  decodeArray,
+  decodeDate,
+  decodeLiteral,
+  decodeDeclaredObject,
+  decodeOpenMap,
+  decodeOptional,
+  decodeString,
+  decodeUniversalValue,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type {
+  IHistoryEntry,
+  ISystemMessage,
+  IToolCall,
+  IUserMessage,
+  TMessageState,
+  TUniversalMessage,
+  TUniversalMessageMetadata,
+  TUniversalMessagePart,
+} from '@robota-sdk/agent-core';
+
+const MESSAGE_STATES = ['complete', 'interrupted'] as const satisfies readonly TMessageState[];
+
+const BASE_MESSAGE_KEYS = ['id', 'timestamp', 'state', 'metadata', 'role', 'content', 'parts'];
+
+const MESSAGE_KEYS_BY_ROLE: Record<TUniversalMessage['role'], readonly string[]> = {
+  user: [...BASE_MESSAGE_KEYS, 'name'],
+  assistant: [...BASE_MESSAGE_KEYS, 'toolCalls'],
+  system: [...BASE_MESSAGE_KEYS, 'name'],
+  tool: [...BASE_MESSAGE_KEYS, 'toolCallId', 'name'],
+};
+
+/**
+ * A metadata value: the declared union, checked member by member.
+ *
+ * `string[]`, `number[]` and `Record<string, number>` are distinguished by their contents rather
+ * than by a tag, so a mixed array is a defect — the union has no member for it.
+ */
+function decodeMetadataValue(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TUniversalMessageMetadata[string] | undefined {
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (value.every((item) => typeof item === 'string')) return value as string[];
+    if (value.every((item) => typeof item === 'number')) return value as number[];
+    addIssue(issues, path, 'expected an array of only strings or only numbers');
+    return undefined;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const numbers: Record<string, number> = {};
+    for (const [key, member] of Object.entries(value as Record<string, unknown>)) {
+      if (typeof member !== 'number') {
+        addIssue(issues, atKey(path, key), `expected a number, received ${describeValue(member)}`);
+        continue;
+      }
+      numbers[key] = member;
+    }
+    return numbers;
+  }
+  addIssue(issues, path, `expected a metadata value, received ${describeValue(value)}`);
+  return undefined;
+}
+
+function decodeMetadata(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TUniversalMessageMetadata | undefined {
+  return decodeOpenMap(value, path, issues, decodeMetadataValue);
+}
+
+function decodeMessagePart(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TUniversalMessagePart | undefined {
+  const kind = decodeLiteral(
+    (value as { type?: unknown } | null)?.type,
+    ['text', 'image_inline', 'image_uri'],
+    atKey(path, 'type'),
+    issues,
+  );
+  if (kind === undefined) return undefined;
+
+  if (kind === 'text') {
+    const raw = decodeDeclaredObject(value, path, issues, ['type', 'text']);
+    if (raw === undefined) return undefined;
+    const text = decodeString(raw['text'], atKey(path, 'text'), issues);
+    return text === undefined ? undefined : { type: 'text', text };
+  }
+
+  if (kind === 'image_inline') {
+    const raw = decodeDeclaredObject(value, path, issues, ['type', 'mimeType', 'data']);
+    if (raw === undefined) return undefined;
+    const mimeType = decodeString(raw['mimeType'], atKey(path, 'mimeType'), issues);
+    const data = decodeString(raw['data'], atKey(path, 'data'), issues);
+    if (mimeType === undefined || data === undefined) return undefined;
+    return { type: 'image_inline', mimeType, data };
+  }
+
+  const raw = decodeDeclaredObject(value, path, issues, ['type', 'uri', 'mimeType']);
+  if (raw === undefined) return undefined;
+  const uri = decodeString(raw['uri'], atKey(path, 'uri'), issues);
+  if (uri === undefined) return undefined;
+  const part: TUniversalMessagePart = { type: 'image_uri', uri };
+  setOptional(
+    part,
+    'mimeType',
+    decodeOptional(raw['mimeType'], atKey(path, 'mimeType'), issues, decodeString),
+  );
+  return part;
+}
+
+function decodeToolCall(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IToolCall | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, ['id', 'type', 'function']);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const type = decodeLiteral(raw['type'], ['function'], atKey(path, 'type'), issues);
+  const fnPath = atKey(path, 'function');
+  const fn = decodeDeclaredObject(raw['function'], fnPath, issues, ['name', 'arguments']);
+  const name =
+    fn === undefined ? undefined : decodeString(fn['name'], atKey(fnPath, 'name'), issues);
+  const args =
+    fn === undefined
+      ? undefined
+      : decodeString(fn['arguments'], atKey(fnPath, 'arguments'), issues);
+  if (id === undefined || type === undefined || name === undefined || args === undefined) {
+    return undefined;
+  }
+  return { id, type, function: { name, arguments: args } };
+}
+
+/** Decode the members every message variant shares, into a partial the variant completes. */
+function decodeMessageBase(
+  raw: Record<string, unknown>,
+  path: string,
+  issues: TDecodeIssues,
+): { id: string; timestamp: Date; state: TMessageState } | undefined {
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const timestamp = decodeDate(raw['timestamp'], atKey(path, 'timestamp'), issues);
+  const state = decodeLiteral(raw['state'], MESSAGE_STATES, atKey(path, 'state'), issues);
+  if (id === undefined || timestamp === undefined || state === undefined) return undefined;
+  return { id, timestamp, state };
+}
+
+function applySharedOptionalMembers(
+  message: TUniversalMessage,
+  raw: Record<string, unknown>,
+  path: string,
+  issues: TDecodeIssues,
+): void {
+  setOptional(
+    message,
+    'metadata',
+    decodeOptional(raw['metadata'], atKey(path, 'metadata'), issues, decodeMetadata),
+  );
+  setOptional(
+    message,
+    'parts',
+    decodeOptional(raw['parts'], atKey(path, 'parts'), issues, (value, partsPath, sink) =>
+      decodeArray(value, partsPath, sink, decodeMessagePart),
+    ),
+  );
+}
+
+export function decodeMessage(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TUniversalMessage | undefined {
+  const role = decodeLiteral(
+    (value as { role?: unknown } | null)?.role,
+    ['user', 'assistant', 'system', 'tool'],
+    atKey(path, 'role'),
+    issues,
+  );
+  if (role === undefined) return undefined;
+
+  const raw = decodeDeclaredObject(value, path, issues, MESSAGE_KEYS_BY_ROLE[role]);
+  if (raw === undefined) return undefined;
+  const base = decodeMessageBase(raw, path, issues);
+  if (base === undefined) return undefined;
+  const contentPath = atKey(path, 'content');
+
+  if (role === 'assistant') {
+    // The one variant whose content is nullable: an assistant turn that only calls tools has none.
+    const content =
+      raw['content'] === null ? null : decodeString(raw['content'], contentPath, issues);
+    if (content === undefined) return undefined;
+    const message: TUniversalMessage = { ...base, role, content };
+    applySharedOptionalMembers(message, raw, path, issues);
+    setOptional(
+      message,
+      'toolCalls',
+      decodeOptional(raw['toolCalls'], atKey(path, 'toolCalls'), issues, (value, callsPath, sink) =>
+        decodeArray(value, callsPath, sink, decodeToolCall),
+      ),
+    );
+    return message;
+  }
+
+  const content = decodeString(raw['content'], contentPath, issues);
+  if (content === undefined) return undefined;
+
+  if (role === 'tool') {
+    const toolCallId = decodeString(raw['toolCallId'], atKey(path, 'toolCallId'), issues);
+    if (toolCallId === undefined) return undefined;
+    const message: TUniversalMessage = { ...base, role, content, toolCallId };
+    applySharedOptionalMembers(message, raw, path, issues);
+    setOptional(
+      message,
+      'name',
+      decodeOptional(raw['name'], atKey(path, 'name'), issues, decodeString),
+    );
+    return message;
+  }
+
+  // `role` is narrowed to `'user' | 'system'` here, and both variants declare `name` — the union of
+  // the two is what makes that assignment checkable rather than a cast through the wider union.
+  const message: IUserMessage | ISystemMessage = { ...base, role, content };
+  applySharedOptionalMembers(message, raw, path, issues);
+  setOptional(
+    message,
+    'name',
+    decodeOptional(raw['name'], atKey(path, 'name'), issues, decodeString),
+  );
+  return message;
+}
+
+/**
+ * A history entry. `data` is declared `unknown` by the contract, so it is checked only for being a
+ * JSON-compatible value — its key set belongs to whatever wrote the entry, not to this contract.
+ */
+export function decodeHistoryEntry(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IHistoryEntry | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'id',
+    'timestamp',
+    'category',
+    'type',
+    'data',
+  ]);
+  if (raw === undefined) return undefined;
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const timestamp = decodeDate(raw['timestamp'], atKey(path, 'timestamp'), issues);
+  const category = decodeString(raw['category'], atKey(path, 'category'), issues);
+  const type = decodeString(raw['type'], atKey(path, 'type'), issues);
+  if (id === undefined || timestamp === undefined || category === undefined || type === undefined) {
+    return undefined;
+  }
+  const entry: IHistoryEntry = { id, timestamp, category, type };
+  setOptional(
+    entry,
+    'data',
+    decodeOptional(raw['data'], atKey(path, 'data'), issues, decodeUniversalValue),
+  );
+  return entry;
+}

--- a/packages/agent-session/src/session-record-codec/record-decoder.ts
+++ b/packages/agent-session/src/session-record-codec/record-decoder.ts
@@ -1,0 +1,148 @@
+/**
+ * TRANS-005 (#2081) — the total decoder for a persisted interactive-session record, and the
+ * versioned envelope that carries one.
+ *
+ * ## Why the version is in an envelope and not in the record
+ *
+ * `IInteractiveSessionRecord` has no version member, and this codec does not add one. A REQUIRED
+ * member would oblige every producer to set it, and migrating producers is another leaf's work; an
+ * OPTIONAL one would mean absent-is-acceptable, which is the permissive reader this codec exists to
+ * remove. An envelope keeps the version mandatory exactly where it is checked, and leaves every
+ * producer untouched until the leaf that migrates it.
+ */
+
+import { atKey } from './decode-outcome.js';
+import { decodeMessage } from './message-decoders.js';
+import { applyOptionalRecordMembers } from './record-optional-members.js';
+import {
+  decodeArray,
+  decodeDeclaredObject,
+  decodeString,
+  decodeTimestampString,
+} from './scalars.js';
+
+import type { TDecodeIssues, TSessionRecordDecodeOutcome } from './decode-outcome.js';
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+
+/**
+ * The version of the persisted record shape this build reads and writes.
+ *
+ * Bump it when the shape changes in a way an older reader would decode WRONGLY rather than not at
+ * all. A reader that meets a version it does not implement reports `unsupported` and stops — it does
+ * not decode the members it recognises, because a partially decoded session is the silent
+ * field-loss this codec replaces.
+ */
+export const INTERACTIVE_SESSION_RECORD_VERSION = 1;
+
+/** A persisted record with the version of the shape it was written in. */
+export interface IVersionedInteractiveSessionRecord {
+  schemaVersion: number;
+  record: IInteractiveSessionRecord;
+}
+
+/**
+ * Every key the record contract declares.
+ *
+ * Exported so a test can compare it against `keyof IInteractiveSessionRecord`: a member added to the
+ * contract without a branch below then fails that comparison rather than being silently dropped by
+ * a decoder that never heard of it.
+ */
+export const INTERACTIVE_SESSION_RECORD_KEYS: readonly string[] = [
+  'id',
+  'name',
+  'cwd',
+  'createdAt',
+  'updatedAt',
+  'messages',
+  'history',
+  'systemPrompt',
+  'toolSchemas',
+  'backgroundTasks',
+  'backgroundTaskEvents',
+  'backgroundJobGroups',
+  'backgroundJobGroupEvents',
+  'skillActivationEvents',
+  'memoryEvents',
+  'usedMemoryReferences',
+  'contextReferences',
+  'sandboxSnapshotId',
+  'goal',
+  'plan',
+  'activeBranch',
+];
+
+/**
+ * Decode a bare persisted record.
+ *
+ * The value is decoded, never cast: what comes back is either a record every member of which was
+ * checked, or the list of every place it failed — not the first place.
+ */
+export function decodeInteractiveSessionRecord(value: unknown): TSessionRecordDecodeOutcome {
+  const issues: TDecodeIssues = [];
+  const record = decodeRecordInto(value, '', issues);
+  if (record === undefined || issues.length > 0) {
+    return { status: 'corrupt', issues };
+  }
+  return { status: 'valid', record };
+}
+
+/**
+ * Decode a versioned envelope.
+ *
+ * The version is read BEFORE the record, and a version this build does not implement returns
+ * `unsupported` WITHOUT nested issues: reporting field defects against a shape from another version
+ * describes the reader's expectations, not the data's condition, and a caller cannot act on it.
+ */
+export function decodeVersionedInteractiveSessionRecord(
+  value: unknown,
+): TSessionRecordDecodeOutcome {
+  const issues: TDecodeIssues = [];
+  const envelope = decodeDeclaredObject(value, '', issues, ['schemaVersion', 'record']);
+  if (envelope === undefined) return { status: 'corrupt', issues };
+
+  const declaredVersion = envelope['schemaVersion'];
+  if (typeof declaredVersion !== 'number' || !Number.isFinite(declaredVersion)) {
+    return { status: 'unsupported', schemaVersion: undefined };
+  }
+  if (declaredVersion !== INTERACTIVE_SESSION_RECORD_VERSION) {
+    return { status: 'unsupported', schemaVersion: declaredVersion };
+  }
+
+  const record = decodeRecordInto(envelope['record'], 'record', issues);
+  if (record === undefined || issues.length > 0) {
+    return { status: 'corrupt', issues };
+  }
+  return { status: 'valid', record };
+}
+
+/** The record decode itself, at whatever path it sits (the root, or `record` inside an envelope). */
+function decodeRecordInto(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IInteractiveSessionRecord | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, INTERACTIVE_SESSION_RECORD_KEYS);
+  if (raw === undefined) return undefined;
+
+  const id = decodeString(raw['id'], atKey(path, 'id'), issues);
+  const cwd = decodeString(raw['cwd'], atKey(path, 'cwd'), issues);
+  const createdAt = decodeTimestampString(raw['createdAt'], atKey(path, 'createdAt'), issues);
+  const updatedAt = decodeTimestampString(raw['updatedAt'], atKey(path, 'updatedAt'), issues);
+  // `messages` is the one required array. An absent one reaches `decodeArray` as `undefined` and is
+  // reported there like any other non-array, so it needs no case of its own.
+  const messages = decodeArray(raw['messages'], atKey(path, 'messages'), issues, decodeMessage);
+
+  if (
+    id === undefined ||
+    cwd === undefined ||
+    createdAt === undefined ||
+    updatedAt === undefined ||
+    messages === undefined
+  ) {
+    return undefined;
+  }
+
+  const record: IInteractiveSessionRecord = { id, cwd, createdAt, updatedAt, messages };
+  applyOptionalRecordMembers(record, raw, path, issues);
+  return record;
+}

--- a/packages/agent-session/src/session-record-codec/record-optional-members.ts
+++ b/packages/agent-session/src/session-record-codec/record-optional-members.ts
@@ -1,0 +1,123 @@
+/**
+ * TRANS-005 (#2081) — the optional members of a persisted session record.
+ *
+ * Written out one member at a time rather than driven from a key→decoder table. A table would be
+ * shorter, but its entries decode to a union of every member type, so the assignment back onto the
+ * record needs a cast — and a cast is what this whole codec exists to remove. Each statement below
+ * is checked by the compiler against the contract member it fills.
+ */
+
+import { decodeBackgroundJobGroupEvent, decodeJobGroupState } from './background-group-decoders.js';
+import { decodeBackgroundTaskState } from './background-task-decoders.js';
+import { decodeBackgroundTaskEvent } from './background-task-event-decoders.js';
+import { atKey, setOptional } from './decode-outcome.js';
+import {
+  decodeContextReferenceItem,
+  decodeMemoryEvent,
+  decodeMemoryReference,
+  decodeSkillActivationEvent,
+} from './event-decoders.js';
+import {
+  decodeActiveBranchPointer,
+  decodeGoalState,
+  decodePlanArtifact,
+} from './goal-plan-branch-decoders.js';
+import { decodeHistoryEntry } from './message-decoders.js';
+import { decodeArray, decodeOptional, decodeString } from './scalars.js';
+import { decodeToolSchema } from './tool-schema-decoders.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+
+/** Decode an optional array member: absent stays absent, present is decoded element by element. */
+function optionalArray<TItem>(
+  raw: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: TDecodeIssues,
+  decodeItem: (value: unknown, path: string, issues: TDecodeIssues) => TItem | undefined,
+): TItem[] | undefined {
+  return decodeOptional(raw[key], atKey(path, key), issues, (member, memberPath, sink) =>
+    decodeArray(member, memberPath, sink, decodeItem),
+  );
+}
+
+/** Fill in every optional member of `record` from `raw`, recording any defect it finds. */
+export function applyOptionalRecordMembers(
+  record: IInteractiveSessionRecord,
+  raw: Record<string, unknown>,
+  path: string,
+  issues: TDecodeIssues,
+): void {
+  for (const key of ['name', 'systemPrompt', 'sandboxSnapshotId'] as const) {
+    setOptional(record, key, decodeOptional(raw[key], atKey(path, key), issues, decodeString));
+  }
+
+  setOptional(record, 'history', optionalArray(raw, 'history', path, issues, decodeHistoryEntry));
+  setOptional(
+    record,
+    'toolSchemas',
+    optionalArray(raw, 'toolSchemas', path, issues, decodeToolSchema),
+  );
+  setOptional(
+    record,
+    'backgroundTasks',
+    optionalArray(raw, 'backgroundTasks', path, issues, decodeBackgroundTaskState),
+  );
+  setOptional(
+    record,
+    'backgroundTaskEvents',
+    optionalArray(raw, 'backgroundTaskEvents', path, issues, decodeBackgroundTaskEvent),
+  );
+  setOptional(
+    record,
+    'backgroundJobGroups',
+    optionalArray(raw, 'backgroundJobGroups', path, issues, decodeJobGroupState),
+  );
+  setOptional(
+    record,
+    'backgroundJobGroupEvents',
+    optionalArray(raw, 'backgroundJobGroupEvents', path, issues, decodeBackgroundJobGroupEvent),
+  );
+  setOptional(
+    record,
+    'skillActivationEvents',
+    optionalArray(raw, 'skillActivationEvents', path, issues, decodeSkillActivationEvent),
+  );
+  setOptional(
+    record,
+    'memoryEvents',
+    optionalArray(raw, 'memoryEvents', path, issues, decodeMemoryEvent),
+  );
+  setOptional(
+    record,
+    'usedMemoryReferences',
+    optionalArray(raw, 'usedMemoryReferences', path, issues, decodeMemoryReference),
+  );
+  setOptional(
+    record,
+    'contextReferences',
+    optionalArray(raw, 'contextReferences', path, issues, decodeContextReferenceItem),
+  );
+
+  setOptional(
+    record,
+    'goal',
+    decodeOptional(raw['goal'], atKey(path, 'goal'), issues, decodeGoalState),
+  );
+  setOptional(
+    record,
+    'plan',
+    decodeOptional(raw['plan'], atKey(path, 'plan'), issues, decodePlanArtifact),
+  );
+  setOptional(
+    record,
+    'activeBranch',
+    decodeOptional(
+      raw['activeBranch'],
+      atKey(path, 'activeBranch'),
+      issues,
+      decodeActiveBranchPointer,
+    ),
+  );
+}

--- a/packages/agent-session/src/session-record-codec/scalars.ts
+++ b/packages/agent-session/src/session-record-codec/scalars.ts
@@ -1,0 +1,269 @@
+/**
+ * TRANS-005 (#2081) — the leaf decoders every nested session-record decoder is built from.
+ *
+ * Each one takes the raw value, the path it sits at, and the issue accumulator; each returns the
+ * decoded value or `undefined` after recording why. `undefined` is NOT "the field was absent" — an
+ * absent optional member is handled by {@link decodeOptional}, and the caller decides validity by
+ * asking whether any issue was recorded, never by testing a return value.
+ */
+
+import { addIssue, atIndex, atKey, describeValue } from './decode-outcome.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+import type { TBackgroundPrimitive } from '@robota-sdk/agent-interface-transport';
+
+/** Decode an optional member: absent stays absent, present is decoded, `null` is a defect. */
+export function decodeOptional<TValue>(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+  decode: (value: unknown, path: string, issues: TDecodeIssues) => TValue | undefined,
+): TValue | undefined {
+  if (value === undefined) return undefined;
+  return decode(value, path, issues);
+}
+
+export function decodeString(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): string | undefined {
+  if (typeof value === 'string') return value;
+  addIssue(issues, path, `expected a string, received ${describeValue(value)}`);
+  return undefined;
+}
+
+export function decodeNumber(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  addIssue(issues, path, `expected a finite number, received ${describeValue(value)}`);
+  return undefined;
+}
+
+export function decodeInteger(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value)) return value;
+  addIssue(issues, path, `expected an integer, received ${describeValue(value)}`);
+  return undefined;
+}
+
+export function decodeBoolean(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  addIssue(issues, path, `expected a boolean, received ${describeValue(value)}`);
+  return undefined;
+}
+
+/** Decode a member of a string-literal union, naming the permitted members when it is not one. */
+export function decodeLiteral<TLiteral extends string>(
+  value: unknown,
+  allowed: readonly TLiteral[],
+  path: string,
+  issues: TDecodeIssues,
+): TLiteral | undefined {
+  if (typeof value === 'string' && (allowed as readonly string[]).includes(value)) {
+    return value as TLiteral;
+  }
+  addIssue(
+    issues,
+    path,
+    `expected one of ${allowed.join(' | ')}, received ${describeValue(value)}`,
+  );
+  return undefined;
+}
+
+/**
+ * Decode a member the contract declares `string` but means as an instant.
+ *
+ * It stays a string — the contract says so — but must be one a date can be read from, because the
+ * session list is ordered by `new Date(updatedAt).getTime()` and an unparseable string sorts as
+ * `NaN`, which is an unstable order rather than an error anyone sees.
+ *
+ * ## The limit, stated because a caller will otherwise over-read it
+ *
+ * This accepts whatever `Date.parse` accepts, which is wider than ISO-8601: `'2026'` parses, and so
+ * do several implementation-defined forms. So the guarantee is exactly "a date can be read from
+ * this", NOT "this is a well-formed instant" — a record carrying `'2026'` decodes, and reads back as
+ * midnight on the first of January.
+ *
+ * Tightening it to strict ISO-8601 is deliberately NOT done here: the contract these members belong
+ * to declares them `string` and says nothing about their format, and a decoder that refuses a value
+ * its own contract permits is inventing a stricter contract than the one it decodes. A consumer that
+ * needs a well-formed instant validates for itself; this one guarantees only that ordering by date
+ * will not silently produce `NaN`.
+ */
+export function decodeTimestampString(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): string | undefined {
+  if (typeof value !== 'string') {
+    addIssue(
+      issues,
+      path,
+      `expected an ISO-8601 timestamp string, received ${describeValue(value)}`,
+    );
+    return undefined;
+  }
+  if (Number.isNaN(Date.parse(value))) {
+    addIssue(issues, path, 'expected a timestamp a date can be parsed from');
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Decode a member the contract declares `Date`.
+ *
+ * JSON has no date type, so a persisted `Date` arrives as a string and every consumer that calls a
+ * `Date` method on it fails at the call rather than at the load. This is the one place that gap is
+ * closed: an ISO-8601 string OR a live `Date` decodes to a `Date`, and nothing else does.
+ */
+export function decodeDate(value: unknown, path: string, issues: TDecodeIssues): Date | undefined {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      addIssue(issues, path, 'expected a valid Date, received an invalid one');
+      return undefined;
+    }
+    return value;
+  }
+  if (typeof value === 'string' && !Number.isNaN(Date.parse(value))) return new Date(value);
+  addIssue(
+    issues,
+    path,
+    `expected a Date or an ISO-8601 timestamp string, received ${describeValue(value)}`,
+  );
+  return undefined;
+}
+
+/** Decode an array, decoding each element at its own indexed path. */
+export function decodeArray<TItem>(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+  decodeItem: (value: unknown, path: string, issues: TDecodeIssues) => TItem | undefined,
+): TItem[] | undefined {
+  if (!Array.isArray(value)) {
+    addIssue(issues, path, `expected an array, received ${describeValue(value)}`);
+    return undefined;
+  }
+  const decoded: TItem[] = [];
+  value.forEach((item, index) => {
+    const element = decodeItem(item, atIndex(path, index), issues);
+    if (element !== undefined) decoded.push(element);
+  });
+  return decoded;
+}
+
+export function decodeStringArray(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): string[] | undefined {
+  return decodeArray(value, path, issues, decodeString);
+}
+
+/**
+ * Decode an object whose members are DECLARED, rejecting any key the contract does not name.
+ *
+ * A persisted record is written by this build's own code at a known version, so an unrecognised key
+ * means the shape drifted — which is what the envelope version exists to report. Silently ignoring
+ * it is how a field goes missing without anyone learning that it did.
+ */
+export function decodeDeclaredObject(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+  declaredKeys: readonly string[],
+): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    addIssue(issues, path, `expected an object, received ${describeValue(value)}`);
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const declared = new Set(declaredKeys);
+  for (const key of Object.keys(record)) {
+    if (!declared.has(key)) {
+      addIssue(issues, atKey(path, key), 'unknown key; the record contract does not declare it');
+    }
+  }
+  return record;
+}
+
+/**
+ * Decode a map the contract leaves OPEN — `metadata`, `data`, a schema's `properties`.
+ *
+ * The key set is the author's, not the contract's, so an unrecognised key here is data rather than
+ * drift. Only the VALUES are constrained.
+ */
+export function decodeOpenMap<TValue>(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+  decodeValue: (value: unknown, path: string, issues: TDecodeIssues) => TValue | undefined,
+): Record<string, TValue> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    addIssue(issues, path, `expected an object, received ${describeValue(value)}`);
+    return undefined;
+  }
+  const decoded: Record<string, TValue> = {};
+  for (const [key, member] of Object.entries(value as Record<string, unknown>)) {
+    const element = decodeValue(member, atKey(path, key), issues);
+    if (element !== undefined) decoded[key] = element;
+  }
+  return decoded;
+}
+
+/**
+ * Decode a value on the universal payload axis.
+ *
+ * `TUniversalValue` admits `Date`, and inside an open map a persisted date is a string that cannot
+ * be told from any other string. Reviving by shape would turn a user's date-like text into a `Date`,
+ * so this decoder does not revive: through persistence, that member of the axis is unreachable. A
+ * live `Date` handed in from memory is still accepted.
+ */
+export function decodeUniversalValue(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TUniversalValue | undefined {
+  if (value === null || value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const decoded: TUniversalValue[] = [];
+    value.forEach((item, index) => {
+      const element = decodeUniversalValue(item, atIndex(path, index), issues);
+      if (element !== undefined) decoded.push(element);
+    });
+    return decoded;
+  }
+  if (typeof value === 'object') {
+    return decodeOpenMap(value, path, issues, decodeUniversalValue);
+  }
+  addIssue(issues, path, `expected a JSON-compatible value, received ${describeValue(value)}`);
+  return undefined;
+}
+
+export function decodeBackgroundPrimitive(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TBackgroundPrimitive | undefined {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  addIssue(issues, path, `expected a string, number or boolean, received ${describeValue(value)}`);
+  return undefined;
+}

--- a/packages/agent-session/src/session-record-codec/tool-schema-decoders.ts
+++ b/packages/agent-session/src/session-record-codec/tool-schema-decoders.ts
@@ -1,0 +1,235 @@
+/**
+ * TRANS-005 (#2081) — decoders for the tool schemas a session record persists.
+ *
+ * `IParameterSchema` is the universal JSON-schema subset, and it is recursive: `items`, `properties`
+ * and `anyOf` all carry the same node type. `properties` is an OPEN map — its keys are the tool
+ * author's parameter names, not contract members — while every node's own member set is declared.
+ */
+
+import { addIssue, atKey, describeValue, setOptional } from './decode-outcome.js';
+import {
+  decodeArray,
+  decodeDeclaredObject,
+  decodeLiteral,
+  decodeNumber,
+  decodeOpenMap,
+  decodeOptional,
+  decodeString,
+  decodeStringArray,
+} from './scalars.js';
+
+import type { TDecodeIssues } from './decode-outcome.js';
+import type {
+  IObjectParameterSchema,
+  IParameterSchema,
+  IToolSchema,
+  TJSONSchemaEnum,
+  TJSONSchemaKind,
+  TParameterDefaultValue,
+} from '@robota-sdk/agent-core';
+
+const SCHEMA_KINDS = [
+  'string',
+  'number',
+  'integer',
+  'boolean',
+  'array',
+  'object',
+  'null',
+] as const satisfies readonly TJSONSchemaKind[];
+
+const PARAMETER_SCHEMA_KEYS = [
+  'type',
+  'description',
+  'enum',
+  'items',
+  'properties',
+  'required',
+  'anyOf',
+  'additionalProperties',
+  'minimum',
+  'maximum',
+  'pattern',
+  'format',
+  'default',
+];
+
+function decodeEnumMember(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): string | number | boolean | undefined {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  addIssue(issues, path, `expected a string, number or boolean, received ${describeValue(value)}`);
+  return undefined;
+}
+
+function decodeDefaultValue(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): TParameterDefaultValue | undefined {
+  if (value === null) return null;
+  return decodeEnumMember(value, path, issues);
+}
+
+/**
+ * `additionalProperties` is either a closure flag or a schema for the properties not named — the
+ * two are told apart by JavaScript type, which is how JSON Schema itself spells it.
+ */
+function decodeAdditionalProperties(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): boolean | IParameterSchema | undefined {
+  if (typeof value === 'boolean') return value;
+  return decodeParameterSchema(value, path, issues);
+}
+
+function decodeParameterSchema(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IParameterSchema | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, PARAMETER_SCHEMA_KEYS);
+  if (raw === undefined) return undefined;
+
+  const schema: IParameterSchema = {};
+  setOptional(
+    schema,
+    'type',
+    decodeOptional(raw['type'], atKey(path, 'type'), issues, (member, memberPath, sink) =>
+      decodeLiteral(member, SCHEMA_KINDS, memberPath, sink),
+    ),
+  );
+  setOptional(
+    schema,
+    'description',
+    decodeOptional(raw['description'], atKey(path, 'description'), issues, decodeString),
+  );
+  setOptional(
+    schema,
+    'enum',
+    decodeOptional(raw['enum'], atKey(path, 'enum'), issues, (member, memberPath, sink) => {
+      const decoded = decodeArray(member, memberPath, sink, decodeEnumMember);
+      return decoded as TJSONSchemaEnum | undefined;
+    }),
+  );
+  setOptional(
+    schema,
+    'items',
+    decodeOptional(raw['items'], atKey(path, 'items'), issues, decodeParameterSchema),
+  );
+  setOptional(
+    schema,
+    'properties',
+    decodeOptional(
+      raw['properties'],
+      atKey(path, 'properties'),
+      issues,
+      (member, memberPath, sink) => decodeOpenMap(member, memberPath, sink, decodeParameterSchema),
+    ),
+  );
+  setOptional(
+    schema,
+    'required',
+    decodeOptional(raw['required'], atKey(path, 'required'), issues, decodeStringArray),
+  );
+  setOptional(
+    schema,
+    'anyOf',
+    decodeOptional(raw['anyOf'], atKey(path, 'anyOf'), issues, (member, memberPath, sink) =>
+      decodeArray(member, memberPath, sink, decodeParameterSchema),
+    ),
+  );
+  setOptional(
+    schema,
+    'additionalProperties',
+    decodeOptional(
+      raw['additionalProperties'],
+      atKey(path, 'additionalProperties'),
+      issues,
+      decodeAdditionalProperties,
+    ),
+  );
+  setOptional(
+    schema,
+    'minimum',
+    decodeOptional(raw['minimum'], atKey(path, 'minimum'), issues, decodeNumber),
+  );
+  setOptional(
+    schema,
+    'maximum',
+    decodeOptional(raw['maximum'], atKey(path, 'maximum'), issues, decodeNumber),
+  );
+  setOptional(
+    schema,
+    'pattern',
+    decodeOptional(raw['pattern'], atKey(path, 'pattern'), issues, decodeString),
+  );
+  setOptional(
+    schema,
+    'format',
+    decodeOptional(raw['format'], atKey(path, 'format'), issues, decodeString),
+  );
+  setOptional(
+    schema,
+    'default',
+    decodeOptional(raw['default'], atKey(path, 'default'), issues, decodeDefaultValue),
+  );
+  return schema;
+}
+
+/** The root of a tool's parameters: an object node that NAMES its properties. */
+function decodeObjectParameterSchema(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IObjectParameterSchema | undefined {
+  const schema = decodeParameterSchema(value, path, issues);
+  if (schema === undefined) return undefined;
+  if (schema.type !== 'object') {
+    addIssue(issues, atKey(path, 'type'), "expected the root parameter schema to be type 'object'");
+    return undefined;
+  }
+  if (schema.properties === undefined) {
+    addIssue(
+      issues,
+      atKey(path, 'properties'),
+      'expected the root parameter schema to name its properties',
+    );
+    return undefined;
+  }
+  return { ...schema, type: 'object', properties: schema.properties };
+}
+
+export function decodeToolSchema(
+  value: unknown,
+  path: string,
+  issues: TDecodeIssues,
+): IToolSchema | undefined {
+  const raw = decodeDeclaredObject(value, path, issues, [
+    'name',
+    'description',
+    'parameters',
+    'outputSchema',
+  ]);
+  if (raw === undefined) return undefined;
+  const name = decodeString(raw['name'], atKey(path, 'name'), issues);
+  const description = decodeString(raw['description'], atKey(path, 'description'), issues);
+  const parameters = decodeObjectParameterSchema(
+    raw['parameters'],
+    atKey(path, 'parameters'),
+    issues,
+  );
+  if (name === undefined || description === undefined || parameters === undefined) return undefined;
+  const schema: IToolSchema = { name, description, parameters };
+  setOptional(
+    schema,
+    'outputSchema',
+    decodeOptional(raw['outputSchema'], atKey(path, 'outputSchema'), issues, decodeParameterSchema),
+  );
+  return schema;
+}


### PR DESCRIPTION
Closes #2081. Leaf under tracker #2067, whose family is issue #2096, issue #2097 and issue #2098.

Work item TRANS-005 — spec: `.agents/spec-docs/done/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`, task: `.agents/tasks/completed/TRANS-005-versioned-total-decoder-for-the-persisted-session-record.md`. Both lifecycle records move in this PR, not a follow-up.

## What was wrong

`IInteractiveSessionRecord` is persisted and transferred but exists only at compile time, so every ingress casts into it. Two consequences are reachable on `develop` today.

**A cast produces a value whose runtime type contradicts its declared type.** The contract declares `messages[].timestamp` and `history[].timestamp` as `Date`; JSON has no date type; and there is no revival step anywhere on the load path — `NodeSessionStore.load` is `JSON.parse(raw) as IInteractiveSessionRecord` (`packages/agent-session/src/session-store.ts:91`), and `WorkspaceSessionStore.load` forwards it unchanged. `packages/agent-framework/src/background-tasks/execution-workspace-detail.ts:19` then calls `entry.timestamp.toISOString()` on it. That is a `TypeError` on resume, in a consumer, far from the load that caused it. Filed as issue #2174 — the consumer fix is a migration this leaf's scope forbids.

**Corruption is indistinguishable from absence.** `NodeSessionStore.load` catches every read failure and returns `undefined` (`session-store.ts:92-95`, with an explicit `// allow-fallback:` marker); `NodeSessionStore.list` skips unreadable files silently (`:114`); and `WorkspaceSessionStore.load` falls through to log replay (`workspace-session-store.ts:63`), which reconstructs a *partial* record — `skillActivationEvents: []`, no `goal`, no `plan`, no `activeBranch`, no `toolSchemas` (`:106-107`). A truncated file resumes as a silently field-stripped session rather than as an error.

## What this adds

One runtime owner of "is this a valid record?" — 13 modules in `packages/agent-session/src/session-record-codec/`.

The outcome has three members and deliberately not a fourth:

| `status` | Means | Carries |
| --- | --- | --- |
| `valid` | Every member decoded | `record` |
| `corrupt` | Not a record of this shape | `issues[]`, each with a `path` |
| `unsupported` | The envelope names a version this build does not implement | the version it saw |

`missing` is **not** a member. Absence is a property of a store, not of a value, so a store composes its own `missing` with these three — collapsing the two is what produced the second defect above.

Four decisions a consumer depends on: dates are **revived** (ISO-8601 string or live `Date` in, `Date` out); string timestamps stay strings but must **parse**, because resume ordering sorts on `new Date(updatedAt).getTime()` and an unparseable value sorts as `NaN` rather than failing; unknown keys on a declared object are a **defect**, while the five contract-open maps stay open; and `TUniversalValue`'s `Date` member is documented as **unreachable through persistence**, because inside an open map a persisted date is indistinguishable from any other string.

## Nothing here changes a byte on disk

`schemaVersion` is **not** added to `IInteractiveSessionRecord`. Required would oblige every producer to set it — migrating producers is out of scope by #2081's own boundary. Optional would mean absent-is-acceptable, which is the permissive reader #2067 exists to remove. So the version lives in an `IVersionedInteractiveSessionRecord` envelope that this leaf defines and tests but no producer writes. Migrating the store, artifact, handoff and replay ingresses is issue #2096, issue #2097 and issue #2098.

## The placement was wrong once, and the correction is the main thing to review

The codec was first written into `agent-interface-transport`, beside the type it decodes, and committed there. **`scan-interface-runtime` refuses that**: an `agent-interface-*` entry publishes contracts, its vocabulary and its discriminators — not mechanisms — and its frozen allowance is 5 (`scripts/harness/interface-entry-baseline.json`). Four new exports took it to 9. The guard names its own remedy: *move it to an owner package.*

**The reasoning error, named rather than quietly fixed.** The original Decision rejected `agent-session` on reachability: three packages consume `IInteractiveSessionRecord` without depending on it. That is true about the **type** and was allowed to stand for the **decoder** without being re-tested. None of those three decodes a record; every actual and planned decoder consumer (#2096, #2097, #2098) is in `agent-session` or in `agent-framework`, which depends on it.

**The frozen allowance was not raised.** A guard whose failure text says "move it", answered by editing that guard's baseline, adopts exactly the debt the guard exists to refuse.

Three things the correction improves rather than merely satisfies:

- `packages/agent-interface-transport/` ends this PR **byte-identical to `develop`** (`git diff origin/develop -- packages/agent-interface-transport/` is empty).
- `.agents/harness.config.json` is reverted — the `fileSizeReexportBarrels` entry I had needed for the contract package's barrel is gone, so this PR touches **no shared configuration**.
- The codec lands beside `session-store.ts`, `session-artifact.ts` and `session-log-validation.ts` — the files #2096/#2097/#2098 migrate.

The spec document carries the amendment in place: the superseded Decision quoted verbatim, the guard that refuted it, and the reasoning error. The gate entries whose evidence predated the move are marked **superseded rather than deleted** — "nothing in those entries was false when written; they are superseded because the thing they measured moved" — and each is re-recorded against the new placement, including GATE-APPROVAL, whose evidence half was genuinely re-tested rather than restated.

Filed on #2067 as a note for the sibling leaves: the tracker's "let the session contract owner provide the decoder" is not implementable here, with the reachability trap named so #2097 and #2098 do not re-derive it.

## How the tests were checked, not just run

**77 codec tests, inside a package suite of 321 across 46 files, all green.** "They pass" is the weak claim, so the stronger ones:

- **The suite was mutation-tested twice.** Breaking date revival and unknown-key rejection in `scalars.ts` turned **7 tests red**. Collapsing `MESSAGE_KEYS_BY_ROLE` into one union of all four variants' keys turned **exactly the 4 variant-key tests red**. Both restored to green. Red-first here was only module-not-found, which proves the import path and not one assertion — the mutation rounds are what establish the tests bite.
- **The second round exists because review found a gap the suite could not.** `message-decoders.ts` claimed each message variant declares its own key set. The original unknown-key coverage used an invented key (`surprise`), which a single-union implementation rejects identically — so it constrained "unknown keys are rejected", not "the key set is per-variant", while the module's own header claimed the latter. Four cases now cover members only *another* variant declares.
- **The fixture is `JSON.parse(JSON.stringify(record))`, not a hand-written literal** — so the input has its `Date`s already flattened the way persistence actually flattens them, rather than the way a test author imagines.

Coverage shape: a nine-case malformed corpus asserting `corrupt` and never a throw; 26 single-field mutations, one per nested contract family, asserting both the status and the reported `path`; and a key-parity test that fails to **compile** if a member is added to `IInteractiveSessionRecord` without a decoder branch.

**The user-execution scenario is stronger evidence than "it passes".** UES-01's expected output was authored *before* implementation, from an executability run. It matched against the `agent-interface-transport` build, and then matched **unchanged** against the `agent-session` build. Because the expectation predates both placements and could not have been fitted to either, that is an independent check that the move preserved *behaviour* — not merely that the tests moved with the code.

## Two things a reviewer should not have to discover

- **A deliberate non-enforcement.** A parameter-schema node carrying neither `type` nor `anyOf` is accepted. `agent-core`'s SPEC prose says walks refuse one; its code does not, and an enum-only node is a shape real producers emit. Rejecting it would be this decoder inventing a rule another package's contract does not hold.
- **A stated limit, recorded in the SPEC and the decoder's doc comment rather than only here.** `decodeTimestampString` accepts whatever `Date.parse` accepts, which is wider than ISO-8601 — `'2026'` parses and reads back as midnight on 1 January. The guarantee is "a date can be read from this", not "this is a well-formed instant". Tightening it would have this leaf inventing a stricter contract than the one it decodes, since the contract declares these members `string` and says nothing about format. Per `helper-limits.md`, a limit judged against the first consumer is not a property of the function.

## Rebase note

ARCH-100 (#2176) landed mid-flight and renamed `SessionStore` → `NodeSessionStore` and `session-persistence.ts` → `workspace-session-store.ts`. The `packages/agent-session/docs/SPEC.md` conflict was resolved by keeping ARCH-100's text and adding to it — their renamed Scope sentence plus the codec sentence, their `NodeSessionStore` row plus the four codec rows, with my stale `SessionStore` row dropped rather than merged.

Every repointed citation above was **verified by reading the file, not by offsetting line numbers** — a citation moved by arithmetic is a citation nobody checked. The Problem section, which describes current code, is repointed; the GATE-WRITE evidence entry, which describes a run that happened before the rename, is annotated in place and **not** rewritten, because an evidence record describes the run that produced it.

## Verification

- `pnpm harness:verify` — exit 0
- `pnpm --filter @robota-sdk/agent-session test` — 46 files, 321 tests, all passing
- `pnpm --filter @robota-sdk/agent-session build` — clean
- `node scripts/harness/run-all-scans.mjs` — **140 passed, 1 skipped, 0 failed**, including `interface-runtime` (`violations=0`), `sdk-public-surface`, `orphan-exports`, `backlog-placement`, `resolving-claims`, `reference-kind-qualified`, `file-size`, `deps`, `spec-public-surface`, `spec-user-execution-section`, `doc-folder-status`
- `git diff origin/develop -- packages/agent-interface-transport/` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH
