### PR TITLE
fix(security)!: plugin git execution takes an argv vector, not a shell string (SEC-017)

### DIFF
--- a/.agents/spec-docs/todo/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
+++ b/.agents/spec-docs/todo/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
@@ -1,0 +1,95 @@
+---
+status: approved
+type: SECURITY
+tags: [security]
+---
+
+# SEC-017: plugin marketplace inputs are interpolated into shell command strings
+
+Paired with `.agents/tasks/SEC-017-plugin-marketplace-inputs-reach-a-shell.md`.
+Converted from [issue #2019](https://github.com/woojubb/robota/issues/2019).
+
+## Problem
+
+See the paired Task for the four interpolation sites. In short: the plugin execution port was a single
+command string, the production adapter passed it to `execSync`, and `execSync` always runs its argument
+through a shell — so any marketplace URL, plugin repository URL or persisted install path containing
+shell syntax executed additional host commands as the user running agent-cli.
+
+## Prior Art Research
+
+Waived: an external survey would be weaker than the in-repo precedent this design already follows.
+`apps/action/src/build-invocation.ts` (SEC-006) already replaced `execSync(args.join(' '))` with a
+file-plus-vector for exactly this reason, and states the principle — _"there is no quoting to get
+right, because no shell ever parses these values"_. The design here is that decision applied to a
+second surface rather than a new one. The waiver is recorded rather than the section left empty, per
+[research.md](../../rules/research.md).
+
+## Architecture Review
+
+**Alternatives.**
+
+1. **Quote the interpolated values.** Rejected, and the issue instructs it directly: _"Do not treat
+   quoting helpers as the primary boundary: remove shell parsing from this workflow."_ A quoting helper
+   is a second parser that must agree with the shell's parser forever, across platforms and shells. A
+   vector removes the second parser rather than trying to match it.
+2. **Validate the URLs and reject metacharacters.** Rejected as the primary boundary for the same
+   reason — it is a denylist over syntax, and it leaves the shell in the path so that anything the
+   validator misses is still executed. Validation remains useful, but not as the thing standing between
+   an attacker and the host.
+3. **Argument vector, shell removed.** Chosen.
+
+**The second door.** Argv stops the shell; it does not stop git. `GIT_SSH_COMMAND`,
+`GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND` and `GIT_ASKPASS` each name a program git executes, so an
+inherited one reaches the same arbitrary execution with no shell involved. The subprocess environment
+is therefore reduced to an explicit allowlist — an allowlist and not a denylist, because the set of
+git-honoured variables is git's to grow and a denylist written today is wrong the next time it does.
+
+**The third door.** `--` precedes the operands at both clone sites. Argv does not stop git reading an
+operand that begins with `-` as an option, and `--upload-pack=…` names a program git runs.
+
+**Capability preservation.** Every call site performs the same git operation with the same timeout and
+stdio. The only behaviour that changes is that values are no longer parsed as syntax.
+
+**Blast radius.** The port, its two consumers, and the one production adapter. `execSync` elsewhere in
+the workspace (`dag-cli/src/commands/mcp.ts`, `agent-transport` headless, `agent-cli/src/startup/
+shell-exec.ts`) is out of this issue's scope and is untouched.
+
+## Completion Criteria
+
+- **TC-01** `TExecFn` takes `(file, args: readonly string[], options)`.
+- **TC-02** All four call sites pass vectors; no template literal builds a git command.
+- **TC-03** The adapter uses `execFileSync` with `shell: false` stated explicitly.
+- **TC-04** Git subprocesses inherit only an allowlisted environment.
+- **TC-05** Both clone sites pass `--` before their operands.
+- **TC-06** Tests assert executable and argv separately, never a joined command string.
+- **TC-07** Hostile input arrives as exactly one argv element, byte for byte.
+- **TC-08** Three mutants die: argv folded to a shell string, `--` removed, environment passthrough.
+
+## Test Plan
+
+See the paired Task. TC-08 is the load-bearing one: without a killed mutant, a security fix's green is
+the accidental-green shape issue #2181 catalogues — and a test that asserts
+`stringContaining('git clone')` passes just as well against the vulnerable code.
+
+## Evidence Log
+
+| Claim                                             | Verified at                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GATE-APPROVAL                                     | Standing owner instruction, current conversation: decide by the repository's rules and escalate only what they cannot settle. This is a filed P1 security issue with stated acceptance criteria and an in-repo precedent (SEC-006) for the chosen design; nothing in it is a product-direction, published-contract or novel-practice decision. Inside the delegated class. |
+| The port was a command string reaching `execSync` | `marketplace-types.ts` pre-change; `default-plugin-command-adapter.ts:35` and `:111`                                                                                                                                                                                                                                                                                       |
+| Four interpolation sites                          | `marketplace-client.ts:79/174/228`, `bundle-plugin-installer.ts:237`                                                                                                                                                                                                                                                                                                       |
+| The repository had already made this fix once     | `apps/action/src/build-invocation.ts`, SEC-006                                                                                                                                                                                                                                                                                                                             |
+| Hostile input arrives as one inert argument       | 8 shell constructs, each asserted byte-for-byte as a single argv element with no fragment split off                                                                                                                                                                                                                                                                        |
+| The environment is allowlisted                    | 12 executable-naming `GIT_*` variables dropped; an unknown variable dropped                                                                                                                                                                                                                                                                                                |
+| Mutants die                                       | argv → shell string: 9 red; `--` removed: 1 red; env passthrough: 14 red; restored: 24 green                                                                                                                                                                                                                                                                               |
+| Existing suites unaffected                        | `agent-framework` 1456 tests pass; `agent-command` typecheck clean                                                                                                                                                                                                                                                                                                         |
+
+## User Execution Test Scenarios
+
+**Not applicable, and the reason is the finding.** Executing it means running `agent-cli` with a
+marketplace URL containing shell metacharacters. On the fixed build that is inert — but demonstrating
+that it WAS exploitable requires running the vulnerable code, and a scenario whose negative case
+executes an attacker's command on the user's machine is not one to hand a user. The property is
+asserted at the port instead, where the hostile value is observable without any process being spawned.
+`.agents/tasks/README.md` requires the not-applicable to carry its reason; this is it.

--- a/.agents/tasks/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
+++ b/.agents/tasks/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
@@ -1,0 +1,104 @@
+---
+title: 'SEC-017: plugin marketplace inputs are interpolated into shell command strings'
+issue: https://github.com/woojubb/robota/issues/2019
+status: in-progress
+created: 2026-08-23
+priority: critical
+urgency: now
+area: packages/agent-framework/src/plugins, packages/agent-command/src/plugins
+depends_on: []
+---
+
+# SEC-017: plugin marketplace inputs are interpolated into shell command strings
+
+## Problem
+
+The plugin execution port was a single command STRING:
+
+```ts
+export type TExecFn = (command: string, options: {...}) => string | Buffer;
+```
+
+and the production adapter passed that string to `execSync`, which always runs its argument through a
+shell. Four sites interpolated attacker-reachable values into it:
+
+| site                             | interpolated                                  |
+| -------------------------------- | --------------------------------------------- |
+| `marketplace-client.ts:79`       | `git clone --depth 1 ${cloneUrl} ${tempDir}`  |
+| `marketplace-client.ts:174`      | `git -C ${entry.installLocation} pull`        |
+| `marketplace-client.ts:228`      | `git -C ${dir} rev-parse HEAD`                |
+| `bundle-plugin-installer.ts:237` | `git clone --depth 1 ${repoUrl} ${targetDir}` |
+
+A marketplace URL, plugin repository URL, marketplace name or persisted install path containing `;`,
+`&&`, `$(…)`, a backtick or a newline therefore executed additional host commands as the user running
+agent-cli — reachable through a copied command, a shared configuration, or compromised plugin metadata.
+
+## Decision
+
+Replace the port with an argument vector and remove the shell from this workflow entirely.
+
+```ts
+export type TExecFn = (
+  file: string,
+  args: readonly string[],
+  options: { timeout: number; stdio?: string },
+) => string | Buffer;
+```
+
+The adapter uses `execFileSync` with `shell: false` passed explicitly rather than left to the default —
+the default is what a later edit changes without noticing, and it is the one line the whole fix rests
+on.
+
+**The repository had already reached this conclusion once.** `apps/action/src/build-invocation.ts`
+(SEC-006) replaced `execSync(args.join(' '))` for the same reason and states it plainly: _"Returning a
+vector (rather than a string) is what makes the invocation safe by construction: there is no quoting to
+get right, because no shell ever parses these values."_ This applies that fix to the plugin surface.
+
+**Quoting helpers were considered and rejected**, per the issue's own instruction not to treat them as
+the primary boundary. A quoting helper is a parser that must agree with the shell's parser forever; a
+vector removes the second parser.
+
+## Two doors, not one
+
+Argv stops the SHELL. It does not stop GIT. `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`,
+`GIT_PROXY_COMMAND` and `GIT_ASKPASS` each name a PROGRAM git executes, so an inherited one turns
+`git clone <url>` into "run whatever that variable says" — the same arbitrary execution, reached
+without any shell at all. So the subprocess environment is reduced to an explicit allowlist.
+
+An allowlist rather than a denylist because the set of git-honoured variables is git's to grow, and a
+denylist written today is wrong the next time it does.
+
+`--` precedes the operands at both clone sites: argv alone does not stop git reading
+`--upload-pack=…` as a flag it should honour.
+
+## Plan
+
+- [x] Port becomes `(file, args, options)` with `readonly string[]`.
+- [x] All four call sites pass vectors.
+- [x] Adapter uses `execFileSync` with `shell: false` and a scrubbed environment.
+- [x] Existing tests migrated from command-string parsing to file+argv assertions.
+- [x] Injection-property and environment tests.
+
+## Test Plan
+
+- `sec-017-argv-injection.test.ts` — eight real shell constructs (`;`, `&&`, `$(…)`, backticks,
+  newline, embedded quotes, spaces, `|`) each asserted to arrive as **exactly one** argv element,
+  byte for byte, with no fragment split off it and no marker command becoming an argument. Plus the
+  `--` separator case for an option-like URL.
+- `sec-017-git-env-scrub.test.ts` — twelve executable-naming `GIT_*` variables dropped; `PATH`/`HOME`
+  and proxy variables kept; an unknown variable dropped, which asserts the direction of the default
+  rather than a list of known-bad names.
+- **Three mutants killed, proven rather than asserted:** argv folded back into one shell string (the
+  original defect) → **9 red**; `--` separator removed → **1 red**; environment scrub made a
+  passthrough → **14 red**; restored → **24 green**.
+- Existing suites: `agent-framework` 1456 tests, `agent-command` typecheck clean.
+
+## User Execution Test Scenarios
+
+**Not applicable as a product scenario, and the reason is the finding itself.** Executing the scenario
+means running `agent-cli` with a marketplace URL containing shell metacharacters — on the fixed build
+it is inert, but the check that it WAS exploitable requires running the vulnerable code, and a scenario
+whose negative case executes an attacker's command on the user's machine is not one to hand a user.
+The property is asserted instead at the port, where the hostile value can be observed without any
+process being spawned: the tests above capture what would have been passed and assert it is one inert
+argument. `.agents/tasks/README.md` requires the not-applicable to carry its reason; this is the reason.

--- a/packages/agent-command/src/plugins/__tests__/sec-017-git-env-scrub.test.ts
+++ b/packages/agent-command/src/plugins/__tests__/sec-017-git-env-scrub.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { scrubbedGitEnv } from '../default-plugin-command-adapter.js';
+
+/**
+ * SEC-017 (issue #2019) — argv stops the SHELL; the environment is the other door.
+ *
+ * `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND` and `GIT_ASKPASS` each name a PROGRAM
+ * git executes. An inherited one turns `git clone <url>` into "run whatever that variable says" —
+ * the same arbitrary execution the string-shell port allowed, reached without any shell at all. So
+ * the argv fix is only half of it, and this asserts the other half.
+ */
+describe('SEC-017 — a git subprocess inherits only an allowlisted environment', () => {
+  // Each of these names a program git will run.
+  const EXECUTABLE_VARIABLES = [
+    'GIT_SSH_COMMAND',
+    'GIT_SSH',
+    'GIT_EXTERNAL_DIFF',
+    'GIT_PROXY_COMMAND',
+    'GIT_ASKPASS',
+    'GIT_EDITOR',
+    'GIT_PAGER',
+    'GIT_CONFIG_COUNT',
+    'GIT_CONFIG_GLOBAL',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+  ];
+
+  it.each(EXECUTABLE_VARIABLES)('drops %s', (name) => {
+    const env = scrubbedGitEnv({ PATH: '/usr/bin', [name]: 'touch /tmp/pwned' });
+    expect(env[name]).toBeUndefined();
+  });
+
+  it('keeps what git needs to run at all', () => {
+    const env = scrubbedGitEnv({
+      PATH: '/usr/bin',
+      HOME: '/home/u',
+      HTTPS_PROXY: 'http://proxy:8080',
+      GIT_SSH_COMMAND: 'touch /tmp/pwned',
+    });
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.HOME).toBe('/home/u');
+    // A proxy variable names a SERVER, not a program to run, and dropping it breaks clone behind a
+    // corporate proxy — a real configuration rather than an attack surface.
+    expect(env.HTTPS_PROXY).toBe('http://proxy:8080');
+    expect(env.GIT_SSH_COMMAND).toBeUndefined();
+  });
+
+  it('is an allowlist, so a variable nobody thought of is dropped rather than passed', () => {
+    // The set of git-honoured variables is git's to grow. A denylist written today is wrong the next
+    // time it does; this asserts the direction of the default, not a list of known-bad names.
+    const env = scrubbedGitEnv({
+      PATH: '/usr/bin',
+      SOME_FUTURE_GIT_HOOK_VARIABLE: 'touch /tmp/pwned',
+      LD_PRELOAD: '/tmp/evil.so',
+    });
+    expect(Object.keys(env)).toEqual(['PATH']);
+  });
+
+  it('does not invent values that were not in the source environment', () => {
+    const env = scrubbedGitEnv({});
+    expect(env).toEqual({});
+  });
+});

--- a/packages/agent-command/src/plugins/default-plugin-command-adapter.ts
+++ b/packages/agent-command/src/plugins/default-plugin-command-adapter.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -26,24 +26,76 @@ interface IPluginServices {
   settingsStore: NodeHostPluginSettingsStore;
 }
 
+/**
+ * Variables a git subprocess may inherit. Everything else is dropped.
+ *
+ * SEC-017 (issue #2019). Argv stops the SHELL from reading attacker-controlled text; it does not stop
+ * GIT itself. `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND` and `GIT_ASKPASS` each name a
+ * program git executes, so an inherited one turns `git clone` into "run whatever that variable says" —
+ * the same outcome the string-shell port had, reached through a different door. An ALLOWLIST rather
+ * than a denylist because the set of git-honoured variables is git's to grow, and a denylist written
+ * today is wrong the next time it does.
+ *
+ * `PATH` and `HOME` are here because git cannot find its own subcommands or the user's config without
+ * them. The proxy variables are here because dropping them breaks clone behind a corporate proxy, which
+ * is a real configuration rather than an attack surface — they name a SERVER, not a program to run.
+ */
+const GIT_ENV_ALLOWLIST = [
+  'PATH',
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'TMPDIR',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+] as const;
+
+/** The inherited environment, reduced to the allowlist. */
+export function scrubbedGitEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of GIT_ENV_ALLOWLIST) {
+    const value = source[key];
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+/**
+ * The argv process adapter injected at the composition root.
+ *
+ * `execFileSync` does not spawn a shell, so no value in `args` is ever parsed as syntax. `shell` is
+ * passed explicitly as `false` rather than left to the default: the default is what a later edit
+ * changes without noticing, and this is the one line the whole fix rests on.
+ */
+export function runGit(
+  file: string,
+  args: readonly string[],
+  options: { timeout: number; stdio?: string },
+): Buffer {
+  return execFileSync(file, [...args], {
+    timeout: options.timeout,
+    stdio: (options.stdio ?? 'pipe') as 'pipe' | 'inherit' | 'ignore',
+    shell: false,
+    env: scrubbedGitEnv(),
+  });
+}
+
 function createPluginServices(cwd: string): IPluginServices {
   const home = homedir();
   const pluginsDir = join(home, '.robota', 'plugins');
   const userSettingsPath = join(home, '.robota', 'settings.json');
 
-  const exec = (command: string, options: { timeout: number; stdio?: string }): Buffer =>
-    execSync(command, {
-      timeout: options.timeout,
-      stdio: (options.stdio ?? 'pipe') as 'pipe' | 'inherit' | 'ignore',
-    });
-
   const settingsStore = new NodeHostPluginSettingsStore(userSettingsPath);
-  const marketplace = new MarketplaceClient({ pluginsDir, exec });
+  const marketplace = new MarketplaceClient({ pluginsDir, exec: runGit });
   const installer = new BundlePluginInstaller({
     pluginsDir,
     settingsStore,
     marketplaceClient: marketplace,
-    exec,
+    exec: runGit,
   });
   const loader = new BundlePluginLoader(pluginsDir);
 
@@ -107,16 +159,11 @@ async function installPlugin(
   }
   if (scope === 'project') {
     const projectPluginsDir = join(services.cwd, '.robota', 'plugins');
-    const projectExec = (command: string, options: { timeout: number; stdio?: string }): Buffer =>
-      execSync(command, {
-        timeout: options.timeout,
-        stdio: (options.stdio ?? 'pipe') as 'pipe' | 'inherit' | 'ignore',
-      });
     const projectInstaller = new BundlePluginInstaller({
       pluginsDir: projectPluginsDir,
       settingsStore: services.settingsStore,
       marketplaceClient: services.marketplace,
-      exec: projectExec,
+      exec: runGit,
     });
     await projectInstaller.install(name, marketplaceName);
     return;

--- a/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
@@ -133,27 +133,35 @@ describe('BundlePluginInstaller', () => {
       ]);
 
       // Mock exec for git clone
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('git clone') && cmd.includes('user/gh-plugin')) {
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (
+          file === 'git' &&
+          args[0] === 'clone' &&
+          args.some((a) => a.includes('user/gh-plugin'))
+        ) {
           // The installer removes the pre-created dir and clones
-          const parts = cmd.split(' ');
-          const targetDir = parts[parts.length - 1];
-          setupDir(targetDir);
+          setupDir(args[args.length - 1] as string);
         }
         return '';
       });
 
       await installer.install('gh-plugin', 'gh-market');
 
+      // SEC-017 (issue #2019): the executable and its ARGUMENT VECTOR are asserted separately. A
+      // `stringContaining('git clone …')` assertion passes just as well when the URL has been folded
+      // back into one shell string, which is the defect this port removes.
       expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining('git clone --depth 1'),
+        'git',
+        [
+          'clone',
+          '--depth',
+          '1',
+          '--',
+          'https://github.com/user/gh-plugin.git',
+          expect.any(String),
+        ],
         expect.objectContaining({ timeout: expect.any(Number) }),
       );
-      const cloneCmd = mockExec.mock.calls.find((c: string[]) =>
-        (c[0] as string).includes('git clone'),
-      );
-      expect(cloneCmd).toBeDefined();
-      expect(cloneCmd![0]).toContain('https://github.com/user/gh-plugin.git');
     });
 
     it('should use git SHA as version when no explicit version', async () => {
@@ -172,8 +180,8 @@ describe('BundlePluginInstaller', () => {
       setupDir(join(marketplaceDir, 'packages', 'no-ver-plugin'));
 
       // Mock git rev-parse to return a SHA
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('rev-parse HEAD')) {
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (file === 'git' && args.includes('rev-parse')) {
           return 'abcdef123456789012345678901234567890\n';
         }
         return '';
@@ -244,8 +252,8 @@ describe('BundlePluginInstaller', () => {
         },
       ]);
 
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('git clone')) {
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (file === 'git' && args[0] === 'clone') {
           throw new Error('git clone failed');
         }
         return '';

--- a/packages/agent-framework/src/plugins/__tests__/marketplace-client.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/marketplace-client.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 import { MarketplaceClient } from '../marketplace-client.js';
 
 import type { TMarketplaceSource } from '../marketplace-client.js';
+import type { TExecFn } from '../marketplace-types.js';
 
 const TMP_BASE = mkdtempSync(join(tmpdir(), 'robota-marketplace-test-'));
 
@@ -31,7 +32,7 @@ describe('MarketplaceClient', () => {
     mockExec = vi.fn().mockReturnValue('');
     client = new MarketplaceClient({
       pluginsDir,
-      exec: mockExec as (cmd: string, opts: { timeout: number; stdio?: string }) => string | Buffer,
+      exec: mockExec as unknown as TExecFn,
     });
   });
 
@@ -46,10 +47,9 @@ describe('MarketplaceClient', () => {
       const source: TMarketplaceSource = { type: 'github', repo: 'owner/marketplace-repo' };
 
       // Mock exec to simulate git clone by creating the directory with a manifest
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('git clone')) {
-          // Extract target directory from clone command
-          const parts = cmd.split(' ');
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (file === 'git' && args[0] === 'clone') {
+          const parts = args;
           const targetDir = parts[parts.length - 1];
           setupDir(join(targetDir, '.claude-plugin'));
           writeJson(join(targetDir, '.claude-plugin', 'marketplace.json'), {
@@ -64,12 +64,21 @@ describe('MarketplaceClient', () => {
       const name = client.addMarketplace(source);
 
       expect(name).toBe('test-marketplace');
+      // SEC-017 (issue #2019): executable and ARGUMENT VECTOR asserted separately. A
+      // `stringContaining` assertion over one command string passes equally well when the URL has
+      // been folded back into a shell line, which is the defect this port removes.
       expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining('git clone --depth 1'),
+        'git',
+        [
+          'clone',
+          '--depth',
+          '1',
+          '--',
+          'https://github.com/owner/marketplace-repo.git',
+          expect.any(String),
+        ],
         expect.objectContaining({ timeout: expect.any(Number) }),
       );
-      const cloneCmd = mockExec.mock.calls[0][0] as string;
-      expect(cloneCmd).toContain('https://github.com/owner/marketplace-repo.git');
 
       // Should be registered in known_marketplaces.json
       const registryPath = join(pluginsDir, 'known_marketplaces.json');
@@ -81,9 +90,9 @@ describe('MarketplaceClient', () => {
     it('should clone a git URL source', () => {
       const source: TMarketplaceSource = { type: 'git', url: 'https://example.com/repo.git' };
 
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('git clone')) {
-          const parts = cmd.split(' ');
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (file === 'git' && args[0] === 'clone') {
+          const parts = args;
           const targetDir = parts[parts.length - 1];
           setupDir(join(targetDir, '.claude-plugin'));
           writeJson(join(targetDir, '.claude-plugin', 'marketplace.json'), {
@@ -98,8 +107,8 @@ describe('MarketplaceClient', () => {
       const name = client.addMarketplace(source);
 
       expect(name).toBe('git-marketplace');
-      const cloneCmd = mockExec.mock.calls[0][0] as string;
-      expect(cloneCmd).toContain('https://example.com/repo.git');
+      expect(mockExec.mock.calls[0][0]).toBe('git');
+      expect(mockExec.mock.calls[0][1]).toContain('https://example.com/repo.git');
     });
 
     it('should throw when clone fails', () => {
@@ -115,9 +124,9 @@ describe('MarketplaceClient', () => {
     it('should throw when cloned repo has no marketplace.json', () => {
       const source: TMarketplaceSource = { type: 'github', repo: 'owner/repo' };
 
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('git clone')) {
-          const parts = cmd.split(' ');
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (file === 'git' && args[0] === 'clone') {
+          const parts = args;
           const targetDir = parts[parts.length - 1];
           // Create dir but no manifest
           setupDir(targetDir);
@@ -133,9 +142,9 @@ describe('MarketplaceClient', () => {
     it('should throw when marketplace name already exists', () => {
       const source: TMarketplaceSource = { type: 'github', repo: 'owner/repo' };
 
-      mockExec.mockImplementation((cmd: string) => {
-        if (cmd.includes('git clone')) {
-          const parts = cmd.split(' ');
+      mockExec.mockImplementation((file: string, args: readonly string[]) => {
+        if (file === 'git' && args[0] === 'clone') {
+          const parts = args;
           const targetDir = parts[parts.length - 1];
           setupDir(join(targetDir, '.claude-plugin'));
           writeJson(join(targetDir, '.claude-plugin', 'marketplace.json'), {
@@ -312,11 +321,11 @@ describe('MarketplaceClient', () => {
       client.updateMarketplace('update-mp');
 
       expect(mockExec).toHaveBeenCalledWith(
-        expect.stringContaining('git -C'),
+        'git',
+        expect.arrayContaining(['-C']),
         expect.objectContaining({ timeout: expect.any(Number) }),
       );
-      const pullCmd = mockExec.mock.calls[0][0] as string;
-      expect(pullCmd).toContain('pull');
+      expect(mockExec.mock.calls[0][1]).toEqual(['-C', expect.any(String), 'pull']);
     });
 
     it('should throw when marketplace not found', () => {

--- a/packages/agent-framework/src/plugins/__tests__/sec-017-argv-injection.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/sec-017-argv-injection.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, afterEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { MarketplaceClient } from '../marketplace-client.js';
+
+import type { TExecFn } from '../marketplace-types.js';
+
+/**
+ * SEC-017 (issue #2019) — a marketplace URL is an ARGUMENT, never syntax.
+ *
+ * The port used to be `(command: string, …)` and the production adapter passed that string to
+ * `execSync`, which always runs its argument through a shell. So a source URL containing `;` or
+ * `$(…)` executed additional host commands during add, update, revision lookup or install.
+ *
+ * These assert the property that makes the fix real rather than the code that implements it: the
+ * hostile text arrives at the port as ONE argv element, byte for byte, with nothing split off it.
+ * A `toContain('git clone')` assertion over a joined string passes just as well when the URL has
+ * been folded back into a shell line — which is the defect, not the fix.
+ */
+describe('SEC-017 — hostile marketplace input reaches the port as a literal argument', () => {
+  let pluginsDir: string;
+  let mockExec: Mock;
+  let client: MarketplaceClient;
+
+  beforeEach(() => {
+    pluginsDir = mkdtempSync(join(tmpdir(), 'sec-017-'));
+    mockExec = vi.fn().mockReturnValue('');
+    client = new MarketplaceClient({ pluginsDir, exec: mockExec as unknown as TExecFn });
+  });
+
+  afterEach(() => {
+    rmSync(pluginsDir, { recursive: true, force: true });
+  });
+
+  // Each is a real shell construct. Under the old string port every one of them was syntax the
+  // shell acted on; under an argv port each must survive as inert text.
+  const HOSTILE = [
+    'https://example.com/repo.git; touch /tmp/pwned',
+    'https://example.com/repo.git && id',
+    'https://example.com/$(id).git',
+    'https://example.com/`id`.git',
+    'https://example.com/repo.git\nid',
+    "https://example.com/'; id; '.git",
+    'https://example.com/repo with spaces.git',
+    'https://example.com/repo.git | cat',
+  ];
+
+  it.each(HOSTILE)('passes %j through as exactly one argv element', (url) => {
+    try {
+      client.addMarketplace({ type: 'git', url });
+    } catch {
+      // The clone is mocked, so the add fails later on a missing manifest. The call we assert on
+      // has already happened, and asserting it is the point — not whether the add succeeded.
+    }
+
+    expect(mockExec).toHaveBeenCalled();
+    const [file, args] = mockExec.mock.calls[0] as [string, readonly string[]];
+
+    expect(file).toBe('git');
+    // Byte-for-byte, as ONE element. Not "an element containing it" — a split would also satisfy
+    // that, and a split is precisely what a shell does.
+    expect(args).toContain(url);
+    expect(args.filter((a) => a === url)).toHaveLength(1);
+
+    // Nothing the shell would have produced: no element is a fragment of the URL, and the marker
+    // commands never became arguments of their own.
+    const fragments = args.filter((a) => a !== url && url.includes(a) && a.length > 2);
+    expect(
+      fragments,
+      `a fragment of the URL became its own argument: ${JSON.stringify(args)}`,
+    ).toEqual([]);
+    expect(args).not.toContain('id');
+    expect(args).not.toContain('touch');
+  });
+
+  it('sends an option-like URL after `--`, so git reads it as an operand', () => {
+    // Argv stops the SHELL. It does not stop GIT: `--upload-pack=…` names a program git runs.
+    try {
+      client.addMarketplace({ type: 'git', url: '--upload-pack=touch /tmp/pwned' });
+    } catch {
+      // as above
+    }
+
+    const [, args] = mockExec.mock.calls[0] as [string, readonly string[]];
+    const separator = args.indexOf('--');
+    expect(
+      separator,
+      'no `--` separator, so an option-like URL is read as an option',
+    ).toBeGreaterThan(-1);
+    expect(args.indexOf('--upload-pack=touch /tmp/pwned')).toBeGreaterThan(separator);
+  });
+});

--- a/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
@@ -234,9 +234,12 @@ export class BundlePluginInstaller {
     // Remove the directory first since mkdirSync already created it
     this.fs.rmSync(targetDir, { recursive: true, force: true });
 
-    const command = `git clone --depth 1 ${repoUrl} ${targetDir}`;
     try {
-      this.exec(command, { timeout: GIT_CLONE_TIMEOUT_MS, stdio: 'pipe' });
+      // `--` before the operands: a repository URL beginning with `-` is an OPERAND, not an option.
+      this.exec('git', ['clone', '--depth', '1', '--', repoUrl, targetDir], {
+        timeout: GIT_CLONE_TIMEOUT_MS,
+        stdio: 'pipe',
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to clone plugin "${pluginName}": ${message}`);

--- a/packages/agent-framework/src/plugins/marketplace-client.ts
+++ b/packages/agent-framework/src/plugins/marketplace-client.ts
@@ -75,9 +75,14 @@ export class MarketplaceClient {
       this.fs.cpSync(source.path, tempDir, { recursive: true });
     } else {
       const cloneUrl = this.resolveCloneUrl(source);
-      const command = `git clone --depth 1 ${cloneUrl} ${tempDir}`;
       try {
-        this.exec(command, { timeout: GIT_TIMEOUT_MS, stdio: 'pipe' });
+        // `--` before the operands: a URL or path beginning with `-` is an OPERAND, never an option.
+        // Argv alone stops shell interpretation; it does not stop git reading `--upload-pack=…` as a
+        // flag it should honour.
+        this.exec('git', ['clone', '--depth', '1', '--', cloneUrl, tempDir], {
+          timeout: GIT_TIMEOUT_MS,
+          stdio: 'pipe',
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`Failed to clone marketplace: ${message}`);
@@ -167,9 +172,11 @@ export class MarketplaceClient {
       this.fs.rmSync(entry.installLocation, { recursive: true, force: true });
       this.fs.cpSync(localSource.path, entry.installLocation, { recursive: true });
     } else {
-      const command = `git -C ${entry.installLocation} pull`;
       try {
-        this.exec(command, { timeout: GIT_TIMEOUT_MS, stdio: 'pipe' });
+        this.exec('git', ['-C', entry.installLocation, 'pull'], {
+          timeout: GIT_TIMEOUT_MS,
+          stdio: 'pipe',
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`Failed to update marketplace "${name}": ${message}`);
@@ -225,7 +232,7 @@ export class MarketplaceClient {
   getMarketplaceSha(name: string): string {
     const dir = this.getMarketplaceDir(name);
     try {
-      const result = this.exec(`git -C ${dir} rev-parse HEAD`, {
+      const result = this.exec('git', ['-C', dir, 'rev-parse', 'HEAD'], {
         timeout: GIT_TIMEOUT_MS,
         stdio: 'pipe',
       });

--- a/packages/agent-framework/src/plugins/marketplace-types.ts
+++ b/packages/agent-framework/src/plugins/marketplace-types.ts
@@ -35,9 +35,25 @@ export interface IKnownMarketplaceEntry {
 /** Shape of known_marketplaces.json. */
 export type TKnownMarketplacesRegistry = Record<string, IKnownMarketplaceEntry>;
 
-/** Exec function type for running shell commands. Injected at composition root. */
+/**
+ * Run one executable with an ARGUMENT VECTOR. Injected at composition root.
+ *
+ * SEC-017 (issue #2019): this was `(command: string, …)`, and the adapter behind it passed that string
+ * to `execSync`, which always runs its argument through a shell. Every marketplace URL, plugin
+ * repository URL and persisted install path was interpolated into that string, so a source containing
+ * `;` or `$(…)` executed additional host commands during add, update, revision lookup or install.
+ *
+ * A vector is what makes it safe by construction rather than by quoting: no shell parses these values,
+ * so there is no quoting to get right. The repository already reached this conclusion once —
+ * `apps/action/src/build-invocation.ts` (SEC-006) replaced `execSync(args.join(' '))` for the same
+ * reason — and this is that fix applied to the plugin surface.
+ *
+ * `file` is the executable. `args` is readonly because an implementation must not be able to fold an
+ * argument back into the command line.
+ */
 export type TExecFn = (
-  command: string,
+  file: string,
+  args: readonly string[],
   options: { timeout: number; stdio?: string },
 ) => string | Buffer;
 
@@ -45,6 +61,6 @@ export type TExecFn = (
 export interface IMarketplaceClientOptions {
   /** Base plugins directory (e.g., `~/.robota/plugins`). */
   pluginsDir: string;
-  /** Shell exec adapter — must be provided at composition root (e.g., execSync). */
+  /** Argv process adapter — must be provided at composition root (e.g., execFileSync). */
   exec: TExecFn;
 }


### PR DESCRIPTION
Closes #2019.

## The defect

The plugin execution port was a single command **string**, and the production adapter passed it to `execSync` — which always runs its argument through a shell. Four sites interpolated attacker-reachable values into it:

| site | interpolated |
| --- | --- |
| `marketplace-client.ts:79` | `git clone --depth 1 ${cloneUrl} ${tempDir}` |
| `marketplace-client.ts:174` | `git -C ${entry.installLocation} pull` |
| `marketplace-client.ts:228` | `git -C ${dir} rev-parse HEAD` |
| `bundle-plugin-installer.ts:237` | `git clone --depth 1 ${repoUrl} ${targetDir}` |

A marketplace URL, plugin repository URL, marketplace name or persisted install path containing `;`, `&&`, `$(…)`, a backtick or a newline therefore executed additional host commands as the user running `agent-cli` — reachable through a copied command, a shared configuration, or compromised plugin metadata.

## The fix, and why not quoting

```ts
export type TExecFn = (
  file: string,
  args: readonly string[],
  options: { timeout: number; stdio?: string },
) => string | Buffer;
```

`execFileSync` with **`shell: false` stated explicitly** rather than left to the default — the default is what a later edit changes without noticing, and it is the one line the whole fix rests on. `args` is `readonly` so an implementation cannot fold an argument back into a command line.

**Quoting was rejected**, as the issue instructs: *"Do not treat quoting helpers as the primary boundary."* A quoting helper is a second parser that must agree with the shell's parser forever, across platforms and shells. A vector removes the second parser rather than trying to match it.

**The repository had already reached this conclusion once.** SEC-006 replaced `execSync(args.join(' '))` in `apps/action/src/build-invocation.ts` and states the principle: *"there is no quoting to get right, because no shell ever parses these values."* This is that fix applied to the plugin surface.

## Two more doors, both closed here

**Argv stops the shell. It does not stop git.** `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`, `GIT_PROXY_COMMAND` and `GIT_ASKPASS` each name a **program git executes** — an inherited one turns `git clone <url>` into "run whatever that variable says", reaching the same arbitrary execution with no shell involved. The subprocess environment is reduced to an explicit **allowlist**, not a denylist, because the set of git-honoured variables is git's to grow and a denylist written today is wrong the next time it does.

**`--` precedes the operands** at both clone sites. Argv does not stop git reading an operand beginning with `-` as an option, and `--upload-pack=…` names a program git runs.

## Tests assert the property, not the code

The previous assertions parsed a joined command string — `stringContaining('git clone --depth 1')` — which **passes just as well against the vulnerable code**. They now assert executable and argv separately.

Eight real shell constructs, each asserted to arrive as **exactly one argv element, byte for byte**, with no fragment split off it and no marker command becoming an argument of its own:

```
https://example.com/repo.git; touch /tmp/pwned      https://example.com/`id`.git
https://example.com/repo.git && id                  https://example.com/repo.git\nid
https://example.com/$(id).git                       https://example.com/'; id; '.git
https://example.com/repo with spaces.git            https://example.com/repo.git | cat
```

## Mutants killed, not asserted

| mutation | result |
| --- | --- |
| argv folded back into one shell string (**the original defect**) | **9 red** |
| `--` separator removed | **1 red** |
| environment scrub made a passthrough | **14 red** |
| restored | **24 green** |

Without this, a security fix's green is the accidental-green shape #2181 catalogues.

## Verification

- `pnpm harness:scan` → **141 passed, 2 skipped, 0 failed**
- `agent-framework` → **1465 tests**, `agent-command` → **292 tests**, all passing
- `pnpm -w typecheck` clean, after rebasing onto ARCH-103 (#2203) and rebuilding

## Scope

The port, its two consumers, and the one production adapter. `execSync` elsewhere in the workspace (`dag-cli/src/commands/mcp.ts`, `agent-transport` headless, `agent-cli/src/startup/shell-exec.ts`) is outside this issue and untouched.

## Why there is no user-execution scenario

Executing one means running `agent-cli` with a marketplace URL containing shell metacharacters. On the fixed build that is inert — but showing it *was* exploitable requires running the vulnerable code, and **a scenario whose negative case executes an attacker's command on the user's machine is not one to hand a user**. The property is asserted at the port instead, where the hostile value is observable without any process being spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY