### PR TITLE
docs(tasks): close three delivered security records, and record what SEC-019 actually proved

### DIFF
--- a/.agents/spec-docs/done/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
+++ b/.agents/spec-docs/done/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: SECURITY
 tags: [security]
 ---

--- a/.agents/spec-docs/done/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/spec-docs/done/SEC-018-plugin-identifiers-escape-their-root.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: SECURITY
 tags: [security]
 ---

--- a/.agents/spec-docs/done/SEC-019-untrusted-text-can-act-on-the-terminal.md
+++ b/.agents/spec-docs/done/SEC-019-untrusted-text-can-act-on-the-terminal.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: SECURITY
 tags: [security]
 ---

--- a/.agents/tasks/completed/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
+++ b/.agents/tasks/completed/SEC-017-plugin-marketplace-inputs-reach-a-shell.md
@@ -1,7 +1,8 @@
 ---
 title: 'SEC-017: plugin marketplace inputs are interpolated into shell command strings'
 issue: https://github.com/woojubb/robota/issues/2019
-status: in-progress
+status: done
+completed: 2026-08-23
 created: 2026-08-23
 priority: critical
 urgency: now
@@ -102,3 +103,9 @@ whose negative case executes an attacker's command on the user's machine is not 
 The property is asserted instead at the port, where the hostile value can be observed without any
 process being spawned: the tests above capture what would have been passed and assert it is one inert
 argument. `.agents/tasks/README.md` requires the not-applicable to carry its reason; this is the reason.
+
+## Delivery
+
+Delivered by PR #2207, merged into `develop`. The record stayed `in-progress` after that
+merge, which is issue #2186 — a task record can stay open after its deliverable lands and nothing
+says so. Closed here rather than left as evidence of the gap.

--- a/.agents/tasks/completed/SEC-018-plugin-identifiers-escape-their-root.md
+++ b/.agents/tasks/completed/SEC-018-plugin-identifiers-escape-their-root.md
@@ -1,7 +1,8 @@
 ---
 title: 'SEC-018: plugin identifiers and registry paths escape the plugin root'
 issue: https://github.com/woojubb/robota/issues/2020
-status: in-progress
+status: done
+completed: 2026-08-23
 created: 2026-08-23
 priority: critical
 urgency: now
@@ -216,3 +217,9 @@ Twice the record claimed a fix that had not landed — once for the four value/s
 two narrowings. Both times the edit was written, believed, and not verified against the file
 afterwards. **An edit is not applied because it was authored**, and the cheapest proof is to read back
 the property rather than the diff you intended.
+
+## Delivery
+
+Delivered by PR #2210, merged into `develop`. The record stayed `in-progress` after that
+merge, which is issue #2186 — a task record can stay open after its deliverable lands and nothing
+says so. Closed here rather than left as evidence of the gap.

--- a/.agents/tasks/completed/SEC-019-untrusted-text-can-act-on-the-terminal.md
+++ b/.agents/tasks/completed/SEC-019-untrusted-text-can-act-on-the-terminal.md
@@ -1,7 +1,8 @@
 ---
 title: 'SEC-019: model and tool output can inject terminal control sequences'
 issue: https://github.com/woojubb/robota/issues/2022
-status: in-progress
+status: done
+completed: 2026-08-23
 created: 2026-08-23
 priority: critical
 urgency: now
@@ -90,11 +91,81 @@ Extracting `useTerminalTitle` shrank `App.tsx` below its frozen size, which requ
 `--write-baseline` in the same change. The regeneration absorbed **exactly one entry**:
 `packages/agent-transport-tui/src/App.tsx` 605 → 602. No other line changed.
 
+## What a terminal actually receives, measured
+
+The first version of this record asserted that Ink passes control sequences through. That is false,
+and it was measured rather than reasoned about — rendered through real Ink into a stream that claims
+to be a tty:
+
+|                          |                                                                                     |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| **stripped by Ink**      | OSC 52 clipboard, OSC 0 title, CSI erase / cursor / alt-screen, DCS, APC, 8-bit CSI |
+| **reaches the terminal** | SGR colour, OSC 8 hyperlink, a bare carriage return                                 |
+
+So the live attack through `<Text>` is narrower than first stated and entirely real: a link whose
+visible text and target differ, and a `\r` that overwrites the line the transcript just printed.
+`useTerminalTitle` writes to stdout directly and is subject to none of Ink's filtering.
+
+The sanitizer covers the whole class anyway, and the measurement is the argument FOR that: Ink's
+removal is incidental — it falls out of slicing text for layout, it is in no contract of Ink's, and a
+dependency upgrade returns the class without a line changing here.
+
+A bare CR was therefore a defect in the sanitizer itself, not in the code it guards. `\r\n` is
+normalized to a newline first, so a document written on Windows keeps its line structure and loses
+only the overwrite primitive.
+
 ## User Execution Test Scenarios
 
-**Not applicable, and the reason is the finding.** Executing one means rendering a document containing
-OSC 52 in a real terminal. On the fixed build nothing happens — but demonstrating it WAS exploitable
-means running the vulnerable code, and a scenario whose negative case overwrites the user's clipboard
-or rewrites their screen is not one to hand a user. The property is asserted at the encoder, where the
-payload is observable as data with nothing written to a terminal — which is also how the issue's own
-reproduction was done.
+**Scenario 1 — a hostile session name cannot act on the terminal through the window title.**
+
+This is the sink no audit of the renderer would have found: the session name is interpolated INTO an
+OSC sequence rather than rendered as content, and `useTerminalTitle` writes it to stdout without
+passing through Ink at all. It is also the one scenario that is safe to hand a user, because the
+payload's negative case sets a window title rather than writing their clipboard.
+
+Prerequisites: a POSIX shell with `script`, a configured provider profile in `~/.robota/settings.json`
+(any profile — no request is made), and a seeded session record. No network and no API key are used.
+
+```
+mkdir -p ~/.robota/sessions
+node -e 'const fs=require("fs"),E="\x1b",B="\x07",n=new Date().toISOString();
+fs.writeFileSync(process.env.HOME+"/.robota/sessions/sec019demo.json",JSON.stringify({
+  id:"sec019demo",name:"demo"+B+E+"]52;c;UFdOQ0xJUA=="+B+"tail",cwd:process.cwd(),
+  createdAt:n,updatedAt:n,messages:[]},null,2))'
+script -q -c "robota --resume sec019demo" /tmp/sec019.raw < /dev/null
+grep -c $'\x1b]52' /tmp/sec019.raw
+```
+
+The name carries a BEL — which would terminate the title's own OSC early — followed by an OSC 52
+clipboard write.
+
+Expected observable result: the capture contains the title writes and no clipboard sequence. On the
+vulnerable build the name is interpolated verbatim, so the BEL closes the title and the OSC 52 that
+follows is delivered to the terminal as a command.
+
+**Evidence — executed 2026-08-23 against the merged build, captured in a real pty:**
+
+```
+name written:  "demo\u0007\u001b]52;c;UFdOQ0xJUA==\u0007tail"
+
+window-title writes observed in the byte stream:
+  "\u001b]0;Robota\u0007"
+  "\u001b]0;Robota — demotail\u0007"
+
+clipboard payload UFdOQ0xJUA== present : false
+OSC 52 introducer present              : false
+```
+
+The title is one well-formed sequence, the BEL and the clipboard write are gone, and the name's safe
+characters survive as `demotail`. Observed matches expected.
+
+**Scenario 2 — a poisoned transcript, NOT executed, and why.**
+
+Seeding an assistant message containing an OSC 8 link and a bare CR and resuming the session was
+attempted. `--resume` restores the conversation into context but the run captured did not re-render
+the transcript, so the assistant text never reached the frame — which means a "no payload found"
+result would have been evidence of nothing at all. Recorded as attempted-and-inconclusive rather than
+counted, because a scenario that does not exercise the path is green for the same reason a correct
+one is. The rendering path is covered instead by `sec-019-tool-label-render.test.ts(x)`, which drives
+the real components through real Ink into a captured tty stream and requires an unsanitized render to
+leak.


### PR DESCRIPTION
Closes out three delivered security items whose records were still open, and corrects two things in SEC-019's record that were wrong.

## Why this is one change

SEC-017 (#2207), SEC-018 (#2210) and SEC-019 (#2212) are all merged into `develop`, and all three records still read `in-progress` with their spec-docs in `todo/`. That is **#2186** — a task record can stay open after its deliverable lands and nothing says so. Three items sitting in it is enough to stop leaving them as evidence of the gap.

## SEC-019 gets more than a status flip

**Its premise was wrong.** The record asserted that Ink passes control sequences through. Measured against a real terminal stream instead:

| | |
| --- | --- |
| **stripped by Ink** | OSC 52 clipboard, OSC 0 title, CSI erase / cursor / alt-screen, DCS, APC, 8-bit CSI |
| **reaches the terminal** | SGR colour, OSC 8 hyperlink, a bare carriage return |

So the live attack through rendered text is narrower than the record claimed and entirely real — a link whose visible text and target differ, and a CR that overwrites the line just printed — while `useTerminalTitle` writes to stdout directly and is subject to none of Ink's filtering. The sanitizer covers the whole class because Ink's removal is **incidental**: it falls out of slicing text for layout, it is in no contract of Ink's, and one upgrade returns it.

**Its user-execution scenario said none was possible.** The reasoning was that demonstrating exploitability means running the vulnerable code against the user's own clipboard or screen. True of the payloads it had in mind, false in general — **the window title is a sink whose negative case sets a window title.**

So there is now an executed scenario: seed a session record whose NAME carries a BEL followed by an OSC 52, resume it through the real binary in a pty, read the captured bytes.

```
name written:  "demo\u0007\u001b]52;c;UFdOQ0xJUA==\u0007tail"

window-title writes observed in the byte stream:
  "\u001b]0;Robota\u0007"
  "\u001b]0;Robota - demotail\u0007"

clipboard payload UFdOQ0xJUA== present : false
OSC 52 introducer present              : false
```

One well-formed title sequence, the BEL and the clipboard write gone, the name's safe characters surviving as `demotail`. Observed matches expected.

**A second scenario is recorded as inconclusive rather than counted.** Seeding a poisoned assistant message and resuming was attempted; `--resume` restored the conversation into context without re-rendering the transcript in the run captured, so the assistant text never reached the frame. A "no payload found" result there would have been evidence of nothing — *a scenario that does not exercise the path is green for the same reason a correct one is.* That path is covered by the render tests instead, which drive the real components through real Ink into a captured tty stream and require an unsanitized render to leak.

## Verification

- `pnpm harness:scan` 141 passed / 2 skipped / 0 failed. (The `dist` scan failed first on `agent-interface-session-mobility`, a package ARCH-107 added and this clone had not built; `pnpm build` cleared it.)
- No source change, so no regression proof applies. The scenario evidence above is the verification.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY
