### PR TITLE
docs(rules): a public surface is not judged by its consumer count (ARCH-102)

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -220,18 +220,18 @@ any project, with the Robota-specific assembly (if any) staying in `agent-cli` /
 
 ## Forward-Provisioned Surface Rule
 
-A public surface in `packages/` with zero in-repo consumers is **not dead code**. Libraries and
-frameworks ship surfaces FOR external consumers; deliberate forward-provisioning ("built ahead so
-it is available when needed") is a legitimate product state (owner decision, 2026-07-04 re-audit).
+**In-repo consumer count is not evidence about whether a `packages/` surface should be public — at any
+count**, because `packages/` is a library others compose into their own agents (owner decisions
+2026-07-04 and 2026-08-23; reasoning in [ARCH-102](spec-docs/todo/ARCH-102-public-surface-is-not-judged-by-consumer-count.md)).
 
-- Removal of an unconsumed public surface is a PRODUCT decision — never a grep-based cleanup.
-  Propose it as a user decision item with options; do not file it as "dead code".
-- Forward-provisioned surfaces carry the same first-class quality bar as consumed ones: accurate
-  SPEC/README, tests, and bug fixes are unconditional — "nobody uses it yet" never downgrades a
-  defect on such a surface.
-- Consumption-based detectors (orphan-export style scans) must not treat in-repo non-consumption
-  of `packages/` public surfaces as a violation. (Pass-through re-exports remain banned — that
-  rule is about ownership, not consumption.)
+- The only grounds for narrowing or removing one are that it is **genuinely unnecessary** or **does
+  not fit the design** — judgements about the surface, never its callers. It is a PRODUCT decision,
+  never a grep-based cleanup: propose it as a user decision item; do not file it as "dead code".
+- Forward-provisioned surfaces carry the same quality bar as consumed ones: accurate SPEC/README,
+  tests and bug fixes are unconditional — "nobody uses it yet" never downgrades a defect.
+- Consumption-based detectors (orphan-export style scans) must not treat in-repo non-consumption of
+  `packages/` public surfaces as a violation. (Pass-through re-exports remain banned — ownership, not
+  consumption.)
 
 ## Planned Packages (Not Yet Created)
 

--- a/.agents/skills/contract-disposition/SKILL.md
+++ b/.agents/skills/contract-disposition/SKILL.md
@@ -8,16 +8,21 @@ description: Decide what to do with an unconsumed or seemingly-immovable public 
 Two mirror-image errors, one substitution. Both were made in a single session, and both were acted on
 by the agent that made them.
 
-| Proxy signal read        | Conclusion drawn        | What was actually true                                    |
-| ------------------------ | ----------------------- | --------------------------------------------------------- |
-| `grep` finds no consumer | "dead — remove it"      | forward-provisioned, or the owner is wrong → **relocate** |
-| the surface is published | "we cannot change this" | pre-release; **nothing is externally exposed**            |
+| Proxy signal read         | Conclusion drawn          | What was actually true                                                                |
+| ------------------------- | ------------------------- | ------------------------------------------------------------------------------------- |
+| `grep` finds no consumer  | "dead — remove it"        | forward-provisioned, or the owner is wrong → **relocate**                             |
+| `grep` finds one consumer | "make it package-private" | a library surface with one in-repo assembly; its other consumers are outside the repo |
+| the surface is published  | "we cannot change this"   | pre-release; **nothing is externally exposed**                                        |
 
 ## Rule Anchor
 
-- [project-structure.md](../../project-structure.md) `:225` — "Removal of an unconsumed public surface
-  is a PRODUCT decision — never a grep-based cleanup." **This rule already existed and was violated
-  anyway**, which is why this skill is a procedure plus a mechanism rather than a restatement.
+- [project-structure.md](../../project-structure.md) § Forward-Provisioned Surface Rule (`:236`) —
+  "Removal or narrowing of a public surface is a PRODUCT decision — never a grep-based cleanup."
+  **This rule already existed and was violated anyway**, which is why this skill is a procedure plus a
+  mechanism rather than a restatement. That section also owns the broader form: **in-repo consumer
+  count is not evidence about whether a surface should be public, at any count** — the only grounds for
+  narrowing or removing one are that it is genuinely unnecessary or that it does not fit the design
+  (owner decision, 2026-08-23).
 - [code-quality.md](../../rules/code-quality.md) `:50`–`:51` — pre-release, legacy is disposable and
   there is no backward-compat constraint to preserve a lesser structure.
 
@@ -47,9 +52,17 @@ nothing" is not among them:
 1. **Keep + document** as intentional forward provision. Forward-provisioned surfaces carry the same
    quality bar as consumed ones — accurate SPEC/README, tests, and bug fixes are unconditional.
 2. **Relocate** if the owner is wrong. The surface is real; it is in the wrong place.
-3. **Remove**, only by an explicit product decision, proposed as a user decision item with options.
+3. **Remove or narrow**, only by an explicit product decision, proposed as a user decision item with
+   options — and only on one of the two grounds that qualify: the surface is genuinely unnecessary, or
+   it does not fit the design. A consumer count is never one of them; it is at most what made you look.
 
-## What "unconsumed" does not tell you
+## What a consumer COUNT does not tell you
+
+The heading below says "unconsumed" because zero is the count that gets misread most often. **The
+reasoning applies at every count**, and one is the second-most-misread: a library surface used by a
+single in-repo assembly is the normal shape for a library whose other consumers compose it from
+outside. `packages/` exists so that anyone can build their own agent from it; this repository's own
+agent is one assembly of it, not the definition of it.
 
 - **A consumer may exist that grep cannot see** — a re-export chain, a string-keyed dispatch, a
   published-package consumer outside this repo, a test.

--- a/.agents/spec-docs/todo/ARCH-102-public-surface-is-not-judged-by-consumer-count.md
+++ b/.agents/spec-docs/todo/ARCH-102-public-surface-is-not-judged-by-consumer-count.md
@@ -1,0 +1,101 @@
+---
+status: approved
+type: RULE
+tags: [architecture]
+---
+
+# ARCH-102: a public surface is not judged by its in-repo consumer count
+
+Paired with
+`.agents/tasks/ARCH-102-public-surface-is-not-judged-by-in-repo-consumer-count.md`.
+Arising from [issue #2177](https://github.com/woojubb/robota/issues/2177) and the owner instruction
+recorded in the Task.
+
+## Problem
+
+See the paired Task for the owner's verbatim instruction. The invariant it establishes:
+
+> `packages/` is a library for composing agents. In-repo consumer count is not evidence about whether
+> a surface should be public — at any count. The only grounds for narrowing or removing one are that
+> it is genuinely unnecessary, or that it does not fit the design.
+
+## Prior Art Research
+
+Waived: this is an in-repo governance amendment stating an owner's product-identity decision about
+this repository's own libraries. There is no external product whose documentation could settle whether
+Robota's surfaces are meant for outside composition — the owner is the only source for that, and they
+stated it directly. The waiver is recorded rather than the section left empty, per
+[research.md](../../rules/research.md).
+
+## Architecture Review
+
+**The rule was already half-written, and the half that was missing is what let it be violated.**
+§ Forward-Provisioned Surface Rule stated the negative (a count is not a reason) only for **zero**, and
+never stated the positive. A reader who accepted it had no criterion left to apply — which reads as
+"never narrow anything", is not the instruction, and is untenable, so in practice the reader fell back
+on the count.
+
+**Alternatives considered.**
+
+1. **Amend the prose only.** Rejected on evidence. The prose already existed and was already violated;
+   `check-contract-disposition.mjs`'s own header says so ("Prose did not hold, so this is the
+   mechanical half"). Amending only the prose would repeat the experiment that failed.
+2. **Weaken or exempt `check-orphan-exports`.** Rejected after reading it. Its logic is already
+   correct — entry points, `package.json` export sources and barrel-re-exported modules are skipped at
+   `check-orphan-exports.mjs:185-188`, so a `packages/` public surface is exempt by construction. The
+   defect is that its FINDING TEXT says none of that and states the banned inference as the whole
+   story. Changing the logic would have removed a working guard on the strength of a misreading of its
+   message. **This is the alternative that nearly shipped**, because a session reported the scan as
+   enforcing the inverse of the owner's instruction, and the report was persuasive until the exemption
+   code was read.
+3. **Amend the prose, the two audit criteria, the disposition skill, and the scan's message.** Chosen.
+   The prose owns the invariant; the auditors are where the finding is generated; the skill is where a
+   disposition is chosen; the scan message is what an agent acts on at 2am when a gate is red.
+
+**Reachability.** The rule is reached from `.agents/project-structure.md`, which `AGENTS.md` routes to
+as the SSOT for package layout. Both auditors and the skill now cite the section by name rather than by
+line number — the line-number citations moved by 11 in this very change, which is the failure mode
+being avoided.
+
+**Capability preservation.** No guard is weakened. `check-orphan-exports` reports the same findings on
+the same inputs — verified by running it before and after the message change. `check-contract-
+disposition` is unchanged in behaviour; only its header citation and its proxy-signal table grew a row.
+
+## Completion Criteria
+
+- **TC-01** § Forward-Provisioned Surface Rule states the invariant at any consumer count, not only zero.
+- **TC-02** It states the two affirmative grounds that DO support narrowing.
+- **TC-03** `architecture-design-auditor` no longer asks whether a public symbol has a consumer.
+- **TC-04** `architecture-structure-auditor` bounds what a low consumer count licenses.
+- **TC-05** `contract-disposition` covers the one-consumer case and cites the rule by section.
+- **TC-06** `check-orphan-exports`'s finding text states what it does not judge; its verdicts are unchanged.
+- **TC-07** The sweep for contradicted documents is recorded with its result.
+- **TC-08** `pnpm harness:scan` green.
+
+## Test Plan
+
+See the paired Task. The load-bearing check is TC-06's second half: the scan must report identically
+before and after, since only its message changed.
+
+## Evidence Log
+
+| Claim                                                 | Verified at                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GATE-APPROVAL                                         | The owner instructed this change directly in the current conversation, in their own words (quoted verbatim in the paired Task), naming the target as the architecture design/audit rules. This is a direct instruction about a specific change, not a standing delegation, so the delegated-class question does not arise.                                                                                                                                                                                      |
+| The rule covered only zero consumers                  | `.agents/project-structure.md` § Forward-Provisioned Surface Rule, pre-change first line                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| The design auditor asked the banned question          | `.claude/agents/architecture-design-auditor.md` criterion 3, pre-change: "Does every public symbol have a real consumer?"                                                                                                                                                                                                                                                                                                                                                                                       |
+| The same auditor contradicted itself                  | criterion 6, unchanged: "Has a necessary boundary been deferred merely because there is only one present consumer?"                                                                                                                                                                                                                                                                                                                                                                                             |
+| `check-orphan-exports` already exempts public surface | `check-orphan-exports.mjs:185-188` — entry basenames, `package.json` export sources, barrel-re-exported modules                                                                                                                                                                                                                                                                                                                                                                                                 |
+| The scan's message caused a real action               | A session cleared nine findings by unexporting, and reported that it did so because the scan was red rather than because it had judged the symbols internal                                                                                                                                                                                                                                                                                                                                                     |
+| The message change altered no verdict                 | `node scripts/harness/check-orphan-exports.mjs` → "orphan export scan passed" before and after                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Sweep result                                          | `.claude/agents`, `.agents/rules`, `.agents/skills`, `.agents/specs`, `AGENTS.md`, `CLAUDE.md` and `scripts/harness/*.mjs` searched for consumer-count-as-reason. Two live carriers found and amended (`contract-disposition`, `check-contract-disposition` header). `finding-depth.md:156` matched on wording but concerns convergence conditions, not public surface — not a contradiction. Archived and completed records were deliberately NOT rewritten: a record describes the state when it was written. |
+
+## Non-goals
+
+- **Deciding any specific surface's fate.** Issue #2177 was answered by the owner (keep it public);
+  this change is about the criterion, not the case.
+- **Repairing every line-number citation into `project-structure.md`.** This change moved that file's
+  lines by 11 and several open Task records now cite stale numbers. Some were already stale before this
+  change, so repairing them means guessing what each meant. The general defect — line-number citations
+  into a living document rot silently and nothing checks them — is filed separately rather than fixed
+  opportunistically here.

--- a/.agents/tasks/ARCH-102-public-surface-is-not-judged-by-in-repo-consumer-count.md
+++ b/.agents/tasks/ARCH-102-public-surface-is-not-judged-by-in-repo-consumer-count.md
@@ -1,0 +1,87 @@
+---
+title: 'ARCH-102: a public surface is not judged by its in-repo consumer count'
+issue: https://github.com/woojubb/robota/issues/2177
+status: in-progress
+created: 2026-08-23
+priority: high
+urgency: now
+area: .agents/project-structure.md, .agents/skills/contract-disposition, .claude/agents, scripts/harness
+depends_on: []
+---
+
+# ARCH-102: a public surface is not judged by its in-repo consumer count
+
+## Problem
+
+The owner gave a standing architectural instruction on 2026-08-23, after observing repeated attempts
+to privatize or delete exported surfaces on the strength of how many places consume them:
+
+> 공개된 인터페이스를 자꾸 한군데서만 쓴다거나 당장 안쓴다는 이유로 private로 바꾸려는 시도가 종종
+> 보이는데 우리는 에이전트를 제작할수 있는 라이브러리를 지향하고 있으며 그렇게 제작해서 에이전트를
+> 보유하고 있습니다. 누구나 이 라이브라리를 조합해서 그들만의 에이전트를 빌딩할 수 있어야 합니다.
+> 한군데서만 쓰인다거나 지금은 안쓰인다라는 이유만으로 그걸 없애려고 하면 안되고 애초에 그게
+> 필요없는것이거나 설계에 안맞을 경우에만 판단해서 private로 전환하거나 제거해야 하는 것입니다.
+
+Two claims, and the second is the operative one. `packages/` is a library for composing agents —
+anyone must be able to build their own agent from it, and this repository's own agent is one assembly
+of it rather than the definition of it. Therefore **in-repo consumer count is not evidence about
+whether a surface should be public, at any count.** The only grounds that support narrowing or
+removing one are that it is genuinely unnecessary, or that it does not fit the design.
+
+## Why the existing rule did not cover it
+
+`.agents/project-structure.md` § Forward-Provisioned Surface Rule already said most of this — and said
+it only about **zero**: _"A public surface in `packages/` with zero in-repo consumers is not dead
+code."_ A surface with exactly one consumer fell outside its literal text, which is the case that
+actually arose (issue #2177: `capability-contracts`, zero external consumers, one internal consumer).
+The rule also stated what is NOT a reason without ever stating what IS, so a reader who accepted it
+had no criterion left to apply and could only conclude "never narrow anything" — which is not the
+instruction and would be wrong.
+
+## Where the contradiction was mechanized
+
+Four places carried the banned inference, and they are the reason the instruction kept being violated
+by sessions that had read the rule:
+
+1. `.claude/agents/architecture-design-auditor.md` criterion 3 asked, verbatim: **"Does every public
+   symbol have a real consumer?"** That is the banned inference stated as an audit criterion. The same
+   file's criterion 6 leans the other way ("Has a necessary boundary been deferred merely because there
+   is only one present consumer?"), so the auditor contradicted itself within one document.
+2. `.claude/agents/architecture-structure-auditor.md` criterion 4 told the auditor to compare exports
+   against consumers without bounding what a low count licenses.
+3. `.agents/skills/contract-disposition/SKILL.md` was framed entirely around "unconsumed" — correct as
+   far as it went, silent on one consumer, and it cited the rule by a line number that this change
+   moves.
+4. `scripts/harness/check-orphan-exports.mjs` reported `"X is exported but referenced nowhere else in
+the workspace"`. Its LOGIC is already correct — entry points, `package.json` export sources and
+   barrel-re-exported modules are all skipped, so a `packages/` public surface is exempt by
+   construction. Its MESSAGE says none of that, and a message is what an agent acts on.
+
+Point 4 is measured, not hypothetical. On 2026-08-23 a session cleared nine of these findings by
+unexporting the symbols. The outcome was right — they were internal helpers of one codec directory, so
+"does not fit the design" applied — but the session reported plainly that it unexported them **because
+a scan was red**, not because it had judged them internal. Had they been genuine composable surface,
+the same red would have produced the same action on the ground the owner has now ruled out.
+
+## Plan
+
+- [x] Extend § Forward-Provisioned Surface Rule from "zero consumers" to any count, and state the two
+      affirmative grounds that DO qualify.
+- [x] Amend `architecture-design-auditor` criterion 3 and `architecture-structure-auditor` criterion 4.
+- [x] Extend `contract-disposition` to the one-consumer case and repoint its rule citation.
+- [x] Make `check-orphan-exports` say what it does not judge, in the finding text and the header.
+- [x] Sweep for what the amended rule now contradicts, and record the result.
+
+## Test Plan
+
+- `pnpm harness:scan` green, including `orphan-exports` (whose message changed but whose logic did not),
+  `document-standards`, `agent-def-convention`, `conflict-markers` and `reference-kind-qualified`.
+- `node scripts/harness/check-orphan-exports.mjs` passes, confirming the message edit changed no verdict.
+- Sweep result recorded in the paired spec-doc rather than asserted.
+
+## User Execution Test Scenarios
+
+Not applicable — rule text, two agent definitions, one skill and one scan's finding message. No
+runnable user-facing product behaviour changes: no CLI command, TUI action, browser flow, or public
+SDK surface. Per `.agents/tasks/README.md` a rule-only change records the not-applicable with its
+reason rather than inventing a product scenario, and the checks belong in the Test Plan above.

--- a/.claude/agents/architecture-design-auditor.md
+++ b/.claude/agents/architecture-design-auditor.md
@@ -27,7 +27,14 @@ Produce findings; never edit code, configuration, or documentation.
 2. **Encapsulation and information hiding.** Do signatures or types leak lower-layer runtime, transport,
    vendor, or storage concepts? Do consumers depend on internal representation or concrete types rather
    than interfaces? Measure casts and implementation-specific branches at real consumption sites.
-3. **Contract quality and evolution safety.** Does every public symbol have a real consumer? Are symmetric
+3. **Contract quality and evolution safety.** Does every public symbol belong to the contract it is
+   exported from, and is it coherent with the rest of that contract? **Do not ask whether it has a
+   consumer.** `packages/` is a library for composing agents, so its consumers may all be outside this
+   repository; an in-repo consumer count — zero, one, or many — is not evidence about whether a symbol
+   should be public. Report a count as an observation if it is useful, never as a reason to privatize
+   or remove. The grounds that DO support narrowing a surface are that it is genuinely unnecessary or
+   that it does not fit the design, and both are judgements about the symbol, not about its callers.
+   See `.agents/project-structure.md` § Forward-Provisioned Surface Rule, which owns this. Are symmetric
    responsibilities such as serialize/deserialize owned together? Find function-valued fields crossing a
    serialization or transport boundary. Determine whether each operation is total or partial and whether
    failure is first-class in the contract rather than an undocumented throw. Check that contract replacement

--- a/.claude/agents/architecture-structure-auditor.md
+++ b/.claude/agents/architecture-structure-auditor.md
@@ -31,7 +31,12 @@ for reading the implementation. Produce findings; never edit code, configuration
    dependency direction.
 4. **Public surfaces.** Compare package entry points and export declarations with actual files and
    consumers. Report leaked internals, missing promised symbols, and configuration that disagrees with the
-   reachable public surface.
+   reachable public surface. **An export with few or no in-repo consumers is none of those things.**
+   `packages/` is a library others compose into their own agents, so a surface can be entirely correct and
+   have every real consumer outside this repository. Never recommend privatizing or deleting a `packages/`
+   export because of how many places consume it; recommend it only when the surface is genuinely
+   unnecessary or does not fit the design, and say which. See `.agents/project-structure.md`
+   § Forward-Provisioned Surface Rule, which owns this.
 5. **Workspace configuration consistency.** Establish whether compiler inheritance, test collection,
    linting, dead-code detection, and other repository-wide checks actually cover every target, especially
    a recently added one.

--- a/scripts/harness/check-contract-disposition.mjs
+++ b/scripts/harness/check-contract-disposition.mjs
@@ -7,12 +7,15 @@
  * its actual state:
  *
  *   grep finds no consumer  → "dead, remove it"      (it was forward-provisioned, or misplaced)
+ *   grep finds one consumer → "make it private"       (a library surface with one in-repo assembly)
  *   the surface is published → "we cannot change it"  (the project is pre-release; nothing is exposed)
  *
- * `project-structure.md:225` already forbids the first — "Removal of an unconsumed public surface is a
- * PRODUCT decision — never a grep-based cleanup" — and it was violated anyway, in a shipped changeset
- * that labelled a carried-but-not-honored field a "dead contract field". Prose did not hold, so this
- * is the mechanical half.
+ * `project-structure.md` § Forward-Provisioned Surface Rule already forbids the first two — "Removal
+ * or narrowing of a public surface is a PRODUCT decision — never a grep-based cleanup", and in-repo
+ * consumer count is not evidence about whether a surface should be public at ANY count (owner
+ * decision, 2026-08-23; ARCH-102). It was violated anyway, in a shipped changeset that labelled a
+ * carried-but-not-honored field a "dead contract field". Prose did not hold, so this is the
+ * mechanical half.
  *
  * WHAT IT CHECKS. Changeset bodies (`.changeset/*.md`) are the surface where a disposition becomes a
  * public claim about a contract. A changeset asserting a contract is dead/unused must name which

--- a/scripts/harness/check-orphan-exports.mjs
+++ b/scripts/harness/check-orphan-exports.mjs
@@ -20,6 +20,18 @@
  * dynamic access (obj[name]) is invisible. The goal is catching refactor
  * fallout, not perfect reachability.
  *
+ * WHAT THIS SCAN DOES NOT SAY, stated because its finding text was read as saying it. A `packages/`
+ * PUBLIC surface is exempt by construction — entry points, `package.json` export sources and
+ * barrel-re-exported modules are all skipped above — so a red here is never evidence that an
+ * exported library surface should be privatized or removed. In-repo consumer count is not evidence
+ * about whether a surface should be public, at any count; the only grounds for narrowing one are
+ * that it is genuinely unnecessary or that it does not fit the design
+ * (`.agents/project-structure.md` § Forward-Provisioned Surface Rule, owner decision 2026-08-23).
+ * Measured 2026-08-23: a session cleared nine of these by unexporting them, and the outcome was
+ * right only because they were genuinely internal helpers of one codec directory. The session said
+ * plainly that it unexported them because a scan was red, not because it had judged them internal —
+ * so the message, not the logic, is what needed fixing.
+ *
  * The 2026-06-11 launch baseline (153 frozen findings) was burned down to
  * zero and removed in HARNESS-015 (2026-06-13) — the scan now enforces
  * unconditionally. Intentional no-consumer exports live in the reasoned
@@ -204,7 +216,14 @@ export async function findOrphanExportFindings(root = WORKSPACE_ROOT, options = 
           findings.push({
             file: relativeFile,
             type: 'orphan-export',
-            detail: `${symbol} is exported but referenced nowhere else in the workspace.`,
+            detail:
+              `${symbol} is exported from a non-entry module that no same-package barrel re-exports, ` +
+              `and no other file references it. This is an INTERNAL export with no consumer — not a ` +
+              `judgement about public surface. A packages/ public surface is exempt here (entry ` +
+              `points, package.json export sources and barrel-re-exported modules are skipped) and is ` +
+              `never judged by consumer count: see .agents/project-structure.md ` +
+              `§ Forward-Provisioned Surface Rule. Unexport it, consume it, or route it through the ` +
+              `barrel if it is meant to be public — do not privatize a public surface to clear this.`,
           });
         }
       }


### PR DESCRIPTION
Owner instruction, 2026-08-23. `packages/` is a library for composing agents — anyone must be able to build their own agent from it, and this repository's own agent is one assembly of it rather than its definition.

**In-repo consumer count is not evidence about whether a surface should be public — at any count.** The only grounds for narrowing or removing one are that it is genuinely unnecessary, or that it does not fit the design.

## Why the existing rule did not hold

§ Forward-Provisioned Surface Rule already said most of this, and said it only about **zero** consumers. A surface with exactly one fell outside its literal text — which is the case that actually arose (#2177). It also said what is *not* a reason without ever saying what *is*, so a reader who accepted it had no criterion left and fell back on the count.

## Where the contradiction was mechanized

| Place | What it said |
| --- | --- |
| `architecture-design-auditor` criterion 3 | **"Does every public symbol have a real consumer?"** — the banned inference, as an audit criterion |
| same file, criterion 6 | "Has a necessary boundary been deferred merely because there is only one present consumer?" — the opposite. **The auditor contradicted itself within one document.** |
| `architecture-structure-auditor` criterion 4 | compared exports against consumers without bounding what a low count licenses |
| `contract-disposition` | framed entirely around "unconsumed"; silent on one consumer |
| `check-orphan-exports` finding text | "X is exported but referenced nowhere else in the workspace" |

## The scan's logic was already right — only its message was wrong

`check-orphan-exports.mjs:185-188` already skips entry points, `package.json` export sources and barrel-re-exported modules, so a `packages/` public surface is **exempt by construction**. Changing that logic was the alternative that nearly shipped, on a persuasive report that the scan enforced the inverse of the owner's instruction. Reading the exemption code refuted it.

What is real is that the *message* says none of that, and a message is what an agent acts on. Measured: a session cleared nine of these findings by unexporting symbols, and reported doing so **because a scan was red**, not because it had judged them internal. The outcome happened to be right — they were internal helpers — but the same red would have produced the same action on genuine library surface.

So the verdicts are unchanged and only the text is. Verified by running the scan before and after.

## Net zero on the routing document

`routing-document-size` refused the first draft: 399 lines against a frozen 385, for inlining prose into a routing document. The amendment was rewritten until the invariant was **stronger** and the file had **not grown** — it lands at exactly 385. The detailed reasoning moved to the paired spec-doc, which is where reasoning belongs.

That ratchet is a *size* check catching a *content* problem for the second time today (see #2178).

## Verification

- `pnpm harness:scan` → **139 passed, 2 skipped, 0 failed**
- `check-orphan-exports` and `check-contract-disposition` both pass; neither changed a verdict
- Sweep for contradicted documents recorded in the spec-doc's Evidence Log. Two live carriers found and amended; `finding-depth.md:156` matched on wording but concerns convergence conditions, not public surface. **Archived and completed records were deliberately not rewritten** — a record describes the state when it was written.

## Not in scope

This change moved `project-structure.md`'s lines by 11, and several open Task records cite it by line number. Some were already stale beforehand, so repairing them means guessing what each meant. The general defect — line-number citations into a living document rot silently and nothing checks them — is left for its own item rather than fixed opportunistically here.

Arising from #2177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY