### PR TITLE
fix(security): untrusted text may not act on the terminal (SEC-019)

### DIFF
--- a/.agents/spec-docs/todo/SEC-019-untrusted-text-can-act-on-the-terminal.md
+++ b/.agents/spec-docs/todo/SEC-019-untrusted-text-can-act-on-the-terminal.md
@@ -1,0 +1,90 @@
+---
+status: approved
+type: SECURITY
+tags: [security]
+---
+
+# SEC-019: model and tool output can inject terminal control sequences
+
+Paired with `.agents/tasks/SEC-019-untrusted-text-can-act-on-the-terminal.md`.
+Converted from [issue #2022](https://github.com/woojubb/robota/issues/2022).
+
+## Problem
+
+See the paired Task for the enumerated sinks. In short: Ink passes terminal control sequences through,
+and seven paths carry untrusted text to it.
+
+## Prior Art Research
+
+Waived: the design question is which boundary in this repository owns terminal encoding, and the
+repository has answered the analogous question twice this week — SEC-006/SEC-017 for shell syntax
+(`build-invocation.ts`, `plugin git execution`) and SEC-018 for path components. The shared conclusion
+is the one applied here: **remove the interpreter's syntax from untrusted values at one boundary, with
+an allowlist, rather than escaping at each sink**. Recorded rather than left empty, per
+[research.md](../../rules/research.md).
+
+## Architecture Review
+
+**Alternatives.**
+
+1. **Escape at each `<Text>` site.** Rejected: seven sinks today and no mechanism keeping a new one
+   from being added unguarded — which is precisely the defect SEC-018 hit five times.
+2. **Filter the RENDERED output.** Rejected on a property, not a preference: the renderer adds ANSI,
+   so filtering its output strips the repository's own colours and diff framing. Asserted directly by
+   a test that renders a coloured diff and requires ANSI to survive — that test goes red if anyone
+   moves the call.
+3. **Denylist the known-dangerous sequences (OSC 52, OSC 8, …).** Rejected: the set belongs to the
+   terminal emulator and grows without us. An allowlist over the control range is complete by
+   construction and gets percent-encoded and 8-bit C1 forms for free.
+4. **Allowlist encoder at the enumerated boundaries.** Chosen.
+
+**Enumeration first.** The sink list was built by enumerating what reaches a terminal, not by following
+the issue's evidence links. That found `App.tsx`'s window-title write — a value interpolated INTO an
+OSC sequence, not rendered as content, and invisible to anyone auditing `renderMarkdown` call sites.
+SEC-018's five rounds are the reason this step was done explicitly.
+
+**Capability preservation.** Tab, newline and carriage return survive; ordinary Unicode is untouched,
+including CJK, emoji and typographic punctuation. The goal is to remove what the TERMINAL acts on, not
+to restrict what a document may say.
+
+**Streaming.** The stateful sanitizer exists and the TUI does not currently need it — the state manager
+accumulates deltas before rendering. That is stated in the module rather than left for a reader to
+infer, because "we have a stateful sanitizer" and "the streaming path is stateful" are different
+claims and only the first is true here.
+
+## Completion Criteria
+
+- **TC-01** Every enumerated sink sanitizes; the list is enumerated rather than sampled.
+- **TC-02** OSC 52/8/0, CSI cursor and erase, DCS/APC/PM, bare ESC/BEL and 8-bit C1 are neutralized.
+- **TC-03** Sanitization cannot be bypassed via code fence, link target, diff block or carriage return.
+- **TC-04** Every split point of a sequence across streaming chunks is covered.
+- **TC-05** Internally generated ANSI still renders.
+- **TC-06** Ordinary Unicode and tab/newline/CR are preserved.
+- **TC-07** Three mutants die; suite green restored.
+- **TC-08** Baseline regeneration reports exactly what it absorbed.
+
+## Test Plan
+
+See the paired Task. TC-05 is the one that fails if the encoder is ever moved to the output, and TC-04
+is the acceptance test the issue names explicitly.
+
+## Evidence Log
+
+| Claim                                                        | Verified at                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GATE-APPROVAL                                                | Standing owner instruction, current conversation: decide by the repository's rules, escalate only what they cannot settle. A filed P1 security issue with stated acceptance criteria and two in-repo precedents (SEC-017, SEC-018) for the design. No product-direction or published-contract-removal decision is involved. |
+| Ink passes control sequences through                         | the sinks render `{value}` directly into `<Text>` with no encoder                                                                                                                                                                                                                                                           |
+| The window title interpolates an untrusted name into an OSC  | `App.tsx` pre-change: ``process.stdout.write(`\x1b]0;${title}\x07`)`` where `title` embeds `sessionName`                                                                                                                                                                                                                    |
+| The error block does not inherit the renderer's sanitization | `ErrorEntryBlock` renders `message.content` into `<Text>` without `renderMarkdown`                                                                                                                                                                                                                                          |
+| The stream path accumulates before rendering                 | `tui-state-manager`: `this.streamBuf += delta; this.streamingText = this.streamBuf`                                                                                                                                                                                                                                         |
+| Every split point is covered                                 | the streaming suite parametrizes over all `PAYLOAD.length - 1` boundaries                                                                                                                                                                                                                                                   |
+| Mutants die                                                  | encoder → identity: 39 red; streaming holds nothing: 15 red; renderer stops sanitizing: 3 red; restored 43 green                                                                                                                                                                                                            |
+| The baseline absorbed one entry                              | `App.tsx` 605 → 602; no other line changed                                                                                                                                                                                                                                                                                  |
+
+## User Execution Test Scenarios
+
+**Not applicable.** Executing one means rendering a document containing OSC 52 in a real terminal. On
+the fixed build nothing happens; demonstrating it WAS exploitable requires running the vulnerable code,
+and a scenario whose negative case overwrites the user's clipboard or rewrites their screen is not one
+to hand a user. The property is asserted at the encoder, where the payload is observable as data with
+nothing written to a terminal — which is how the issue's own reproduction was done.

--- a/.agents/tasks/SEC-019-untrusted-text-can-act-on-the-terminal.md
+++ b/.agents/tasks/SEC-019-untrusted-text-can-act-on-the-terminal.md
@@ -1,0 +1,100 @@
+---
+title: 'SEC-019: model and tool output can inject terminal control sequences'
+issue: https://github.com/woojubb/robota/issues/2022
+status: in-progress
+created: 2026-08-23
+priority: critical
+urgency: now
+area: packages/agent-transport-tui
+depends_on: []
+---
+
+# SEC-019: model and tool output can inject terminal control sequences
+
+## Problem
+
+Untrusted text — model responses, tool output, file contents, plugin text — reaches Ink `<Text>`, and
+**Ink passes control sequences through**. So a malicious repository, fetched document, plugin or model
+response could act on the terminal independently of what the transcript appeared to say: OSC 52 writes
+the clipboard, OSC 8 makes a link whose visible text and target differ, CSI moves the cursor or erases
+what is on screen.
+
+## The sinks, enumerated rather than sampled
+
+SEC-018 cost five review rounds because its sink list came from a filed issue's evidence links rather
+than from an enumeration. So this one started by enumerating:
+
+| sink                                                                                   | what reaches it                                                                                            |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `renderMarkdown` — 3 call sites (`MessageList`, `StreamingIndicator`, `ToolDiffBlock`) | assistant content, streamed text, tool diff markdown                                                       |
+| `MessageList` tool summary lines                                                       | `s.line`, `line` — tool stdout, rendered raw                                                               |
+| `MessageList` tool name                                                                | `toolName` — raw                                                                                           |
+| `MessageList` error block                                                              | provider errors, tool stderr, file contents — **does not go through the renderer**, so it inherits nothing |
+| `ToolDiffBlock` file header                                                            | `summary.file` — a path from a tool result                                                                 |
+| `App.tsx` window title                                                                 | **`sessionName` interpolated INTO an OSC sequence**                                                        |
+
+The last one is not a rendering path at all and would have been missed by looking only at
+`renderMarkdown` call sites: a name containing BEL terminates the OSC early and everything after it is
+read by the terminal as its own command.
+
+## Decision
+
+One allowlist encoder, `sanitizeTerminalText`, applied at each enumerated sink.
+
+**Allowlist, not denylist** — everything passes except the control range, where exactly tab, newline
+and carriage return survive. A denylist of known-dangerous sequences is wrong for the reason it is
+wrong for shell metacharacters: the set belongs to the terminal emulator and a list written today is
+incomplete the next time one adds an escape. Percent-encoded and 8-bit C1 forms fall out for free.
+
+**Sanitize the INPUT, never the output.** The renderer ADDS ANSI — colours, bold, diff framing — so
+filtering its output would strip the repository's own presentation along with the attacker's. That
+ordering is the whole design, and it is asserted directly: a test renders a diff block with colour on
+and requires ANSI to survive.
+
+**An unterminated sequence swallows what follows it**, which is what a real terminal does. Keeping the
+tail would print the payload's own text as content — the deceptive half of OSC 8.
+
+## Streaming
+
+`createStreamingTerminalSanitizer` holds an incomplete escape back until the chunk that completes it
+arrives. **The TUI does not currently need it** — `tui-state-manager` accumulates each delta into a
+buffer and renders the buffer, so a split sequence is already joined before `renderMarkdown` sees it,
+which is stated here rather than assumed. It is provided because a caller that sanitizes per chunk
+needs it, and having only the stateless function available is how that caller would get it wrong.
+
+## Plan
+
+- [x] `sanitize-terminal-text.ts`: stateless encoder + stateful streaming sanitizer.
+- [x] Applied at all seven enumerated sinks.
+- [x] `useTerminalTitle` extracted — the one place the TUI writes an escape to stdout directly.
+
+## Test Plan
+
+- 15 real attacks from the issue's impact list — OSC 52 (both terminators), OSC 8, OSC 0, CSI cursor,
+  CSI erase, CSI private mode, DCS, APC, PM, bare ESC, bare BEL, 8-bit C1 CSI and OSC, unterminated
+  OSC — each asserted to leave **no byte a terminal interprets**, checked by codepoint rather than by
+  pattern.
+- Bypass attempts through a markdown **code fence**, a **link target**, and a **diff block with a
+  carriage return** — the three places raw text is expected to survive verbatim.
+- **Every split point** of a sequence across two streaming chunks, not a sampled one.
+- Ordinary Unicode (CJK, emoji, accents, typographic quotes) untouched; tab/newline/CR preserved.
+- Internally generated ANSI survives, which is the ordering assertion.
+- **Three mutants killed, each confirmed applied before its result was read:** encoder made identity →
+  **39 red**; streaming holds nothing back → **15 red**; `renderMarkdown` stops sanitizing → **3 red**;
+  restored → **43 green**.
+- `agent-transport-tui` 619 tests, lint clean, `pnpm harness:scan` 141 passed / 0 failed.
+
+## Baseline regeneration, reported rather than passed silently
+
+Extracting `useTerminalTitle` shrank `App.tsx` below its frozen size, which requires
+`--write-baseline` in the same change. The regeneration absorbed **exactly one entry**:
+`packages/agent-transport-tui/src/App.tsx` 605 → 602. No other line changed.
+
+## User Execution Test Scenarios
+
+**Not applicable, and the reason is the finding.** Executing one means rendering a document containing
+OSC 52 in a real terminal. On the fixed build nothing happens — but demonstrating it WAS exploitable
+means running the vulnerable code, and a scenario whose negative case overwrites the user's clipboard
+or rewrites their screen is not one to hand a user. The property is asserted at the encoder, where the
+payload is observable as data with nothing written to a terminal — which is also how the issue's own
+reproduction was done.

--- a/packages/agent-transport-tui/src/App.tsx
+++ b/packages/agent-transport-tui/src/App.tsx
@@ -31,6 +31,7 @@ import TransportTUI from './TransportTUI.js';
 import { TuiCliAdapterProvider } from './tui-cli-adapter-context.js';
 import { PALETTE } from './tui-palette.js';
 import UpdateNotice from './UpdateNotice.js';
+import { useTerminalTitle } from './use-terminal-title.js';
 
 import type { ITuiCliAdapter } from './tui-cli-adapter.js';
 import type { TuiInteractionChannel } from './TuiInteractionChannel.js';
@@ -274,11 +275,7 @@ function AppInner(
     };
   }, [props.startupUpdateNotice]);
 
-  // Update terminal title
-  useEffect(() => {
-    const title = sessionName ? `Robota — ${sessionName}` : 'Robota';
-    process.stdout.write(`\x1b]0;${title}\x07`);
-  }, [sessionName]);
+  useTerminalTitle(sessionName);
 
   // ESC abort
   useInput((_input: string, key: { escape: boolean }) => {

--- a/packages/agent-transport-tui/src/MessageList.tsx
+++ b/packages/agent-transport-tui/src/MessageList.tsx
@@ -6,6 +6,7 @@ import { formatCommandOutputSummary } from './command-output-summary.js';
 import { humanizeToolName } from './humanize-tool-name.js';
 import { renderMarkdown } from './render-markdown.js';
 import { RoleLabel } from './RoleLabel.js';
+import { sanitizeTerminalText } from './sanitize-terminal-text.js';
 import { STATUS_GLYPH } from './status-glyph.js';
 import { getToolSummaryLabel, toolSummaryStatusKind } from './tool-summary-status.js';
 import ToolCommandOutput from './ToolCommandOutput.js';
@@ -57,7 +58,7 @@ function ToolMessage({ message }: { message: TUniversalMessage }): React.ReactEl
           <Box key={i} flexDirection="column">
             <Text color={PALETTE.text.success}>
               {'  '}
-              {'✓'} {s.line}
+              {'✓'} {sanitizeTerminalText(s.line)}
             </Text>
             {s.diffLines && s.diffLines.length > 0 && (
               <ToolDiffBlock file={s.diffFile} lines={s.diffLines} />
@@ -78,7 +79,7 @@ function ToolMessage({ message }: { message: TUniversalMessage }): React.ReactEl
         </Text>
         {toolName && (
           <Text color={PALETTE.text.emphasis} dimColor>
-            [{toolName}]
+            [{sanitizeTerminalText(toolName)}]
           </Text>
         )}
       </Box>
@@ -86,7 +87,7 @@ function ToolMessage({ message }: { message: TUniversalMessage }): React.ReactEl
       {lines.map((line, i) => (
         <Text key={i} color={PALETTE.text.success}>
           {'  '}
-          {'✓'} {line}
+          {'✓'} {sanitizeTerminalText(line)}
         </Text>
       ))}
     </Box>
@@ -95,7 +96,10 @@ function ToolMessage({ message }: { message: TUniversalMessage }): React.ReactEl
 
 /** ERR-001 G2: a failed turn renders as a styled error block, not a plain system note. */
 function ErrorEntryBlock({ message }: { message: TUniversalMessage }): React.ReactElement {
-  const content = (message.content ?? '').replace(/^Error:\s*/, '');
+  // SEC-019: an error message is untrusted text — it carries provider responses, tool stderr and
+  // file contents — and it reaches `<Text>` without going through the markdown renderer, so it does
+  // not inherit that path's sanitization.
+  const content = sanitizeTerminalText((message.content ?? '').replace(/^Error:\s*/, ''));
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box>

--- a/packages/agent-transport-tui/src/MessageList.tsx
+++ b/packages/agent-transport-tui/src/MessageList.tsx
@@ -209,7 +209,7 @@ function ToolSummaryEntry({ entry }: { entry: IHistoryEntry }): React.ReactEleme
       {lines.map((line, i) => (
         <Text key={i} color={PALETTE.text.success}>
           {'  '}
-          {line}
+          {sanitizeTerminalText(line)}
         </Text>
       ))}
     </Box>
@@ -218,12 +218,17 @@ function ToolSummaryEntry({ entry }: { entry: IHistoryEntry }): React.ReactEleme
 
 function EventEntry({ entry }: { entry: IHistoryEntry }): React.ReactElement {
   const eventData = entry.data as Record<string, TUniversalValue> | undefined;
-  const eventMessage =
+  // SEC-019: an event message is BUILT by a neutral package from untrusted parts — a skill name that
+  // may come from a plugin, a memory topic the model chose — and interpolated into a sentence. The
+  // formatter cannot sanitize for a terminal (the same string reaches the GUI, where escapes are not
+  // the threat and stripping them would be arbitrary), so this render site is the boundary.
+  const eventMessage = sanitizeTerminalText(
     typeof eventData?.message === 'string'
       ? eventData.message
       : typeof eventData?.content === 'string'
         ? eventData.content
-        : entry.type;
+        : entry.type,
+  );
 
   return (
     <Box flexDirection="column" marginBottom={1}>

--- a/packages/agent-transport-tui/src/StreamingIndicator.tsx
+++ b/packages/agent-transport-tui/src/StreamingIndicator.tsx
@@ -6,7 +6,7 @@
 import { Box, Text } from 'ink';
 import React from 'react';
 
-import { humanizeToolName } from './humanize-tool-name.js';
+import { humanizeToolArgument, humanizeToolName } from './humanize-tool-name.js';
 import { renderMarkdown } from './render-markdown.js';
 import { STATUS_GLYPH, toolStateStatusKind } from './status-glyph.js';
 import ToolDiffBlock from './ToolDiffBlock.js';
@@ -52,7 +52,7 @@ function renderTools(activeTools: IToolState[]): React.ReactElement {
           <Box key={`${t.toolName}-${i}`} flexDirection="column">
             <Text color={color} strikethrough={strikethrough}>
               {'  '}
-              {icon} {humanizeToolName(t.toolName)}({t.firstArg})
+              {icon} {humanizeToolName(t.toolName)}({humanizeToolArgument(t.firstArg)})
             </Text>
             {t.diffLines && t.diffLines.length > 0 && (
               <ToolDiffBlock file={t.diffFile} lines={t.diffLines} />

--- a/packages/agent-transport-tui/src/ToolDiffBlock.tsx
+++ b/packages/agent-transport-tui/src/ToolDiffBlock.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from 'ink';
 import React from 'react';
 
 import { renderMarkdown } from './render-markdown.js';
+import { sanitizeTerminalText } from './sanitize-terminal-text.js';
 import { PALETTE } from './tui-palette.js';
 import { buildToolDiffSummary } from './utils/tool-diff-summary.js';
 
@@ -19,7 +20,7 @@ export default function ToolDiffBlock({ file, lines }: IProps): React.ReactEleme
     <Box flexDirection="column" marginLeft={4}>
       {summary.file && (
         <Text color={PALETTE.text.emphasis} dimColor>
-          │ {summary.file}
+          │ {sanitizeTerminalText(summary.file)}
         </Text>
       )}
       <Text>{renderMarkdown(summary.markdown)}</Text>

--- a/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
@@ -38,6 +38,15 @@ const ATTACKS: Array<[string, string, string]> = [
   ['CSI cursor move', ESC + '[10;10H', 'beforeafter'],
   ['CSI erase display', ESC + '[2J', 'beforeafter'],
   ['CSI private mode', ESC + '[?1049h', 'beforeafter'],
+  // ECMA-48 parameter bytes are 0x30-0x3F, which is `0123456789:;<=>?` — not the digits, `;` and
+  // `?` an author writes from memory. Every row below was left as visible text by that shorter
+  // class, and the first two are not exotic: colon-separated SGR is the standard truecolor form and
+  // the `<` report is what a terminal sends on every mouse event.
+  ['CSI truecolor SGR, colon form', ESC + '[38:2:255:0:0m', 'beforeafter'],
+  ['CSI SGR mouse report', ESC + '[<0;10;20M', 'beforeafter'],
+  ['CSI device attributes, > parameter', ESC + '[>c', 'beforeafter'],
+  ['CSI = parameter', ESC + '[=1h', 'beforeafter'],
+  ['8-bit CSI SGR mouse report', C1(0x9b) + '<0;10;20M', 'beforeafter'],
   ['DCS', ESC + 'Pq#0;2;0;0;0' + ESC + '\\', 'beforeafter'],
   ['APC', ESC + '_Ginline=1' + ESC + '\\', 'beforeafter'],
   ['PM', ESC + '^payload' + ESC + '\\', 'beforeafter'],
@@ -110,6 +119,15 @@ describe('SEC-019 - a control sequence in untrusted text is neutralized', () => 
     const out = sanitizeTerminalText('before' + ESC + 'Pq#0;2;0;0;0' + ESC + '\\' + 'after');
     expect(out).toBe('beforeafter');
     expect(out).not.toContain('q#0');
+  });
+
+  it('removes a CSI carrying any ECMA-48 parameter byte, not only digits and ? and ;', () => {
+    // The shorter parameter class left `38:2:255:0:0m` and `<0;10;20M` standing as text: neither
+    // matched the CSI alternative, the two-character-escape alternative does not accept `[` as its
+    // second character, and the lone-control fallback took only the ESC.
+    for (const body of ['38:2:255:0:0m', '<0;10;20M', '>c', '=1h', ':::x']) {
+      expect(sanitizeTerminalText(`before${ESC}[${body}after`)).toBe('beforeafter');
+    }
   });
 
   it('removes the whole 8-bit sequence, not only its one-byte C1 introducer', () => {

--- a/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
@@ -93,6 +93,37 @@ describe('SEC-019 - a control sequence in untrusted text is neutralized', () => 
     expect(out).toBe('before');
   });
 
+  // The two cases below repeat rows of the table above under literal titles ON PURPOSE.
+  //
+  // `it.each` builds each case's title from a printf placeholder (`'removes %s'`), and the
+  // accidental-green floor reads added case titles out of the diff — where the only text present is
+  // `removes %s`, which matches no runtime title. Every `it.each` case is therefore invisible to it,
+  // so a suite built entirely from tables can supply no red proof at all. Measured on this branch:
+  // reversing the fix turned 5 `it.each` cases red and the floor still reported accidental-green.
+  //
+  // These two are the named proof for the defect review found on PR #2212, and they are the cases
+  // that must go red if anyone restores the introducer-only behaviour.
+
+  it('removes the whole DCS sequence, not only its two-character introducer', () => {
+    // The lazy-quantifier bug left this as 'beforeq#0;2;0;0;0after' while every "no control byte
+    // survives" assertion in the file stayed green.
+    const out = sanitizeTerminalText('before' + ESC + 'Pq#0;2;0;0;0' + ESC + '\\' + 'after');
+    expect(out).toBe('beforeafter');
+    expect(out).not.toContain('q#0');
+  });
+
+  it('removes the whole 8-bit sequence, not only its one-byte C1 introducer', () => {
+    // A terminal reads \x9b and `ESC [` as the same CSI. An alternation that names only the 7-bit
+    // spelling leaves the parameters standing: '2J' and '52;c;x' as visible text.
+    expect(sanitizeTerminalText('before' + C1(0x9b) + '2J' + 'after')).toBe('beforeafter');
+    expect(sanitizeTerminalText('before' + C1(0x9d) + '52;c;x' + BEL + 'after')).toBe(
+      'beforeafter',
+    );
+    expect(sanitizeTerminalText('before' + C1(0x9f) + 'Ginline=1' + C1(0x9c) + 'after')).toBe(
+      'beforeafter',
+    );
+  });
+
   it('keeps tab, newline and carriage return, which are content', () => {
     expect(sanitizeTerminalText('a\tb\nc\rd')).toBe('a\tb\nc\rd');
   });

--- a/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
@@ -203,6 +203,44 @@ describe('SEC-019 - a sequence split across streaming chunks is still removed', 
     expect(hasTerminalControl(s.flush())).toBe(false);
   });
 
+  // A sequence that ENDED inside the chunk is not an incomplete tail, and treating it as one is a
+  // stall rather than a leak: `push` returns the text before it and holds everything after, so the
+  // trailing content does not appear until the next chunk or the flush. Found in review of PR #2212
+  // — the streaming table above splits an OSC and never puts a COMPLETE sequence mid-chunk, so it
+  // could not see this.
+
+  it('emits text that follows a DCS sequence already terminated inside the chunk', () => {
+    const s = createStreamingTerminalSanitizer();
+    expect(s.push('hello' + ESC + 'Pq#0;2;0;0;0' + ESC + '\\' + 'world')).toBe('helloworld');
+    expect(s.flush()).toBe('');
+  });
+
+  it('emits text that follows an 8-bit APC sequence already terminated inside the chunk', () => {
+    const s = createStreamingTerminalSanitizer();
+    expect(s.push('hello' + C1(0x9f) + 'Ginline=1' + C1(0x9c) + 'world')).toBe('helloworld');
+    expect(s.flush()).toBe('');
+  });
+
+  // Exhaustive splits for the DCS family too, not only OSC. The 7-bit and 8-bit bodies are the two
+  // branches that carry the lookahead, so they are the two that must survive every boundary.
+  const DCS_PAYLOAD = 'A' + ESC + 'Pq#0;2;0;0;0' + ESC + '\\' + 'B';
+  const DCS_SPLITS = Array.from({ length: DCS_PAYLOAD.length - 1 }, (_, i) => i + 1);
+
+  it.each(DCS_SPLITS)('DCS split at %i', (at) => {
+    const s = createStreamingTerminalSanitizer();
+    const out = s.push(DCS_PAYLOAD.slice(0, at)) + s.push(DCS_PAYLOAD.slice(at)) + s.flush();
+    expect(out).toBe('AB');
+  });
+
+  const APC8_PAYLOAD = 'A' + C1(0x9f) + 'Ginline=1' + C1(0x9c) + 'B';
+  const APC8_SPLITS = Array.from({ length: APC8_PAYLOAD.length - 1 }, (_, i) => i + 1);
+
+  it.each(APC8_SPLITS)('8-bit APC split at %i', (at) => {
+    const s = createStreamingTerminalSanitizer();
+    const out = s.push(APC8_PAYLOAD.slice(0, at)) + s.push(APC8_PAYLOAD.slice(at)) + s.flush();
+    expect(out).toBe('AB');
+  });
+
   it('passes ordinary chunked text through unchanged', () => {
     const s = createStreamingTerminalSanitizer();
     expect(s.push('hello ') + s.push('world') + s.flush()).toBe('hello world');

--- a/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
@@ -16,26 +16,48 @@ import {
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
 
-// Each entry is a real attack from the issue's impact list, not a synthetic control character.
-const ATTACKS: Array<[string, string]> = [
-  ['OSC 52 clipboard write', ESC + ']52;c;aGVsbG8=' + BEL],
-  ['OSC 52 with ST terminator', ESC + ']52;c;aGVsbG8=' + ESC + '\\'],
+// Each entry is a real attack from the issue's impact list, not a synthetic control character, and
+// each carries the EXACT output expected from `'before' + payload + 'after'`.
+//
+// The exact string is the point. The first version of this table asserted only that no control byte
+// survived and that `before` was still there, and both held for a sanitizer that stripped a DCS
+// introducer and left `q#0;2;0;0;0` standing as visible text — the defect review found on PR #2212.
+// An assertion that a buggy implementation also satisfies is not a regression test.
+const C1 = (code: number): string => String.fromCharCode(code);
+const ATTACKS: Array<[string, string, string]> = [
+  ['OSC 52 clipboard write', ESC + ']52;c;aGVsbG8=' + BEL, 'beforeafter'],
+  ['OSC 52 with ST terminator', ESC + ']52;c;aGVsbG8=' + ESC + '\\', 'beforeafter'],
   [
     'OSC 8 deceptive hyperlink',
     ESC + ']8;;https://evil.example' + BEL + 'click me' + ESC + ']8;;' + BEL,
+    // The visible half survives as ordinary text; only the target and its framing are gone, which is
+    // exactly the deception being removed — the link text was never the dangerous part.
+    'beforeclick meafter',
   ],
-  ['OSC 0 window title', ESC + ']0;pwned' + BEL],
-  ['CSI cursor move', ESC + '[10;10H'],
-  ['CSI erase display', ESC + '[2J'],
-  ['CSI private mode', ESC + '[?1049h'],
-  ['DCS', ESC + 'Pq#0;2;0;0;0' + ESC + '\\'],
-  ['APC', ESC + '_Ginline=1' + ESC + '\\'],
-  ['PM', ESC + '^payload' + ESC + '\\'],
-  ['bare ESC', ESC],
-  ['bare BEL', BEL],
-  ['8-bit CSI (C1)', String.fromCharCode(0x9b) + '2J'],
-  ['8-bit OSC (C1)', String.fromCharCode(0x9d) + '52;c;x' + BEL],
-  ['unterminated OSC', ESC + ']52;c;dangling'],
+  ['OSC 0 window title', ESC + ']0;pwned' + BEL, 'beforeafter'],
+  ['CSI cursor move', ESC + '[10;10H', 'beforeafter'],
+  ['CSI erase display', ESC + '[2J', 'beforeafter'],
+  ['CSI private mode', ESC + '[?1049h', 'beforeafter'],
+  ['DCS', ESC + 'Pq#0;2;0;0;0' + ESC + '\\', 'beforeafter'],
+  ['APC', ESC + '_Ginline=1' + ESC + '\\', 'beforeafter'],
+  ['PM', ESC + '^payload' + ESC + '\\', 'beforeafter'],
+  ['SOS with BEL terminator', ESC + 'Xdata' + BEL, 'beforeafter'],
+  ['bare ESC', ESC, 'beforeafter'],
+  ['bare BEL', BEL, 'beforeafter'],
+  // The 8-bit spellings are the same sequences with a one-byte introducer. They are listed
+  // separately because an alternation that names only `ESC [` removes the introducer and leaves the
+  // parameters — the identical defect, reached by a different route.
+  ['8-bit CSI (C1)', C1(0x9b) + '2J', 'beforeafter'],
+  ['8-bit OSC with BEL', C1(0x9d) + '52;c;x' + BEL, 'beforeafter'],
+  ['8-bit OSC with 8-bit ST', C1(0x9d) + '52;c;x' + C1(0x9c), 'beforeafter'],
+  ['8-bit DCS', C1(0x90) + 'q#0;2;0;0;0' + C1(0x9c), 'beforeafter'],
+  ['8-bit APC', C1(0x9f) + 'Ginline=1' + C1(0x9c), 'beforeafter'],
+  ['8-bit PM', C1(0x9e) + 'payload' + C1(0x9c), 'beforeafter'],
+  ['lone 8-bit ST', C1(0x9c), 'beforeafter'],
+  // An unterminated sequence swallows what follows, which is what the terminal itself does.
+  ['unterminated OSC', ESC + ']52;c;dangling', 'before'],
+  ['unterminated 8-bit APC', C1(0x9f) + 'dangling', 'before'],
+  ['unterminated DCS', ESC + 'Pq#0;2;0;0;0', 'before'],
 ];
 
 /** No byte a terminal reads as a command survives. */
@@ -50,11 +72,12 @@ function hasTerminalControl(text: string): boolean {
 }
 
 describe('SEC-019 - a control sequence in untrusted text is neutralized', () => {
-  it.each(ATTACKS)('removes %s', (_label, payload) => {
+  it.each(ATTACKS)('removes %s', (_label, payload, expected) => {
     const out = sanitizeTerminalText('before' + payload + 'after');
+    // The exact output, not a property. `hasTerminalControl` is asserted as well because the two
+    // claims are different: one says the string is safe, the other says the whole sequence is gone.
+    expect(out).toBe(expected);
     expect(hasTerminalControl(out), JSON.stringify(out)).toBe(false);
-    // Text before the sequence always survives; only the machinery is gone.
-    expect(out.startsWith('before')).toBe(true);
   });
 
   it('keeps the text after a TERMINATED sequence', () => {
@@ -121,6 +144,18 @@ describe('SEC-019 - a sequence split across streaming chunks is still removed', 
     const out = s.push(PAYLOAD.slice(0, at)) + s.push(PAYLOAD.slice(at)) + s.flush();
     expect(hasTerminalControl(out), JSON.stringify(out)).toBe(false);
     expect(out).toBe('AB');
+  });
+
+  // The 8-bit spelling has its own held-back tail in `INCOMPLETE_TAIL`, and a claim with no test is
+  // the thing this file exists to refuse. Same exhaustive split, different introducer.
+  const C1_PAYLOAD = 'A' + C1(0x9d) + '52;c;aGVsbG8=' + C1(0x9c) + 'B';
+  const C1_SPLITS = Array.from({ length: C1_PAYLOAD.length - 1 }, (_, i) => i + 1);
+
+  it.each(C1_SPLITS)('8-bit OSC split at %i', (at) => {
+    const s = createStreamingTerminalSanitizer();
+    const out = s.push(C1_PAYLOAD.slice(0, at)) + s.push(C1_PAYLOAD.slice(at)) + s.flush();
+    expect(out).toBe('AB');
+    expect(hasTerminalControl(out), JSON.stringify(out)).toBe(false);
   });
 
   it('holds back an incomplete tail rather than emitting its visible half', () => {

--- a/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderMarkdown } from '../render-markdown.js';
+import {
+  createStreamingTerminalSanitizer,
+  sanitizeTerminalText,
+} from '../sanitize-terminal-text.js';
+
+/**
+ * SEC-019 (issue #2022) - untrusted text may not act on the terminal.
+ *
+ * Model output, tool output, file contents and plugin text reach Ink `<Text>`, and Ink passes control
+ * sequences through. These assert the property rather than the implementation: after sanitization the
+ * string contains no byte a terminal interprets as a command, and ordinary content is untouched.
+ */
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+
+// Each entry is a real attack from the issue's impact list, not a synthetic control character.
+const ATTACKS: Array<[string, string]> = [
+  ['OSC 52 clipboard write', ESC + ']52;c;aGVsbG8=' + BEL],
+  ['OSC 52 with ST terminator', ESC + ']52;c;aGVsbG8=' + ESC + '\\'],
+  [
+    'OSC 8 deceptive hyperlink',
+    ESC + ']8;;https://evil.example' + BEL + 'click me' + ESC + ']8;;' + BEL,
+  ],
+  ['OSC 0 window title', ESC + ']0;pwned' + BEL],
+  ['CSI cursor move', ESC + '[10;10H'],
+  ['CSI erase display', ESC + '[2J'],
+  ['CSI private mode', ESC + '[?1049h'],
+  ['DCS', ESC + 'Pq#0;2;0;0;0' + ESC + '\\'],
+  ['APC', ESC + '_Ginline=1' + ESC + '\\'],
+  ['PM', ESC + '^payload' + ESC + '\\'],
+  ['bare ESC', ESC],
+  ['bare BEL', BEL],
+  ['8-bit CSI (C1)', String.fromCharCode(0x9b) + '2J'],
+  ['8-bit OSC (C1)', String.fromCharCode(0x9d) + '52;c;x' + BEL],
+  ['unterminated OSC', ESC + ']52;c;dangling'],
+];
+
+/** No byte a terminal reads as a command survives. */
+function hasTerminalControl(text: string): boolean {
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (ch === '\t' || ch === '\n' || ch === '\r') continue;
+    if (code <= 0x1f || code === 0x7f) return true;
+    if (code >= 0x80 && code <= 0x9f) return true;
+  }
+  return false;
+}
+
+describe('SEC-019 - a control sequence in untrusted text is neutralized', () => {
+  it.each(ATTACKS)('removes %s', (_label, payload) => {
+    const out = sanitizeTerminalText('before' + payload + 'after');
+    expect(hasTerminalControl(out), JSON.stringify(out)).toBe(false);
+    // Text before the sequence always survives; only the machinery is gone.
+    expect(out.startsWith('before')).toBe(true);
+  });
+
+  it('keeps the text after a TERMINATED sequence', () => {
+    const out = sanitizeTerminalText('before' + ESC + ']52;c;aGk=' + BEL + 'after');
+    expect(out).toBe('beforeafter');
+  });
+
+  it('swallows what follows an UNTERMINATED sequence, as a terminal would', () => {
+    // An unterminated OSC consumes subsequent bytes until a terminator arrives, so dropping the tail
+    // matches what the terminal itself does. Keeping it would print the payload's own text as if it
+    // were content, which is the deceptive half of OSC 8.
+    const out = sanitizeTerminalText('before' + ESC + ']52;c;dangling-and-then-some');
+    expect(out).toBe('before');
+  });
+
+  it('keeps tab, newline and carriage return, which are content', () => {
+    expect(sanitizeTerminalText('a\tb\nc\rd')).toBe('a\tb\nc\rd');
+  });
+
+  it('leaves ordinary Unicode alone - the goal is what the TERMINAL acts on', () => {
+    const text = 'héllo 世界 🙂 café — “quoted”';
+    expect(sanitizeTerminalText(text)).toBe(text);
+  });
+
+  it('cannot be bypassed through a markdown code fence', () => {
+    // A fence is where an author expects raw text to survive verbatim, which is exactly why it is
+    // the first place an attacker would put an escape.
+    const out = renderMarkdown('```\n' + ESC + ']52;c;aGk=' + BEL + '\n```', { color: false });
+    expect(out).not.toContain(ESC + ']');
+    expect(out).not.toContain(BEL);
+  });
+
+  it('cannot be bypassed through a markdown link target', () => {
+    const out = renderMarkdown('[text](' + ESC + ']8;;https://evil.example' + BEL + ')', {
+      color: false,
+    });
+    expect(out).not.toContain(BEL);
+  });
+
+  it('cannot be bypassed through a diff block or a carriage return', () => {
+    const out = renderMarkdown('```diff\n- a' + ESC + '[2J\r+ b\n```', { color: false });
+    expect(out).not.toContain(ESC + '[2J');
+  });
+
+  it('still emits the colours the renderer generates AFTER sanitization', () => {
+    // The ordering is the design: sanitize the INPUT, never the output. If the sanitizer were moved
+    // to the output this goes red, because the repository's own diff colouring is ANSI too.
+    //
+    // A diff block rather than `**bold**`: bold comes from chalk, which disables itself off a TTY, so
+    // that assertion would be testing chalk's environment detection instead of this ordering.
+    const out = renderMarkdown('```diff\n- removed\n+ added\n```', { color: true });
+    expect(out, 'internally generated ANSI was stripped').toContain(ESC + '[');
+  });
+});
+
+describe('SEC-019 - a sequence split across streaming chunks is still removed', () => {
+  const PAYLOAD = 'A' + ESC + ']52;c;aGVsbG8=' + BEL + 'B';
+
+  // EVERY split point, not a sampled one: the issue asks for exactly this.
+  const SPLITS = Array.from({ length: PAYLOAD.length - 1 }, (_, i) => i + 1);
+
+  it.each(SPLITS)('split at %i', (at) => {
+    const s = createStreamingTerminalSanitizer();
+    const out = s.push(PAYLOAD.slice(0, at)) + s.push(PAYLOAD.slice(at)) + s.flush();
+    expect(hasTerminalControl(out), JSON.stringify(out)).toBe(false);
+    expect(out).toBe('AB');
+  });
+
+  it('holds back an incomplete tail rather than emitting its visible half', () => {
+    const s = createStreamingTerminalSanitizer();
+    // `ESC ]52;c;` alone is not yet dangerous and not yet safe to print — emitting `52;c;` as text
+    // would show the middle of a sequence while dropping the part that made it an escape.
+    expect(s.push('x' + ESC + ']52;c;')).toBe('x');
+    expect(s.push('aGk=' + BEL + 'y')).toBe('y');
+  });
+
+  it('flushes an escape that never completes, rather than leaking it', () => {
+    const s = createStreamingTerminalSanitizer();
+    expect(s.push('x' + ESC + ']52;c;dangling')).toBe('x');
+    expect(hasTerminalControl(s.flush())).toBe(false);
+  });
+
+  it('passes ordinary chunked text through unchanged', () => {
+    const s = createStreamingTerminalSanitizer();
+    expect(s.push('hello ') + s.push('world') + s.flush()).toBe('hello world');
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-terminal-sanitizer.test.ts
@@ -73,7 +73,7 @@ const ATTACKS: Array<[string, string, string]> = [
 function hasTerminalControl(text: string): boolean {
   for (const ch of text) {
     const code = ch.codePointAt(0) ?? 0;
-    if (ch === '\t' || ch === '\n' || ch === '\r') continue;
+    if (ch === '\t' || ch === '\n') continue;
     if (code <= 0x1f || code === 0x7f) return true;
     if (code >= 0x80 && code <= 0x9f) return true;
   }
@@ -142,8 +142,18 @@ describe('SEC-019 - a control sequence in untrusted text is neutralized', () => 
     );
   });
 
-  it('keeps tab, newline and carriage return, which are content', () => {
-    expect(sanitizeTerminalText('a\tb\nc\rd')).toBe('a\tb\nc\rd');
+  it('keeps tab and newline, which are content', () => {
+    expect(sanitizeTerminalText('a\tb\nc')).toBe('a\tb\nc');
+  });
+
+  it('normalizes CRLF and removes a bare CR, which is a cursor move', () => {
+    // Measured against a real terminal stream: Ink strips OSC 52 and CSI on its way out, and passes
+    // a bare `\r` through intact. `safe text\rEVIL` therefore prints EVIL over what the transcript
+    // said — the same "what you read is not what happened" attack as a deceptive hyperlink, with no
+    // escape sequence in it at all. The first version of this module kept CR as content.
+    expect(sanitizeTerminalText('safe text\rEVIL')).toBe('safe textEVIL');
+    expect(sanitizeTerminalText('a\r\nb\r\nc')).toBe('a\nb\nc');
+    expect(sanitizeTerminalText('trailing\r')).toBe('trailing');
   });
 
   it('leaves ordinary Unicode alone - the goal is what the TERMINAL acts on', () => {

--- a/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * SEC-019 (issue #2022) — the RENDERED FRAME carries no payload from a poisoned tool label.
+ *
+ * Round-3 review of PR #2212 found a tool name reaching `<Text>` unsanitized. The call had been
+ * added — to one of the two branches in `MessageList` that show a tool name. Whenever a tool's
+ * content happened to parse as a structured summary, the other branch ran and the name went through
+ * raw. Three further sites had the same gap.
+ *
+ * Asserting "the call is present at every site" is the assertion that failed: it is a claim about
+ * source text, and it is satisfied by a file where the call exists once. These tests ask the
+ * question the defect actually answers — RENDER the component with every tool-shaped field poisoned,
+ * and require that the payload is not in the frame. A new render site inside these components is
+ * covered without anyone remembering to extend the test.
+ *
+ * What this does NOT cover, stated because the boundary matters: a component these tests do not
+ * render. The floor is the components, not the package.
+ */
+
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import MessageList from '../MessageList.js';
+import StreamingIndicator from '../StreamingIndicator.js';
+
+import { createToolMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
+
+import type { IHistoryEntry } from '@robota-sdk/agent-core';
+import type { IToolState } from '@robota-sdk/agent-interface-transport';
+
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+
+/** OSC 52 writes the system clipboard; its introducer and parameters are what must not survive. */
+const CLIPBOARD_WRITE = `${ESC}]52;c;cG93bmVk${BEL}`;
+/** OSC 8 renders a link whose visible text and target differ. */
+const DECEPTIVE_LINK = `${ESC}]8;;https://evil.example${BEL}`;
+/** CSI erases the screen above the prompt. */
+const ERASE_DISPLAY = `${ESC}[2J`;
+
+const POISON = `${CLIPBOARD_WRITE}${DECEPTIVE_LINK}${ERASE_DISPLAY}`;
+
+/**
+ * The markers whose presence proves the payload reached the terminal.
+ *
+ * Not `hasTerminalControl`: the renderer emits ANSI of its own — colours, dim, bold — so a frame
+ * legitimately contains ESC. The question is whether THIS payload's introducers and parameters are
+ * in it, which is what a terminal would act on.
+ */
+function carriesPayload(frame: string): boolean {
+  return (
+    frame.includes(`${ESC}]52`) ||
+    frame.includes(`${ESC}]8;;`) ||
+    frame.includes(`${ESC}[2J`) ||
+    frame.includes('52;c;cG93bmVk') ||
+    frame.includes('https://evil.example')
+  );
+}
+
+function frameOf(element: React.ReactElement): string {
+  const { lastFrame, unmount } = render(element);
+  const frame = lastFrame() ?? '';
+  unmount();
+  return frame;
+}
+
+describe('SEC-019 — a poisoned tool label never reaches the frame', () => {
+  // Built through the real constructors, not a hand-written object literal. The first version of
+  // these two cases used `category: 'message'`; MessageList dispatches on `'chat'`, so nothing
+  // rendered and both cases passed WITH the fix reversed. The mutation is what exposed that — a
+  // render test that renders nothing is green for the same reason a correct one is.
+  const toolEntry = (content: string): IHistoryEntry =>
+    messageToHistoryEntry(
+      createToolMessage(content, { toolCallId: 'call-1', name: `Read${POISON}` }),
+    );
+
+  it('MessageList: structured tool summary branch (the branch review found unguarded)', () => {
+    // The content parses as IToolCallSummary[], which is what selects the branch that rendered the
+    // tool name through `humanizeToolName` alone.
+    const frame = frameOf(
+      <MessageList history={[toolEntry(JSON.stringify([{ line: 'read ok' }]))]} />,
+    );
+    expect(frame).toContain('Read');
+    expect(carriesPayload(frame)).toBe(false);
+  });
+
+  it('MessageList: plain-text tool branch', () => {
+    const frame = frameOf(<MessageList history={[toolEntry(`not json ${POISON}`)]} />);
+    expect(frame).toContain('Read');
+    expect(carriesPayload(frame)).toBe(false);
+  });
+
+  it('MessageList: the tool-summary event label, name and first argument both', () => {
+    const entry: IHistoryEntry = {
+      id: 'evt-1',
+      timestamp: new Date(),
+      category: 'event',
+      type: 'tool-summary',
+      data: {
+        tools: [
+          {
+            toolName: `Read${POISON}`,
+            firstArg: `file.ts${POISON}`,
+            isRunning: false,
+            result: 'success',
+          },
+        ],
+        summary: `✓ Read(file.ts)${POISON}`,
+      },
+    } as unknown as IHistoryEntry;
+    const frame = frameOf(<MessageList history={[entry]} />);
+    expect(frame).toContain('Read');
+    expect(carriesPayload(frame)).toBe(false);
+  });
+
+  it('StreamingIndicator: the live tool line, name and first argument both', () => {
+    const tools: IToolState[] = [
+      {
+        toolName: `Read${POISON}`,
+        firstArg: `file.ts${POISON}`,
+        isRunning: true,
+      } as unknown as IToolState,
+    ];
+    const frame = frameOf(<StreamingIndicator text="" activeTools={tools} />);
+    expect(frame).toContain('Read');
+    expect(carriesPayload(frame)).toBe(false);
+  });
+
+  it('StreamingIndicator: the streamed assistant text', () => {
+    expect(
+      carriesPayload(frameOf(<StreamingIndicator text={`hello ${POISON}`} activeTools={[]} />)),
+    ).toBe(false);
+  });
+
+  it('the poison is detectable when nothing sanitizes it — the detector is not vacuous', () => {
+    // Without this the whole file passes for a detector that always returns false.
+    expect(carriesPayload(`before${POISON}after`)).toBe(true);
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
@@ -33,8 +33,16 @@ const BEL = String.fromCharCode(7);
 
 /** OSC 52 writes the system clipboard; its introducer and parameters are what must not survive. */
 const CLIPBOARD_WRITE = `${ESC}]52;c;cG93bmVk${BEL}`;
-/** OSC 8 renders a link whose visible text and target differ. */
-const DECEPTIVE_LINK = `${ESC}]8;;https://evil.example${BEL}`;
+/**
+ * OSC 8 renders a link whose visible text and target differ.
+ *
+ * The target carries an opaque marker and the detector looks for THAT, not for the host. A
+ * `frame.includes('https://evil.example')` reads as URL-substring sanitization to any analyser and
+ * to any reader, and the objection is right even in a detector: a substring test on a URL is
+ * unreliable in general, and a marker is both stricter here and not a claim about URLs.
+ */
+const LINK_MARKER = 'pwn-link-marker-8f3a';
+const DECEPTIVE_LINK = `${ESC}]8;;https://evil.example/${LINK_MARKER}${BEL}`;
 /** CSI erases the screen above the prompt. */
 const ERASE_DISPLAY = `${ESC}[2J`;
 
@@ -53,7 +61,7 @@ function carriesPayload(frame: string): boolean {
     frame.includes(`${ESC}]8;;`) ||
     frame.includes(`${ESC}[2J`) ||
     frame.includes('52;c;cG93bmVk') ||
-    frame.includes('https://evil.example')
+    frame.includes(LINK_MARKER)
   );
 }
 

--- a/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
@@ -1,29 +1,40 @@
 /**
- * SEC-019 (issue #2022) — the RENDERED FRAME carries no payload from a poisoned tool label.
+ * SEC-019 (issue #2022) — what actually reaches the terminal, measured rather than assumed.
  *
- * Round-3 review of PR #2212 found a tool name reaching `<Text>` unsanitized. The call had been
- * added — to one of the two branches in `MessageList` that show a tool name. Whenever a tool's
- * content happened to parse as a structured summary, the other branch ran and the name went through
- * raw. Three further sites had the same gap.
+ * ## The oracle, and why it is not `lastFrame()`
  *
- * Asserting "the call is present at every site" is the assertion that failed: it is a claim about
- * source text, and it is satisfied by a file where the call exists once. These tests ask the
- * question the defect actually answers — RENDER the component with every tool-shaped field poisoned,
- * and require that the payload is not in the frame. A new render site inside these components is
- * covered without anyone remembering to extend the test.
+ * The first version of this file asserted against `ink-testing-library`'s `lastFrame()`. That is not
+ * what the terminal receives. Ink strips most control sequences on its way out — a side effect of
+ * slicing text for layout, not a documented guarantee — so a frame assertion is green whether the
+ * code sanitizes or not, for every sequence Ink happens to remove. Mutation exposed it: removing the
+ * sanitization from three call sites left every frame-based case passing.
  *
- * What this does NOT cover, stated because the boundary matters: a component these tests do not
- * render. The floor is the components, not the package.
+ * So these tests render through REAL Ink into a fake TTY and read the bytes it writes.
+ *
+ * ## What Ink removes and what it does not — measured on this dependency version
+ *
+ *   stripped   OSC 52 (clipboard), OSC 0 (title), CSI erase/cursor/alt-screen, DCS, APC, 8-bit CSI
+ *   REACHES    SGR colour, OSC 8 hyperlink, a bare carriage return
+ *
+ * The two that reach are the live attack surface through `<Text>`: a link whose visible text and
+ * target differ, and a CR that overwrites the line the transcript just printed. `useTerminalTitle`
+ * writes to stdout directly and is subject to none of Ink's filtering.
+ *
+ * The sanitizer covers the whole class anyway, and the reason is the measurement itself: Ink's
+ * stripping is incidental. It is not in Ink's contract, no test of Ink's asserts it, and a dependency
+ * upgrade can return the entire class silently. A security boundary that rests on another project's
+ * implementation detail is a boundary in name.
  */
 
-import { render } from 'ink-testing-library';
+import { render as inkRender, Text } from 'ink';
 import React from 'react';
+import { Writable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
+
+import { createToolMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 
 import MessageList from '../MessageList.js';
 import StreamingIndicator from '../StreamingIndicator.js';
-
-import { createToolMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
 import type { IToolState } from '@robota-sdk/agent-interface-session';
@@ -31,117 +42,166 @@ import type { IToolState } from '@robota-sdk/agent-interface-session';
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);
 
-/** OSC 52 writes the system clipboard; its introducer and parameters are what must not survive. */
-const CLIPBOARD_WRITE = `${ESC}]52;c;cG93bmVk${BEL}`;
-/**
- * OSC 8 renders a link whose visible text and target differ.
- *
- * The target carries an opaque marker and the detector looks for THAT, not for the host. A
- * `frame.includes('https://evil.example')` reads as URL-substring sanitization to any analyser and
- * to any reader, and the objection is right even in a detector: a substring test on a URL is
- * unreliable in general, and a marker is both stricter here and not a claim about URLs.
- */
+/** OSC 8 renders a link whose visible text and target differ — and Ink passes it through. */
 const LINK_MARKER = 'pwn-link-marker-8f3a';
 const DECEPTIVE_LINK = `${ESC}]8;;https://evil.example/${LINK_MARKER}${BEL}`;
-/** CSI erases the screen above the prompt. */
+/** A bare CR returns the cursor to column zero and overwrites what was printed. */
+const OVERWRITE = `\rpwn-overwrite-4c1e`;
+/** Stripped by this Ink version; included because the sanitizer must not depend on that. */
+const CLIPBOARD_WRITE = `${ESC}]52;c;cG93bmVk${BEL}`;
 const ERASE_DISPLAY = `${ESC}[2J`;
 
-const POISON = `${CLIPBOARD_WRITE}${DECEPTIVE_LINK}${ERASE_DISPLAY}`;
+const POISON = `${CLIPBOARD_WRITE}${DECEPTIVE_LINK}${ERASE_DISPLAY}${OVERWRITE}`;
 
-/**
- * The markers whose presence proves the payload reached the terminal.
- *
- * Not `hasTerminalControl`: the renderer emits ANSI of its own — colours, dim, bold — so a frame
- * legitimately contains ESC. The question is whether THIS payload's introducers and parameters are
- * in it, which is what a terminal would act on.
- */
-function carriesPayload(frame: string): boolean {
+/** The markers whose presence in the byte stream proves the payload reached the terminal. */
+function carriesPayload(stream: string): boolean {
   return (
-    frame.includes(`${ESC}]52`) ||
-    frame.includes(`${ESC}]8;;`) ||
-    frame.includes(`${ESC}[2J`) ||
-    frame.includes('52;c;cG93bmVk') ||
-    frame.includes(LINK_MARKER)
+    stream.includes(LINK_MARKER) ||
+    // The CR immediately before the marker, not the marker alone: once the CR is gone the words are
+    // ordinary content and printing them is correct. Asserting on the text would have failed a
+    // correct sanitizer, which is the mirror of asserting on nothing.
+    stream.includes(OVERWRITE) ||
+    stream.includes('52;c;cG93bmVk') ||
+    stream.includes(`${ESC}]52`) ||
+    stream.includes(`${ESC}[2J`)
   );
 }
 
-function frameOf(element: React.ReactElement): string {
-  const { lastFrame, unmount } = render(element);
-  const frame = lastFrame() ?? '';
-  unmount();
-  return frame;
+/** Every byte Ink writes for one render, through a stream that claims to be a terminal. */
+async function streamOf(element: React.ReactElement): Promise<string> {
+  const chunks: string[] = [];
+  const stdout = new Writable({
+    write(chunk, _encoding, done) {
+      chunks.push(String(chunk));
+      done();
+    },
+  }) as unknown as NodeJS.WriteStream;
+  Object.assign(stdout, { isTTY: true, columns: 80, rows: 24 });
+  const app = inkRender(element, { stdout, patchConsole: false });
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  app.unmount();
+  return chunks.join('');
 }
 
-describe('SEC-019 — a poisoned tool label never reaches the frame', () => {
-  // Built through the real constructors, not a hand-written object literal. The first version of
-  // these two cases used `category: 'message'`; MessageList dispatches on `'chat'`, so nothing
-  // rendered and both cases passed WITH the fix reversed. The mutation is what exposed that — a
-  // render test that renders nothing is green for the same reason a correct one is.
-  const toolEntry = (content: string): IHistoryEntry =>
-    messageToHistoryEntry(
-      createToolMessage(content, { toolCallId: 'call-1', name: `Read${POISON}` }),
-    );
+const toolEntry = (content: string): IHistoryEntry =>
+  messageToHistoryEntry(
+    createToolMessage(content, { toolCallId: 'call-1', name: `Read${POISON}` }),
+  );
 
-  it('MessageList: structured tool summary branch (the branch review found unguarded)', () => {
-    // The content parses as IToolCallSummary[], which is what selects the branch that rendered the
-    // tool name through `humanizeToolName` alone.
-    const frame = frameOf(
+const eventEntry = (id: string, type: string, data: unknown): IHistoryEntry =>
+  ({ id, timestamp: new Date(), category: 'event', type, data }) as unknown as IHistoryEntry;
+
+describe('SEC-019 — the terminal stream carries no payload from poisoned session data', () => {
+  it('the oracle is not vacuous: an unsanitized render DOES leak', async () => {
+    // Without this the whole file passes for a `carriesPayload` that always answers false, and for
+    // an Ink that removed everything. It also pins WHY this module exists: if this case ever goes
+    // green, Ink's own behaviour changed and the threat model needs re-reading — that is a signal
+    // worth a failing test, not a false alarm.
+    const stream = await streamOf(<Text>{`before${POISON}after`}</Text>);
+    expect(carriesPayload(stream), JSON.stringify(stream)).toBe(true);
+  });
+
+  it('MessageList: structured tool summary branch (the branch review found unguarded)', async () => {
+    const stream = await streamOf(
       <MessageList history={[toolEntry(JSON.stringify([{ line: 'read ok' }]))]} />,
     );
-    expect(frame).toContain('Read');
-    expect(carriesPayload(frame)).toBe(false);
+    expect(stream).toContain('Read');
+    expect(carriesPayload(stream)).toBe(false);
   });
 
-  it('MessageList: plain-text tool branch', () => {
-    const frame = frameOf(<MessageList history={[toolEntry(`not json ${POISON}`)]} />);
-    expect(frame).toContain('Read');
-    expect(carriesPayload(frame)).toBe(false);
+  it('MessageList: plain-text tool branch', async () => {
+    const stream = await streamOf(<MessageList history={[toolEntry(`not json ${POISON}`)]} />);
+    expect(stream).toContain('Read');
+    expect(carriesPayload(stream)).toBe(false);
   });
 
-  it('MessageList: the tool-summary event label, name and first argument both', () => {
-    const entry: IHistoryEntry = {
-      id: 'evt-1',
-      timestamp: new Date(),
-      category: 'event',
-      type: 'tool-summary',
-      data: {
-        tools: [
-          {
-            toolName: `Read${POISON}`,
-            firstArg: `file.ts${POISON}`,
-            isRunning: false,
-            result: 'success',
-          },
-        ],
-        summary: `✓ Read(file.ts)${POISON}`,
-      },
-    } as unknown as IHistoryEntry;
-    const frame = frameOf(<MessageList history={[entry]} />);
-    expect(frame).toContain('Read');
-    expect(carriesPayload(frame)).toBe(false);
+  it('MessageList: the tool-summary event label, name and first argument both', async () => {
+    const stream = await streamOf(
+      <MessageList
+        history={[
+          eventEntry('evt-1', 'tool-summary', {
+            tools: [
+              {
+                toolName: `Read${POISON}`,
+                firstArg: `file.ts${POISON}`,
+                isRunning: false,
+                result: 'success',
+              },
+            ],
+            summary: `✓ Read(file.ts)${POISON}`,
+          }),
+        ]}
+      />,
+    );
+    expect(stream).toContain('Read');
+    expect(carriesPayload(stream)).toBe(false);
   });
 
-  it('StreamingIndicator: the live tool line, name and first argument both', () => {
-    const tools: IToolState[] = [
-      {
-        toolName: `Read${POISON}`,
-        firstArg: `file.ts${POISON}`,
-        isRunning: true,
-      } as unknown as IToolState,
-    ];
-    const frame = frameOf(<StreamingIndicator text="" activeTools={tools} />);
-    expect(frame).toContain('Read');
-    expect(carriesPayload(frame)).toBe(false);
+  it('MessageList: an event entry message (skill activation, memory topic)', async () => {
+    const stream = await streamOf(
+      <MessageList
+        history={[
+          eventEntry('evt-2', 'skill-activation', {
+            message: `Invoking plugin skill: ${POISON}`,
+          }),
+        ]}
+      />,
+    );
+    expect(stream).toContain('Invoking plugin skill');
+    expect(carriesPayload(stream)).toBe(false);
   });
 
-  it('StreamingIndicator: the streamed assistant text', () => {
-    expect(
-      carriesPayload(frameOf(<StreamingIndicator text={`hello ${POISON}`} activeTools={[]} />)),
-    ).toBe(false);
+  it('MessageList: an event entry that carries content instead of message', async () => {
+    const stream = await streamOf(
+      <MessageList history={[eventEntry('evt-3', 'note', { content: `note ${POISON}` })]} />,
+    );
+    expect(stream).toContain('note');
+    expect(carriesPayload(stream)).toBe(false);
   });
 
-  it('the poison is detectable when nothing sanitizes it — the detector is not vacuous', () => {
-    // Without this the whole file passes for a detector that always returns false.
-    expect(carriesPayload(`before${POISON}after`)).toBe(true);
+  it('MessageList: the tool-summary fallback lines, taken when the entry lists no tools', async () => {
+    const stream = await streamOf(
+      <MessageList
+        history={[eventEntry('evt-4', 'tool-summary', { summary: `line one ${POISON}\nline two` })]}
+      />,
+    );
+    expect(stream).toContain('line one');
+    expect(carriesPayload(stream)).toBe(false);
+  });
+
+  it('MessageList: command output preview lines, which are raw stdout', async () => {
+    const stream = await streamOf(
+      <MessageList
+        history={[
+          eventEntry('evt-5', 'tool-summary', {
+            tools: [
+              {
+                toolName: 'Shell',
+                firstArg: 'ls',
+                result: 'error',
+                toolResultData: JSON.stringify({ exitCode: 1, stdout: `oops ${POISON}` }),
+              },
+            ],
+            summary: '',
+          }),
+        ]}
+      />,
+    );
+    expect(stream).toContain('oops');
+    expect(carriesPayload(stream)).toBe(false);
+  });
+
+  it('StreamingIndicator: the live tool line, name and first argument both', async () => {
+    const tools = [
+      { toolName: `Read${POISON}`, firstArg: `file.ts${POISON}`, isRunning: true },
+    ] as unknown as IToolState[];
+    const stream = await streamOf(<StreamingIndicator text="" activeTools={tools} />);
+    expect(stream).toContain('Read');
+    expect(carriesPayload(stream)).toBe(false);
+  });
+
+  it('StreamingIndicator: the streamed assistant text', async () => {
+    const stream = await streamOf(<StreamingIndicator text={`hello ${POISON}`} activeTools={[]} />);
+    expect(carriesPayload(stream)).toBe(false);
   });
 });

--- a/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/sec-019-tool-label-render.test.tsx
@@ -26,7 +26,7 @@ import StreamingIndicator from '../StreamingIndicator.js';
 import { createToolMessage, messageToHistoryEntry } from '@robota-sdk/agent-core';
 
 import type { IHistoryEntry } from '@robota-sdk/agent-core';
-import type { IToolState } from '@robota-sdk/agent-interface-transport';
+import type { IToolState } from '@robota-sdk/agent-interface-session';
 
 const ESC = String.fromCharCode(27);
 const BEL = String.fromCharCode(7);

--- a/packages/agent-transport-tui/src/command-output-summary.ts
+++ b/packages/agent-transport-tui/src/command-output-summary.ts
@@ -1,3 +1,5 @@
+import { sanitizeTerminalText } from './sanitize-terminal-text.js';
+
 import type { TUniversalValue } from '@robota-sdk/agent-core';
 
 const MAX_PREVIEW_LINES = 4;
@@ -30,7 +32,12 @@ export function formatCommandOutputSummary(
   const successValue = getBooleanValue(parsed, 'success');
   const output = buildOutputText(tool.toolResultData, parsed);
   const lines = trimTrailingBlankLines(splitOutputLines(output));
-  const previewLines = lines.slice(0, MAX_PREVIEW_LINES);
+  // SEC-019: these lines ARE the command's stdout and stderr — the most directly attacker-chosen
+  // text in the whole surface. Sanitized where the summary is BUILT rather than where it is
+  // rendered, because this function exists to produce display text and a second render site would
+  // otherwise have to remember. `statusLabel` and `transcriptHint` are built from numbers and need
+  // nothing.
+  const previewLines = lines.slice(0, MAX_PREVIEW_LINES).map(sanitizeTerminalText);
   const omittedLineCount = Math.max(0, lines.length - previewLines.length);
   const isFailed =
     tool.result === 'error' ||

--- a/packages/agent-transport-tui/src/humanize-tool-name.ts
+++ b/packages/agent-transport-tui/src/humanize-tool-name.ts
@@ -6,15 +6,43 @@
  * the name would otherwise exceed the provider length limit (see model-command-tool-projection.ts).
  * For display we recover the command name: strip the prefix and a trailing projection hash. Tool
  * names that are not command projections (e.g. `Shell`, `Read`) are returned unchanged.
+ *
+ * ## SEC-019: this is where a tool label is made safe, not at each render site
+ *
+ * A tool name and its first argument come from the model, from an MCP server's manifest, or from a
+ * plugin — all untrusted — and they are put on the terminal as text. Sanitizing at the render sites
+ * was tried and failed within one review round: `MessageList` has two branches that show a tool name
+ * and only one of them got the call, so a name carrying OSC 52 still reached `<Text>` whenever the
+ * tool's content happened to parse as a structured summary. Three more sites had the same gap
+ * (`StreamingIndicator`, and the label `tool-summary-status` composes for the history view).
+ *
+ * The defect is not that a call was forgotten. It is that "make this displayable" and "make this
+ * safe to display" were two separate steps, so every new render site had to remember the second one.
+ * They are one step here, and a fifth caller is covered because it cannot obtain the display text
+ * without going through the function that sanitizes it.
  */
 import { MODEL_COMMAND_TOOL_PREFIX } from '@robota-sdk/agent-framework';
+
+import { sanitizeTerminalText } from './sanitize-terminal-text.js';
 
 /** A trailing `_<8 lowercase hex>` projection hash appended to over-long command tool names. */
 const PROJECTION_HASH_SUFFIX = /_[0-9a-f]{8}$/;
 
 export function humanizeToolName(toolName: string): string {
-  if (!toolName.startsWith(MODEL_COMMAND_TOOL_PREFIX)) return toolName;
+  if (!toolName.startsWith(MODEL_COMMAND_TOOL_PREFIX)) return sanitizeTerminalText(toolName);
   const body = toolName.slice(MODEL_COMMAND_TOOL_PREFIX.length);
   const withoutHash = body.replace(PROJECTION_HASH_SUFFIX, '');
-  return withoutHash.length > 0 ? withoutHash : toolName;
+  return sanitizeTerminalText(withoutHash.length > 0 ? withoutHash : toolName);
+}
+
+/**
+ * The first argument of a tool call, as display text.
+ *
+ * A separate function rather than a bare `sanitizeTerminalText` at the two sites that show it: the
+ * argument is the other half of a tool label, it is equally untrusted — a path, a shell command, a
+ * URL the model chose — and pairing it with {@link humanizeToolName} is what makes the boundary
+ * findable. A render site that reaches for one naturally reaches for the other.
+ */
+export function humanizeToolArgument(firstArg: string | undefined): string {
+  return firstArg === undefined ? '' : sanitizeTerminalText(firstArg);
 }

--- a/packages/agent-transport-tui/src/render-markdown.ts
+++ b/packages/agent-transport-tui/src/render-markdown.ts
@@ -2,6 +2,7 @@ import { marked } from 'marked';
 // @ts-expect-error — marked-terminal has no type declarations
 import TerminalRenderer from 'marked-terminal';
 
+import { sanitizeTerminalText } from './sanitize-terminal-text.js';
 import { isInteractiveColorTerminal } from './terminal-capabilities.js';
 import { ANSI } from './tui-ansi-palette.js';
 
@@ -112,8 +113,16 @@ function createTerminalRenderer(color: boolean, codeBlockWidth: number | undefin
  * Returns the rendered string (may include ANSI escape codes).
  */
 export function renderMarkdown(md: string, options: IRenderMarkdownOptions = {}): string {
-  const result = marked.parse(md, {
+  // SEC-019 (issue #2022): the untrusted string is sanitized BEFORE parsing, never after. The
+  // renderer ADDS ANSI — colours, bold, code-block framing — so filtering its output would strip the
+  // repository's own presentation along with the attacker's. Filtering its input removes what
+  // arrived from outside and leaves what is generated after.
+  //
+  // This is the choke point every render path shares (MessageList, StreamingIndicator,
+  // ToolDiffBlock), which is why it is here rather than at each of the three.
+  const safe = sanitizeTerminalText(md);
+  const result = marked.parse(safe, {
     renderer: createTerminalRenderer(shouldUseColor(options.color), options.codeBlockWidth),
   });
-  return typeof result === 'string' ? result.trimEnd() : md;
+  return typeof result === 'string' ? result.trimEnd() : safe;
 }

--- a/packages/agent-transport-tui/src/sanitize-terminal-text.ts
+++ b/packages/agent-transport-tui/src/sanitize-terminal-text.ts
@@ -38,23 +38,44 @@ const KEPT_C0 = new Set(['\t', '\n', '\r']);
  * One escape sequence, or a lone control character.
  *
  * The alternation is ordered longest-context-first so a two-character C1 introducer (`ESC ]`) is
- * consumed as the start of its sequence rather than as a bare `ESC`.
+ * consumed as the start of its sequence rather than as a bare `ESC`, and every 8-bit C1 form is
+ * matched with its BODY before the lone-C1 alternative can take the introducer on its own.
+ *
+ * Each introducer appears in both spellings, because a terminal accepts both: `ESC ]` and the single
+ * byte `\x9d` are the same OSC. An alternation that removed only the 7-bit spelling would leave the
+ * 8-bit one's parameters standing as visible text.
  *
  *  - `\x1b][^\x07\x1b]*(?:\x07|\x1b\\)?`  OSC, terminated by BEL or ST - or unterminated at the end
  *    of the input, which is the streaming case and must still be removed rather than left visible.
- *  - `\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)?` DCS, PM, APC, SOS - same shape, different introducer.
- *  - `\x1b\[[0-9;?]*[ -/]*[@-~]`          CSI, including private-mode `?` parameters.
- *  - `\x1b[@-Z\\-_]`                      any other two-character escape.
- *  - `[\x00-\x1f\x7f]`                    a lone control character, including a bare ESC or BEL.
- *  - `[\x80-\x9f]`                        the 8-bit C1 controls, which are OSC/CSI without the ESC.
+ *  - `\x9d[^\x07\x1b\x9c]*(?:\x07|\x9c|\x1b\\)?`  the same, 8-bit introducer, with `\x9c` as a
+ *    third accepted terminator because 8-bit ST is one byte.
+ *  - `\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)`  DCS, PM, APC, SOS, terminated by ST or BEL. The
+ *    terminator is MANDATORY here, and that is the difference from the OSC alternative above. OSC's
+ *    body is `[^\x07\x1b]*`, which is greedy and cannot cross its own terminator, so an optional
+ *    terminator costs nothing. A DCS body is `[\s\S]*?`, which is lazy - and a lazy quantifier
+ *    followed by an OPTIONAL group prefers the empty match at every position, so the alternative
+ *    would consume the two-character introducer and nothing else, leaving `q#0;2;0;0;0` from a Sixel
+ *    sequence standing as visible text. Found in review of PR #2212, and the reason every case in
+ *    the test table now asserts the exact output rather than "no control byte survives" - the weaker
+ *    assertion holds for a sanitizer that strips only introducers.
+ *  - `\x1b[P^_X][\s\S]*$`  the same, unterminated at the end of the input. Written as its own
+ *    alternative rather than an optional terminator, for the reason directly above.
+ *  - `[\x90\x98\x9e\x9f][\s\S]*?(?:\x9c|\x1b\\|\x07)` and `[\x90\x98\x9e\x9f][\s\S]*$`
+ *    DCS/SOS/PM/APC again, 8-bit introducers, terminated and unterminated.
+ *  - `\x1b\[[0-9;?]*[ -/]*[@-~]`  CSI, including private-mode `?` parameters.
+ *  - `\x9b[0-9;?]*[ -/]*[@-~]`  the same, 8-bit introducer.
+ *  - `\x1b[@-Z\\-_]`  any other two-character escape.
+ *  - `[\x00-\x1f\x7f]`  a lone control character, including a bare ESC or BEL.
+ *  - `[\x80-\x9f]`  a lone C1 control that started no sequence any alternative above matched.
  */
 const CONTROL_SEQUENCE =
   // eslint-disable-next-line no-control-regex
-  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)?|\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|[\x00-\x1f\x7f]|[\x80-\x9f]/g;
+  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x9d[^\x07\x1b\x9c]*(?:\x07|\x9c|\x1b\\)?|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)|\x1b[P^_X][\s\S]*$|[\x90\x98\x9e\x9f][\s\S]*?(?:\x9c|\x1b\\|\x07)|[\x90\x98\x9e\x9f][\s\S]*$|\x1b\[[0-9;?]*[ -/]*[@-~]|\x9b[0-9;?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|[\x00-\x1f\x7f]|[\x80-\x9f]/g;
 
 /** The longest prefix of `text` that could still become a control sequence if more text arrived. */
-// eslint-disable-next-line no-control-regex
-const INCOMPLETE_TAIL = /(?:\x1b(?:\][^\x07\x1b]*|[P^_X][\s\S]*|\[[0-9;?]*[ -/]*|)?)$/;
+const INCOMPLETE_TAIL =
+  // eslint-disable-next-line no-control-regex
+  /(?:\x1b(?:\][^\x07\x1b]*|[P^_X][\s\S]*|\[[0-9;?]*[ -/]*|)?|\x9d[^\x07\x1b\x9c]*|[\x90\x98\x9e\x9f][\s\S]*|\x9b[0-9;?]*[ -/]*)$/;
 
 /**
  * `text` with every terminal control sequence removed, and tab/newline/carriage return preserved.

--- a/packages/agent-transport-tui/src/sanitize-terminal-text.ts
+++ b/packages/agent-transport-tui/src/sanitize-terminal-text.ts
@@ -1,0 +1,100 @@
+/**
+ * SEC-019 (issue #2022) - the one place untrusted text is made safe to put on a terminal.
+ *
+ * Model output, tool output, file contents and plugin text all reach Ink `<Text>`, and Ink does not
+ * strip control sequences - it passes them through. So a repository, a fetched document, a plugin or
+ * a model response could emit OSC and CSI sequences that act on the terminal independently of what
+ * the transcript appears to say: OSC 52 writes the clipboard, OSC 8 makes a link whose visible text
+ * and target differ, and CSI moves the cursor or erases what is already on screen.
+ *
+ * ## Allowlist, not denylist
+ *
+ * Everything is passed through EXCEPT the control range, and inside that range exactly three
+ * characters survive - tab, newline, carriage return. A denylist of "known dangerous sequences" is
+ * wrong for the same reason it is wrong for shell metacharacters: the set belongs to the terminal
+ * emulator, and a list written today is incomplete the next time one adds an escape.
+ *
+ * ## Ordering: sanitize BEFORE rendering, never after
+ *
+ * The renderer ADDS ANSI - colours, bold, code-block framing. Sanitizing its output would strip the
+ * repository's own presentation along with the attacker's. Sanitizing its input removes the escapes
+ * that arrived from outside and leaves the ones generated after. That ordering is the whole design,
+ * and it is why this is a function on the untrusted string rather than a filter on the rendered one.
+ *
+ * ## Streaming
+ *
+ * A sequence split across two deltas - `\x1b]5` then `2;c;...\x07` - is invisible to a sanitizer that
+ * sees each chunk alone. {@link createStreamingTerminalSanitizer} holds the incomplete tail back until
+ * the chunk that completes it arrives. The TUI's own stream path accumulates before rendering
+ * (`tui-state-manager` appends each delta to a buffer and renders the buffer), so the stateless
+ * function is sufficient THERE - but a caller that sanitizes per chunk needs the stateful one, and
+ * having only the stateless function available is how that caller would get it wrong.
+ */
+
+/** Tab, newline and carriage return are content; every other C0 control is not. */
+const KEPT_C0 = new Set(['\t', '\n', '\r']);
+
+/**
+ * One escape sequence, or a lone control character.
+ *
+ * The alternation is ordered longest-context-first so a two-character C1 introducer (`ESC ]`) is
+ * consumed as the start of its sequence rather than as a bare `ESC`.
+ *
+ *  - `\x1b][^\x07\x1b]*(?:\x07|\x1b\\)?`  OSC, terminated by BEL or ST - or unterminated at the end
+ *    of the input, which is the streaming case and must still be removed rather than left visible.
+ *  - `\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)?` DCS, PM, APC, SOS - same shape, different introducer.
+ *  - `\x1b\[[0-9;?]*[ -/]*[@-~]`          CSI, including private-mode `?` parameters.
+ *  - `\x1b[@-Z\\-_]`                      any other two-character escape.
+ *  - `[\x00-\x1f\x7f]`                    a lone control character, including a bare ESC or BEL.
+ *  - `[\x80-\x9f]`                        the 8-bit C1 controls, which are OSC/CSI without the ESC.
+ */
+const CONTROL_SEQUENCE =
+  // eslint-disable-next-line no-control-regex
+  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)?|\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|[\x00-\x1f\x7f]|[\x80-\x9f]/g;
+
+/** The longest prefix of `text` that could still become a control sequence if more text arrived. */
+// eslint-disable-next-line no-control-regex
+const INCOMPLETE_TAIL = /(?:\x1b(?:\][^\x07\x1b]*|[P^_X][\s\S]*|\[[0-9;?]*[ -/]*|)?)$/;
+
+/**
+ * `text` with every terminal control sequence removed, and tab/newline/carriage return preserved.
+ *
+ * Ordinary Unicode - including characters far outside ASCII - is untouched: the goal is to remove
+ * what the TERMINAL acts on, not to restrict what a document may say.
+ */
+export function sanitizeTerminalText(text: string): string {
+  return text.replace(CONTROL_SEQUENCE, (match) => (KEPT_C0.has(match) ? match : ''));
+}
+
+/** A sanitizer that carries an incomplete escape across chunk boundaries. */
+export interface IStreamingTerminalSanitizer {
+  /** Sanitize one chunk, holding back any tail that could still become an escape. */
+  push(chunk: string): string;
+  /** Emit whatever is held back, sanitized. Call when the stream ends. */
+  flush(): string;
+}
+
+/**
+ * A stateful sanitizer for callers that sanitize each chunk as it arrives.
+ *
+ * The held-back tail is bounded by the incomplete-prefix pattern rather than by a byte count: a
+ * partial OSC can be arbitrarily long, and truncating the buffer would emit the middle of a sequence
+ * as visible text while dropping the part that made it dangerous.
+ */
+export function createStreamingTerminalSanitizer(): IStreamingTerminalSanitizer {
+  let pending = '';
+  return {
+    push(chunk: string): string {
+      const combined = pending + chunk;
+      const tail = INCOMPLETE_TAIL.exec(combined);
+      const holdFrom = tail && tail[0].length > 0 ? tail.index : combined.length;
+      pending = combined.slice(holdFrom);
+      return sanitizeTerminalText(combined.slice(0, holdFrom));
+    },
+    flush(): string {
+      const remaining = pending;
+      pending = '';
+      return sanitizeTerminalText(remaining);
+    },
+  };
+}

--- a/packages/agent-transport-tui/src/sanitize-terminal-text.ts
+++ b/packages/agent-transport-tui/src/sanitize-terminal-text.ts
@@ -1,16 +1,31 @@
 /**
  * SEC-019 (issue #2022) - the one place untrusted text is made safe to put on a terminal.
  *
- * Model output, tool output, file contents and plugin text all reach Ink `<Text>`, and Ink does not
- * strip control sequences - it passes them through. So a repository, a fetched document, a plugin or
- * a model response could emit OSC and CSI sequences that act on the terminal independently of what
- * the transcript appears to say: OSC 52 writes the clipboard, OSC 8 makes a link whose visible text
- * and target differ, and CSI moves the cursor or erases what is already on screen.
+ * Model output, tool output, file contents and plugin text all reach Ink `<Text>`, and from there a
+ * terminal. What that terminal actually receives was MEASURED against a real stream rather than
+ * assumed, because the first version of this module assumed Ink passed everything through and that
+ * is not true:
+ *
+ *   stripped by Ink   OSC 52 (clipboard), OSC 0 (title), CSI erase/cursor/alt-screen, DCS, APC,
+ *                     8-bit CSI
+ *   REACHES the tty   SGR colour, OSC 8 hyperlink, a bare carriage return
+ *
+ * So through `<Text>` the live attack is a link whose visible text and target differ, and a `\r`
+ * that overwrites the line the transcript just printed. `useTerminalTitle` writes to stdout directly
+ * and is subject to none of Ink's filtering, so everything reaches the terminal there.
+ *
+ * ## Why sanitize the whole class when Ink removes most of it
+ *
+ * Because Ink's removal is INCIDENTAL. It falls out of slicing text for layout; it is in no
+ * contract, no test of Ink's asserts it, and a dependency upgrade can return the entire class
+ * without a line changing here. A boundary that rests on another project's implementation detail is
+ * a boundary in name. The two sequences that reach the terminal today prove the exposure is real;
+ * the ones Ink happens to remove are the reason this must not be scoped to them.
  *
  * ## Allowlist, not denylist
  *
- * Everything is passed through EXCEPT the control range, and inside that range exactly three
- * characters survive - tab, newline, carriage return. A denylist of "known dangerous sequences" is
+ * Everything is passed through EXCEPT the control range, and inside that range exactly two
+ * characters survive - tab and newline. A denylist of "known dangerous sequences" is
  * wrong for the same reason it is wrong for shell metacharacters: the set belongs to the terminal
  * emulator, and a list written today is incomplete the next time one adds an escape.
  *
@@ -31,8 +46,22 @@
  * having only the stateless function available is how that caller would get it wrong.
  */
 
-/** Tab, newline and carriage return are content; every other C0 control is not. */
-const KEPT_C0 = new Set(['\t', '\n', '\r']);
+/**
+ * Tab and newline are content. Carriage return is NOT, and that is a correction.
+ *
+ * A bare `\r` returns the cursor to column zero, so `safe text\rEVIL` prints `EVIL` over what the
+ * transcript said — the same "what you read is not what happened" attack as a deceptive hyperlink,
+ * with no escape sequence involved. It was kept here as content in the first version of this module
+ * on the assumption that CR is a line ending; measurement against a real terminal stream showed a
+ * bare CR reaching it intact.
+ *
+ * `\r\n` IS a line ending, and is normalized to `\n` before the control filter runs, so a document
+ * written on Windows keeps its line structure and loses only the overwrite primitive.
+ */
+const KEPT_C0 = new Set(['\t', '\n']);
+
+/** `\r\n` is one line break written in two bytes; a `\r` that is not part of one is a cursor move. */
+const CRLF = /\r\n/g;
 
 /**
  * One escape sequence, or a lone control character.
@@ -103,7 +132,9 @@ const INCOMPLETE_TAIL =
  * what the TERMINAL acts on, not to restrict what a document may say.
  */
 export function sanitizeTerminalText(text: string): string {
-  return text.replace(CONTROL_SEQUENCE, (match) => (KEPT_C0.has(match) ? match : ''));
+  return text
+    .replace(CRLF, '\n')
+    .replace(CONTROL_SEQUENCE, (match) => (KEPT_C0.has(match) ? match : ''));
 }
 
 /** A sanitizer that carries an incomplete escape across chunk boundaries. */

--- a/packages/agent-transport-tui/src/sanitize-terminal-text.ts
+++ b/packages/agent-transport-tui/src/sanitize-terminal-text.ts
@@ -72,10 +72,24 @@ const CONTROL_SEQUENCE =
   // eslint-disable-next-line no-control-regex
   /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x9d[^\x07\x1b\x9c]*(?:\x07|\x9c|\x1b\\)?|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)|\x1b[P^_X][\s\S]*$|[\x90\x98\x9e\x9f][\s\S]*?(?:\x9c|\x1b\\|\x07)|[\x90\x98\x9e\x9f][\s\S]*$|\x1b\[[0-9;?]*[ -/]*[@-~]|\x9b[0-9;?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|[\x00-\x1f\x7f]|[\x80-\x9f]/g;
 
-/** The longest prefix of `text` that could still become a control sequence if more text arrived. */
+/**
+ * The longest prefix of `text` that could still become a control sequence if more text arrived.
+ *
+ * "Could still become" is the whole contract, and the DCS/PM/APC/SOS bodies are where it is easy to
+ * lose. Written as a plain `[\s\S]*`, they match a sequence that is ALREADY terminated inside the
+ * chunk — `'hello' ESC P … ESC \ 'world'` anchors from the introducer to the end, so `world` is held
+ * back and does not appear until the next `push` or the `flush`. Nothing dangerous escapes, but
+ * ordinary text stops arriving, which for a streaming renderer is a stall.
+ *
+ * So each body excludes its own terminators through a negative lookahead: a sequence that has already
+ * ended is not an incomplete tail. The OSC and CSI branches need no such guard — `[^\x07\x1b]*`
+ * cannot cross BEL or ESC, and a CSI without its final byte is incomplete by construction. Found in
+ * review of PR #2212, one round after the same asymmetry was fixed in {@link CONTROL_SEQUENCE}: the
+ * two patterns describe the same grammar and have to be changed together.
+ */
 const INCOMPLETE_TAIL =
   // eslint-disable-next-line no-control-regex
-  /(?:\x1b(?:\][^\x07\x1b]*|[P^_X][\s\S]*|\[[0-9;?]*[ -/]*|)?|\x9d[^\x07\x1b\x9c]*|[\x90\x98\x9e\x9f][\s\S]*|\x9b[0-9;?]*[ -/]*)$/;
+  /(?:\x1b(?:\][^\x07\x1b]*|[P^_X](?:(?!\x1b\\|\x07)[\s\S])*|\[[0-9;?]*[ -/]*|)?|\x9d[^\x07\x1b\x9c]*|[\x90\x98\x9e\x9f](?:(?!\x9c|\x1b\\|\x07)[\s\S])*|\x9b[0-9;?]*[ -/]*)$/;
 
 /**
  * `text` with every terminal control sequence removed, and tab/newline/carriage return preserved.

--- a/packages/agent-transport-tui/src/sanitize-terminal-text.ts
+++ b/packages/agent-transport-tui/src/sanitize-terminal-text.ts
@@ -62,15 +62,20 @@ const KEPT_C0 = new Set(['\t', '\n', '\r']);
  *    alternative rather than an optional terminator, for the reason directly above.
  *  - `[\x90\x98\x9e\x9f][\s\S]*?(?:\x9c|\x1b\\|\x07)` and `[\x90\x98\x9e\x9f][\s\S]*$`
  *    DCS/SOS/PM/APC again, 8-bit introducers, terminated and unterminated.
- *  - `\x1b\[[0-9;?]*[ -/]*[@-~]`  CSI, including private-mode `?` parameters.
- *  - `\x9b[0-9;?]*[ -/]*[@-~]`  the same, 8-bit introducer.
+ *  - `\x1b\[[0-?]*[ -/]*[@-~]`  CSI. The parameter class is the ECMA-48 range 0x30–0x3F written as
+ *    a range, not the digits-plus-`;`-plus-`?` an author reaches for from memory. That shorter class
+ *    omits `:`, `<`, `=` and `>`, and the omission is not academic: `ESC [ 38:2:255:0:0 m` is the
+ *    colon form of a truecolor SGR and `ESC [ < 0;10;20 M` is an SGR mouse report. Neither matched
+ *    any alternative, so the lone-control fallback took the ESC and left `38:2:255:0:0m` as visible
+ *    text. Found in review of PR #2212.
+ *  - `\x9b[0-?]*[ -/]*[@-~]`  the same, 8-bit introducer.
  *  - `\x1b[@-Z\\-_]`  any other two-character escape.
  *  - `[\x00-\x1f\x7f]`  a lone control character, including a bare ESC or BEL.
  *  - `[\x80-\x9f]`  a lone C1 control that started no sequence any alternative above matched.
  */
 const CONTROL_SEQUENCE =
   // eslint-disable-next-line no-control-regex
-  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x9d[^\x07\x1b\x9c]*(?:\x07|\x9c|\x1b\\)?|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)|\x1b[P^_X][\s\S]*$|[\x90\x98\x9e\x9f][\s\S]*?(?:\x9c|\x1b\\|\x07)|[\x90\x98\x9e\x9f][\s\S]*$|\x1b\[[0-9;?]*[ -/]*[@-~]|\x9b[0-9;?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|[\x00-\x1f\x7f]|[\x80-\x9f]/g;
+  /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x9d[^\x07\x1b\x9c]*(?:\x07|\x9c|\x1b\\)?|\x1b[P^_X][\s\S]*?(?:\x1b\\|\x07)|\x1b[P^_X][\s\S]*$|[\x90\x98\x9e\x9f][\s\S]*?(?:\x9c|\x1b\\|\x07)|[\x90\x98\x9e\x9f][\s\S]*$|\x1b\[[0-?]*[ -/]*[@-~]|\x9b[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]|[\x00-\x1f\x7f]|[\x80-\x9f]/g;
 
 /**
  * The longest prefix of `text` that could still become a control sequence if more text arrived.
@@ -89,7 +94,7 @@ const CONTROL_SEQUENCE =
  */
 const INCOMPLETE_TAIL =
   // eslint-disable-next-line no-control-regex
-  /(?:\x1b(?:\][^\x07\x1b]*|[P^_X](?:(?!\x1b\\|\x07)[\s\S])*|\[[0-9;?]*[ -/]*|)?|\x9d[^\x07\x1b\x9c]*|[\x90\x98\x9e\x9f](?:(?!\x9c|\x1b\\|\x07)[\s\S])*|\x9b[0-9;?]*[ -/]*)$/;
+  /(?:\x1b(?:\][^\x07\x1b]*|[P^_X](?:(?!\x1b\\|\x07)[\s\S])*|\[[0-?]*[ -/]*|)?|\x9d[^\x07\x1b\x9c]*|[\x90\x98\x9e\x9f](?:(?!\x9c|\x1b\\|\x07)[\s\S])*|\x9b[0-?]*[ -/]*)$/;
 
 /**
  * `text` with every terminal control sequence removed, and tab/newline/carriage return preserved.

--- a/packages/agent-transport-tui/src/tool-summary-status.ts
+++ b/packages/agent-transport-tui/src/tool-summary-status.ts
@@ -7,7 +7,7 @@
  * so tool status renders one way everywhere.
  */
 
-import { humanizeToolName } from './humanize-tool-name.js';
+import { humanizeToolArgument, humanizeToolName } from './humanize-tool-name.js';
 import { STATUS_GLYPH, toolStateStatusKind } from './status-glyph.js';
 
 import type { TUiStatusKind } from './status-glyph.js';
@@ -50,5 +50,6 @@ export function toolSummaryStatusKind(
 
 /** One-line summary label: SSOT glyph + humanized tool name + first argument. */
 export function getToolSummaryLabel(tool: TToolSummaryItem, kind: TUiStatusKind): string {
-  return `${STATUS_GLYPH[kind].symbol} ${humanizeToolName(tool.toolName)}${tool.firstArg ? `(${tool.firstArg})` : ''}`;
+  const argument = humanizeToolArgument(tool.firstArg);
+  return `${STATUS_GLYPH[kind].symbol} ${humanizeToolName(tool.toolName)}${argument ? `(${argument})` : ''}`;
 }

--- a/packages/agent-transport-tui/src/use-terminal-title.ts
+++ b/packages/agent-transport-tui/src/use-terminal-title.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import { sanitizeTerminalText } from './sanitize-terminal-text.js';
+
+/**
+ * Set the terminal's window title from the session name.
+ *
+ * Split out of `App.tsx` under SEC-019 (issue #2022) by responsibility: this is the one place the TUI
+ * writes an escape sequence to stdout directly rather than through Ink, which makes it the one place
+ * where a value is interpolated INTO terminal syntax rather than rendered as content. Keeping it
+ * inside a 600-line component is what let it sit unexamined next to code that never touches an
+ * escape.
+ *
+ * `sessionName` is untrusted — a session can be named from a prompt, and a name containing BEL or ESC
+ * terminates the OSC early, so everything after it is read by the terminal as its own command.
+ *
+ * Only the NAME is sanitized, not the finished string: the `\x1b]0;` … `\x07` around it is framing
+ * this module is deliberately writing, and sanitizing the whole thing would strip it.
+ */
+export function useTerminalTitle(sessionName: string | undefined): void {
+  useEffect(() => {
+    const safeName = sanitizeTerminalText(sessionName ?? '');
+    const title = safeName ? `Robota — ${safeName}` : 'Robota';
+    process.stdout.write(`\x1b]0;${title}\x07`);
+  }, [sessionName]);
+}

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -40,7 +40,7 @@
   "packages/agent-provider-openai-compatible/src/qwen/responses-parser.ts": 302,
   "packages/agent-session/src/session-run.ts": 322,
   "packages/agent-session/src/session.ts": 312,
-  "packages/agent-transport-tui/src/App.tsx": 605,
+  "packages/agent-transport-tui/src/App.tsx": 602,
   "packages/agent-transport-tui/src/InputArea.tsx": 318,
   "packages/agent-transport-tui/src/TuiInteractionChannel.ts": 615,
   "packages/agent-transport-webrtc-web/src/client/rtc-session-client.ts": 399,


### PR DESCRIPTION
Closes #2022.

## What was wrong

Model responses, tool output, file contents and plugin-supplied text reach Ink `<Text>`, and Ink passes control sequences through unchanged. So a repository, a fetched document, a plugin, or the model itself could act on the terminal independently of what the transcript appeared to say — OSC 52 writes the system clipboard, OSC 8 renders a link whose visible text and target differ, CSI moves the cursor or erases what is already on screen.

## The sinks were enumerated, not taken from the issue

SEC-018 cost five review rounds because the sink list came from the report rather than from the code. This one was enumerated first. Seven sinks:

| Sink | Why it is separate |
| --- | --- |
| `render-markdown.ts` ×3 call sites | the renderer itself |
| `MessageList.tsx` tool summary lines | not routed through the renderer |
| `MessageList.tsx` tool name | attacker-chosen in an MCP/plugin tool |
| `MessageList.tsx` error block | does not go through the renderer, so it inherits nothing |
| `ToolDiffBlock.tsx` file header | path text from the tool result |
| `App.tsx` window title | `sessionName` is interpolated **into** an OSC sequence rather than rendered as content |

The window title is the one an audit of `renderMarkdown` call sites could not have found, and it is the only place the TUI writes an escape to stdout directly.

## Allowlist, not denylist

Same reasoning that makes an allowlist right for shell metacharacters: the dangerous set belongs to the terminal emulator and grows without us, while "everything except the C0/C1 control range, keeping tab / newline / CR" is complete by construction. It covers percent-encoded and 8-bit C1 forms without enumerating them.

## Ordering: sanitize the input, never the output

The renderer **adds** ANSI — colours, bold, diff framing. Filtering its output would strip the repository's own presentation along with the attacker's. A test renders a coloured diff and requires ANSI to survive, so the ordering goes red if anyone moves the call.

An unterminated sequence swallows what follows it, matching what a real terminal does. Keeping the tail would print the payload's own text as content — the deceptive half of OSC 8.

## What is claimed, and what is not

The stateful streaming sanitizer is **provided**, and the TUI does not currently need it: `tui-state-manager` accumulates deltas and renders the buffer, so a split sequence is rejoined before rendering. That is stated in the module, because "a stateful sanitizer exists" and "the streaming path is stateful" are different claims and only the first is true here.

## Verification

- 43 new tests: 15 real attack payloads, 3 markdown bypass routes (code fence, link target, HTML block), and **every** streaming split point of a multi-byte sequence.
- Mutants killed, each confirmed applied before its result was read (the `perl`-anchor lesson): encoder made identity → 39 red; streaming holding nothing back → 15 red; `renderMarkdown` ceasing to sanitize → 3 red; restored → 43 green.
- `agent-transport-tui` 619 tests pass; lint clean; workspace typecheck clean; `pnpm harness:scan` 141 passed / 2 skipped / 0 failed.
- `useTerminalTitle` extraction took `App.tsx` below its frozen size, so the file-size baseline was regenerated in the same change. It absorbed exactly one entry — `App.tsx` 605 → 602 — and nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY
