### PR TITLE
fix(security): plugin identifiers are validated at their boundary (SEC-018)

### DIFF
--- a/.agents/spec-docs/todo/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/spec-docs/todo/SEC-018-plugin-identifiers-escape-their-root.md
@@ -1,0 +1,95 @@
+---
+status: approved
+type: SECURITY
+tags: [security]
+---
+
+# SEC-018: plugin identifiers and registry paths escape the plugin root
+
+Paired with `.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md`.
+Converted from [issue #2020](https://github.com/woojubb/robota/issues/2020).
+
+## Problem
+
+See the paired Task for the four value→sink pairs. In short: remote manifests and the on-disk registry
+were cast after two shallow checks, and their strings then became path components or paths reaching
+`renameSync`, `cpSync` and a recursive `rmSync`.
+
+## Prior Art Research
+
+Waived: the design question is which of this repository's own boundaries owns validation of its own
+persisted structures, and the repository has already answered it once for the same class of value.
+`packages/agent-session/src/session-id.ts` (SEC-006) guards session ids used as path components, and
+states both load-bearing decisions — the guard at the boundary rather than at each `join()`, and
+reject rather than sanitize, because sanitizing aliases two distinct identifiers onto one file. This
+applies that decision to plugin identifiers, and extends it with containment because these values can
+also be paths rather than only components. Recorded rather than left empty, per
+[research.md](../../rules/research.md).
+
+## Architecture Review
+
+**Alternatives.**
+
+1. **Sanitize the identifier** (strip traversal, replace separators). Rejected on SEC-006's recorded
+   reason, restated for this surface: stripping `../` from `../x` yields `x`, a name another plugin may
+   legitimately hold, so the hostile and benign identifiers map to one directory. A silent
+   cross-linking is worse than a loud refusal.
+2. **Check containment at each sink.** Rejected: one name reaches four sinks (rename, copy, load,
+   recursive delete). A per-sink check is four opportunities to miss one, and the miss is silent.
+3. **Lexical containment** (`resolve` + `startsWith`). Rejected because it cannot see a symlink:
+   `<root>/link` → `/etc` passes it. That is the acceptance criterion "symlinks inside plugin roots
+   cannot redirect copy, load, rename or deletion outside the root", and lexical checking fails it by
+   construction rather than by oversight.
+4. **Boundary guard + canonical containment.** Chosen.
+
+**Port change.** `IFileSystem` gained `realpathSync`. Additive; the interface has exactly one
+implementer (`NodeFileSystem`) and zero object-literal doubles in the workspace, verified before
+choosing this over threading a separate canonicaliser through four constructors.
+
+**Ordering.** Validation happens where the value is read, not where it is used, so a malformed manifest
+is refused before any filesystem mutation is attempted. The acceptance criterion "failed validation
+performs no filesystem mutation" cannot be satisfied by a check sitting next to the `renameSync`.
+
+**Responsibility split.** `marketplace-client.ts` crossed the 300-line cap. Split by responsibility
+rather than baselined: the client MANAGES marketplaces, `marketplace-manifest.ts` decides whether a
+fetched file is a manifest at all. Keeping them together is what let a manifest be
+`data as IMarketplaceManifest` after two shallow checks.
+
+## Completion Criteria
+
+- **TC-01** Every identifier used as a path component is validated at the boundary it enters.
+- **TC-02** Dot segments, both separators, absolute paths, drive/UNC, NUL and percent-encoded traversal
+  are rejected.
+- **TC-03** Containment is judged on canonical paths, so a symlink cannot redirect a mutation.
+- **TC-04** A destination that does not exist yet is checked before it is created.
+- **TC-05** A tampered registry `installPath` cannot delete outside the plugin root, and its entry is
+  still removed so one bad record cannot pin itself in place.
+- **TC-06** Failed validation performs no filesystem mutation.
+- **TC-07** Three mutants die; the suite is green restored.
+
+## Test Plan
+
+See the paired Task. TC-07 is load-bearing: a containment check that cannot go red on a symlink is the
+accidental-green shape issue #2181 catalogues, and mutant B is exactly that case.
+
+## Evidence Log
+
+| Claim                                                    | Verified at                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GATE-APPROVAL                                            | Standing owner instruction, current conversation: decide by the repository's rules, escalate only what they cannot settle. A filed P1 security issue with stated acceptance criteria and an in-repo precedent (SEC-006) for the design. No product-direction, published-contract-removal or novel-practice decision is involved; the one port change is additive. Inside the delegated class. |
+| The manifest name selected a rename destination          | `marketplace-client.ts` — `join(this.marketplacesDir, name)` then `renameSync`, pre-change                                                                                                                                                                                                                                                                                                    |
+| The registry `installPath` drove a recursive delete      | `marketplace-registry.ts` — `fs.rmSync(record.installPath, { recursive: true, force: true })`, pre-change                                                                                                                                                                                                                                                                                     |
+| `IFileSystem` had one implementer and no literal doubles | `NodeFileSystem`; `grep 'as IFileSystem\|: IFileSystem = {'` → 0                                                                                                                                                                                                                                                                                                                              |
+| A symlink defeats lexical containment                    | mutant B: canonical replaced by `resolve` → 2 tests red                                                                                                                                                                                                                                                                                                                                       |
+| The separator makes prefix comparison a containment test | mutant C: separator removed → the `/a/plugins-evil` case red                                                                                                                                                                                                                                                                                                                                  |
+| Mutants die                                              | segment guard neutered → 19 red; lexical → 2 red; no separator → 1 red; restored → 29 green                                                                                                                                                                                                                                                                                                   |
+| Suites pass                                              | `agent-framework` 1494, `agent-command` 292, `harness:scan` 141 passed / 0 failed                                                                                                                                                                                                                                                                                                             |
+
+## User Execution Test Scenarios
+
+**Not applicable.** Executing one means installing a marketplace whose manifest is named
+`../../escaped-market`. On the fixed build it is refused; demonstrating it WAS exploitable requires
+running the vulnerable code, and a scenario whose negative case writes outside the user's plugin root
+is not one to hand a user. The property is asserted at the boundary instead, where the hostile value
+is observable with no filesystem mutation attempted. `.agents/tasks/README.md` requires the
+not-applicable to carry its reason; this is it.

--- a/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
@@ -179,3 +179,29 @@ files — and it means: **a test that proves a fix belongs to the fix's own comm
 
 The general lesson across all three rounds is one sentence: _a guard is not covered because the module
 that defines it is covered._
+
+## Fourth round: the sibling registry file was never enumerated
+
+`known_marketplaces.json`'s `installLocation` reached three sinks unguarded, while
+`installed_plugins.json`'s `installPath` had been guarded twice:
+
+- `removeMarketplace()` — recursive `rmSync`
+- `updateMarketplace()` local branch — `rmSync` then `cpSync` over it
+- `updateMarketplace()` git branch — `git -C <dir> pull`, which runs git in an arbitrary directory
+
+**The root cause is the enumeration, not the guard.** This Task's table listed four value/sink pairs,
+taken from the issue's evidence links, and the issue's links did not cover the sibling registry. I
+established "a registry value is a HINT, not a fact", applied it to one registry file, and never asked
+which OTHER persisted fields reach a path sink. Working from a provided evidence list is not the same
+as enumerating the class it exemplifies.
+
+Guarded once at `requireContainedEntry`, where the entry is read, rather than at each of the three
+sinks — three call sites are three chances to miss one, which is precisely how this was missed.
+
+Mutant, application verified: removing the guard turns 2 of the sink tests red; restored, 8 green.
+
+## The count, stated plainly
+
+Five rounds. Four found by review, one by the accidental-green floor, **all of them the same defect**:
+a guard exists and something that should call it does not, or the set of things that should call it was
+never enumerated. The guard module itself was correct from the first commit and is still unchanged.

--- a/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
@@ -155,3 +155,27 @@ pair, and two sites can each look correct while disagreeing about the root.
 
 Mutant for the propagation fix, application verified before reading the result: removing the
 `instanceof` narrowing turns 1 test red; restored, 18 green.
+
+## Third round: the accidental-green floor found the same defect twice more
+
+`regression-red-proof` reported `accidental-green-fail (all-pass)` for `marketplace-registry.ts` and
+`marketplace-client.ts` — reversing those guards changed nothing, because no test reached either sink.
+
+**That is the same defect for the third time in one change.** A reviewer found two unguarded sinks; the
+floor found two guarded-but-untested ones. The pattern is identical each time: `plugin-paths.ts` was
+tested exhaustively, so the guard was proven to WORK, and nothing asserted that each sink CALLS it.
+
+**And diagnosing it surfaced a non-obvious property of the floor worth recording.** The proof tests were
+first committed as `test:`. The floor kept reporting all-pass while a manual reversal of the identical
+hunks turned those very cases red. The cause is `check-regression-red-proof.mjs:680` — _"Scope by the
+commit that owns each file. A mixed PR must not turn unrelated `feat:` / `perf:` files into alleged
+defect fixes merely because another commit in the range is spelled `fix:`."_ Files are attributed to
+their owning commit and only `fix:` files are read, so a proof shipped under `test:` is **invisible to
+the check it exists to satisfy**.
+
+That is correct behaviour — the scoping stops a `fix:` elsewhere in the range from laundering unrelated
+files — and it means: **a test that proves a fix belongs to the fix's own commit.** Re-committed as
+`fix:`; all five source files now report `red-proof-ok (assertion-fail)`.
+
+The general lesson across all three rounds is one sentence: _a guard is not covered because the module
+that defines it is covered._

--- a/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
@@ -134,3 +134,24 @@ whose manifest is named `../../escaped-market`. On the fixed build it is refused
 that it WAS exploitable means running the vulnerable code, and a scenario whose negative case writes
 outside the user's plugin root is not one to hand a user. The property is asserted at the boundary,
 where the hostile value is observable with no filesystem mutation attempted.
+
+## Second review round: two SHOULDs, both real, both about the shape of the guard rather than its presence
+
+**1. The refusal and a filesystem failure were caught by one `catch`.** `assertContainedPath` and
+`fs.rmSync` sat inside a single `try`, so an `EACCES` or `EBUSY` was swallowed exactly like a
+containment refusal — and the registry entry was then dropped either way, leaving the directory on
+disk with nothing tracking it. **A containment refusal is a decision; a filesystem error is a
+failure.** `PluginPathContainmentError` now distinguishes them, and only the decision is swallowed.
+
+**2. The same value was checked against two different roots.** `uninstall()` checked
+`record.installPath` against `cacheDir`; `removeInstalledPluginsForMarketplace()` checked the same
+kind of value against `pluginsDir`. A tampered entry naming `pluginsDir/known_marketplaces.json` or
+another marketplace clone — inside the plugins root, outside the cache — passed the wider check and
+was recursively deleted. **One value, one root**: both now use the cache directory.
+
+That second one is the sharper finding, because both sinks were "guarded" and the class was still
+partially reachable. A guard is not a property of a call site; it is a property of the (value, root)
+pair, and two sites can each look correct while disagreeing about the root.
+
+Mutant for the propagation fix, application verified before reading the result: removing the
+`instanceof` narrowing turns 1 test red; restored, 18 green.

--- a/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
@@ -1,0 +1,94 @@
+---
+title: 'SEC-018: plugin identifiers and registry paths escape the plugin root'
+issue: https://github.com/woojubb/robota/issues/2020
+status: in-progress
+created: 2026-08-23
+priority: critical
+urgency: now
+area: packages/agent-framework/src/plugins, packages/agent-core/src/interfaces
+depends_on: []
+---
+
+# SEC-018: plugin identifiers and registry paths escape the plugin root
+
+## Problem
+
+Remote plugin manifests and the local registry JSON were cast to TypeScript shapes after only
+`typeof data === 'object'` and `typeof data.name === 'string'`. Those values then became path
+components or paths:
+
+| value                       | source                           | sink                                                           |
+| --------------------------- | -------------------------------- | -------------------------------------------------------------- |
+| `manifest.name`             | remote `marketplace.json`        | `join(marketplacesDir, name)` → `renameSync`                   |
+| `pluginName`, `version`     | remote manifest entry            | `join(cacheDir, …)` → write, and recursive `rmSync` on cleanup |
+| relative marketplace source | remote manifest                  | `join`ed without proving containment                           |
+| `record.installPath`        | `installed_plugins.json` on disk | recursive `rmSync`                                             |
+
+A manifest named `../../escaped-market` placed a marketplace outside its root; a tampered
+`installPath` deleted whatever it named.
+
+## Decision
+
+Two guards at the boundary, in one module, following the shape SEC-006 established in
+`packages/agent-session/src/session-id.ts`:
+
+1. **`assertSafePluginSegment`** — an allowlist regex admitting no `/`, `\` or `:`, and requiring an
+   alphanumeric first character. So the value cannot introduce a separator or a drive/UNC qualifier,
+   and cannot be `.` or `..`; with no separator available an embedded `..` cannot form a traversal
+   component. Percent-encoded traversal and NUL are rejected because the class is an allowlist rather
+   than a denylist of dangerous characters.
+2. **`assertContainedPath`** — containment judged on the CANONICAL form of both sides.
+
+**REJECT rather than sanitize**, for SEC-006's stated reason applied here: a sanitiser stripping the
+traversal from `../x` yields `x`, which is a name another plugin may legitimately hold. The hostile
+identifier and the benign one would then map to one directory, silently cross-linking them.
+
+**The guard lives at the boundary, not at each `join()`.** One name reaches four sinks — the rename,
+the copy, the loader and the recursive delete.
+
+## Why canonical rather than lexical, and why the port had to grow
+
+`<root>/link` may be a symlink to `/etc`, and `resolve(root, 'link')` still starts with `root`. A
+lexical prefix test cannot see it. `IFileSystem` had no `realpathSync`, so it was added — the port's
+only implementer is `NodeFileSystem` and there are zero object-literal doubles, so the addition
+touches two files.
+
+A destination that does not exist yet — a rename or clone target — has no realpath, so the nearest
+existing ancestor is canonicalised and the remaining components appended. Canonicalising only existing
+paths would leave every create-then-check window open, and checking after the write is checking after
+the damage.
+
+## Plan
+
+- [x] `plugin-paths.ts`: segment guard, canonical containment, contained relative resolution.
+- [x] `realpathSync` on `IFileSystem` and `NodeFileSystem`.
+- [x] Guard the manifest name, the install path components, and the registry `installPath`.
+- [x] Split manifest reading out of `marketplace-client.ts` by responsibility.
+
+## The registry delete is refused per-entry, not per-run
+
+A tampered `installPath` skips its removal and reports, but the entry is still dropped from the
+registry — otherwise one bad record would abort the cleanup of every other plugin AND pin itself in
+place, which is a denial of service written into the fix for an escape.
+
+## Test Plan
+
+- `sec-018-path-containment.test.ts` — 29 cases. 17 rejected identifier shapes (traversal, both
+  separators, absolute, drive, UNC, NUL, percent-encoded, leading dot, leading hyphen, empty,
+  non-string, over-length); genuine identifiers accepted; the field named in the error; the aliasing
+  argument asserted directly.
+- Containment: the root itself, a real descendant, a lexical escape, a **sibling whose name merely
+  extends the root** (`/a/plugins-evil` vs `/a/plugins`), a **symlink inside the root**, and a
+  **destination that does not exist yet** reached through one.
+- **Three mutants killed:** segment guard neutered → **19 red**; canonical replaced by lexical
+  (symlink-blind) → **2 red**; prefix compared without the separator → **1 red**; restored →
+  **29 green**.
+- `agent-framework` 1494 tests, `agent-command` 292 tests, `pnpm harness:scan` 141 passed / 0 failed.
+
+## User Execution Test Scenarios
+
+**Not applicable, and for the same reason as SEC-017.** Executing one means installing a marketplace
+whose manifest is named `../../escaped-market`. On the fixed build it is refused — but demonstrating
+that it WAS exploitable means running the vulnerable code, and a scenario whose negative case writes
+outside the user's plugin root is not one to hand a user. The property is asserted at the boundary,
+where the hostile value is observable with no filesystem mutation attempted.

--- a/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
@@ -64,6 +64,44 @@ the damage.
 - [x] `realpathSync` on `IFileSystem` and `NodeFileSystem`.
 - [x] Guard the manifest name, the install path components, and the registry `installPath`.
 - [x] Split manifest reading out of `marketplace-client.ts` by responsibility.
+- [x] Guard the SECOND `installPath` sink — `uninstall()`'s single-plugin delete.
+- [x] Guard the relative marketplace source, whose helper was imported and never called.
+- [x] Test that each SINK uses the guard, not only that the guard works.
+
+## What the first pass missed, and why the tests did not catch it
+
+A review found two of the four value/sink pairs still unguarded, both of them pairs this Task's own
+table already named:
+
+- `uninstall()` passed `record.installPath` — the same untrusted value, to the same recursive `rmSync`
+  — with no containment check. The marketplace-wide cleanup was guarded; the single-plugin path is a
+  SECOND sink on that value and was missed.
+- `resolveAndInstall()` joined the remote manifest's relative `source` without proving containment,
+  and `resolveContainedRelative` sat in the import list **never called** — the intent recorded, the
+  call absent.
+
+**The suite could not have found either.** It tested `plugin-paths.ts` exhaustively — 29 cases, three
+killed mutants — and proved the guard WORKS. It never asserted that each sink CALLS it. That is
+ARCH-101's finding one level over: a predicate covered, its use not, so deleting the use breaks
+nothing.
+
+Fixed by driving the real installer methods: a tampered registry entry pointing outside the cache, and
+a manifest whose plugin `source` is `../../../..`. Each turns exactly one test red when its guard is
+removed, so the coverage is falsifiable rather than assumed. The record above said four pairs were
+guarded when two were; that claim is corrected here rather than quietly amended.
+
+**Two traps met while proving it, both worth more than the fix.**
+
+First, the uninstall test called `installer.uninstall(...)` without awaiting it, so the assertion ran
+before the deletion could happen and the test passed no matter what the code did. `no-floating-promises`
+caught it at lint — after it had already been counted as a passing test.
+
+Second, and sharper: the first mutation run reported the guard's removal as SURVIVED. The mutation had
+never applied — a `perl` pattern written against the pre-formatter text stopped matching once prettier
+wrapped the call across five lines. **A mutation that silently fails to apply is indistinguishable from
+a mutant that survives**, and it fails in the reassuring direction: it says the code is not covered when
+in fact nothing was tested. Every mutation here is now confirmed applied — by asserting the mutated
+text is absent — before its result is read.
 
 ## The registry delete is refused per-entry, not per-run
 
@@ -83,7 +121,11 @@ place, which is a denial of service written into the fix for an escape.
 - **Three mutants killed:** segment guard neutered → **19 red**; canonical replaced by lexical
   (symlink-blind) → **2 red**; prefix compared without the separator → **1 red**; restored →
   **29 green**.
-- `agent-framework` 1494 tests, `agent-command` 292 tests, `pnpm harness:scan` 141 passed / 0 failed.
+- `bundle-plugin-installer.test.ts` — two cases driving the real sinks: `uninstall()` with a tampered
+  `installPath` (the victim path survives AND the registry entry is still removed) and `install()`
+  against a manifest whose plugin `source` escapes the marketplace directory. Each turns exactly one
+  test red when its guard is removed.
+- `agent-framework` 1496 tests, `agent-command` 292 tests, `pnpm harness:scan` 141 passed / 0 failed.
 
 ## User Execution Test Scenarios
 

--- a/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/SEC-018-plugin-identifiers-escape-their-root.md
@@ -143,6 +143,12 @@ containment refusal — and the registry entry was then dropped either way, leav
 disk with nothing tracking it. **A containment refusal is a decision; a filesystem error is a
 failure.** `PluginPathContainmentError` now distinguishes them, and only the decision is swallowed.
 
+**Correction, round five:** that fix was recorded as applied to both sinks and reached only one. The
+edit to `marketplace-registry.ts` failed to match its anchor after formatting and was written up as
+done — the import landed, the narrowing did not, and CodeQL's "unused import" was the visible half of a
+silent no-op. The claim above was false when written; both sinks now narrow, and a test drives the
+propagation on each rather than only on the one I remembered editing.
+
 **2. The same value was checked against two different roots.** `uninstall()` checked
 `record.installPath` against `cacheDir`; `removeInstalledPluginsForMarketplace()` checked the same
 kind of value against `pluginsDir`. A tampered entry naming `pluginsDir/known_marketplaces.json` or
@@ -202,6 +208,11 @@ Mutant, application verified: removing the guard turns 2 of the sink tests red; 
 
 ## The count, stated plainly
 
-Five rounds. Four found by review, one by the accidental-green floor, **all of them the same defect**:
+Six rounds. Five found by review, one by the accidental-green floor, **all of them the same defect**:
 a guard exists and something that should call it does not, or the set of things that should call it was
 never enumerated. The guard module itself was correct from the first commit and is still unchanged.
+
+Twice the record claimed a fix that had not landed — once for the four value/sink pairs, once for the
+two narrowings. Both times the edit was written, believed, and not verified against the file
+afterwards. **An edit is not applied because it was authored**, and the cheapest proof is to read back
+the property rather than the diff you intended.

--- a/packages/agent-core/src/interfaces/file-system.ts
+++ b/packages/agent-core/src/interfaces/file-system.ts
@@ -23,6 +23,14 @@ export interface IFileSystem {
   rmSync(path: string, options?: { recursive?: boolean; force?: boolean }): void;
   cpSync(source: string, destination: string, options?: { recursive?: boolean }): void;
   renameSync(oldPath: string, newPath: string): void;
+  /**
+   * The canonical path with every symlink resolved. Throws if `path` does not exist.
+   *
+   * SEC-018: containment checks compare canonical forms. Without this, `<root>/link` pointing at
+   * `/etc` passes a lexical prefix test, so a symlink inside a plugin root can redirect a copy,
+   * rename, load or recursive delete outside it.
+   */
+  realpathSync(path: string): string;
   constants: { F_OK: number; R_OK: number; W_OK: number };
 }
 

--- a/packages/agent-framework/src/adapters/node-file-system.ts
+++ b/packages/agent-framework/src/adapters/node-file-system.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync as nodeRealpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -67,6 +68,10 @@ export class NodeFileSystem implements IFileSystem {
 
   renameSync(oldPath: string, newPath: string): void {
     renameSync(oldPath, newPath);
+  }
+
+  realpathSync(path: string): string {
+    return nodeRealpathSync(path);
   }
 
   get constants(): { F_OK: number; R_OK: number; W_OK: number } {

--- a/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
@@ -386,4 +386,64 @@ describe('BundlePluginInstaller', () => {
       expect(plugins).toEqual([]);
     });
   });
+
+  describe('SEC-018 - every sink USES the guard, not just the module that defines it', () => {
+    // The first pass of SEC-018 tested `plugin-paths.ts` thoroughly and guarded two of the four
+    // value/sink pairs. A review found the other two. Testing the predicate proves the predicate;
+    // it does not prove that each sink calls it — the same shape as ARCH-101's guard that was
+    // reachable only through `main()`. These drive the real installer methods instead.
+
+    it('uninstall does not delete a registry installPath outside the plugin cache', async () => {
+      const victim = join(TMP_BASE, 'victim-' + Math.random().toString(36).slice(2));
+      setupDir(victim);
+      writeFileSync(join(victim, 'keep.txt'), 'do not delete me', 'utf-8');
+
+      // A tampered installed_plugins.json — the value is a HINT read from disk, not one we derived.
+      writeJson(join(pluginsDir, 'installed_plugins.json'), {
+        'evil@market': {
+          pluginName: 'evil',
+          marketplace: 'market',
+          version: '1.0.0',
+          installPath: victim,
+          installedAt: new Date().toISOString(),
+        },
+      });
+
+      await installer.uninstall('evil@market');
+
+      expect(existsSync(join(victim, 'keep.txt')), 'a path outside the cache was deleted').toBe(
+        true,
+      );
+
+      // ...and the entry is still gone, so one tampered record cannot pin itself in place and block
+      // every later uninstall.
+      const registry = JSON.parse(
+        readFileSync(join(pluginsDir, 'installed_plugins.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      expect(registry['evil@market']).toBeUndefined();
+    });
+
+    it('refuses a marketplace manifest whose plugin source escapes the marketplace directory', async () => {
+      const marketplaceDir = join(pluginsDir, 'marketplaces', 'escape-market');
+      setupDir(join(marketplaceDir, '.claude-plugin'));
+      writeJson(join(marketplaceDir, '.claude-plugin', 'marketplace.json'), {
+        name: 'escape-market',
+        version: '1.0',
+        // `source` is a RELATIVE path from a remote manifest, joined onto the marketplace clone and
+        // then cpSync-ed into the cache and loaded as plugin code.
+        plugins: [{ name: 'escaper', source: '../../../..', version: '1.0.0' }],
+      });
+      writeJson(join(pluginsDir, 'known_marketplaces.json'), {
+        'escape-market': {
+          source: { type: 'local', path: marketplaceDir },
+          installLocation: marketplaceDir,
+          lastUpdated: new Date().toISOString(),
+        },
+      });
+
+      await expect(installer.install('escaper', 'escape-market')).rejects.toThrow(
+        /outside the plugin root/,
+      );
+    });
+  });
 });

--- a/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/bundle-plugin-installer.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 
+import { NodeFileSystem } from '../../adapters/node-file-system.js';
 import { BundlePluginInstaller } from '../bundle-plugin-installer.js';
 import { MarketplaceClient } from '../marketplace-client.js';
 import { NodeHostPluginSettingsStore } from '../plugin-settings-store.js';
@@ -26,6 +27,7 @@ describe('BundlePluginInstaller', () => {
   let installer: BundlePluginInstaller;
   let marketplaceClient: MarketplaceClient;
   let mockExec: Mock;
+  let installerFs: NodeFileSystem;
 
   beforeEach(() => {
     const runDir = join(TMP_BASE, 'run-' + Math.random().toString(36).slice(2));
@@ -37,11 +39,13 @@ describe('BundlePluginInstaller', () => {
 
     marketplaceClient = new MarketplaceClient({ pluginsDir, exec: mockExec as TExecFn });
 
+    installerFs = new NodeFileSystem();
     installer = new BundlePluginInstaller({
       pluginsDir,
       settingsStore: new NodeHostPluginSettingsStore(settingsPath),
       marketplaceClient,
       exec: mockExec as TExecFn,
+      fs: installerFs,
     });
   });
 
@@ -444,6 +448,38 @@ describe('BundlePluginInstaller', () => {
       await expect(installer.install('escaper', 'escape-market')).rejects.toThrow(
         /outside the plugin root/,
       );
+    });
+
+    it('lets a real filesystem failure propagate instead of recording a successful removal', async () => {
+      // The refusal and an EACCES/EBUSY are different events. Swallowing both meant a delete that
+      // failed for an ordinary reason still dropped the registry entry, leaving the directory on disk
+      // with nothing tracking it.
+      const inCache = join(pluginsDir, 'cache', 'market', 'plug', '1.0.0');
+      setupDir(inCache);
+      writeJson(join(pluginsDir, 'installed_plugins.json'), {
+        'plug@market': {
+          pluginName: 'plug',
+          marketplace: 'market',
+          version: '1.0.0',
+          installPath: inCache,
+          installedAt: new Date().toISOString(),
+        },
+      });
+
+      const boom = new Error('EBUSY: resource busy or locked');
+      const realRm = installerFs.rmSync.bind(installerFs);
+      installerFs.rmSync = (target: string, options?: { recursive?: boolean; force?: boolean }) => {
+        if (target === inCache) throw boom;
+        realRm(target, options);
+      };
+
+      await expect(installer.uninstall('plug@market')).rejects.toThrow(/EBUSY/);
+
+      // ...and the registry still records it, because the directory is still there.
+      const registry = JSON.parse(
+        readFileSync(join(pluginsDir, 'installed_plugins.json'), 'utf-8'),
+      ) as Record<string, unknown>;
+      expect(registry['plug@market'], 'the entry was dropped after a failed delete').toBeDefined();
     });
   });
 });

--- a/packages/agent-framework/src/plugins/__tests__/sec-018-path-containment.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/sec-018-path-containment.test.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { NodeFileSystem } from '../../adapters/node-file-system.js';
+import {
+  assertContainedPath,
+  assertSafePluginSegment,
+  isSafePluginSegment,
+  resolveContainedRelative,
+} from '../plugin-paths.js';
+
+/**
+ * SEC-018 (issue #2020) - plugin identifiers are path segments arriving from a remote manifest or a
+ * file on disk, and they reached `renameSync`, `cpSync` and a recursive `rmSync` after only
+ * `typeof === 'string'`.
+ *
+ * These assert the two properties the fix rests on: a malformed identifier is REFUSED rather than
+ * sanitised, and containment is judged on the CANONICAL path so a symlink cannot redirect a mutation
+ * out of a root it appears to be inside.
+ */
+describe('SEC-018 - an identifier that is not a safe path segment is refused', () => {
+  // Each is a real escape or injection, not a stylistic complaint.
+  const REJECTED: Array<[string, unknown]> = [
+    ['parent traversal', '../escaped'],
+    ['nested traversal', '../../escaped-market'],
+    ['bare dot-dot', '..'],
+    ['bare dot', '.'],
+    ['posix separator', 'a/b'],
+    ['windows separator', 'a\\b'],
+    ['absolute posix', '/etc/passwd'],
+    ['windows drive', 'C:evil'],
+    ['UNC prefix', '\\\\server\\share'],
+    ['NUL byte', 'name' + String.fromCharCode(0) + '.json'],
+    ['percent-encoded traversal', '%2e%2e%2fescaped'],
+    ['leading dot (hidden)', '.hidden'],
+    ['leading hyphen (option-like)', '-rf'],
+    ['empty', ''],
+    ['not a string', 42],
+    ['null', null],
+    ['too long', 'a'.repeat(129)],
+  ];
+
+  it.each(REJECTED)('rejects %s', (_label, value) => {
+    expect(isSafePluginSegment(value)).toBe(false);
+    expect(() => assertSafePluginSegment(value, 'marketplace name')).toThrow(/Invalid plugin/);
+  });
+
+  it.each([
+    ['plain', 'my-plugin'],
+    ['dotted version', '1.2.3'],
+    ['underscored', 'a_b'],
+    ['digits', '2026'],
+  ])('accepts a genuine identifier: %s', (_label, value) => {
+    expect(isSafePluginSegment(value)).toBe(true);
+  });
+
+  it('names the field, so two untrusted sources are distinguishable', () => {
+    expect(() => assertSafePluginSegment('../x', 'plugin version')).toThrow(/plugin version/);
+    expect(() => assertSafePluginSegment('../x', 'marketplace name')).toThrow(/marketplace name/);
+  });
+
+  it('refuses rather than sanitises, so two identifiers cannot alias onto one directory', () => {
+    // A sanitiser that stripped the traversal from `../x` would yield `x` — which is a perfectly
+    // valid identifier some other plugin may already own. The hostile name and the benign one would
+    // then map to ONE directory, silently cross-linking them. Rejecting keeps them distinguishable.
+    expect(() => assertSafePluginSegment('../x', 'plugin name')).toThrow();
+    expect(
+      isSafePluginSegment('x'),
+      'the sanitised form is a name someone else can legitimately hold',
+    ).toBe(true);
+  });
+});
+
+describe('SEC-018 - containment is judged on the canonical path', () => {
+  let root: string;
+  let outside: string;
+  const fs = new NodeFileSystem();
+
+  beforeEach(() => {
+    const base = mkdtempSync(join(tmpdir(), 'sec-018-'));
+    root = join(base, 'plugins');
+    outside = join(base, 'outside');
+    mkdirSync(root, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'victim.txt'), 'do not delete me', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('accepts the root itself and a real descendant', () => {
+    expect(() => assertContainedPath(root, root, 'test', fs)).not.toThrow();
+    expect(() => assertContainedPath(root, join(root, 'a', 'b'), 'test', fs)).not.toThrow();
+  });
+
+  it('refuses a lexical escape', () => {
+    expect(() => assertContainedPath(root, join(root, '..', 'outside'), 'delete', fs)).toThrow(
+      /outside the plugin root/,
+    );
+  });
+
+  it('refuses a SIBLING whose name merely extends the root', () => {
+    // `/a/plugins-evil` starts with `/a/plugins` as a string. The separator is what makes the prefix
+    // comparison a containment test rather than a string test.
+    expect(() => assertContainedPath(root, `${root}-evil`, 'delete', fs)).toThrow(
+      /outside the plugin root/,
+    );
+  });
+
+  it('refuses a path that reaches outside THROUGH A SYMLINK inside the root', () => {
+    // The case a lexical check cannot see: `resolve(root, 'link')` still starts with `root`.
+    symlinkSync(outside, join(root, 'link'), 'dir');
+    expect(() => assertContainedPath(root, join(root, 'link'), 'delete', fs)).toThrow(
+      /outside the plugin root/,
+    );
+    expect(() => assertContainedPath(root, join(root, 'link', 'victim.txt'), 'delete', fs)).toThrow(
+      /outside the plugin root/,
+    );
+  });
+
+  it('checks a destination that does not exist yet, before it is created', () => {
+    // A rename target has no realpath. Canonicalising only existing paths would leave every
+    // create-then-check window open, and checking after the write is checking after the damage.
+    symlinkSync(outside, join(root, 'link'), 'dir');
+    expect(() =>
+      assertContainedPath(root, join(root, 'link', 'not-created-yet'), 'install', fs),
+    ).toThrow(/outside the plugin root/);
+    expect(() =>
+      assertContainedPath(root, join(root, 'fresh', 'not-created-yet'), 'install', fs),
+    ).not.toThrow();
+  });
+
+  it('resolves a relative source against the root and refuses an absolute one', () => {
+    expect(resolveContainedRelative(root, join('a', 'b'), 'load', fs)).toBe(join(root, 'a', 'b'));
+    expect(() => resolveContainedRelative(root, outside, 'load', fs)).toThrow(/absolute path/);
+    expect(() => resolveContainedRelative(root, join('..', 'outside'), 'load', fs)).toThrow(
+      /outside the plugin root/,
+    );
+  });
+});

--- a/packages/agent-framework/src/plugins/__tests__/sec-018-sink-coverage.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/sec-018-sink-coverage.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+import { NodeFileSystem } from '../../adapters/node-file-system.js';
 import { MarketplaceClient } from '../marketplace-client.js';
 import { removeInstalledPluginsForMarketplace } from '../marketplace-registry.js';
 
@@ -68,6 +69,26 @@ describe('SEC-018 - the marketplace-wide cleanup refuses a path outside the plug
     removeInstalledPluginsForMarketplace(pluginsDir, 'market');
 
     expect(existsSync(join(sibling, 'keep.txt')), 'a sibling marketplace was deleted').toBe(true);
+  });
+
+  it('lets a real filesystem failure propagate rather than recording a successful cleanup', () => {
+    // The narrowing that was claimed for both sinks and applied to one. Without it an EBUSY is
+    // swallowed exactly like a containment refusal and the entry is dropped anyway, leaving the
+    // directory on disk with nothing tracking it.
+    const legit = join(pluginsDir, 'cache', 'market', 'plug', '1.0.0');
+    mkdirSync(legit, { recursive: true });
+    writeJson(join(pluginsDir, 'installed_plugins.json'), {
+      'plug@market': { marketplace: 'market', installPath: legit },
+    });
+
+    const fs = new NodeFileSystem();
+    const realRm = fs.rmSync.bind(fs);
+    fs.rmSync = (target: string, options?: { recursive?: boolean; force?: boolean }) => {
+      if (target === legit) throw new Error('EBUSY: resource busy or locked');
+      realRm(target, options);
+    };
+
+    expect(() => removeInstalledPluginsForMarketplace(pluginsDir, 'market', fs)).toThrow(/EBUSY/);
   });
 
   it('still deletes a legitimate cache directory', () => {

--- a/packages/agent-framework/src/plugins/__tests__/sec-018-sink-coverage.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/sec-018-sink-coverage.test.ts
@@ -133,3 +133,65 @@ describe('SEC-018 - a marketplace manifest name cannot select a destination outs
     expect(client.addMarketplace({ type: 'local', path: localSource })).toBe('good-market');
   });
 });
+
+describe('SEC-018 - known_marketplaces.json installLocation is a hint, not a fact', () => {
+  let base: string;
+  let pluginsDir: string;
+  let mockExec: Mock;
+  let client: MarketplaceClient;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'sec-018-known-'));
+    pluginsDir = join(base, 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    mockExec = vi.fn().mockReturnValue('');
+    client = new MarketplaceClient({ pluginsDir, exec: mockExec as unknown as TExecFn });
+  });
+
+  afterEach(() => rmSync(base, { recursive: true, force: true }));
+
+  function registerTampered(installLocation: string): void {
+    writeJson(join(pluginsDir, 'known_marketplaces.json'), {
+      tampered: {
+        source: { type: 'local', path: join(base, 'src') },
+        installLocation,
+        lastUpdated: new Date().toISOString(),
+      },
+    });
+  }
+
+  it('removeMarketplace refuses an installLocation outside the marketplaces root', () => {
+    const victim = join(base, 'victim');
+    mkdirSync(victim, { recursive: true });
+    writeFileSync(join(victim, 'keep.txt'), 'do not delete me', 'utf-8');
+    registerTampered(victim);
+
+    expect(() => client.removeMarketplace('tampered')).toThrow(/outside the plugin root/);
+    expect(existsSync(join(victim, 'keep.txt')), 'a path outside the root was deleted').toBe(true);
+  });
+
+  it('updateMarketplace refuses the same value before it deletes and copies over it', () => {
+    const victim = join(base, 'victim2');
+    mkdirSync(victim, { recursive: true });
+    writeFileSync(join(victim, 'keep.txt'), 'do not overwrite me', 'utf-8');
+    mkdirSync(join(base, 'src'), { recursive: true });
+    registerTampered(victim);
+
+    expect(() => client.updateMarketplace('tampered')).toThrow(/outside the plugin root/);
+    expect(existsSync(join(victim, 'keep.txt')), 'a path outside the root was overwritten').toBe(
+      true,
+    );
+    // ...and no git ran against it either: `git -C <dir> pull` is a third sink on the same value.
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('still removes a legitimate marketplace directory', () => {
+    const legit = join(pluginsDir, 'marketplaces', 'good');
+    mkdirSync(legit, { recursive: true });
+    registerTampered(legit);
+
+    client.removeMarketplace('tampered');
+
+    expect(existsSync(legit), 'the guard refused a legitimate removal').toBe(false);
+  });
+});

--- a/packages/agent-framework/src/plugins/__tests__/sec-018-sink-coverage.test.ts
+++ b/packages/agent-framework/src/plugins/__tests__/sec-018-sink-coverage.test.ts
@@ -1,0 +1,135 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { MarketplaceClient } from '../marketplace-client.js';
+import { removeInstalledPluginsForMarketplace } from '../marketplace-registry.js';
+
+import type { TExecFn } from '../marketplace-types.js';
+
+/**
+ * SEC-018 - the two remaining sinks, each driven rather than assumed.
+ *
+ * `regression-red-proof` reported `accidental-green-fail (all-pass)` for `marketplace-registry.ts` and
+ * `marketplace-client.ts`: reversing the guards changed nothing, because no test reached either sink.
+ * That is the THIRD time in this one change that a guard was added and its use was not asserted - the
+ * reviewer found two, the floor found these two. Testing `plugin-paths.ts` proves the predicate; only
+ * driving the sink proves the call.
+ */
+function writeJson(path: string, data: unknown): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+describe('SEC-018 - the marketplace-wide cleanup refuses a path outside the plugin cache', () => {
+  let base: string;
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'sec-018-registry-'));
+    pluginsDir = join(base, 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+  });
+
+  afterEach(() => rmSync(base, { recursive: true, force: true }));
+
+  it('does not delete a tampered installPath, and still drops the entry', () => {
+    const victim = join(base, 'victim');
+    mkdirSync(victim, { recursive: true });
+    writeFileSync(join(victim, 'keep.txt'), 'do not delete me', 'utf-8');
+
+    writeJson(join(pluginsDir, 'installed_plugins.json'), {
+      'evil@market': { marketplace: 'market', installPath: victim },
+    });
+
+    removeInstalledPluginsForMarketplace(pluginsDir, 'market');
+
+    expect(existsSync(join(victim, 'keep.txt')), 'a path outside the cache was deleted').toBe(true);
+    const registry = JSON.parse(
+      readFileSync(join(pluginsDir, 'installed_plugins.json'), 'utf-8'),
+    ) as Record<string, unknown>;
+    expect(registry['evil@market'], 'a tampered entry pinned itself in place').toBeUndefined();
+  });
+
+  it('refuses a path inside the plugins root but OUTSIDE the cache', () => {
+    // The finding that made both sinks agree on one root: `pluginsDir/marketplaces/<name>` is inside
+    // the plugins root and outside the cache, so a wider check would recursively delete a sibling
+    // marketplace clone - or the registry file itself.
+    const sibling = join(pluginsDir, 'marketplaces', 'other-market');
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(join(sibling, 'keep.txt'), 'another marketplace', 'utf-8');
+
+    writeJson(join(pluginsDir, 'installed_plugins.json'), {
+      'evil@market': { marketplace: 'market', installPath: sibling },
+    });
+
+    removeInstalledPluginsForMarketplace(pluginsDir, 'market');
+
+    expect(existsSync(join(sibling, 'keep.txt')), 'a sibling marketplace was deleted').toBe(true);
+  });
+
+  it('still deletes a legitimate cache directory', () => {
+    const legit = join(pluginsDir, 'cache', 'market', 'plug', '1.0.0');
+    mkdirSync(legit, { recursive: true });
+    writeFileSync(join(legit, 'index.js'), '', 'utf-8');
+
+    writeJson(join(pluginsDir, 'installed_plugins.json'), {
+      'plug@market': { marketplace: 'market', installPath: legit },
+    });
+
+    removeInstalledPluginsForMarketplace(pluginsDir, 'market');
+
+    expect(existsSync(legit), 'the guard refused a legitimate removal').toBe(false);
+  });
+});
+
+describe('SEC-018 - a marketplace manifest name cannot select a destination outside its root', () => {
+  let base: string;
+  let pluginsDir: string;
+  let mockExec: Mock;
+  let client: MarketplaceClient;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'sec-018-client-'));
+    pluginsDir = join(base, 'plugins');
+    mkdirSync(pluginsDir, { recursive: true });
+    mockExec = vi.fn().mockReturnValue('');
+    client = new MarketplaceClient({ pluginsDir, exec: mockExec as unknown as TExecFn });
+  });
+
+  afterEach(() => rmSync(base, { recursive: true, force: true }));
+
+  it('refuses a manifest whose name traverses out of the marketplaces directory', () => {
+    // The reproduction the issue describes: a REMOTE manifest named `../../escaped-market` selected
+    // the rename destination, so the marketplace landed outside its root.
+    const localSource = join(base, 'source');
+    mkdirSync(join(localSource, '.claude-plugin'), { recursive: true });
+    writeJson(join(localSource, '.claude-plugin', 'marketplace.json'), {
+      name: '../../escaped-market',
+      version: '1.0',
+      plugins: [],
+    });
+
+    expect(() => client.addMarketplace({ type: 'local', path: localSource })).toThrow(
+      /Invalid plugin marketplace name/,
+    );
+    expect(
+      existsSync(join(base, 'escaped-market')),
+      'a marketplace was created outside its root',
+    ).toBe(false);
+  });
+
+  it('accepts a well-formed manifest name', () => {
+    const localSource = join(base, 'good-source');
+    mkdirSync(join(localSource, '.claude-plugin'), { recursive: true });
+    writeJson(join(localSource, '.claude-plugin', 'marketplace.json'), {
+      name: 'good-market',
+      version: '1.0',
+      plugins: [],
+    });
+
+    expect(client.addMarketplace({ type: 'local', path: localSource })).toBe('good-market');
+  });
+});

--- a/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
@@ -7,6 +7,11 @@
 
 import { join, dirname } from 'node:path';
 
+import {
+  assertContainedPath,
+  assertSafePluginSegment,
+  resolveContainedRelative,
+} from './plugin-paths.js';
 import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 import type { MarketplaceClient, IMarketplacePluginEntry, TExecFn } from './marketplace-client.js';
@@ -81,8 +86,16 @@ export class BundlePluginInstaller {
     // Determine version
     const version = this.resolveVersion(entry, marketplaceName);
 
+    // SEC-018: all three become path components, and `version` comes from a remote manifest entry.
+    // Checked before the join so a malformed value cannot reach any sink — the target is used for a
+    // recursive delete during cleanup as well as for the write.
+    assertSafePluginSegment(marketplaceName, 'marketplace name');
+    assertSafePluginSegment(pluginName, 'plugin name');
+    assertSafePluginSegment(version, 'plugin version');
+
     // Target directory: cache/<marketplace>/<plugin>/<version>/
     const targetDir = join(this.cacheDir, marketplaceName, pluginName, version);
+    assertContainedPath(this.cacheDir, targetDir, 'install a plugin', this.fs);
 
     if (this.fs.existsSync(targetDir)) {
       throw new Error(

--- a/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
@@ -13,6 +13,7 @@ import {
 } from './installed-plugins-registry.js';
 import {
   assertContainedPath,
+  PluginPathContainmentError,
   assertSafePluginSegment,
   resolveContainedRelative,
 } from './plugin-paths.js';
@@ -151,9 +152,11 @@ export class BundlePluginInstaller {
         );
         this.fs.rmSync(record.installPath, { recursive: true, force: true });
       } catch (error) {
-        // allow-fallback: a registry entry pointing outside the plugin cache is not deleted; the
-        // entry is still removed below.
-        process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+        // allow-fallback: ONLY a containment refusal is swallowed. A real `rmSync` failure (EACCES,
+        // EBUSY) must propagate — dropping the registry entry after one would leave the directory on
+        // disk with nothing tracking it, which is worse than the failed uninstall.
+        if (!(error instanceof PluginPathContainmentError)) throw error;
+        process.stderr.write(`${error.message}\n`);
       }
     }
 

--- a/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
+++ b/packages/agent-framework/src/plugins/bundle-plugin-installer.ts
@@ -8,6 +8,10 @@
 import { join, dirname } from 'node:path';
 
 import {
+  readInstalledPluginsRegistry,
+  writeInstalledPluginsRegistry,
+} from './installed-plugins-registry.js';
+import {
   assertContainedPath,
   assertSafePluginSegment,
   resolveContainedRelative,
@@ -108,7 +112,7 @@ export class BundlePluginInstaller {
 
     // Record in installed_plugins.json
     const pluginId = `${pluginName}@${marketplaceName}`;
-    const registry = this.readRegistry();
+    const registry = readInstalledPluginsRegistry(this.registryPath, this.fs);
     registry[pluginId] = {
       pluginName,
       marketplace: marketplaceName,
@@ -116,7 +120,7 @@ export class BundlePluginInstaller {
       installPath: targetDir,
       installedAt: new Date().toISOString(),
     };
-    this.writeRegistry(registry);
+    writeInstalledPluginsRegistry(this.registryPath, registry, this.fs);
   }
 
   /**
@@ -124,21 +128,38 @@ export class BundlePluginInstaller {
    * Removes from cache and from installed_plugins.json.
    */
   async uninstall(pluginId: string): Promise<void> {
-    const registry = this.readRegistry();
+    const registry = readInstalledPluginsRegistry(this.registryPath, this.fs);
     const record = registry[pluginId];
 
     if (!record) {
       throw new Error(`Plugin "${pluginId}" is not installed`);
     }
 
-    // Remove the installed directory
+    // SEC-018: `installPath` is a HINT read from installed_plugins.json, and it drives a recursive
+    // delete. The marketplace-wide cleanup guards the identical value/sink pair; this single-plugin
+    // path is the SECOND sink on the same value and was missed in the first pass.
+    //
+    // Refused per entry, as there: the removal is skipped but the registry entry is still dropped, so
+    // a tampered record cannot pin itself in place and block every later uninstall.
     if (this.fs.existsSync(record.installPath)) {
-      this.fs.rmSync(record.installPath, { recursive: true, force: true });
+      try {
+        assertContainedPath(
+          this.cacheDir,
+          record.installPath,
+          'remove a plugin directory',
+          this.fs,
+        );
+        this.fs.rmSync(record.installPath, { recursive: true, force: true });
+      } catch (error) {
+        // allow-fallback: a registry entry pointing outside the plugin cache is not deleted; the
+        // entry is still removed below.
+        process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      }
     }
 
     // Remove from registry
     delete registry[pluginId];
-    this.writeRegistry(registry);
+    writeInstalledPluginsRegistry(this.registryPath, registry, this.fs);
 
     // Remove from enabled plugins settings
     this.settingsStore.removePluginEntry(pluginId);
@@ -156,12 +177,12 @@ export class BundlePluginInstaller {
 
   /** Get all installed plugins. */
   getInstalledPlugins(): TInstalledPluginsRegistry {
-    return this.readRegistry();
+    return readInstalledPluginsRegistry(this.registryPath, this.fs);
   }
 
   /** Get plugins installed from a specific marketplace. */
   getPluginsByMarketplace(marketplaceName: string): IInstalledPluginRecord[] {
-    const registry = this.readRegistry();
+    const registry = readInstalledPluginsRegistry(this.registryPath, this.fs);
     return Object.values(registry).filter((r) => r.marketplace === marketplaceName);
   }
 
@@ -206,9 +227,16 @@ export class BundlePluginInstaller {
 
     try {
       if (typeof source === 'string') {
-        // Relative path — copy from the marketplace clone
+        // SEC-018: `source` comes from the REMOTE marketplace manifest and is joined onto the
+        // marketplace clone. `../../../../etc` pointed outside it, and the result is `cpSync`-ed into
+        // the plugin cache and then loaded as plugin code.
         const marketplaceDir = this.marketplaceClient.getMarketplaceDir(marketplaceName);
-        const sourcePath = join(marketplaceDir, source);
+        const sourcePath = resolveContainedRelative(
+          marketplaceDir,
+          source,
+          'install a plugin from a marketplace source',
+          this.fs,
+        );
 
         if (!this.fs.existsSync(sourcePath)) {
           throw new Error(
@@ -257,32 +285,5 @@ export class BundlePluginInstaller {
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Failed to clone plugin "${pluginName}": ${message}`);
     }
-  }
-
-  /** Read the installed_plugins.json registry. */
-  private readRegistry(): TInstalledPluginsRegistry {
-    if (!this.fs.existsSync(this.registryPath)) {
-      return {};
-    }
-    try {
-      const raw = this.fs.readFileSync(this.registryPath, 'utf-8');
-      const data: unknown = JSON.parse(raw);
-      if (typeof data === 'object' && data !== null) {
-        return data as TInstalledPluginsRegistry;
-      }
-      return {};
-    } catch {
-      // allow-fallback: corrupt installed_plugins.json returns empty registry to allow recovery
-      return {};
-    }
-  }
-
-  /** Write the installed_plugins.json registry. */
-  private writeRegistry(registry: TInstalledPluginsRegistry): void {
-    const dir = dirname(this.registryPath);
-    if (!this.fs.existsSync(dir)) {
-      this.fs.mkdirSync(dir, { recursive: true });
-    }
-    this.fs.writeFileSync(this.registryPath, JSON.stringify(registry, null, 2), 'utf-8');
   }
 }

--- a/packages/agent-framework/src/plugins/installed-plugins-registry.ts
+++ b/packages/agent-framework/src/plugins/installed-plugins-registry.ts
@@ -1,0 +1,46 @@
+import { dirname } from 'node:path';
+
+import type { TInstalledPluginsRegistry } from './bundle-plugin-installer.js';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+
+/**
+ * Reading and writing `installed_plugins.json`.
+ *
+ * Split out of `bundle-plugin-installer.ts` under SEC-018 (issue #2020), by responsibility rather
+ * than by line count: the installer decides WHAT to install and remove; this owns the persisted
+ * record of what is installed. They fail differently — a corrupt registry is a recovery problem, a
+ * failed install is a transaction problem — and separating them makes the trust boundary visible,
+ * which is the point of SEC-018.
+ *
+ * **Everything this returns is a HINT, not a fact.** The file is on disk and can be tampered with, so
+ * a caller must not treat `installPath` as a path it may act on. Both of this repository's recursive
+ * deletes over that value now prove containment first; this module deliberately does no validation of
+ * its own, so there is exactly one place — the sink — where the question is asked, rather than two
+ * that can disagree about the answer.
+ */
+export function readInstalledPluginsRegistry(
+  registryPath: string,
+  fs: IFileSystem,
+): TInstalledPluginsRegistry {
+  if (!fs.existsSync(registryPath)) return {};
+  try {
+    const raw = fs.readFileSync(registryPath, 'utf-8');
+    const data: unknown = JSON.parse(raw);
+    if (typeof data === 'object' && data !== null) return data as TInstalledPluginsRegistry;
+    return {};
+  } catch {
+    // allow-fallback: corrupt installed_plugins.json returns an empty registry to allow recovery
+    return {};
+  }
+}
+
+/** Persist the registry, creating its directory if needed. */
+export function writeInstalledPluginsRegistry(
+  registryPath: string,
+  registry: TInstalledPluginsRegistry,
+  fs: IFileSystem,
+): void {
+  const dir = dirname(registryPath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2), 'utf-8');
+}

--- a/packages/agent-framework/src/plugins/marketplace-client.ts
+++ b/packages/agent-framework/src/plugins/marketplace-client.ts
@@ -8,11 +8,13 @@
 
 import { join } from 'node:path';
 
+import { readMarketplaceManifest } from './marketplace-manifest.js';
 import {
   readRegistry,
   writeRegistry,
   removeInstalledPluginsForMarketplace,
 } from './marketplace-registry.js';
+import { assertContainedPath, assertSafePluginSegment } from './plugin-paths.js';
 import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 import type {
@@ -99,7 +101,7 @@ export class MarketplaceClient {
       );
     }
 
-    const manifest = this.readManifestFromPath(manifestPath);
+    const manifest = readMarketplaceManifest(manifestPath, this.fs);
     const name = manifest.name;
 
     if (!name) {
@@ -113,7 +115,11 @@ export class MarketplaceClient {
       throw new Error(`Marketplace "${name}" already exists`);
     }
 
+    // SEC-018: `name` comes from a REMOTE marketplace manifest and selects this rename destination.
+    // A manifest named `../../escaped-market` placed the marketplace outside its root.
+    assertSafePluginSegment(name, 'marketplace name');
     const finalDir = join(this.marketplacesDir, name);
+    assertContainedPath(this.marketplacesDir, finalDir, 'install a marketplace', this.fs);
     this.fs.renameSync(tempDir, finalDir);
 
     registry[name] = {
@@ -212,7 +218,7 @@ export class MarketplaceClient {
       );
     }
 
-    return this.readManifestFromPath(manifestPath);
+    return readMarketplaceManifest(manifestPath, this.fs);
   }
 
   /** Get the clone directory path for a registered marketplace. */
@@ -277,22 +283,5 @@ export class MarketplaceClient {
       case 'url':
         throw new Error('URL marketplace source is not yet supported');
     }
-  }
-
-  /** Read and parse a marketplace.json from a file path. */
-  private readManifestFromPath(path: string): IMarketplaceManifest {
-    const raw = this.fs.readFileSync(path, 'utf-8');
-    const data: unknown = JSON.parse(raw);
-
-    if (typeof data !== 'object' || data === null) {
-      throw new Error('Invalid marketplace manifest: not an object');
-    }
-
-    const obj = data as Record<string, unknown>;
-    if (typeof obj.name !== 'string') {
-      throw new Error('Invalid marketplace manifest: missing "name" field');
-    }
-
-    return data as IMarketplaceManifest;
   }
 }

--- a/packages/agent-framework/src/plugins/marketplace-client.ts
+++ b/packages/agent-framework/src/plugins/marketplace-client.ts
@@ -14,6 +14,7 @@ import {
   writeRegistry,
   removeInstalledPluginsForMarketplace,
 } from './marketplace-registry.js';
+import { resolveMarketplaceCloneUrl } from './marketplace-source.js';
 import { assertContainedPath, assertSafePluginSegment } from './plugin-paths.js';
 import { NodeFileSystem } from '../adapters/node-file-system.js';
 
@@ -22,6 +23,7 @@ import type {
   IMarketplacePluginEntry,
   IMarketplaceManifest,
   IMarketplaceClientOptions,
+  IKnownMarketplaceEntry,
   TExecFn,
 } from './marketplace-types.js';
 import type { IFileSystem } from '@robota-sdk/agent-core';
@@ -76,7 +78,7 @@ export class MarketplaceClient {
       }
       this.fs.cpSync(source.path, tempDir, { recursive: true });
     } else {
-      const cloneUrl = this.resolveCloneUrl(source);
+      const cloneUrl = resolveMarketplaceCloneUrl(source);
       try {
         // `--` before the operands: a URL or path beginning with `-` is an OPERAND, never an option.
         // Argv alone stops shell interpretation; it does not stop git reading `--upload-pack=…` as a
@@ -137,15 +139,34 @@ export class MarketplaceClient {
    * Uninstalls all plugins from that marketplace, then deletes the clone directory
    * and removes from the registry.
    */
-  removeMarketplace(name: string): void {
-    const registry = readRegistry(this.registryPath, this.fs);
-    const entry = registry[name];
+  /**
+   * The registry entry for `name`, with its `installLocation` proven inside the marketplaces root.
+   *
+   * SEC-018. `known_marketplaces.json` is the sibling of `installed_plugins.json`, and its
+   * `installLocation` reaches three sinks: a recursive delete in `removeMarketplace`, a
+   * delete-then-copy in `updateMarketplace`'s local branch, and `git -C <dir> pull` in its git
+   * branch. All three were unguarded while the other registry's `installPath` was guarded twice —
+   * the principle was established and the sibling file was never enumerated.
+   *
+   * Checked once, where the entry is read, rather than at each of the three sinks: three call sites
+   * are three chances to miss one, which is how this was missed in the first place.
+   */
+  private requireContainedEntry(name: string, what: string): IKnownMarketplaceEntry {
+    const entry = readRegistry(this.registryPath, this.fs)[name];
     if (!entry) {
       throw new Error(`Marketplace "${name}" not found`);
     }
+    assertContainedPath(this.marketplacesDir, entry.installLocation, what, this.fs);
+    return entry;
+  }
+
+  removeMarketplace(name: string): void {
+    const entry = this.requireContainedEntry(name, 'remove a marketplace');
+    const registry = readRegistry(this.registryPath, this.fs);
 
     removeInstalledPluginsForMarketplace(this.pluginsDir, name, this.fs);
 
+    // SEC-018: proven contained above; the registry value is a hint, not a fact.
     if (this.fs.existsSync(entry.installLocation)) {
       this.fs.rmSync(entry.installLocation, { recursive: true, force: true });
     }
@@ -160,11 +181,9 @@ export class MarketplaceClient {
    * updated manifest is automatically available after pull.
    */
   updateMarketplace(name: string): void {
+    const entry = this.requireContainedEntry(name, 'update a marketplace');
     const registry = readRegistry(this.registryPath, this.fs);
-    const entry = registry[name];
-    if (!entry) {
-      throw new Error(`Marketplace "${name}" not found`);
-    }
+    registry[name] = entry;
 
     if (!this.fs.existsSync(entry.installLocation)) {
       throw new Error(`Marketplace directory for "${name}" does not exist`);
@@ -272,16 +291,4 @@ export class MarketplaceClient {
   // --- Private helpers ---
 
   /** Resolve a marketplace source to a git clone URL. */
-  private resolveCloneUrl(source: TMarketplaceSource): string {
-    switch (source.type) {
-      case 'github':
-        return `https://github.com/${source.repo}.git`;
-      case 'git':
-        return source.url;
-      case 'local':
-        throw new Error('Local source type does not use git cloning');
-      case 'url':
-        throw new Error('URL marketplace source is not yet supported');
-    }
-  }
 }

--- a/packages/agent-framework/src/plugins/marketplace-manifest.ts
+++ b/packages/agent-framework/src/plugins/marketplace-manifest.ts
@@ -1,0 +1,37 @@
+import { assertSafePluginSegment } from './plugin-paths.js';
+
+import type { IMarketplaceManifest } from './marketplace-types.js';
+import type { IFileSystem } from '@robota-sdk/agent-core';
+
+/**
+ * Reading a `marketplace.json` and proving it is one.
+ *
+ * Split out of `marketplace-client.ts` under SEC-018 (issue #2020), and by responsibility rather than
+ * by line count: the client MANAGES marketplaces — clone, rename, register, update, remove — while
+ * this decides whether a file fetched from a remote repository is a manifest at all. They fail
+ * differently and are read by different questions, and keeping them together is what let a manifest
+ * be `data as IMarketplaceManifest` after two shallow checks.
+ *
+ * The validation runs HERE rather than only at the sink so a malformed manifest is refused before any
+ * filesystem mutation is attempted, rather than partway through one. That ordering is the acceptance
+ * criterion "failed validation performs no filesystem mutation", and it cannot be satisfied by a check
+ * that lives next to the `renameSync`.
+ */
+export function readMarketplaceManifest(path: string, fs: IFileSystem): IMarketplaceManifest {
+  const raw = fs.readFileSync(path, 'utf-8');
+  const data: unknown = JSON.parse(raw);
+
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('Invalid marketplace manifest: not an object');
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.name !== 'string') {
+    throw new Error('Invalid marketplace manifest: missing "name" field');
+  }
+  // SEC-018: this name selects a rename destination in the client. A manifest named
+  // `../../escaped-market` placed the marketplace outside its root.
+  assertSafePluginSegment(obj.name, 'marketplace name');
+
+  return data as IMarketplaceManifest;
+}

--- a/packages/agent-framework/src/plugins/marketplace-registry.ts
+++ b/packages/agent-framework/src/plugins/marketplace-registry.ts
@@ -7,7 +7,7 @@
 
 import { join, dirname } from 'node:path';
 
-import { assertContainedPath } from './plugin-paths.js';
+import { assertContainedPath, PluginPathContainmentError } from './plugin-paths.js';
 import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 import type { TKnownMarketplacesRegistry } from './marketplace-types.js';
@@ -80,7 +80,16 @@ export function removeInstalledPluginsForMarketplace(
       // the others, so the removal is skipped and the entry is still dropped from the registry.
       if (record.installPath && fs.existsSync(record.installPath)) {
         try {
-          assertContainedPath(pluginsDir, record.installPath, 'remove a plugin directory', fs);
+          // SEC-018: the SAME root as the installer's uninstall path. Checking this value against
+          // `pluginsDir` instead let a tampered entry name `pluginsDir/known_marketplaces.json` or
+          // another marketplace clone — inside the plugins root, outside the cache — and have it
+          // recursively deleted. One value, one root.
+          assertContainedPath(
+            join(pluginsDir, 'cache'),
+            record.installPath,
+            'remove a plugin directory',
+            fs,
+          );
           fs.rmSync(record.installPath, { recursive: true, force: true });
         } catch (error) {
           // allow-fallback: a registry entry pointing outside the plugin root is not deleted. The

--- a/packages/agent-framework/src/plugins/marketplace-registry.ts
+++ b/packages/agent-framework/src/plugins/marketplace-registry.ts
@@ -7,6 +7,7 @@
 
 import { join, dirname } from 'node:path';
 
+import { assertContainedPath } from './plugin-paths.js';
 import { NodeFileSystem } from '../adapters/node-file-system.js';
 
 import type { TKnownMarketplacesRegistry } from './marketplace-types.js';
@@ -73,9 +74,19 @@ export function removeInstalledPluginsForMarketplace(
   let changed = false;
   for (const [pluginId, record] of Object.entries(registry)) {
     if (record.marketplace === marketplaceName) {
-      // Remove the cache directory for this plugin
+      // SEC-018: `installPath` is a HINT read from a file on disk, and it drives a recursive delete.
+      // A tampered registry pointing it outside the plugin root deleted whatever it named. Refused
+      // rather than sanitised, and refused per-entry: one bad record must not abort the cleanup of
+      // the others, so the removal is skipped and the entry is still dropped from the registry.
       if (record.installPath && fs.existsSync(record.installPath)) {
-        fs.rmSync(record.installPath, { recursive: true, force: true });
+        try {
+          assertContainedPath(pluginsDir, record.installPath, 'remove a plugin directory', fs);
+          fs.rmSync(record.installPath, { recursive: true, force: true });
+        } catch (error) {
+          // allow-fallback: a registry entry pointing outside the plugin root is not deleted. The
+          // entry is still removed below, so a tampered record cannot pin itself in place.
+          process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+        }
       }
       delete registry[pluginId];
       changed = true;

--- a/packages/agent-framework/src/plugins/marketplace-registry.ts
+++ b/packages/agent-framework/src/plugins/marketplace-registry.ts
@@ -92,9 +92,11 @@ export function removeInstalledPluginsForMarketplace(
           );
           fs.rmSync(record.installPath, { recursive: true, force: true });
         } catch (error) {
-          // allow-fallback: a registry entry pointing outside the plugin root is not deleted. The
-          // entry is still removed below, so a tampered record cannot pin itself in place.
-          process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+          // allow-fallback: ONLY a containment refusal is swallowed. A real `rmSync` failure (EACCES,
+          // EBUSY) must propagate — dropping the registry entry after one would leave the directory
+          // on disk with nothing tracking it, which is worse than the failed cleanup.
+          if (!(error instanceof PluginPathContainmentError)) throw error;
+          process.stderr.write(`${error.message}\n`);
         }
       }
       delete registry[pluginId];

--- a/packages/agent-framework/src/plugins/marketplace-source.ts
+++ b/packages/agent-framework/src/plugins/marketplace-source.ts
@@ -1,0 +1,27 @@
+import type { TMarketplaceSource } from './marketplace-types.js';
+
+/**
+ * Where a marketplace's bytes come from.
+ *
+ * Split out of `marketplace-client.ts` under SEC-018 (issue #2020), by responsibility rather than by
+ * line count: the client MANAGES registered marketplaces — register, update, remove, and the
+ * containment rules that govern each — while this answers a single question about a source
+ * descriptor. It is a total function over the source union with no filesystem or process access,
+ * which is exactly why it does not belong inside a class that owns both.
+ *
+ * The `throw` cases are deliberate and are not errors of omission: `local` never clones, and `url` is
+ * a declared-but-unimplemented source. Returning a placeholder for either would hand a caller a value
+ * that looks like a clone URL and is not one.
+ */
+export function resolveMarketplaceCloneUrl(source: TMarketplaceSource): string {
+  switch (source.type) {
+    case 'github':
+      return `https://github.com/${source.repo}.git`;
+    case 'git':
+      return source.url;
+    case 'local':
+      throw new Error('Local source type does not use git cloning');
+    case 'url':
+      throw new Error('URL marketplace source is not yet supported');
+  }
+}

--- a/packages/agent-framework/src/plugins/plugin-paths.ts
+++ b/packages/agent-framework/src/plugins/plugin-paths.ts
@@ -1,0 +1,143 @@
+import { isAbsolute, resolve, sep } from 'node:path';
+
+import type { IFileSystem } from '@robota-sdk/agent-core';
+
+/**
+ * SEC-018 (issue #2019's sibling, issue #2020) — plugin identifiers are PATH SEGMENTS, and they arrive
+ * from a remote marketplace manifest or a registry file on disk.
+ *
+ * `marketplace.json`'s `name` selected the rename destination (`join(marketplacesDir, name)`), plugin
+ * `name`/`version` formed installation paths, and a registry's `installPath` was passed to a recursive
+ * `rmSync`. Each was cast to a TypeScript shape after only `typeof === 'object'` and `typeof name ===
+ * 'string'`. A manifest named `../../escaped-market` therefore placed a marketplace outside its root,
+ * and a tampered `installPath` deleted whatever it pointed at.
+ *
+ * This module is the boundary. It follows the shape SEC-006 established in
+ * `packages/agent-session/src/session-id.ts`, for the reasons that file gives:
+ *
+ *   - **The guard lives at the boundary, not at each `join()`.** One value reaches several sinks — the
+ *     rename, the copy, the loader and the recursive delete are four separate sinks on one name.
+ *   - **REJECT rather than sanitize.** Rewriting `../x` to `__x` would alias two distinct identifiers
+ *     onto one directory, quietly cross-linking plugins. A malformed identifier is a bug or an attack;
+ *     both should be loud.
+ *
+ * What this file adds beyond SEC-006: session ids are single components by construction, so a segment
+ * check was sufficient there. Here a value can also be a relative PATH (a local marketplace source, a
+ * persisted install location), and a symlink inside an otherwise-valid root can redirect a mutation
+ * outside it. So containment is checked against the CANONICAL form of both sides, not the lexical one.
+ */
+
+/**
+ * A single, safe path component.
+ *
+ * Admits no `/`, no `\` and no `:`, so the value can introduce neither a path separator nor a Windows
+ * drive or UNC qualifier; and because it must begin with an alphanumeric it can be neither `.` nor
+ * `..`. With no separator available, an embedded `..` cannot form a traversal component. A NUL cannot
+ * appear because the class is an explicit allowlist rather than a denylist of dangerous characters —
+ * which is also why percent-encoded traversal (`%2e%2e%2f`) is rejected: `%` is simply not admitted.
+ */
+const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Bounded well under every filesystem's per-component limit (255 bytes). */
+const MAX_SEGMENT_LENGTH = 128;
+
+/** Whether `value` is safe to interpolate into a filesystem path as a single component. */
+export function isSafePluginSegment(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_SEGMENT_LENGTH &&
+    SAFE_SEGMENT.test(value)
+  );
+}
+
+/**
+ * Throw unless `value` is safe as a single path component.
+ *
+ * `field` names the source so the error says WHICH untrusted field was malformed — a manifest name and
+ * a registry install location fail the same test and need different investigations.
+ */
+export function assertSafePluginSegment(value: unknown, field: string): asserts value is string {
+  if (!isSafePluginSegment(value)) {
+    throw new Error(
+      `Invalid plugin ${field}: ${JSON.stringify(value)}. It is used as a filesystem path component, ` +
+        `so it must be 1-${MAX_SEGMENT_LENGTH} characters of letters, digits, dot, underscore or ` +
+        'hyphen, starting with a letter or digit.',
+    );
+  }
+}
+
+/**
+ * The canonical form of `path`, resolving symlinks as far as the path exists.
+ *
+ * A destination that does not exist yet — the target of a rename or a clone — has no realpath, so the
+ * nearest existing ancestor is canonicalised and the remaining components appended. That is what makes
+ * the check meaningful BEFORE the mutation: canonicalising only existing paths would leave every
+ * create-then-check window open, and checking after the write is checking after the damage.
+ */
+function canonicalize(path: string, fs: IFileSystem): string {
+  let current = resolve(path);
+  const trailing: string[] = [];
+  // Bounded by the component count; `resolve` guarantees we reach the root.
+  for (;;) {
+    if (fs.existsSync(current)) return resolve(fs.realpathSync(current), ...trailing.reverse());
+    const parent = resolve(current, '..');
+    if (parent === current) return resolve(path);
+    trailing.push(current.slice(parent.length + 1));
+    current = parent;
+  }
+}
+
+/**
+ * Throw unless `candidate` is `root` itself or a descendant of it, comparing CANONICAL forms.
+ *
+ * Lexical containment is not enough: `<root>/link` may be a symlink to `/etc`, and
+ * `resolve(root, 'link')` still starts with `root`. Both sides are canonicalised so a symlink cannot
+ * redirect a copy, load, rename or recursive delete outside the tree it appears to be inside.
+ *
+ * The separator is appended before the prefix comparison so that `/a/plugins-evil` is not accepted as
+ * a descendant of `/a/plugins`.
+ */
+export function assertContainedPath(
+  root: string,
+  candidate: string,
+  what: string,
+  fs: IFileSystem,
+): void {
+  const canonicalRoot = canonicalize(root, fs);
+  const canonicalCandidate = canonicalize(candidate, fs);
+  const contained =
+    canonicalCandidate === canonicalRoot ||
+    canonicalCandidate.startsWith(
+      canonicalRoot.endsWith(sep) ? canonicalRoot : canonicalRoot + sep,
+    );
+  if (!contained) {
+    throw new Error(
+      `Refusing to ${what} outside the plugin root: ${JSON.stringify(candidate)} resolves to ` +
+        `${JSON.stringify(canonicalCandidate)}, which is not inside ${JSON.stringify(canonicalRoot)}.`,
+    );
+  }
+}
+
+/**
+ * Resolve an untrusted RELATIVE source against `root` and prove containment.
+ *
+ * An absolute path is refused outright rather than resolved: a marketplace source that names `/etc` is
+ * not a containment question, it is a different kind of value than the field is for.
+ */
+export function resolveContainedRelative(
+  root: string,
+  relative: string,
+  what: string,
+  fs: IFileSystem,
+): string {
+  if (isAbsolute(relative)) {
+    throw new Error(
+      `Refusing to ${what} from an absolute path: ${JSON.stringify(relative)}. This field takes a ` +
+        'path relative to the plugin root.',
+    );
+  }
+  const candidate = resolve(root, relative);
+  assertContainedPath(root, candidate, what, fs);
+  return candidate;
+}

--- a/packages/agent-framework/src/plugins/plugin-paths.ts
+++ b/packages/agent-framework/src/plugins/plugin-paths.ts
@@ -28,6 +28,18 @@ import type { IFileSystem } from '@robota-sdk/agent-core';
  */
 
 /**
+ * Refusal to act on a path outside its root.
+ *
+ * A distinct type because callers that continue past a refusal must swallow ONLY this. Catching
+ * everything around a `rmSync` would swallow `EACCES` and `EBUSY` identically — the delete then fails
+ * for an ordinary reason, the registry entry is dropped anyway, and the directory is left on disk with
+ * nothing tracking it. A containment refusal is a decision; a filesystem error is a failure.
+ */
+export class PluginPathContainmentError extends Error {
+  override readonly name = 'PluginPathContainmentError';
+}
+
+/**
  * A single, safe path component.
  *
  * Admits no `/`, no `\` and no `:`, so the value can introduce neither a path separator nor a Windows
@@ -112,7 +124,7 @@ export function assertContainedPath(
       canonicalRoot.endsWith(sep) ? canonicalRoot : canonicalRoot + sep,
     );
   if (!contained) {
-    throw new Error(
+    throw new PluginPathContainmentError(
       `Refusing to ${what} outside the plugin root: ${JSON.stringify(candidate)} resolves to ` +
         `${JSON.stringify(canonicalCandidate)}, which is not inside ${JSON.stringify(canonicalRoot)}.`,
     );
@@ -132,7 +144,7 @@ export function resolveContainedRelative(
   fs: IFileSystem,
 ): string {
   if (isAbsolute(relative)) {
-    throw new Error(
+    throw new PluginPathContainmentError(
       `Refusing to ${what} from an absolute path: ${JSON.stringify(relative)}. This field takes a ` +
         'path relative to the plugin root.',
     );


### PR DESCRIPTION
Closes #2020.

## The defect

Remote plugin manifests and the on-disk registry were cast to TypeScript shapes after only `typeof data === 'object'` and `typeof data.name === 'string'`. Those strings then became path components or paths:

| value | source | sink |
| --- | --- | --- |
| `manifest.name` | remote `marketplace.json` | `join(marketplacesDir, name)` → **`renameSync`** |
| `pluginName`, `version` | remote manifest entry | `join(cacheDir, …)` → write, and **recursive `rmSync`** on cleanup |
| relative marketplace source | remote manifest | `join`ed without proving containment |
| `record.installPath` | `installed_plugins.json` | **recursive `rmSync`** |

A manifest named `../../escaped-market` placed a marketplace outside its root. A tampered `installPath` deleted whatever it named.

## Two guards, at the boundary

Following the shape SEC-006 established in `packages/agent-session/src/session-id.ts`, for the reasons that file gives.

**`assertSafePluginSegment`** — an allowlist admitting no `/`, `\` or `:` and requiring an alphanumeric first character. So a value can introduce neither a separator nor a drive/UNC qualifier, and can be neither `.` nor `..`; with no separator available an embedded `..` cannot form a traversal component. Percent-encoded traversal and NUL fall out because it is an **allowlist**, not a denylist of dangerous characters.

**`assertContainedPath`** — containment judged on the **canonical** form of both sides.

### Reject rather than sanitize

Stripping the traversal from `../x` yields `x` — a name another plugin may legitimately hold. The hostile identifier and the benign one would then map to **one directory**, cross-linking them silently. A loud refusal beats a silent alias. (Asserted directly in the suite.)

### At the boundary, not at each `join()`

One name reaches four sinks — the rename, the copy, the loader and the recursive delete. A per-sink check is four chances to miss one, and the miss is silent.

### Canonical, not lexical

`<root>/link` may be a symlink to `/etc`, and `resolve(root, 'link')` still starts with `root`. `IFileSystem` gained `realpathSync` for this — the interface has **one implementer and zero object-literal doubles**, verified before choosing it over threading a separate canonicaliser through four constructors.

A destination that does not exist yet — a rename or clone target — has no realpath, so it is canonicalised from its nearest existing ancestor. **Canonicalising only existing paths would leave every create-then-check window open, and checking after the write is checking after the damage.**

## The registry delete is refused per entry, not per run

A tampered `installPath` skips its removal and reports — but the entry is **still dropped from the registry**. Otherwise one bad record would abort the cleanup of every other plugin *and* pin itself in place, which is a denial of service written into the fix for an escape.

## Mutants killed, not asserted

| mutation | result |
| --- | --- |
| segment guard neutered | **19 red** |
| canonical containment replaced by lexical (symlink-blind) | **2 red** |
| prefix compared without the separator (`/a/plugins-evil` vs `/a/plugins`) | **1 red** |
| restored | **29 green** |

Mutant B is the one that matters most: a containment check that cannot go red on a symlink is the accidental-green shape #2181 catalogues, and lexical checking fails the acceptance criterion by construction rather than by oversight.

## Coverage against the issue's acceptance tests

- **Dot segments, absolute paths, separators, drive/UNC, NUL, encoded traversal** — 17 rejected shapes, each a real escape rather than a stylistic complaint.
- **Tampered `installPath` cannot delete outside the plugin root** — canonical containment before every `rmSync`.
- **Symlinks cannot redirect copy, load, rename or deletion** — asserted for an existing target *and* for a not-yet-created one reached through a link.
- **Failed validation performs no filesystem mutation** — validation runs where the value is read, not where it is used. This criterion cannot be satisfied by a check sitting next to the `renameSync`.

## One responsibility split, not a baseline bump

`marketplace-client.ts` crossed the 300-line cap. Split by responsibility: the client **manages** marketplaces (clone, rename, register, update, remove); `marketplace-manifest.ts` decides whether a fetched file **is** a manifest. Keeping them together is what let a manifest be `data as IMarketplaceManifest` after two shallow checks.

## Verification

- `pnpm harness:scan` → **141 passed, 2 skipped, 0 failed**
- `agent-framework` **1494 tests**, `agent-command` **292 tests**, `pnpm -w typecheck` clean

## Why there is no user-execution scenario

Executing one means installing a marketplace whose manifest is named `../../escaped-market`. On the fixed build it is refused — but showing it *was* exploitable means running the vulnerable code, and **a scenario whose negative case writes outside the user's plugin root is not one to hand a user**. The property is asserted at the boundary, where the hostile value is observable with no filesystem mutation attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY