### PR TITLE
feat(harness): interface packages compose downward across declared layers (ARCH-101)

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -316,12 +316,12 @@ doubles→owner /testing`). Pre-existing mechanisms are frozen per package in
   `scripts/harness/interface-entry-baseline.json` and the count may only shrink. The entry edge
   exists because the source edge alone measured something narrower than this rule's words, so a
   100-line prototype-walking forwarder sat outside the rule and inside the green.
-- An `agent-interface-*` package's internal dependencies are a subset of `{agent-core}` —
-  contracts never depend on implementation packages (INFRA-025; mechanized as the
-  `INTERFACE-DEPS` rule in the `deps` scan). `agent-interface-transport` owns the
-  background-task/subagent/compaction data contracts and, post-DATA-001, the
-  session/workspace/command/event/usage contract families; `agent-executor`/`agent-session` import
-  them and keep only runtime SPI.
+- An `agent-interface-*` package depends on `{agent-core}`, and on a PEER `agent-interface-*` package
+  only DOWNWARD across the declared layers, one-directionally. Same-layer and upward are refused, as
+  is any implementation package — contracts never depend on implementations (INFRA-025; ARCH-101;
+  mechanized as the `INTERFACE-DEPS` rule in the `deps` scan). The layer that authorizes an edge is
+  declared once in [`specs/contract-family-owner-map.md`](specs/contract-family-owner-map.md) and read
+  by both guards through `scripts/harness/interface-layers.mjs`. Do not restate a layer elsewhere.
 - Implementation packages (`agent-transport` with subpath `/headless`; the per-concern `agent-transport-tui` / `-ws` / `-http` / `-mcp` packages; `agent-provider` with subpaths `/anthropic`, `/openai`, etc.; `agent-command`) depend on the corresponding `agent-interface-*` package, not on `agent-framework`, for interface types. The transport-facing contract types (command, interaction, event, workspace, session, and transport contracts) live in `agent-interface-transport` as their SSOT (per INFRA-010). This is **mechanically enforced** by `scripts/harness/check-interface-imports.mjs` (wired into `pnpm harness:scan` as the `interface-imports` scan): any implementation package that imports an `agent-interface-transport`-exported symbol from `@robota-sdk/agent-framework` fails the gate. Runtime values and framework-owned types (e.g. `TInteractiveSessionOptions`, `ICommandHostContext`, `ICommandModule`, `TSettingsData`) still come from `agent-framework`.
 - `agent-framework` depends on the `agent-interface-transport` package to consume the contracts it needs (it does not depend on `agent-interface-tui`, which only `agent-transport-tui` consumes).
 - Do not place interface packages in `agent-core` — `agent-core` is zero-deps and owns foundational primitives only.

--- a/.agents/spec-docs/todo/ARCH-101-interface-packages-compose-downward-across-declared-layers.md
+++ b/.agents/spec-docs/todo/ARCH-101-interface-packages-compose-downward-across-declared-layers.md
@@ -1,0 +1,215 @@
+---
+status: approved
+type: RULE
+tags: [typescript]
+---
+
+# ARCH-101: interface packages compose downward across declared layers
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2180.
+Unblocks issues #2108–#2113 under tracker issue #2068.
+
+## Problem
+
+`.agents/project-structure.md` § Interface Package Rule restricts an `agent-interface-*` package's
+internal dependencies to a subset of `{agent-core}`. `checkInterfacePackageDeps`
+(`scripts/harness/check-dependency-direction.mjs:232-246`) enforces the literal reading: any
+`@robota-sdk/*` production dependency other than `agent-core` is an `[INTERFACE-DEPS]` violation.
+
+The contract-family owner map merged by ARCH-100 requires interface→interface edges. The owner has
+since ruled that the general layer rule governs this prefix too — composition across **differing**
+layers, one-directional, is permitted; only **same-layer** dependencies are forbidden. So the target
+graph is legal.
+
+**Concrete symptom, and it is what blocks work today.** Nothing implements the ruling. Issue #2109
+creates `agent-interface-execution`; `agent-interface-transport` retains `session-contracts` and
+`session-capability-contracts` until issue #2110, and those name 20 execution symbols. So transport's
+manifest must depend on `agent-interface-execution`, and `pnpm harness:scan` fails with
+
+```
+[INTERFACE-DEPS] Interface-package violation: @robota-sdk/agent-interface-transport must not
+depend on @robota-sdk/agent-interface-execution … (deps ⊆ {@robota-sdk/agent-core}).
+```
+
+**Reproduction condition.** The first migration leaf that creates an owner package while any consumer
+of its families remains behind — which, by the migration order, is every leaf.
+
+**The second half, which is easy to miss.** Relaxing the prohibition is not sufficient and is not
+safe alone. Today a same-layer interface edge is refused only as a side effect of refusing _every_
+edge, and `interface-family-owner` proves the module graph is **acyclic** — which no longer implies
+legal, because a same-layer edge can be perfectly acyclic. Relax the prohibition without adding a
+direction check and the case the ruling exists to forbid becomes reachable and unguarded.
+
+## Prior Art Research
+
+- **ArchUnit — `layeredArchitecture()`** (ArchUnit User Guide, "Layered Architecture",
+  <https://www.archunit.org/userguide/html/000_Index.html#_layer_checks>). The documented form of
+  exactly this check: layers are _declared by name_, packages are assigned to them, and the assertion
+  is about which layer may be accessed by which. The declaration is data the checker reads, not prose
+  a reviewer applies — which is the shape adopted here.
+- **Nx — Enforce Module Boundaries** (Nx documentation, `@nx/enforce-module-boundaries`,
+  <https://nx.dev/features/enforce-module-boundaries>). Packages carry **tags**; a rule declares which
+  tag may depend on which. Already cited by ARCH-100 for the owner map; it is the same mechanism
+  applied to the second axis, which is why the layer declaration belongs beside the owner map rather
+  than in a separate registry.
+
+**How the research feeds the decision.** Both say the same two things: the layer assignment is data,
+and the direction assertion is derived from it rather than restated. That is why the declaration gets
+one machine-readable owner (Decision, point 1) and why neither guard is allowed to hard-code a layer
+(Alternative B, rejected).
+
+## Architecture Review Checklist
+
+- [x] Affected package/layer list complete — `.agents/project-structure.md` (the rule),
+      `.agents/specs/contract-family-owner-map.md` (the declaration), a new shared parser under
+      `scripts/harness/`, and the two guards that consume it. No production package is touched.
+- [x] Sibling scan complete — `checkFullGraphCycles` already keeps the whole workspace graph acyclic
+      and is untouched; it is necessary and, as the Problem section says, no longer sufficient.
+      `interface-runtime` and `interface-imports` police different properties of the same packages and
+      are unaffected. `rule-statement-floor` (HARNESS-117) will require the amended rule to keep
+      stating `INTERFACE-DEPS`, which it does.
+- [x] At least 2 alternatives considered — see Alternatives Considered.
+- [x] Decision rationale documented — see Decision.
+
+**New-surface placement:** N/A — no new package, app, presentation or interface surface. One rule is
+amended, one parser module and two guard predicates are added.
+
+## Alternatives Considered
+
+**A — One machine-readable layer declaration, one shared parser, two consumers.** (chosen)
+
+- Pro: one owner for the fact. The map already declares the layers for human readers and is already
+  parsed by `interface-family-owner`; making the declaration data lets `checkInterfacePackageDeps`
+  enforce the same assignment on manifests. A layer added or moved is picked up by both guards at
+  once.
+- Con: `check-dependency-direction.mjs` gains a dependency on a document, which is a heavier coupling
+  than it has today.
+
+**B — Hard-code the layer assignment in each guard.**
+
+- Pro: no document coupling; each guard stays self-contained.
+- Con: two copies of one fact, in two files, with nothing comparing them — the exact drift this
+  repository keeps paying for and that ARCH-100's owner map was built to avoid. Rejected.
+
+**C — Relax `checkInterfacePackageDeps` to permit any interface→interface edge and rely on
+`checkFullGraphCycles`.**
+
+- Pro: smallest change; the acyclicity guarantee genuinely already exists.
+- Con: **acyclicity does not forbid a same-layer edge.** `command → execution` is acyclic and illegal.
+  This would encode the half of the ruling that was already true and drop the half that is new.
+  Rejected.
+
+## Decision
+
+Adopt **A**, in one change rather than two.
+
+1. **The declaration gets one owner.** `.agents/specs/contract-family-owner-map.md` gains a
+   machine-readable layer table beside its owner map, under its own marker. It already holds the
+   family→owner assignment; the layer is the second axis of the same fact and belongs with it.
+2. **One parser, not two.** A shared `scripts/harness/interface-layers.mjs` reads it and answers
+   `layerOf(pkg)` and `isLegalEdge(from, to)`. **Neither guard parses the document.** Two guards
+   parsing one markdown table would be two parsers that can disagree about one fact, which is the
+   duplication this decision exists to avoid — the document coupling in Alternative A's Con is
+   accepted once, in one place, rather than twice.
+3. **Both guards consume it.** `checkInterfacePackageDeps` judges manifest edges;
+   `interface-family-owner` judges module edges. Same predicate, two altitudes.
+
+**Why this is one pull request.** Points 2 and 3 cannot ship apart. Relaxing the manifest prohibition
+without the module-level direction check leaves a window in which the new rule exists and nothing
+enforces the part of it that is new — worse than the flat prohibition it replaces, because it reads
+as governed.
+
+The trade-off that drove A over B: B is cheaper and self-contained, and it would put the layer of
+`agent-interface-session` in two files with no mechanism comparing them. A rule whose two enforcers
+can disagree about what it says is not one rule.
+
+**Pattern note.** Issue #2194 asks where a package's layer lives and how the architecture map and a
+package `SPEC.md` relate. ARCH-101 does not answer it, but it establishes a worked precedent for one
+family: the layer is declared once as data, in the cross-cutting spec that owns the family map, and
+guards derive from it. Whoever takes issue #2194 has that rather than a blank page.
+
+## Completion Criteria
+
+- [ ] **TC-01** `.agents/project-structure.md` § Interface Package Rule states that an
+      `agent-interface-*` package may depend on another only downward across declared layers and
+      one-directionally, and that same-layer and upward dependencies are refused.
+- [ ] **TC-02** The layer assignment is machine-readable in
+      `.agents/specs/contract-family-owner-map.md` under a marker, and `interface-layers.mjs` parses
+      it; a missing marker fails rather than yielding an empty legal-by-default answer.
+- [ ] **TC-03** `checkInterfacePackageDeps` accepts a downward interface→interface manifest edge and
+      reports a same-layer one and an upward one, each with the layers named.
+- [ ] **TC-04** `interface-family-owner` reports a same-layer and an upward MODULE edge, and each case
+      is demonstrated to pass the acyclicity check — proving the new check is not redundant.
+- [ ] **TC-05** Every new refusal is demonstrated RED before the code satisfying it is written.
+- [ ] **TC-06** `pnpm harness:scan` exits 0 and `pnpm harness:verify-like-ci` reports green.
+
+## Test Plan
+
+| TC    | Test Type          | Tool / Approach                                                                                  | Notes                                                       |
+| ----- | ------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| TC-01 | Document assertion | Read the amended rule; `rule-statement-floor` asserts `INTERFACE-DEPS` is still stated           | —                                                           |
+| TC-02 | Unit               | `vitest` over `interface-layers.mjs` with in-memory documents, including the missing-marker case | —                                                           |
+| TC-03 | Unit               | `vitest` over `checkInterfacePackageDeps` with synthetic package maps                            | —                                                           |
+| TC-04 | Unit (falsifying)  | `vitest`: a same-layer edge that `findCycles` reports as acyclic must still be refused           | This is what proves the new check adds a property           |
+| TC-05 | Procedure          | Each new case run against the pre-change guard and observed failing                              | manual red-before-green step, recorded in the PR body       |
+| TC-06 | Gate               | `pnpm harness:scan`; `pnpm harness:verify-like-ci`                                               | manual invocation — `verify-like-ci` is the CI-mirror entry |
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** draft → review-ready
+**Judged by:** self-assessment against `.agents/specs/gate-catalogue.md` § GATE-WRITE. Not a
+`backlog-gate-guard` verdict — no guardian agent was dispatched.
+
+- Frontmatter: `status: draft`, `type: RULE`, `tags: [typescript]`; frontmatter scan exits 0.
+- Problem — concrete symptom: the exact `[INTERFACE-DEPS]` failure text issue #2109 will produce, with
+  the guard's file and line.
+- Problem — reproduction condition: the first leaf creating an owner package while a consumer remains
+  behind, which is every leaf.
+- Problem — no "TBD"/"TODO"/vagueness; includes the non-obvious second half (relaxing alone is unsafe).
+- Prior Art Research: 2 documentation sources with links (ArchUnit `layeredArchitecture()`; Nx
+  `@nx/enforce-module-boundaries`), tied to Decision point 1 and to rejecting Alternative B.
+- Architecture Review Checklist: all 4 `[x]`; sibling scan names `checkFullGraphCycles`,
+  `interface-runtime`, `interface-imports` and `rule-statement-floor`, and says why each is unaffected
+  or still necessary.
+- New-surface placement: N/A with reason.
+- Alternatives Considered: 3 entries with Pro and Con; B and C each carry the specific property that
+  rejected them.
+- Decision: names the driving trade-off — a rule whose two enforcers can disagree about what it says
+  is not one rule — and states why points 2 and 3 are one pull request.
+- Completion Criteria: 6 items, all `TC-N`, command or observable-behavior form.
+- Test Plan: 6 rows for 6 TCs; each has Test Type and Tool/Approach; the two manual rows carry Notes.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-23
+
+**Status upgrade:** review-ready → approved
+
+This item amends repository policy — the Interface Package Rule and the guard enforcing it — which is
+**outside** the standing delegation's class. It does not pass on that delegation. It passes on a
+**specific owner ruling on this specific question.**
+
+**The ruling, as relayed.** Asked whether the general layer rule governs `agent-interface-*`, the
+owner answered: 「같은 공통 접두어라고 해도 단계 계층이 다를경우 단방향 조합이 가능하다. 오직 같은
+단계만 안된다」 — same prefix is permitted when the layers differ and the composition is
+one-directional; only same-layer is forbidden — and, on the direct follow-up, 「판정2는
+agent-interface에도 적용된다」.
+
+**Provenance, stated because it bounds this entry.** The ruling was not given in this session's
+thread. It reached this session by relay from the orchestrating session, as with ARCH-100, and the
+same limit applies. What is different here, and worth naming: the ruling was obtained **through the
+escalation path rather than around it.** Issue #2180 was filed precisely because the amendment was
+owner-reserved, escalated for that reason, and this ruling is the answer that came back. That
+distinguishes an authorization produced by the mechanism from one assumed in its absence — but it
+does not convert a relay into a first-hand instruction, and this entry does not claim it does.
+
+**Scope check against the ruling.** What is built here is exactly what was ruled and no more: downward
+one-directional composition permitted, same-layer refused, upward refused. It does not decide which
+package sits in which layer — that assignment is ARCH-100's, already merged and unchanged. It moves no
+production TypeScript and changes no published surface.
+
+**Verification of the premise, independent of the relay.** The ruling's applicability was checked
+against the real graph rather than assumed: the only cross-family edges are `mobility → session`,
+`session → command` and `session → execution`, all strictly downward, with **zero same-layer edges**.
+The single upward edge is the accidental `workspace-contracts → session-contracts` re-export, already
+the first precondition of issue #2109. So the merged target graph satisfies the ruling as stated.

--- a/.agents/specs/contract-family-owner-map.md
+++ b/.agents/specs/contract-family-owner-map.md
@@ -41,14 +41,35 @@ a file-level move plan for issue #2112 would silently fail.
 
 ## Target dependency graph, and the two corrections it rests on
 
-```text
-layer 0 (no outbound edges)
-  agent-interface-transport   agent-interface-command
-  agent-interface-execution   agent-interface-analytics
+### Layer declaration (ARCH-101 · issue #2180)
 
-layer 1  agent-interface-session  →  command, execution, analytics
-layer 2  agent-interface-session-mobility  →  session
+<!-- arch-101:layer-map -->
+
+The owner ruled that the general layer rule governs this prefix: an `agent-interface-*` package may
+compose another **when the layers differ and the composition is one-directional**. Only **same-layer**
+dependencies are forbidden, and an upward dependency is forbidden by the same sentence.
+
+So these numbers are not description. They are **the thing that authorizes each edge**, and both
+guards read this table through one parser (`scripts/harness/interface-layers.mjs`). Rows are
+`| layer | package |`.
+
+| Layer | Package                            |
+| ----- | ---------------------------------- |
+| 0     | `agent-interface-transport`        |
+| 0     | `agent-interface-command`          |
+| 0     | `agent-interface-execution`        |
+| 0     | `agent-interface-analytics`        |
+| 1     | `agent-interface-session`          |
+| 2     | `agent-interface-session-mobility` |
+
+```text
+layer 0   transport   command   execution   analytics     (no edges among them)
+layer 1   session      → command, execution, analytics
+layer 2   mobility     → session
 ```
+
+A layer-0 package depends on no other `agent-interface-*` package. `agent-interface-tui` is not in the
+table: it composes no peer and is depended on by none, so it has no layer to declare until it does.
 
 The graph is acyclic **only** with these two corrections, each a precondition of its leaf:
 

--- a/.agents/specs/contract-family-owner-map.md
+++ b/.agents/specs/contract-family-owner-map.md
@@ -71,6 +71,15 @@ layer 2   mobility     → session
 A layer-0 package depends on no other `agent-interface-*` package. `agent-interface-tui` is not in the
 table: it composes no peer and is depended on by none, so it has no layer to declare until it does.
 
+**There is no family root here, and there must never be one.** The owner's rule is that a family root
+may not depend on its own members — only the reverse — and that an aggregator over a family carries a
+**completely different prefix**, with its purpose in the name. This family has no `agent-interface`
+root package and no aggregator, so the root→member direction is vacuous by construction rather than
+enforced. If a bundle over these six is ever wanted it may be named neither `agent-interface` nor
+`agent-interface-*`; adding one under either name would create the root the rule forbids. No guard
+checks this, deliberately — a check that can never fire is its own defect, and the naming rule
+forecloses the case.
+
 The graph is acyclic **only** with these two corrections, each a precondition of its leaf:
 
 1. **issue #2109** — `workspace-contracts.ts` imports `IBackgroundJobGroupState` from

--- a/.agents/tasks/ARCH-101-interface-packages-compose-downward-across-declared-layers.md
+++ b/.agents/tasks/ARCH-101-interface-packages-compose-downward-across-declared-layers.md
@@ -1,0 +1,76 @@
+---
+title: 'ARCH-101: interface packages compose downward across declared layers'
+status: in-progress
+created: 2026-08-23
+priority: high
+urgency: now
+area: .agents/project-structure.md, .agents/specs, scripts/harness
+depends_on: []
+---
+
+# ARCH-101: interface packages compose downward across declared layers
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2180.
+Unblocks issues #2108–#2113 under tracker issue #2068.
+
+## Problem
+
+The Interface Package Rule restricts an `agent-interface-*` package's internal dependencies to a
+subset of `{agent-core}`, and `checkInterfacePackageDeps` enforces that literally. The contract-family
+owner map merged by ARCH-100 requires interface→interface edges, so the decomposition cannot start.
+
+The owner has ruled that the general layer rule governs `agent-interface-*` as well: a package may
+compose another with the same prefix **when the layers differ and the composition is one-directional**;
+only **same-layer** dependencies are forbidden.
+
+That makes the merged target graph legal. It does not make it buildable: **no guard implements the
+ruling.** `checkInterfacePackageDeps` still refuses every interface→interface edge, so issue #2109
+goes red on its first push — `agent-interface-transport` retains `session-contracts` until
+issue #2110 and must depend on `agent-interface-execution`.
+
+## Existing Evidence
+
+Measured on `origin/develop`.
+
+- Cross-family module edges, after the pass-through correction: `mobility → session` (2 symbols),
+  `session → command` (4), `session → execution` (20). All strictly downward; **zero same-layer edges**.
+- The one upward edge is `workspace-contracts → session-contracts`, the accidental re-export that is
+  already the first precondition of issue #2109.
+- `check-dependency-direction.mjs:232-246` fails any `@robota-sdk/*` dependency other than
+  `agent-core`, unchanged.
+- The layers are declared in `.agents/specs/contract-family-owner-map.md` as a fenced diagram —
+  description, not data. Nothing reads them.
+- `interface-family-owner` proves the module graph is acyclic. **Acyclic no longer implies legal**: a
+  same-layer edge can be perfectly acyclic.
+
+## Directions Considered
+
+- Make the layer declaration machine-readable in the map and have both guards read it through one
+  shared parser (chosen).
+- Hard-code the layer assignment in each guard. Rejected: two copies of one fact, which is the drift
+  this repository keeps paying for.
+- Relax `checkInterfacePackageDeps` to allow any interface→interface edge and rely on
+  `checkFullGraphCycles`. Rejected: acyclicity does not forbid a same-layer edge, so the ruling would
+  be unenforced.
+
+## Completion Criteria
+
+- [ ] The Interface Package Rule states the layer ruling: downward one-directional composition is
+      permitted, same-layer and upward are refused.
+- [ ] The layer assignment is machine-readable, with one owner and one parser.
+- [ ] `checkInterfacePackageDeps` permits a downward interface→interface manifest edge and refuses a
+      same-layer or upward one.
+- [ ] `interface-family-owner` refuses a same-layer or upward module edge, not only a cycle.
+- [ ] Each new refusal is demonstrated red before the code that satisfies it.
+- [ ] `pnpm harness:scan` exit 0.
+
+## Test Plan
+
+- Unit tests over the shared layer parser and both guards' new predicates.
+- Falsification: a same-layer edge and an upward edge each flip a verdict that acyclicity alone passes.
+- Full harness scan and `pnpm harness:verify-like-ci`.
+
+## User Execution Test Scenarios
+
+This task delivers no user-facing behavior: it amends a rule and two repository verification scans, and
+moves no production TypeScript. The verification surface is the harness gate, recorded in the Test Plan.

--- a/scripts/harness/__tests__/check-interface-package-deps.test.mjs
+++ b/scripts/harness/__tests__/check-interface-package-deps.test.mjs
@@ -97,3 +97,57 @@ describe('checkFullGraphCycles (HARNESS-022)', () => {
     expect(checkFullGraphCycles(packages)).toEqual([]);
   });
 });
+
+describe('checkInterfacePackageDeps — peer edges by declared layer (ARCH-101)', () => {
+  const layers = new Map([
+    ['agent-interface-transport', 0],
+    ['agent-interface-command', 0],
+    ['agent-interface-execution', 0],
+    ['agent-interface-session', 1],
+    ['agent-interface-session-mobility', 2],
+  ]);
+  const pkg = (name, dependencies) => new Map([[name, { name, path: '/x', dependencies }]]);
+  const run = (name, deps) => checkInterfacePackageDeps(pkg(name, deps), layers);
+
+  it('ACCEPTS a downward peer edge — the whole point of the amendment', () => {
+    expect(
+      run('@robota-sdk/agent-interface-session', ['@robota-sdk/agent-interface-execution']),
+    ).toEqual([]);
+  });
+
+  it('ACCEPTS a downward edge spanning two layers', () => {
+    expect(
+      run('@robota-sdk/agent-interface-session-mobility', [
+        '@robota-sdk/agent-interface-execution',
+      ]),
+    ).toEqual([]);
+  });
+
+  it('REFUSES a same-layer peer edge', () => {
+    const v = run('@robota-sdk/agent-interface-command', ['@robota-sdk/agent-interface-execution']);
+    expect(v).toHaveLength(1);
+    expect(v[0].message).toContain('SAME-LAYER');
+  });
+
+  it('REFUSES an upward peer edge', () => {
+    const v = run('@robota-sdk/agent-interface-execution', ['@robota-sdk/agent-interface-session']);
+    expect(v).toHaveLength(1);
+    expect(v[0].message).toContain('UPWARD');
+  });
+
+  it('REFUSES an undeclared peer rather than treating it as legal by default', () => {
+    const v = run('@robota-sdk/agent-interface-session', ['@robota-sdk/agent-interface-nowhere']);
+    expect(v).toHaveLength(1);
+    expect(v[0].message).toContain('no declared layer');
+  });
+
+  it('still REFUSES an implementation dependency, which layers do not excuse', () => {
+    const v = run('@robota-sdk/agent-interface-session', ['@robota-sdk/agent-framework']);
+    expect(v).toHaveLength(1);
+    expect(v[0].dep).toBe('@robota-sdk/agent-framework');
+  });
+
+  it('still allows agent-core', () => {
+    expect(run('@robota-sdk/agent-interface-session', ['@robota-sdk/agent-core'])).toEqual([]);
+  });
+});

--- a/scripts/harness/__tests__/interface-layers.test.mjs
+++ b/scripts/harness/__tests__/interface-layers.test.mjs
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bareName,
+  explainEdge,
+  isInterfacePackage,
+  judgeEdge,
+  parseLayerDeclaration,
+  readInterfaceLayers,
+} from '../interface-layers.mjs';
+
+function docOf(rows) {
+  return [
+    'prose that must be ignored',
+    '<!-- arch-101:layer-map -->',
+    '| Layer | Package |',
+    '| --- | --- |',
+    ...rows,
+    '',
+  ].join('\n');
+}
+
+describe('parseLayerDeclaration (ARCH-101)', () => {
+  it('reads a layer per package', () => {
+    const { layers } = parseLayerDeclaration(
+      docOf(['| 0 | `agent-interface-execution` |', '| 1 | `agent-interface-session` |']),
+    );
+    expect(layers.get('agent-interface-execution')).toBe(0);
+    expect(layers.get('agent-interface-session')).toBe(1);
+  });
+
+  it('signals a missing marker instead of returning an empty map that would read as a pass', () => {
+    expect(parseLayerDeclaration('# no marker here').missingMarker).toBe(true);
+  });
+
+  it('stops at the end of the table, so a later example row is not absorbed', () => {
+    const doc = [
+      '<!-- arch-101:layer-map -->',
+      '| Layer | Package |',
+      '| --- | --- |',
+      '| 0 | `agent-interface-execution` |',
+      '',
+      'An EXAMPLE of the form, not a declaration:',
+      '',
+      '| 9 | `agent-interface-invented` |',
+      '',
+    ].join('\n');
+    const { layers } = parseLayerDeclaration(doc);
+    expect(layers.has('agent-interface-execution')).toBe(true);
+    expect(layers.has('agent-interface-invented')).toBe(false);
+  });
+});
+
+describe('judgeEdge — the ruling, encoded', () => {
+  const layers = new Map([
+    ['agent-interface-transport', 0],
+    ['agent-interface-command', 0],
+    ['agent-interface-execution', 0],
+    ['agent-interface-session', 1],
+    ['agent-interface-session-mobility', 2],
+  ]);
+
+  it('permits a downward edge', () => {
+    expect(judgeEdge('agent-interface-session', 'agent-interface-execution', layers)).toMatchObject(
+      {
+        legal: true,
+        reason: 'downward',
+      },
+    );
+  });
+
+  it('permits a downward edge spanning more than one layer', () => {
+    expect(
+      judgeEdge('agent-interface-session-mobility', 'agent-interface-execution', layers).legal,
+    ).toBe(true);
+  });
+
+  it('REFUSES a same-layer edge — the case the ruling exists to forbid', () => {
+    expect(judgeEdge('agent-interface-command', 'agent-interface-execution', layers)).toMatchObject(
+      {
+        legal: false,
+        reason: 'same-layer',
+      },
+    );
+  });
+
+  it('REFUSES an upward edge, because composition is one-directional', () => {
+    expect(judgeEdge('agent-interface-execution', 'agent-interface-session', layers)).toMatchObject(
+      {
+        legal: false,
+        reason: 'upward',
+      },
+    );
+  });
+
+  it('REFUSES an undeclared package rather than treating it as legal by default', () => {
+    const v = judgeEdge('agent-interface-session', 'agent-interface-nowhere', layers);
+    expect(v.legal).toBe(false);
+    expect(v.reason).toBe('undeclared');
+    expect(v.missing).toEqual(['agent-interface-nowhere']);
+  });
+
+  it('normalises an npm scope, so a manifest specifier and a bare name compare equal', () => {
+    expect(
+      judgeEdge(
+        '@robota-sdk/agent-interface-session',
+        '@robota-sdk/agent-interface-execution',
+        layers,
+      ).legal,
+    ).toBe(true);
+  });
+});
+
+describe('helpers', () => {
+  it('bareName strips a scope', () => {
+    expect(bareName('@robota-sdk/agent-interface-session')).toBe('agent-interface-session');
+    expect(bareName('agent-interface-session')).toBe('agent-interface-session');
+  });
+
+  it('isInterfacePackage recognises the prefix through a scope', () => {
+    expect(isInterfacePackage('@robota-sdk/agent-interface-session')).toBe(true);
+    expect(isInterfacePackage('@robota-sdk/agent-framework')).toBe(false);
+  });
+
+  it('explainEdge names both layers on a refusal, so the reader can act', () => {
+    const layers = new Map([
+      ['a-x', 0],
+      ['b-y', 0],
+    ]);
+    const msg = explainEdge('a-x', 'b-y', judgeEdge('a-x', 'b-y', layers));
+    expect(msg).toContain('SAME-LAYER');
+    expect(msg).toContain('layer 0');
+  });
+});
+
+describe('the real declaration', () => {
+  const layers = readInterfaceLayers();
+
+  it('declares every owner in the merged map', () => {
+    for (const pkg of [
+      'agent-interface-transport',
+      'agent-interface-command',
+      'agent-interface-execution',
+      'agent-interface-analytics',
+      'agent-interface-session',
+      'agent-interface-session-mobility',
+    ]) {
+      expect(layers.has(pkg), `${pkg} has no declared layer`).toBe(true);
+    }
+  });
+
+  it('makes every edge of the merged target graph legal', () => {
+    for (const [from, to] of [
+      ['agent-interface-session', 'agent-interface-command'],
+      ['agent-interface-session', 'agent-interface-execution'],
+      ['agent-interface-session', 'agent-interface-analytics'],
+      ['agent-interface-session-mobility', 'agent-interface-session'],
+    ]) {
+      expect(judgeEdge(from, to, layers).legal, `${from} → ${to}`).toBe(true);
+    }
+  });
+
+  it('keeps the layer-0 owners mutually forbidden, which is what makes them independent', () => {
+    expect(judgeEdge('agent-interface-command', 'agent-interface-execution', layers).legal).toBe(
+      false,
+    );
+    expect(judgeEdge('agent-interface-transport', 'agent-interface-analytics', layers).legal).toBe(
+      false,
+    );
+  });
+});

--- a/scripts/harness/__tests__/scan-interface-family-owner.test.mjs
+++ b/scripts/harness/__tests__/scan-interface-family-owner.test.mjs
@@ -9,6 +9,7 @@ import { judgeEdge, readInterfaceLayers } from '../interface-layers.mjs';
 
 import {
   findCycles,
+  findLayerViolations,
   findContractModules,
   migrationWaves,
   parseOwnerMap,
@@ -413,5 +414,59 @@ describe('LAYER — acyclicity does not imply legality (ARCH-101 · issue #2180)
       }
     }
     expect(illegal).toEqual([]);
+  });
+});
+
+describe("findLayerViolations — the SCAN's use of the layer predicate, not the predicate alone", () => {
+  // regression-red-proof reported `accidental-green-fail (all-pass)` when this condition lived inline
+  // in main(): the suite tested judgeEdge directly and never that the scan consulted it, so reversing
+  // the scan's fix left every test green. These cases fail if the condition is removed.
+  const layers = new Map([
+    ['agent-interface-command', 0],
+    ['agent-interface-execution', 0],
+    ['agent-interface-session', 1],
+  ]);
+  const edgesOf = (from, to) => new Map([[from, new Map([[to, new Set(['ISomeType (a → b)'])]])]]);
+
+  it('returns nothing for a legal downward edge', () => {
+    expect(
+      findLayerViolations(edgesOf('agent-interface-session', 'agent-interface-execution'), layers),
+    ).toEqual([]);
+  });
+
+  it('reports a same-layer edge', () => {
+    const out = findLayerViolations(
+      edgesOf('agent-interface-command', 'agent-interface-execution'),
+      layers,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('LAYER:');
+    expect(out[0]).toContain('SAME-LAYER');
+  });
+
+  it('reports an upward edge', () => {
+    const out = findLayerViolations(
+      edgesOf('agent-interface-execution', 'agent-interface-session'),
+      layers,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('UPWARD');
+  });
+
+  it('names the symbols that carry an illegal edge, so it can be acted on', () => {
+    const out = findLayerViolations(
+      edgesOf('agent-interface-command', 'agent-interface-execution'),
+      layers,
+    );
+    expect(out[0]).toContain('ISomeType');
+  });
+
+  it('reports an undeclared owner rather than passing it', () => {
+    const out = findLayerViolations(
+      edgesOf('agent-interface-session', 'agent-interface-unlisted'),
+      layers,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('no declared layer');
   });
 });

--- a/scripts/harness/__tests__/scan-interface-family-owner.test.mjs
+++ b/scripts/harness/__tests__/scan-interface-family-owner.test.mjs
@@ -5,6 +5,8 @@ import { describe, expect, it } from 'vitest';
 
 import { makeTemp } from './make-temp.mjs';
 
+import { judgeEdge, readInterfaceLayers } from '../interface-layers.mjs';
+
 import {
   findCycles,
   findContractModules,
@@ -368,5 +370,48 @@ describe('readExaminedModuleCount — the size this scan reports (measurement-pr
 
   it('the count it reports is the set it actually checks', () => {
     expect(readExaminedModuleCount()).toBe(findContractModules().length);
+  });
+});
+
+describe('LAYER — acyclicity does not imply legality (ARCH-101 · issue #2180)', () => {
+  // The reason the layer condition had to ship in the SAME change that relaxed the manifest
+  // prohibition: a same-layer edge is perfectly acyclic, so `findCycles` reports nothing and the case
+  // the ruling exists to forbid would be reachable and unguarded.
+  const twoOwners = new Map([
+    ['a-contracts', 'agent-interface-command'],
+    ['b-contracts', 'agent-interface-execution'],
+  ]);
+  const sameLayer = new Map([
+    ['agent-interface-command', 0],
+    ['agent-interface-execution', 0],
+  ]);
+
+  const edges = projectGraph(
+    { 'a-contracts': "import type { IThing } from './b-contracts.js';", 'b-contracts': '' },
+    twoOwners,
+    new Map(),
+  );
+
+  it('the same-layer graph is ACYCLIC — findCycles reports nothing', () => {
+    expect(findCycles(edges, new Set(twoOwners.values()))).toEqual([]);
+  });
+
+  it('and it is still ILLEGAL — the layer check refuses what acyclicity permits', () => {
+    const verdict = judgeEdge('agent-interface-command', 'agent-interface-execution', sameLayer);
+    expect(verdict.legal).toBe(false);
+    expect(verdict.reason).toBe('same-layer');
+  });
+
+  it('the real module graph is legal under the real declaration', () => {
+    const parsed = parseOwnerMap(readFileSync(RULE_DOC, 'utf8'));
+    const realEdges = projectGraph(realSources(), parsed.moduleOwner, parsed.symbolOwner, PENDING);
+    const layers = readInterfaceLayers();
+    const illegal = [];
+    for (const [from, outs] of realEdges) {
+      for (const to of outs.keys()) {
+        if (!judgeEdge(from, to, layers).legal) illegal.push(`${from} → ${to}`);
+      }
+    }
+    expect(illegal).toEqual([]);
   });
 });

--- a/scripts/harness/check-dependency-direction.mjs
+++ b/scripts/harness/check-dependency-direction.mjs
@@ -25,6 +25,12 @@
  *
  * Exit code 0 = clean, 1 = violations found.
  */
+import {
+  explainEdge,
+  isInterfacePackage,
+  judgeEdge,
+  readInterfaceLayers,
+} from './interface-layers.mjs';
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
@@ -220,26 +226,53 @@ function checkPluginLayerDeps(packages) {
 }
 
 /**
- * Rule 5 (INFRA-025): agent-interface-* packages are pure contract SSOTs — their production
- * dependencies must be a subset of {agent-core}. Depending on an implementation package
- * reverses the contract direction (the inversion that let executor/session types leak into
- * agent-interface-transport until 2026-07-04).
+ * Rule 5 (INFRA-025, amended by ARCH-101): agent-interface-* packages are pure contract SSOTs.
+ *
+ * TWO things are refused, and they are different:
+ *
+ *  - depending on an IMPLEMENTATION package, which reverses the contract direction (the inversion
+ *    that let executor/session types leak into agent-interface-transport until 2026-07-04);
+ *  - depending on a PEER interface package at the same declared layer, or upward.
+ *
+ * The rule used to say `deps ⊆ {agent-core}` — the interface layer had to be EDGELESS. That was an
+ * exact proxy while one package held every contract family. ARCH-100 decomposed it into six owners,
+ * and the owner then ruled that the general layer rule governs this prefix too: composition across
+ * DIFFERING layers, one-directional, is permitted; only SAME-LAYER is forbidden. Edgelessness is an
+ * over-approximation of that, and it forbade the target graph, so it is replaced by the direct
+ * property.
+ *
+ * The layer assignment is NOT decided here. It is declared once in
+ * `.agents/specs/contract-family-owner-map.md` and read through `interface-layers.mjs`, which
+ * `interface-family-owner` also uses for module-level edges. One fact, one parser, two altitudes.
  */
-export function checkInterfacePackageDeps(packages) {
+export function checkInterfacePackageDeps(packages, layers = readInterfaceLayers()) {
   const violations = [];
   const interfacePrefix = `${HARNESS.internalPackagePrefix}interface-`;
 
   for (const [name, pkg] of packages) {
     if (!name.startsWith(interfacePrefix)) continue;
     for (const dep of pkg.dependencies) {
-      if (dep.startsWith(HARNESS.npmScopePrefix) && dep !== HARNESS.corePackage) {
+      if (!dep.startsWith(HARNESS.npmScopePrefix) || dep === HARNESS.corePackage) continue;
+
+      if (!isInterfacePackage(dep)) {
         violations.push({
           package: name,
           dep,
           message:
             `Interface-package violation: ${name} must not depend on ${dep}. ` +
             `agent-interface-* packages own contracts; implementations depend on them, ` +
-            `never the reverse (deps ⊆ {${HARNESS.corePackage}}).`,
+            `never the reverse. A peer agent-interface-* package is permitted only DOWNWARD ` +
+            `across declared layers (ARCH-101).`,
+        });
+        continue;
+      }
+
+      const verdict = judgeEdge(name, dep, layers);
+      if (!verdict.legal) {
+        violations.push({
+          package: name,
+          dep,
+          message: `Interface-package violation: ${explainEdge(name, dep, verdict)}`,
         });
       }
     }

--- a/scripts/harness/interface-layers.mjs
+++ b/scripts/harness/interface-layers.mjs
@@ -1,0 +1,129 @@
+/**
+ * ARCH-101 (issue #2180) — the declared layer of each `agent-interface-*` package, and the one
+ * predicate that decides whether an edge between two of them is legal.
+ *
+ * ## The rule this encodes
+ *
+ * The owner ruled that the general layer rule governs this prefix: a package may compose another with
+ * the same prefix **when the layers differ and the composition is one-directional**. Only SAME-LAYER
+ * is forbidden — and an upward edge is forbidden by the same sentence, because "one-directional"
+ * fixes which way the composition runs.
+ *
+ * The Interface Package Rule previously said `deps ⊆ {agent-core}`, i.e. the interface layer had to be
+ * EDGELESS. That was an exact proxy for the property while one package held every contract family;
+ * decomposing into six owners (ARCH-100) makes the proxy an over-approximation that forbids the target
+ * graph. Edgelessness is replaced here by the direct property.
+ *
+ * ## Why this file exists rather than the check living in either guard
+ *
+ * TWO guards need the same answer at different altitudes: `checkInterfacePackageDeps` judges MANIFEST
+ * edges (`package.json` dependencies) and `interface-family-owner` judges MODULE edges (imports
+ * between contract files). If each parsed the declaration itself, one fact would have two parsers that
+ * can disagree about it — which is the duplication class this repository keeps paying for, and which
+ * ARCH-100's owner map was built to avoid. The document coupling is accepted ONCE, here.
+ *
+ * ## What it does NOT decide
+ *
+ * Which package belongs in which layer. That assignment is ARCH-100's, declared in
+ * `.agents/specs/contract-family-owner-map.md`, and this module only reads it. A package absent from
+ * the declaration has NO layer, and an edge touching it is `unknown` rather than legal — a caller that
+ * treats "no layer declared" as permission has re-created the vacuous green this pair of guards exists
+ * to refuse.
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+export const LAYER_DOC = path.join(ROOT, '.agents/specs/contract-family-owner-map.md');
+const MARKER = '<!-- arch-101:layer-map -->';
+
+/**
+ * Parse the layer table. PURE over the document text.
+ *
+ * @returns {{layers: Map<string, number>, missingMarker: boolean}} `layers` keys are bare package
+ *   names (`agent-interface-session`), not npm specifiers — callers normalise.
+ */
+export function parseLayerDeclaration(docText) {
+  const layers = new Map();
+  const at = docText.indexOf(MARKER);
+  if (at === -1) return { layers, missingMarker: true };
+
+  // Bounded to the ONE table after the marker. An unbounded read would absorb a later example row as
+  // a real declaration and nothing would say so — the same fail-open the owner-map parser was fixed
+  // for in HARNESS-116.
+  let started = false;
+  for (const line of docText.slice(at).split('\n')) {
+    const isRow = /^\s*\|/.test(line);
+    if (started && !isRow) break;
+    if (isRow) started = true;
+    const m = line.match(/^\|\s*(\d+)\s*\|\s*`(agent-interface-[a-z-]+)`\s*\|/);
+    if (m) layers.set(m[2], Number(m[1]));
+  }
+  return { layers, missingMarker: false };
+}
+
+/** Strip an npm scope so a scoped specifier and the bare name compare equal. */
+export function bareName(pkg) {
+  return pkg.replace(/^@[^/]+\//, '');
+}
+
+/** Read the declaration from the repository. Throws rather than returning an empty legal-by-default map. */
+export function readInterfaceLayers(docPath = LAYER_DOC) {
+  if (!existsSync(docPath)) {
+    throw new Error(`interface-layers: cannot read ${path.relative(ROOT, docPath)}`);
+  }
+  const { layers, missingMarker } = parseLayerDeclaration(readFileSync(docPath, 'utf8'));
+  if (missingMarker) {
+    throw new Error(
+      `interface-layers: ${path.relative(ROOT, docPath)} has no ${MARKER} marker. The layer ` +
+        `declaration is what authorizes every interface→interface edge; without it there is nothing ` +
+        `to check, and a guard that passes because it found no input is the defect it exists to refuse.`,
+    );
+  }
+  return layers;
+}
+
+/** Is this an `agent-interface-*` package? */
+export function isInterfacePackage(pkg) {
+  return bareName(pkg).startsWith('agent-interface-');
+}
+
+/**
+ * Judge one interface→interface edge against the declaration.
+ *
+ * @returns {{legal: boolean, reason: 'downward'|'same-layer'|'upward'|'undeclared', from?: number, to?: number, missing?: string[]}}
+ */
+export function judgeEdge(from, to, layers) {
+  const a = layers.get(bareName(from));
+  const b = layers.get(bareName(to));
+  if (a === undefined || b === undefined) {
+    return {
+      legal: false,
+      reason: 'undeclared',
+      missing: [
+        a === undefined ? bareName(from) : null,
+        b === undefined ? bareName(to) : null,
+      ].filter(Boolean),
+    };
+  }
+  if (a === b) return { legal: false, reason: 'same-layer', from: a, to: b };
+  if (a < b) return { legal: false, reason: 'upward', from: a, to: b };
+  return { legal: true, reason: 'downward', from: a, to: b };
+}
+
+/** The failure sentence for an illegal edge, in the vocabulary the rule uses. */
+export function explainEdge(from, to, verdict) {
+  const f = bareName(from);
+  const t = bareName(to);
+  switch (verdict.reason) {
+    case 'same-layer':
+      return `${f} → ${t} is a SAME-LAYER dependency (both layer ${verdict.from}). Interface packages compose only across differing layers; move one, or the types they share belong in one package.`;
+    case 'upward':
+      return `${f} (layer ${verdict.from}) → ${t} (layer ${verdict.to}) runs UPWARD. Composition is one-directional: a lower layer never names a higher one.`;
+    case 'undeclared':
+      return `${f} → ${t} cannot be judged: ${verdict.missing.join(' and ')} ${verdict.missing.length > 1 ? 'have' : 'has'} no declared layer in .agents/specs/contract-family-owner-map.md. Declare the layer; an undeclared package is not legal by default.`;
+    default:
+      return `${f} → ${t} is legal (layer ${verdict.from} → ${verdict.to}).`;
+  }
+}

--- a/scripts/harness/scan-interface-family-owner.mjs
+++ b/scripts/harness/scan-interface-family-owner.mjs
@@ -245,6 +245,33 @@ export function readExaminedModuleCount(srcDir = SOURCE_PKG) {
   return findContractModules(srcDir).length;
 }
 
+/**
+ * LAYER — module edges that run same-layer or upward between owner packages.
+ *
+ * PURE and EXPORTED, and that is not incidental. When this lived inline in `main()` the tests
+ * exercised `judgeEdge` directly and never the scan's USE of it, so reversing this condition left the
+ * whole suite green — `regression-red-proof` reported `accidental-green-fail (all-pass)` on exactly
+ * that. A guard reachable only through `main()` is a guard no test can falsify.
+ *
+ * ACYCLICITY does not cover this: `command → execution` is perfectly acyclic and forbidden, because
+ * both sit at layer 0 and the ruling permits composition only across DIFFERING layers,
+ * one-directionally.
+ */
+export function findLayerViolations(edges, layers) {
+  const out = [];
+  for (const [from, outs] of edges) {
+    for (const [to, why] of outs) {
+      const verdict = judgeEdge(from, to, layers);
+      if (verdict.legal) continue;
+      const sample = [...why].slice(0, 3).join(', ');
+      out.push(
+        `LAYER: ${explainEdge(from, to, verdict)} (via ${sample}${why.size > 3 ? `, … ${why.size} total` : ''})`,
+      );
+    }
+  }
+  return out;
+}
+
 function main() {
   const fail = [];
   const note = [];
@@ -295,10 +322,6 @@ function main() {
     fail.push(`ACYCLICITY: the projected package graph has a cycle — ${c.join(' → ')}`);
   }
 
-  // LAYER — acyclicity no longer implies legality. `command → execution` is perfectly acyclic and
-  // forbidden: both sit at layer 0, and the ruling permits composition only across DIFFERING layers,
-  // one-directionally. Without this condition, relaxing the manifest prohibition (ARCH-101) would
-  // leave the case the ruling exists to forbid reachable and unguarded at the module level.
   let layers;
   try {
     layers = readInterfaceLayers();
@@ -306,17 +329,7 @@ function main() {
     console.error(`interface-family-owner: ${error.message}`);
     process.exit(1);
   }
-  for (const [from, outs] of edges) {
-    for (const [to, why] of outs) {
-      const verdict = judgeEdge(from, to, layers);
-      if (!verdict.legal) {
-        const sample = [...why].slice(0, 3).join(', ');
-        fail.push(
-          `LAYER: ${explainEdge(from, to, verdict)} (via ${sample}${why.size > 3 ? `, … ${why.size} total` : ''})`,
-        );
-      }
-    }
-  }
+  fail.push(...findLayerViolations(edges, layers));
 
   // PLACEMENT — a module is misplaced only once its declared owner package actually exists. Before
   // that, sitting in `agent-interface-transport` is the expected pre-migration state, not a

--- a/scripts/harness/scan-interface-family-owner.mjs
+++ b/scripts/harness/scan-interface-family-owner.mjs
@@ -15,6 +15,11 @@
 //   3. PLACEMENT — an `agent-interface-*` package holds a module it does not own. Inert until the
 //      migration leaves (issues #2108-#2113) begin to move families; it is the condition that keeps
 //      the map honest once they do.
+//   4. LAYER (ARCH-101) — a module edge runs same-layer or upward between owner packages. ACYCLICITY
+//      does not cover this: `command → execution` is perfectly acyclic and forbidden, because both
+//      sit at layer 0 and the ruling permits composition only across DIFFERING layers,
+//      one-directionally. The layer declaration is read through `interface-layers.mjs`, the same
+//      parser `check-dependency-direction.mjs` uses for manifest edges.
 //
 // Today every module still lives in `agent-interface-transport`, so (3) passes trivially and (1)+(2)
 // verify the PLAN against the real source. The scan is the reason the plan cannot rot between now and
@@ -45,6 +50,10 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// ARCH-101: the layer declaration authorizes each edge, and ONE parser owns it. This scan judges
+// MODULE edges; `check-dependency-direction.mjs` judges MANIFEST edges. Same predicate, two altitudes.
+import { explainEdge, judgeEdge, readInterfaceLayers } from './interface-layers.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const RULE_DOC = path.join(ROOT, '.agents/specs/contract-family-owner-map.md');
@@ -286,6 +295,29 @@ function main() {
     fail.push(`ACYCLICITY: the projected package graph has a cycle — ${c.join(' → ')}`);
   }
 
+  // LAYER — acyclicity no longer implies legality. `command → execution` is perfectly acyclic and
+  // forbidden: both sit at layer 0, and the ruling permits composition only across DIFFERING layers,
+  // one-directionally. Without this condition, relaxing the manifest prohibition (ARCH-101) would
+  // leave the case the ruling exists to forbid reachable and unguarded at the module level.
+  let layers;
+  try {
+    layers = readInterfaceLayers();
+  } catch (error) {
+    console.error(`interface-family-owner: ${error.message}`);
+    process.exit(1);
+  }
+  for (const [from, outs] of edges) {
+    for (const [to, why] of outs) {
+      const verdict = judgeEdge(from, to, layers);
+      if (!verdict.legal) {
+        const sample = [...why].slice(0, 3).join(', ');
+        fail.push(
+          `LAYER: ${explainEdge(from, to, verdict)} (via ${sample}${why.size > 3 ? `, … ${why.size} total` : ''})`,
+        );
+      }
+    }
+  }
+
   // PLACEMENT — a module is misplaced only once its declared owner package actually exists. Before
   // that, sitting in `agent-interface-transport` is the expected pre-migration state, not a
   // violation: the map states a TARGET. So this edge arms itself one leaf at a time — the moment
@@ -318,7 +350,7 @@ function main() {
 
   const waves = migrationWaves(edges, owners);
   console.log(
-    `::examined:: ${modules.length} contract modules, ${owners.size} declared owners, ${placementChecked} modules placement-checked, ${placementPending} awaiting an owner package that does not exist yet`,
+    `::examined:: ${modules.length} contract modules, ${owners.size} declared owners, ${layers.size} declared layers, ${placementChecked} modules placement-checked, ${placementPending} awaiting an owner package that does not exist yet`,
   );
   for (const n of note) console.log(`- [note] ${n}`);
   if (PENDING_CORRECTIONS.length) {
@@ -341,7 +373,8 @@ function main() {
     process.exit(1);
   }
   console.log(
-    'interface-family-owner scan passed — owner map is total and the projected package graph is acyclic.',
+    'interface-family-owner scan passed — owner map is total, every module edge is a legal downward ' +
+      'layer composition, and the projected package graph is acyclic.',
   );
 }
 


### PR DESCRIPTION
Closes #2180. Unblocks #2108 through #2113 under tracker #2068.

## What was blocking

The Interface Package Rule required an **edgeless** interface layer — `deps ⊆ {agent-core}`. That was
an exact proxy for the property while one package held every contract family. ARCH-100 decomposed it
into six owners and the proxy became an over-approximation that forbids the target graph.

The owner ruled that the general layer rule governs this prefix: composition across **differing**
layers, one-directional, is permitted; only **same-layer** is forbidden, and upward is forbidden by
the same sentence.

**Nothing implemented the ruling.** `checkInterfacePackageDeps` still failed every
interface→interface edge, so #2109 would have gone red on its first push — `agent-interface-transport`
retains `session-contracts` until #2110 and must depend on `agent-interface-execution`.

## Why this is one PR and not two

Relaxing the manifest prohibition alone would be **worse than the prohibition it replaces**.

Today a same-layer edge is refused only as a side effect of refusing *every* edge, and
`interface-family-owner` proves the module graph is **acyclic** — which no longer implies legal.
`command → execution` is perfectly acyclic and forbidden.

That is fixed permanently by a test that asserts both halves on the same fixture:

> `the same-layer graph is ACYCLIC — findCycles reports nothing`
> `and it is still ILLEGAL — the layer check refuses what acyclicity permits`

Relax without the direction check and the case the ruling exists to forbid becomes reachable and
unguarded at the module level.

## One fact, one parser, two altitudes

The layer declaration is machine-readable in `.agents/specs/contract-family-owner-map.md`, beside the
owner map it is the second axis of. `scripts/harness/interface-layers.mjs` is the **only** thing that
parses it:

- `check-dependency-direction.mjs` judges **manifest** edges (`package.json` dependencies)
- `interface-family-owner` judges **module** edges (imports between contract files)

Both call the same `judgeEdge`. Two guards parsing one markdown table would be two parsers that can
disagree about one fact — the duplication class ARCH-100's map was built to avoid. The document
coupling is accepted once, in one place.

**An undeclared package is not legal by default.** An edge touching one is refused, naming what is
missing, rather than passing because nothing was found.

## Falsified before shipping

Each case demonstrated red against the guard, not assumed:

| case | result |
| --- | --- |
| downward (`session → execution`) | accepted |
| downward across two layers (`mobility → execution`) | accepted |
| **same-layer** (`command → execution`) | refused, both layers named |
| **upward** (`execution → session`) | refused, direction named |
| **undeclared** peer | refused, missing package named |
| implementation dep (`session → agent-framework`) | refused |
| `agent-core` | accepted |

And at module level, by editing the real declaration to put session at layer 0: three `LAYER:`
findings appeared while **`ACYCLICITY:` reported nothing** — the proof that the new condition adds a
property the old one did not have.

## The rule amendment

Six lines out, six lines in. `.agents/project-structure.md` stays at its frozen **385** —
`routing-document-size` is satisfied by construction rather than by an exemption. `rule-statement-floor`
(HARNESS-117) confirms the amended rule still states `INTERFACE-DEPS`.

## A third constraint, checked and deliberately not implemented

The owner also ruled that a family root may not depend on its own members, only the reverse, and that
an aggregator over a family carries a completely different prefix.

I checked whether it falls out of the layer declaration for free. **It does not in general** — a root
and its members can sit at different layers and the edge is still forbidden in one direction, so it is
a directional rule about a pair rather than a layer rule.

For this family it is **vacuous by construction**: there is no `agent-interface` root and no
aggregator, and the naming half of the rule forecloses ever adding one inside the prefix. Recorded in
the map so a later reader does not add a bundle under either name. No guard checks it, deliberately —
a check that can never fire is its own defect.

## Scope

No production TypeScript is moved. `.agents/project-structure.md` and the auditor definitions are not
in conflict with ARCH-102, which merged as `fe3ed577f` before this branch was cut.

## Verification at `e4161906b`

- `pnpm harness:verify-like-ci` — PASS, all 12 stages
- `pnpm harness:scan` — 140 passed, 2 skipped, 0 failed
- 43 unit tests across the two suites

`typecheck` failed on the first two runs and was **not this branch** — it touches zero `.ts` files.
`#2193` (SEC-015) landed on `agent-session` while my local `dist/` predated it. `pnpm build`, then
green. Second time today; the `dist` scan's advisory says exactly this, and it is worth reading before
treating a cross-package type error as your own.