### PR TITLE
docs(spec): a package SPEC points at the manifest instead of restating it (DOCS-028)

### DIFF
--- a/.agents/skills/spec-writing-standard/SKILL.md
+++ b/.agents/skills/spec-writing-standard/SKILL.md
@@ -34,7 +34,13 @@ Use when no `docs/SPEC.md` exists for the package.
 2. **Write all required sections** (all mandatory):
    - **Scope**: What the package owns (2–4 sentences).
    - **Boundaries**: What the package does NOT own and where those responsibilities live.
-   - **Architecture Overview**: Layer structure, key components, design patterns used.
+   - **Architecture Overview**: Layer structure, key components, design patterns used. This means the
+     structure INSIDE the package. The package's position in the repository — its family, its layer,
+     and which dependency edges are legal — belongs to
+     [`.agents/specs/ARCHITECTURE-MAP.md`](../../specs/ARCHITECTURE-MAP.md) and to the package's own
+     `package.json`, and a SPEC points at them rather than restating them (DOCS-028). Measured before
+     that rule existed: 7 SPECs stated a dependency set in prose, five by copy-paste, and two were
+     already false. `spec-manifest-restatement` in `pnpm harness:scan` refuses a new one.
    - **Type Ownership**: SSOT types this package defines. Table: Type | Location | Purpose.
    - **Public API Surface**: Exported classes, functions, types. Table: Export | Kind | Description. The table MUST list every runtime export of the package entry (`src/index.ts`) — the reverse-edge `check-spec-public-surface` gate enforces this completeness contract.
    - **Extension Points**: How consumers extend behavior (abstract classes, interfaces, strategies).

--- a/.agents/spec-docs/todo/DOCS-028-a-spec-restates-a-fact-its-manifest-owns.md
+++ b/.agents/spec-docs/todo/DOCS-028-a-spec-restates-a-fact-its-manifest-owns.md
@@ -1,0 +1,77 @@
+---
+status: approved
+type: RULE
+tags: [architecture]
+---
+
+# DOCS-028: a package SPEC restates a fact its manifest owns
+
+Paired with `.agents/tasks/DOCS-028-a-spec-restates-a-fact-its-manifest-owns.md`.
+Arising from [issue #2194](https://github.com/woojubb/robota/issues/2194).
+
+## Problem
+
+See the paired Task for the measurement. In short: the architecture map states its relationship to
+package SPECs; SPECs state no relationship back, and 2 of the 7 layer claims they carried were already
+false.
+
+## Prior Art Research
+
+Waived: the decision is which of this repository's own documents owns a fact, settled by this
+repository's own rule (`learning-loop.md` § Contradiction Between Rules). No external product's
+documentation bears on it. Recorded rather than left empty, per [research.md](../../rules/research.md).
+
+## Architecture Review
+
+**Alternatives.**
+
+1. **Parse the prose claim and diff it against `package.json`.** Rejected by `learning-loop.md`:
+   _"Prefer deleting the restatement to keeping both and checking them."_ It keeps two copies of one
+   fact and adds a parser between them — the arrangement that produced the drift. It also makes the
+   check argue about prose, which is where a check stops being falsifiable.
+2. **Delete the Layer field entirely.** Rejected: the layer NAME is a classification the manifest does
+   not carry, and it is genuinely the SPEC's to state. Only the dependency enumeration is a
+   restatement.
+3. **A sweep with no check.** Rejected on the repository's own recorded evidence — the rule that
+   removal of an unconsumed surface is a product decision "already existed and was violated anyway",
+   which is why `check-contract-disposition` exists. A sweep without a floor drifts back.
+4. **Remove the restatement, point at the owner, and refuse a new one.** Chosen.
+
+**Reachability.** The rule is reached from the two documents a SPEC author actually reads —
+`spec-writing-standard` and `spec-template.md` — which previously made zero reference to the map.
+
+**Falsifiability.** The decision is an exported pure predicate, tested directly. ARCH-101's
+`regression-red-proof` failure is the precedent: a condition living inline in `main()` was covered by
+tests that exercised only the shared predicate, so deleting the condition broke nothing.
+
+## Completion Criteria
+
+- **TC-01** No SPEC's Layer field enumerates dependencies; all 7 point at the owner instead.
+- **TC-02** `spec-manifest-restatement` refuses a Layer field naming a workspace package, and is wired.
+- **TC-03** Its finder is classified fail-closed and its declared size is registered and tested.
+- **TC-04** `spec-writing-standard` and `spec-template.md` name the map and say who owns what.
+- **TC-05** Three mutants die; the suite is green restored.
+- **TC-06** `pnpm harness:scan` green.
+
+## Test Plan
+
+See the paired Task. The load-bearing evidence is TC-05 — without a killed mutant, a new scan's green
+is the accidental-green shape issue #2181 catalogues.
+
+## Evidence Log
+
+| Claim                                        | Verified at                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GATE-APPROVAL                                | Standing owner instruction, current conversation: "레포 속 규칙대로 모두 너가 판단하고 레포 속 규칙을 기반으로 선택하기 어려운 것만 나에게 요청하며 모든 작업을 진행하며 마지막까지 완료해줘" — decide by the repository's rules and escalate only what the rules cannot settle. This item is settled by `learning-loop.md` § Contradiction Between Rules, quoted above, so it is inside the delegated class. |
+| 7 SPECs stated a layer in prose              | `grep -rl '^- \*\*Layer\*\*' packages/*/docs/SPEC.md` → 7 of 58                                                                                                                                                                                                                                                                                                                                               |
+| Two were false                               | `agent-builtin-providers` and `agent-provider-openai`, compared to their `package.json` dependencies                                                                                                                                                                                                                                                                                                          |
+| Five were copy-pasted                        | identical sentence across the five leaf providers                                                                                                                                                                                                                                                                                                                                                             |
+| The map states the relationship one way only | `ARCHITECTURE-MAP.md` ¶3; `spec-writing-standard` and `spec-template.md` → zero references to the map                                                                                                                                                                                                                                                                                                         |
+| The check can go red                         | mutants: predicate neutered → 3 red; `=` → `+=` on the counter → 1 red; governed-tree guard removed → 1 red; restored → 8 green                                                                                                                                                                                                                                                                               |
+| Scans pass                                   | `pnpm harness:scan` → 141 passed, 2 skipped, 0 failed                                                                                                                                                                                                                                                                                                                                                         |
+
+## User Execution Test Scenarios
+
+Not applicable — documentation fields, an authoring standard, a template comment and one harness scan;
+no runnable user-facing product behaviour changes. The reason is recorded per
+`.agents/tasks/README.md`, and the applicable checks including the mutation proof are in the Test Plan.

--- a/.agents/tasks/DOCS-028-a-spec-restates-a-fact-its-manifest-owns.md
+++ b/.agents/tasks/DOCS-028-a-spec-restates-a-fact-its-manifest-owns.md
@@ -1,0 +1,84 @@
+---
+title: 'DOCS-028: a package SPEC restates a fact its manifest owns'
+issue: https://github.com/woojubb/robota/issues/2194
+status: in-progress
+created: 2026-08-23
+priority: high
+urgency: now
+area: packages/*/docs/SPEC.md, .agents/skills/spec-writing-standard, .agents/templates, scripts/harness
+depends_on: []
+---
+
+# DOCS-028: a package SPEC restates a fact its manifest owns
+
+## Problem
+
+`.agents/specs/ARCHITECTURE-MAP.md` states its relationship to package SPECs in one direction —
+"Package `docs/SPEC.md` files remain the owner contracts for each package … without duplicating
+package-level contract truth". Nothing states the other direction, and the consequence is measurable.
+
+7 of 58 package SPECs stated a layer in prose, and the sentence carried the package's dependency set
+with it. **Two were false:**
+
+| package                   | SPEC claimed                                                      | manifest declared                                |
+| ------------------------- | ----------------------------------------------------------------- | ------------------------------------------------ |
+| `agent-builtin-providers` | "Layer 1 (depends on `agent-core` only among framework packages)" | `agent-core` + four provider siblings            |
+| `agent-provider-openai`   | the same sentence                                                 | `agent-core`, `agent-provider-openai-compatible` |
+
+Five of the seven were the identical sentence, copy-pasted. It was true for the leaf providers and was
+never true for the aggregator, which has depended on four siblings since ARCH-PROVIDER-002 created it.
+
+Disclosure: STRUCT-011 renamed that package and moved its SPEC without noticing the false claim.
+
+## Why this is the same defect as the one that made ARCH-100's contradiction invisible
+
+A package's layer had three possible homes and no owner: prose in some SPECs, ARCH-101's
+machine-readable table in the map (for one family), and `project-structure.md` § Layered Assembly
+Architecture. Nothing compared any pair. That is why a merged owner map could state a target the
+Interface Package Rule forbade and nothing brought them into contact — no package SPEC referenced
+either document.
+
+## Decision
+
+The repository's own rule settles the shape. `learning-loop.md` § Contradiction Between Rules:
+_"Prefer deleting the restatement to keeping both and checking them."_
+
+So the fix is **not** a check that parses the prose claim and diffs it against the manifest — that
+keeps two copies and puts a parser between them, which is the arrangement that produced the drift.
+The restatements are removed, the SPEC points at the owner, and a check refuses a new one.
+
+ARCH-101 established the same shape one family over: one declaration, one reader, no second copy.
+
+## Plan
+
+- [x] Rewrite the `**Layer**:` field in all 7 SPECs: keep the layer NAME (a classification the manifest
+      does not carry), drop the dependency enumeration, point at the owner.
+- [x] Add `spec-manifest-restatement` — refuses a Layer field that names a workspace package.
+- [x] State the relationship in `spec-writing-standard` and `spec-template.md`, which made **zero**
+      reference to the architecture map.
+- [x] Wire the scan, classify its finder, and register its declared size.
+
+## Test Plan
+
+- `scripts/harness/__tests__/check-spec-manifest-restatement.test.mjs` — 8 cases against the exported
+  predicate, not through `main()`: a guard reachable only through `main()` is a guard no test can
+  falsify (ARCH-101).
+- **Three mutants killed, proven not asserted.** Predicate never reports → 3 red. Counter accumulates
+  (`=` → `+=`) → 1 red. Governed-tree guard removed → 1 red. Restored → 8 green.
+- The two rows in the fixture are the real claims that were false in the tree.
+- `pnpm harness:scan` → 141 passed, 2 skipped, 0 failed.
+
+## What the check does NOT cover, stated so its green is not read as wider than it is
+
+Only the structured `- **Layer**:` field. A SPEC's prose elsewhere may still restate a dependency set,
+and this cannot see it. That is deliberate: a SPEC legitimately states BOUNDARIES ("must never depend
+on the framework"), which are constraints the manifest does not own, and no pattern separates a
+boundary claim from a dependency restatement without reading intent. A wider check would fail on
+correct documents, which gets suppressed rather than obeyed.
+
+## User Execution Test Scenarios
+
+Not applicable — documentation fields, an authoring standard, a template comment, and one harness
+scan. No runnable user-facing product behaviour changes. Per `.agents/tasks/README.md` a
+documentation/harness change records the not-applicable with its reason; the checks that do apply,
+including the mutation proof, are in the Test Plan.

--- a/.agents/templates/spec-template.md
+++ b/.agents/templates/spec-template.md
@@ -10,7 +10,12 @@
 
 ## Architecture Overview
 
-{Layer structure, key components, design patterns used.}
+{Layer structure, key components, design patterns used — INSIDE this package.}
+
+<!-- The package's position in the repository is not this document's to state. Its family, its layer,
+     and which dependency edges are legal live in .agents/specs/ARCHITECTURE-MAP.md and in this
+     package's package.json. Point at them; do not restate them. `spec-manifest-restatement` refuses
+     a Layer field that enumerates dependencies (DOCS-028). -->
 
 ## Type Ownership
 

--- a/packages/agent-builtin-providers/docs/SPEC.md
+++ b/packages/agent-builtin-providers/docs/SPEC.md
@@ -9,7 +9,7 @@ Users who need a provider not included here can implement `IAIProvider` from `@r
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-builtin-providers`
-- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`, `agent-session`, `agent-tools`, `agent-command`, or `agent-transport`)
+- **Layer**: Layer 1 — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: (none directly — composes the LLM leaf packages)
 - **Platform**: node
 

--- a/packages/agent-provider-anthropic/docs/SPEC.md
+++ b/packages/agent-provider-anthropic/docs/SPEC.md
@@ -9,7 +9,7 @@ Users who need a provider not included here can implement `IAIProvider` from `@r
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-provider-anthropic`
-- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`, `agent-session`, `agent-tools`, `agent-command`, or `agent-transport`)
+- **Layer**: Layer 1 — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: `@anthropic-ai/sdk`
 - **Platform**: node
 

--- a/packages/agent-provider-bytedance/docs/SPEC.md
+++ b/packages/agent-provider-bytedance/docs/SPEC.md
@@ -9,7 +9,7 @@ Users who need a provider not included here can implement `IAIProvider` from `@r
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-provider-bytedance`
-- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`, `agent-session`, `agent-tools`, `agent-command`, or `agent-transport`)
+- **Layer**: Layer 1 — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: (bespoke HTTP — no vendor SDK)
 - **Platform**: node
 

--- a/packages/agent-provider-gemini/docs/SPEC.md
+++ b/packages/agent-provider-gemini/docs/SPEC.md
@@ -9,7 +9,7 @@ Users who need a provider not included here can implement `IAIProvider` from `@r
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-provider-gemini`
-- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`, `agent-session`, `agent-tools`, `agent-command`, or `agent-transport`)
+- **Layer**: Layer 1 — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: `@google/genai`
 - **Platform**: node
 

--- a/packages/agent-provider-openai-compatible/docs/SPEC.md
+++ b/packages/agent-provider-openai-compatible/docs/SPEC.md
@@ -9,7 +9,7 @@ Users who need a provider not included here can implement `IAIProvider` from `@r
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-provider-openai-compatible`
-- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`, `agent-session`, `agent-tools`, `agent-command`, or `agent-transport`)
+- **Layer**: Layer 1 — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: `openai`
 - **Platform**: node
 

--- a/packages/agent-provider-openai/docs/SPEC.md
+++ b/packages/agent-provider-openai/docs/SPEC.md
@@ -9,7 +9,7 @@ Users who need a provider not included here can implement `IAIProvider` from `@r
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-provider-openai`
-- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`, `agent-session`, `agent-tools`, `agent-command`, or `agent-transport`)
+- **Layer**: Layer 1 — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: `openai`
 - **Platform**: node
 

--- a/packages/agent-tool-defaults/docs/SPEC.md
+++ b/packages/agent-tool-defaults/docs/SPEC.md
@@ -28,7 +28,7 @@ independently.
 ## Package Identity
 
 - **npm name**: `@robota-sdk/agent-tool-defaults`
-- **Layer**: composition leaf (depends on `agent-core` and `agent-tools` only; never imports from `agent-framework`, `agent-session`, `agent-command`, or `agent-transport`)
+- **Layer**: composition leaf — the dependency set that places it there is declared in this package\'s manifest and enforced by `check-dependency-direction.mjs`; not restated here
 - **SDK**: (none directly — composes the tool factories)
 - **Platform**: node
 

--- a/scripts/harness/__tests__/check-spec-manifest-restatement.test.mjs
+++ b/scripts/harness/__tests__/check-spec-manifest-restatement.test.mjs
@@ -1,0 +1,147 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { makeTemp } from './make-temp.mjs';
+
+import {
+  collectSpecs,
+  examinedSpecCount,
+  findLayerRestatements,
+} from '../check-spec-manifest-restatement.mjs';
+
+function createFixture(files) {
+  const root = makeTemp('robota-spec-manifest-restatement-');
+  for (const [relativePath, content] of Object.entries(files)) {
+    const target = path.join(root, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, content, 'utf8');
+  }
+  return root;
+}
+
+/**
+ * DOCS-028 (issue #2194) — the decision is tested through the exported predicate, not through
+ * `main()`.
+ *
+ * ARCH-101 established why: a guard reachable only through `main()` is a guard no test can falsify,
+ * and `regression-red-proof` found exactly that shape when the layer condition lived inline in a
+ * scan's `main()` while the tests exercised only the shared predicate. Here the predicate IS the
+ * decision, so neutering it turns these red.
+ *
+ * The two rows in `RESTATEMENTS` are the real claims this scan was written for — both were live in
+ * the tree and both were FALSE: `agent-builtin-providers` said "agent-core only" while depending on
+ * four provider siblings, and `agent-provider-openai` said the same while depending on
+ * `agent-provider-openai-compatible`.
+ */
+const NAMES = [
+  '@robota-sdk/agent-provider-openai-compatible',
+  '@robota-sdk/agent-builtin-providers',
+  'agent-provider-openai-compatible',
+  'agent-builtin-providers',
+  'agent-provider-openai',
+  'agent-tool-defaults',
+  'agent-framework',
+  'agent-core',
+  'agent-tools',
+  'tool',
+];
+
+const spec = (layerLine) => ({
+  file: 'packages/x/docs/SPEC.md',
+  text: `# SPEC: x\n\n## Package Identity\n\n- **npm name**: \`@robota-sdk/x\`\n${layerLine}\n- **Platform**: node\n`,
+});
+
+describe('a SPEC may not restate the dependency set its manifest owns', () => {
+  it('refuses the exact claim that was false in the tree', () => {
+    const found = findLayerRestatements(
+      [
+        spec(
+          '- **Layer**: Layer 1 (depends on `agent-core` only among framework packages; never imports from `agent-framework`)',
+        ),
+      ],
+      NAMES,
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].named).toContain('agent-core');
+  });
+
+  it('refuses a claim naming the scoped package specifier', () => {
+    const found = findLayerRestatements(
+      [spec('- **Layer**: composition leaf (depends on `@robota-sdk/agent-tools`)')],
+      NAMES,
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it('accepts a layer name that points at the owner instead of enumerating', () => {
+    const found = findLayerRestatements(
+      [
+        spec(
+          "- **Layer**: Layer 1 — the dependency set that places it there is declared in this package's manifest and enforced by `check-dependency-direction.mjs`; not restated here",
+        ),
+      ],
+      NAMES,
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('does not match a package name as a substring of a longer one', () => {
+    // `tool` is a whole-token match only: a Layer field mentioning `agent-tool-defaults` must not be
+    // reported for `tool`. `\b` cannot express this, because a hyphen is itself a word boundary.
+    const found = findLayerRestatements(
+      [spec('- **Layer**: the tool-defaults composition leaf')],
+      ['tool'],
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('reports the longest matching name rather than a prefix of it', () => {
+    const found = findLayerRestatements(
+      [spec('- **Layer**: Layer 1 (depends on `agent-provider-openai-compatible`)')],
+      NAMES,
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].named).toContain('agent-provider-openai-compatible');
+    expect(found[0].named).not.toContain('agent-provider-openai');
+  });
+
+  it('ignores a SPEC with no Layer field at all', () => {
+    const found = findLayerRestatements(
+      [{ file: 'packages/y/docs/SPEC.md', text: '# SPEC: y\n\n## Scope\n\nSomething.\n' }],
+      NAMES,
+    );
+    expect(found).toEqual([]);
+  });
+});
+
+describe('DOCS-028 — the scan reports the size of what it examined', () => {
+  it('counts the SPECs it walked, and does not accumulate across runs', () => {
+    // measurement-provenance.md: a counter is an output and is tested as one. "examined 0 SPECs"
+    // reads exactly like a clean tree, which is why the number itself must be asserted — and
+    // asserted against a fixture, so the expected value is a property of the fixture rather than of
+    // whatever the workspace happens to hold today.
+    const root = createFixture({
+      'packages/one/package.json': '{"name":"@robota-sdk/one"}',
+      'packages/one/docs/SPEC.md': '# SPEC: one\n',
+      'packages/two/package.json': '{"name":"@robota-sdk/two"}',
+      'packages/two/docs/SPEC.md': '# SPEC: two\n',
+      // A package with no SPEC is another scan's finding, not this one's, and must not be counted.
+      'packages/three/package.json': '{"name":"@robota-sdk/three"}',
+    });
+
+    collectSpecs(root);
+    expect(examinedSpecCount()).toBe(2);
+
+    // Run it AGAIN over the same fixture: an accumulating counter would say 4.
+    collectSpecs(root);
+    expect(examinedSpecCount(), 'the counter accumulates across runs').toBe(2);
+  });
+
+  it('refuses a root without the tree it governs rather than reporting zero', () => {
+    // guard-scope-fail-closed: "no findings" over an unread corpus reads identically to a clean one.
+    const bare = makeTemp('robota-spec-manifest-restatement-bare-');
+    expect(() => collectSpecs(bare)).toThrow(/packages/);
+  });
+});

--- a/scripts/harness/check-spec-manifest-restatement.mjs
+++ b/scripts/harness/check-spec-manifest-restatement.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+/**
+ * DOCS-028 (issue #2194) — a package SPEC does not restate a fact its manifest owns.
+ *
+ * ## The defect this closes, measured
+ *
+ * 7 of 58 package SPECs stated a layer in prose, and the sentence carried the package's dependency
+ * set with it: "Layer 1 (depends on `agent-core` only among framework packages …)". Five of the seven
+ * were the IDENTICAL sentence, copy-pasted. **Two were false.** `agent-builtin-providers` claimed
+ * `agent-core` only while depending on four provider siblings — untrue since ARCH-PROVIDER-002 created
+ * it as the aggregator — and `agent-provider-openai` claimed the same while depending on
+ * `agent-provider-openai-compatible`.
+ *
+ * Nothing compared any of them to `package.json`, which is where the answer actually lives.
+ *
+ * ## Why a check rather than a sweep, and why THIS check rather than a comparison
+ *
+ * The obvious fix is to parse the prose claim and diff it against the manifest. That keeps two copies
+ * of one fact and puts a parser between them, which is the arrangement that produced the drift.
+ * `learning-loop.md` § Contradiction Between Rules settles it: *"Prefer deleting the restatement to
+ * keeping both and checking them."* So the restatements were removed, and this refuses a new one.
+ *
+ * ARCH-101 established the same shape one family over: one declaration, one reader, no second copy.
+ *
+ * ## WHAT IT CHECKS — deliberately narrow
+ *
+ * The `- **Layer**:` field in a SPEC's `## Package Identity` section must not name a workspace
+ * package. The layer NAME is a classification the manifest does not carry and belongs in the SPEC;
+ * the dependency set that places the package at that layer is `package.json`'s, and is enforced by
+ * `check-dependency-direction.mjs`.
+ *
+ * ## WHAT IT DOES NOT CHECK, stated so the green is not read as wider than it is
+ *
+ * Only that one structured field. A SPEC's prose elsewhere may still restate a dependency set, and
+ * this check cannot see it. That is deliberate rather than an oversight: a SPEC legitimately states
+ * BOUNDARIES ("must never depend on the framework"), which are constraints the manifest does not own,
+ * and no pattern separates a boundary claim from a dependency restatement without reading intent.
+ * Widening it would produce a check that fails on correct documents, which gets suppressed rather
+ * than obeyed.
+ *
+ * Exit code 0 = clean, 1 = findings.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { requireGovernedTree } from './governed-tree.mjs';
+import { loadHarnessConfig } from './harness-config.mjs';
+import { listWorkspacePackageDirs } from './workspace-packages.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+const HARNESS = loadHarnessConfig();
+
+/** The structured Layer field, if the SPEC has one. */
+const LAYER_FIELD = /^- \*\*Layer\*\*: (.+)$/m;
+
+/**
+ * A finding per SPEC whose Layer field names a workspace package.
+ *
+ * Exported for the fixture: the decision is a pure function of (text, package names), so it is
+ * tested directly rather than through `main()` — a guard reachable only through `main()` is a guard
+ * no test can falsify (ARCH-101, issue #2181).
+ */
+export function findLayerRestatements(specs, workspacePackageNames) {
+  const findings = [];
+  for (const { file, text } of specs) {
+    const match = LAYER_FIELD.exec(text);
+    if (!match) continue;
+    const claim = match[1];
+    // A whole token, not a substring: `tool` must not match inside `tool-defaults`, and `\b` does
+    // not help because a hyphen is itself a word boundary.
+    const named = workspacePackageNames.filter((name) =>
+      new RegExp(`(?<![\\w-])${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![\\w-])`).test(claim),
+    );
+    if (named.length > 0) {
+      findings.push({
+        file,
+        named,
+        detail:
+          `the Layer field names ${named.map((n) => `\`${n}\``).join(', ')}. ` +
+          `A package's dependency set is declared in its package.json and enforced by ` +
+          `check-dependency-direction.mjs — restating it here creates a second copy that drifts ` +
+          `(measured: 2 of 7 such claims were already false). State the layer NAME and point at the ` +
+          `owner; do not enumerate dependencies.`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * The corpus, and the names a Layer field may not enumerate.
+ *
+ * Exported so the size this scan declares is the output of the traversal that did the work, and is
+ * tested as that output rather than asserted in prose (measurement-provenance.md).
+ */
+let examinedCount = 0;
+
+export function collectSpecs(root) {
+  requireGovernedTree(root, ['packages'], {
+    scan: 'spec-manifest-restatement',
+    why: 'the package SPEC corpus IS the population — over a root without it there is no SPEC to judge, and "no findings" would claim no SPEC restates its manifest when none was read.',
+  });
+  // Absolute paths, per `listWorkspacePackageDirs`'s contract. Reported relative to the root so a
+  // finding is a path a reader can paste.
+  const dirs = listWorkspacePackageDirs(root);
+  const names = [];
+  const specs = [];
+  for (const dir of dirs) {
+    const base = path.basename(dir);
+    names.push(`${HARNESS.npmScopePrefix}${base}`, base);
+    const specPath = path.join(dir, 'docs', 'SPEC.md');
+    try {
+      specs.push({ file: path.relative(root, specPath), text: readFileSync(specPath, 'utf8') });
+    } catch {
+      // allow-fallback: a package without a SPEC is another scan's finding, not this one's
+    }
+  }
+  // Longest first, so `agent-provider-openai-compatible` is reported rather than its prefix.
+  names.sort((a, b) => b.length - a.length);
+  // Assigned, never incremented: a counter that accumulates across runs reports a size that grew
+  // without the corpus growing (measurement-provenance.md).
+  examinedCount = specs.length;
+  return { specs, names };
+}
+
+/**
+ * The number this scan declares it examined, readable by a test rather than only printable.
+ *
+ * measurement-provenance.md requires the reader convention (`examined…Count`) so the declaration is
+ * an OUTPUT a fixture can assert on, not a string in a log nobody can reach.
+ */
+export function examinedSpecCount() {
+  return examinedCount;
+}
+
+export async function main() {
+  const { specs, names } = collectSpecs(WORKSPACE_ROOT);
+
+  const findings = findLayerRestatements(specs, names);
+  process.stdout.write(`::examined:: ${specs.length} package SPEC(s)\n`);
+  if (findings.length === 0) {
+    process.stdout.write(
+      'spec-manifest-restatement scan passed. It bounds the Layer field only — prose elsewhere in a ' +
+        'SPEC may still restate a dependency set, and this check cannot see it.\n',
+    );
+    return;
+  }
+  process.stdout.write('spec-manifest-restatement scan failed:\n');
+  for (const f of findings) process.stdout.write(`- ${f.file}: ${f.detail}\n`);
+  process.exitCode = 1;
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(import.meta.filename)) {
+  await main();
+}

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -73,6 +73,7 @@
     "shell-portability",
     "skill-registration",
     "spec-doc-frontmatter",
+    "spec-manifest-restatement",
     "spec-paths",
     "spec-research",
     "spec-user-execution-section",

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -6,6 +6,7 @@
     "scripts/harness/check-contract-disposition.mjs",
     "scripts/harness/check-fixture-floor.mjs",
     "scripts/harness/check-sdk-public-surface.mjs",
+    "scripts/harness/check-spec-manifest-restatement.mjs",
     "scripts/harness/check-spec-whitebox-leakage.mjs",
     "scripts/harness/check-stub-markers.mjs",
     "scripts/harness/check-workspace-refs.mjs",

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -378,6 +378,10 @@ export const SCAN_COMMANDS = [
     command: ['node', 'scripts/harness/check-capability-placement.mjs'],
   },
   {
+    name: 'spec-manifest-restatement',
+    command: ['node', 'scripts/harness/check-spec-manifest-restatement.mjs'],
+  },
+  {
     name: 'nested-package-glob-coverage',
     command: ['node', 'scripts/harness/check-nested-package-glob-coverage.mjs'],
   },

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -87,6 +87,14 @@ const REGISTRATION_FILE = path.join(HARNESS_DIR, 'run-all-scans.mjs');
  */
 export const MANDATORY_TREE_GUARDS = [
   {
+    // DOCS-028 (issue #2194). Measured as `collectSpecs(bare)`: throws `packages missing from
+    // <root>` before a single SPEC is opened.
+    file: 'check-spec-manifest-restatement.mjs',
+    finder: 'collectSpecs',
+    tree: 'packages',
+    why: 'the package SPEC corpus IS the population this check governs — over a root without it there is no SPEC to judge, and "no findings" would claim that no SPEC restates its manifest when none was read. The defect it exists to catch was two SPECs whose stated dependency set was already false',
+  },
+  {
     // issue #2036. Measured BEFORE the guard existed: over a root with no `.github`, this returned
     // `[]` — which reads as "every declared context name is published" when nothing was read at all.
     // The classification is what caught it, exactly as it caught INFRA-127's exported finder.


### PR DESCRIPTION
Closes #2194.

## The relationship was stated in one direction only, and it cost real accuracy

`.agents/specs/ARCHITECTURE-MAP.md` says *"Package `docs/SPEC.md` files remain the owner contracts for each package … without duplicating package-level contract truth."* Nothing said the other direction — `spec-writing-standard` and `spec-template.md` made **zero** reference to the architecture map.

Measured consequence: **7 of 58 SPECs stated a layer in prose, carrying the package's dependency set with it. Two were false.**

| package | SPEC claimed | manifest declared |
| --- | --- | --- |
| `agent-builtin-providers` | "Layer 1 (depends on `agent-core` only among framework packages)" | `agent-core` + **four provider siblings** |
| `agent-provider-openai` | the same sentence | `agent-core`, **`agent-provider-openai-compatible`** |

Five of the seven were the identical copy-pasted sentence — true for the leaf providers, never true for the aggregator, which has depended on four siblings since ARCH-PROVIDER-002 created it.

Disclosure: STRUCT-011 (#2201) renamed that package and moved its SPEC without noticing the false claim.

## This is the same defect that made ARCH-100's contradiction invisible

A package's layer had **three possible homes and no owner**: prose in some SPECs, ARCH-101's machine-readable table in the map (for one family), and `project-structure.md` § Layered Assembly Architecture. Nothing compared any pair — which is why a merged owner map could state a target the Interface Package Rule forbade and nothing brought them into contact.

## Why not "parse the claim and diff it against the manifest"

`.agents/rules/learning-loop.md` settles it: *"Prefer deleting the restatement to keeping both and checking them."*

A comparison keeps two copies of one fact and puts a parser between them — the arrangement that produced the drift. So the restatements are removed, each SPEC keeps the layer **name** (a classification the manifest does not carry, genuinely the SPEC's to state), drops the enumeration, and points at the owner. ARCH-101 established the same shape one family over: one declaration, one reader, no second copy.

## What the check does NOT cover

Only the structured `- **Layer**:` field. A SPEC's prose elsewhere may still restate a dependency set and this cannot see it.

That is deliberate. A SPEC legitimately states **boundaries** ("must never depend on the framework"), which are constraints the manifest does not own, and no pattern separates a boundary claim from a dependency restatement without reading intent. A wider check would fail on correct documents, which gets suppressed rather than obeyed. Stated in the scan header so the green is not read as wider than it is.

## Falsifiability, proven rather than asserted

The predicate is exported and tested directly — **a guard reachable only through `main()` is a guard no test can falsify** (ARCH-101, whose `regression-red-proof` failure was exactly that: a condition inline in `main()` while the tests exercised only the shared predicate).

**Three mutants killed:**

| mutation | result |
| --- | --- |
| predicate never reports | **3 red** |
| counter accumulates (`=` → `+=`) | **1 red** |
| governed-tree guard removed | **1 red** |
| restored | **8 green** |

The two rows in the fixture are the real claims that were false in the tree.

## The harness held this change to its own bar, and that is worth reading

Four of its meta-scans refused the first version, each correctly:

- `fixture-floor` — no fixture at the conventional path: *"a check with no fixture has never been shown to go red on the condition it names"*.
- `harness-scope-literal` — I had hardcoded `@robota-sdk/`: *"a hardcoded scope does not fail when the scope changes, it matches nothing, and that reads as a pass"*. Now built from `HARNESS.npmScopePrefix`.
- `measurement-provenance` — the declared size had no reader export and no exact-count or reset assertion. Both added, against a fixture rather than the live tree.
- `guard-scope-fail-closed` — the root finder was unclassified. Now uses `requireGovernedTree` and is pinned in `MANDATORY_TREE_GUARDS`, proven to throw over a bare root rather than reporting zero.

I also caught the scan reporting `::examined:: 0 package SPEC(s)` **and passing** — a green over an empty corpus — before any of those fired. Caused by double-prefixing an already-absolute path.

## Verification

- `pnpm harness:scan` → **141 passed, 2 skipped, 0 failed**
- `check-spec-manifest-restatement.test.mjs` → 8 passed, with the mutation table above
- All 7 SPEC Layer fields rewritten; `spec-writing-standard` and `spec-template.md` now name the map and say which facts belong to which document

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY