### PR TITLE
fix(security): a session record is not readable by another account on the host (SEC-020)

### DIFF
--- a/.agents/tasks/SEC-020-session-records-are-world-readable-by-default-and-are-not-excluded-from-git.md
+++ b/.agents/tasks/SEC-020-session-records-are-world-readable-by-default-and-are-not-excluded-from-git.md
@@ -1,0 +1,167 @@
+---
+title: 'SEC-020: session records are world-readable by default and are not excluded from Git'
+issue: https://github.com/woojubb/robota/issues/2021
+status: in-progress
+created: 2026-08-23
+priority: critical
+urgency: now
+area: packages/agent-core, packages/agent-session, packages/agent-framework, packages/agent-cli
+depends_on: []
+---
+
+# SEC-020: session records are world-readable by default and are not excluded from Git
+
+## Problem
+
+`~/.robota` and a project's `.robota` hold the record of everything a session did: prompts, model
+output, tool results, file contents that passed through a tool, and — in `settings.json` — provider
+credentials. On a shared workstation or a CI host, another local account reads them unless the mode
+says otherwise, and today for the session records it does not.
+
+**Measured under umask 022, before any change** (probe against the real classes, not a reading of
+the source):
+
+| writer                                                                                                  | directory           | file     |
+| ------------------------------------------------------------------------------------------------------- | ------------------- | -------- |
+| `NodeSessionStore`                                                                                      | **0755**            | **0644** |
+| `NodeSessionLogSink`, directory pre-created at 0777                                                     | **0777** (retained) | 0600     |
+| `~/.robota` itself (`settings-io`, `node-host-settings-store`, `host-identity`, `trusted-device-store`) | **0755**            | 0600     |
+
+Three distinct causes, one shape:
+
+1. **No mode is requested at all.** `NodeSessionStore.ensureDir` calls `mkdirSync(baseDir, {
+recursive: true })` and `save` calls `writeFileSync(tempPath, …)` with no mode, so the umask
+   decides. The temp file is renamed into place, so the final record inherits 0644.
+2. **`mkdirSync(path, { mode })` does not set the mode of a directory that already exists.**
+   `recursive: true` returns successfully and adopts whatever is there. This is not a hypothesis —
+   `guarded-directory.ts` already documents it for the pairing rendezvous, and the measurement above
+   reproduces it for the session log directory. A 0777 directory means another account can unlink and
+   replace a 0600 record, and can enumerate session IDs, without ever reading a byte of one.
+3. **`writeFileSync(path, data, { mode })` applies the mode only at CREATION.** An existing 0644
+   record keeps 0644 forever, so a store written by an older version is never repaired by a newer
+   one. Every 0600 in the table above is a mode that was right on the day the file was first written.
+
+`robota init` adds no ignore rule, so a project-local `.robota/sessions` is committable by accident.
+
+**The direction is backwards where it matters most.** The project-local path already writes 0600/0700
+through `project-relative-writer.ts`. `NodeSessionStore` is the FALLBACK taken when project access is
+`restricted` — that is, when trust could NOT be established — and it is the one with no modes at all.
+The less trusted the workspace, the weaker the persistence.
+
+## Direction
+
+One owner-only host-filesystem primitive, in `agent-core` beside `utils/path-containment.ts` (which
+already imports `node:fs`, so this is placement by ownership rather than a new precedent). Create,
+`chmod` unconditionally, then `stat` and refuse — the third step is what makes the first two checkable,
+and it is the only one that catches a directory someone else pre-created.
+
+Applied at every host writer under `.robota`, plus a repair path for a file an older version left
+wide. `robota init` writes `.robota/.gitignore` with targeted entries rather than touching the user's
+root `.gitignore`; verified that git honours the nested file and that `settings.json` and `agents/`
+stay tracked while `sessions/`, `logs/`, `checkpoints/` and `settings.local.json` do not.
+
+Windows cannot express owner-only through `chmod`. The primitive reports which guarantee is in force
+rather than asserting the POSIX one everywhere, and the limitation for a project-local `.robota`
+inside a world-writable directory is recorded rather than papered over.
+
+## Not in scope
+
+`agent-provider-openai`'s payload logger, `dag-adapters-local` and `local-peer-registry` share cause 2
+and 3 and are not session records. They are cited, not changed.
+
+## Test Plan
+
+30 cases, and every one sets a PERMISSIVE umask (0o022) explicitly. A case that inherits a
+restrictive umask passes whether or not the mode was requested — the assertion holds either way,
+which is the accidental-green shape.
+
+`packages/agent-core/src/utils/owner-only-store.test.ts` — TC-01 to TC-16, TC-29, TC-30
+: the primitive against a real filesystem: fresh create, a directory pre-created at 0777, idempotence,
+missing parents, a non-directory target, a file pre-existing at 0644, no temp file left behind, a
+stale temp path at 0666, tighten on a missing path, and the platform guarantee named through an
+injected platform so it runs on Linux CI.
+
+`packages/agent-session/src/__tests__/sec-020-owner-only-session-records.test.ts` — TC-15 to TC-23
+: the real writers, asserting the MODE ON DISK. That is how the defect was measured in the first
+place, and it is the only assertion that could have caught it: `NodeSessionLogSink` REQUESTED 0700
+and got 0777, so "a mode was requested" was true of the broken code.
+
+`packages/agent-cli/src/init/__tests__/sec-020-runtime-data-ignore.test.ts` — TC-24 to TC-28
+: the ignore rules, ending with a case that asks GIT rather than reading the file back. The claim is
+about what git does, and asserting the file's text proves only that the writer wrote what it was
+told.
+
+## Mutation
+
+Each mutant was applied, `agent-core` REBUILT — the session tests resolve the primitive through the
+package build, so a source mutation is invisible to them without it — and the applied-check scoped to
+the code line.
+
+| mutant                                              | agent-core red | agent-session red |
+| --------------------------------------------------- | -------------- | ----------------- |
+| M1 remove the unconditional directory `chmod`       | 1              | 2                 |
+| M2 neuter the mode verification                     | 2              | 0                 |
+| M3 remove the mode from the temp-file creation      | 4              | 4                 |
+| M4 always report the Windows guarantee              | 6              | 4                 |
+| M5 remove `tightenExistingFile` from the log append | 0              | 1                 |
+
+**Two of these survived their first run, and both were defects in this work rather than in the
+tests.**
+
+M2 survived because nothing could reach the condition the verification exists for. Every case that
+reached it was already caught by `mkdir` or `chmod` throwing, so deleting the check entirely changed
+no result — a guard present and unproven, which is the shape issue #2181 and issue #2215 are about. Fixed by
+adding the IO seams `guarded-directory.ts` already documents the need for, and TC-29/TC-30 now
+exercise a filesystem that accepts `chmod` and ignores it.
+
+M3 survived because the write set the mode at creation AND chmodded afterwards, so removing the
+first changed nothing. The redundancy was also the bug: tightening after the write leaves a window in
+which the whole record is on disk readable. The `chmod` is gone, the write uses `wx` so `mode`
+is guaranteed to apply, and the verification proves it took.
+
+## Not in scope, cited rather than changed
+
+`agent-provider-openai`'s payload logger, `dag-adapters-local` and `local-peer-registry` share causes
+2 and 3 above and are not session records.
+
+## User Execution Test Scenarios
+
+**Scenario 1 — a session record is not readable by another account.**
+
+```
+umask 022
+cd "$(mktemp -d)" && git init -q .
+robota init --yes
+robota -p 'say hello'
+ls -ld .robota/sessions && ls -l .robota/sessions/*.json
+```
+
+Expected: `drwx------` on the directory and `-rw-------` on each record. Before this change the same
+two commands print `drwxr-xr-x` and `-rw-r--r--`.
+
+**Scenario 2 — a pre-created wide directory is repaired rather than adopted.**
+
+```
+umask 022
+cd "$(mktemp -d)" && git init -q .
+mkdir -p .robota/logs && chmod 0777 .robota/logs
+robota init --yes
+robota -p 'say hello'
+ls -ld .robota/logs
+```
+
+Expected: `drwx------`. Before this change it stays `drwxrwxrwx`.
+
+**Scenario 3 — session data is not committable by accident.**
+
+```
+cd "$(mktemp -d)" && git init -q .
+robota init --yes
+robota -p 'say hello'
+git status --porcelain
+```
+
+Expected: `.robota/settings.json`, `.robota/.gitignore` and `AGENTS.md` appear as untracked;
+`.robota/sessions/` and `.robota/logs/` do not.
+
+**Evidence:** to be captured after implementation, against the merged build.

--- a/apps/agent-server/src/session/persistent-session-store.ts
+++ b/apps/agent-server/src/session/persistent-session-store.ts
@@ -8,7 +8,10 @@ let store: IInteractiveSessionStore | undefined;
 
 export function getPlaygroundSessionStore(): IInteractiveSessionStore {
   if (!store) {
-    store = createNodeHostSessionStore(join(process.cwd(), '.robota', 'sessions'));
+    // SEC-020: the project store ROOT is passed as owned, so a `.robota` an older version left at
+    // 0755 is tightened along with the sessions directory inside it.
+    const root = join(process.cwd(), '.robota');
+    store = createNodeHostSessionStore(join(root, 'sessions'), root);
   }
   return store;
 }

--- a/packages/agent-cli/src/init/__tests__/sec-020-runtime-data-ignore.test.ts
+++ b/packages/agent-cli/src/init/__tests__/sec-020-runtime-data-ignore.test.ts
@@ -1,0 +1,133 @@
+/**
+ * SEC-020 (issue #2021) — `robota init` keeps runtime session data out of Git.
+ *
+ * The claim is about what GIT does, so the last case asks git rather than reading the file back. A
+ * test that asserts the file's TEXT proves the writer wrote what it was told to write, which is the
+ * uninteresting half — the interesting half is that `.robota/settings.json` and `.robota/agents/`
+ * stay tracked while the transcripts do not.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createWorkspaceProjectMutation } from '@robota-sdk/agent-framework';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTrustedWorkspaceProjectAccess } from '../../__tests__/helpers/trusted-workspace-project-access.js';
+import { runInitCommand } from '../init-command.js';
+
+import type { ITerminalOutput } from '@robota-sdk/agent-core';
+import type {
+  ITrustedWorkspaceProjectAccess,
+  IWorkspaceProjectMutation,
+} from '@robota-sdk/agent-framework';
+
+const IGNORE_PATH = join('.robota', '.gitignore');
+
+function createTerminal(): { terminal: ITerminalOutput; output(): string } {
+  const lines: string[] = [];
+  const push = (text = ''): void => {
+    lines.push(text);
+  };
+  return {
+    terminal: { writeLine: push, writeError: push, write: push } as unknown as ITerminalOutput,
+    output: () => lines.join('\n'),
+  };
+}
+
+describe('SEC-020 — robota init writes targeted runtime-data ignore rules', () => {
+  let cwd: string;
+  let projectAccess: ITrustedWorkspaceProjectAccess;
+  let projectMutation: IWorkspaceProjectMutation;
+
+  beforeEach(async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'sec-020-init-'));
+    projectAccess = await createTrustedWorkspaceProjectAccess(cwd);
+    projectMutation = createWorkspaceProjectMutation(projectAccess.authority, {
+      status: 'approved',
+      purpose: 'initialize test project',
+    });
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  async function init(): Promise<string> {
+    const { terminal, output } = createTerminal();
+    await runInitCommand(terminal, {
+      projectAccess,
+      projectMutation,
+      yes: true,
+      promptFn: vi.fn(async () => 'n') as never,
+      isTTY: false,
+      ci: false,
+    });
+    return output();
+  }
+
+  it('TC-24: creates .robota/.gitignore with the four runtime-data entries', async () => {
+    const output = await init();
+    const text = readFileSync(join(cwd, IGNORE_PATH), 'utf8');
+    for (const entry of ['sessions/', 'logs/', 'checkpoints/', 'settings.local.json']) {
+      expect(text).toContain(entry);
+    }
+    expect(output).toContain('Created: .robota/.gitignore');
+  });
+
+  it('TC-25: does NOT ignore project memory, which is a decision rather than an omission', async () => {
+    // `.agents/memory/` is checked in by design in this repository and project memory is the same
+    // kind of artefact. Ignoring it by default would make that choice for every user of the CLI.
+    await init();
+    expect(readFileSync(join(cwd, IGNORE_PATH), 'utf8')).not.toContain('memory/');
+  });
+
+  it('TC-26: running init twice changes nothing and says so', async () => {
+    await init();
+    const first = readFileSync(join(cwd, IGNORE_PATH), 'utf8');
+    const output = await init();
+    expect(readFileSync(join(cwd, IGNORE_PATH), 'utf8')).toBe(first);
+    expect(output).toContain('already covers runtime session data');
+  });
+
+  it('TC-27: a line the user added by hand survives, and a missing entry is added', async () => {
+    await init();
+    const path = join(cwd, IGNORE_PATH);
+    writeFileSync(path, '# mine\nscratch/\nsessions/\n', 'utf8');
+    const output = await init();
+    const text = readFileSync(path, 'utf8');
+    expect(text).toContain('scratch/');
+    expect(text).toContain('# mine');
+    expect(text).toContain('logs/');
+    expect(output).toContain('Updated: .robota/.gitignore');
+  });
+
+  it('TC-28: git itself ignores the transcripts and tracks the reviewable settings', async () => {
+    const git = (...args: string[]): string =>
+      execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+    git('init', '-q', '.');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'test');
+    await init();
+
+    mkdirSync(join(cwd, '.robota', 'sessions'), { recursive: true });
+    mkdirSync(join(cwd, '.robota', 'logs'), { recursive: true });
+    mkdirSync(join(cwd, '.robota', 'agents'), { recursive: true });
+    writeFileSync(join(cwd, '.robota', 'sessions', 'a.json'), '{}');
+    writeFileSync(join(cwd, '.robota', 'logs', 'a.jsonl'), '{}');
+    writeFileSync(join(cwd, '.robota', 'agents', 'a.md'), '# agent');
+    writeFileSync(join(cwd, '.robota', 'settings.local.json'), '{}');
+
+    git('add', '-A');
+    const staged = git('diff', '--cached', '--name-only').split('\n');
+
+    expect(staged).toContain('.robota/settings.json');
+    expect(staged).toContain('.robota/agents/a.md');
+    expect(staged).toContain('.robota/.gitignore');
+    expect(staged).not.toContain('.robota/sessions/a.json');
+    expect(staged).not.toContain('.robota/logs/a.jsonl');
+    expect(staged).not.toContain('.robota/settings.local.json');
+  });
+});

--- a/packages/agent-cli/src/init/init-command.ts
+++ b/packages/agent-cli/src/init/init-command.ts
@@ -5,6 +5,7 @@ import {
   WorkspaceAuthorityRequiredError,
 } from '@robota-sdk/agent-framework';
 
+import { writeRuntimeDataIgnore } from './runtime-data-ignore.js';
 import { AGENT_CLI_BIN } from '../constants.js';
 
 import type { ITerminalOutput } from '@robota-sdk/agent-core';
@@ -151,6 +152,19 @@ export async function runInitCommand(
     promptFn: options.promptFn ?? promptInput,
     terminal,
   };
+
+  // SEC-020: BEFORE the overwrite prompt, deliberately. These rules are additive and protective —
+  // the merge below never removes a line — and the path that reaches the prompt is precisely the one
+  // where `.robota/` is already populated, so transcripts may already be sitting in the tree waiting
+  // to be committed. Declining to overwrite AGENTS.md is not a reason to leave them exposed, and a
+  // second call site for the cancel path would be one more thing to remember.
+  const ignoreOutcome = writeRuntimeDataIgnore(reader, mutation);
+  terminal.writeLine('');
+  terminal.writeLine(
+    ignoreOutcome === 'unchanged'
+      ? 'Unchanged: .robota/.gitignore (already covers runtime session data)'
+      : `${ignoreOutcome === 'created' ? 'Created' : 'Updated'}: .robota/.gitignore`,
+  );
 
   const hasClaudeDir =
     reader.inspectKind('.claude', 'inspect Claude project settings') === 'directory';

--- a/packages/agent-cli/src/init/runtime-data-ignore.ts
+++ b/packages/agent-cli/src/init/runtime-data-ignore.ts
@@ -1,0 +1,75 @@
+/**
+ * `robota init` keeps runtime session data out of Git (SEC-020, issue #2021).
+ *
+ * Its own module rather than a helper inside the command, for two reasons that agree. It is a
+ * separate responsibility — the command decides what a NEW project looks like, this decides what
+ * must never be COMMITTED, and the second outlives the first because it runs again on every later
+ * init. And folding it into the command took that file past its size ceiling, which is the
+ * anti-monolith rule saying the same thing mechanically.
+ */
+
+import type {
+  IWorkspaceProjectMutation,
+  IWorkspaceProjectReader,
+} from '@robota-sdk/agent-framework';
+
+const IGNORE_PATH = '.robota/.gitignore';
+
+const HEADER =
+  '# Robota runtime session data — transcripts, tool output and machine-local settings.';
+
+/**
+ * The runtime data that must not be committed.
+ *
+ * Session records and logs carry prompts, model output, tool results and whatever a tool read out of
+ * the working tree; `settings.local.json` is the machine-local override. None of it is reviewable
+ * project configuration, and all of it is trivially committed by accident.
+ *
+ * `memory/` is deliberately NOT here, and the omission is a decision rather than an oversight.
+ * Project memory is the same kind of artefact this repository checks in on purpose, and ignoring it
+ * by default would make that choice for every user of the CLI. A user who wants it ignored adds one
+ * line, which the merge below preserves.
+ */
+const RUNTIME_DATA_IGNORE_ENTRIES = [
+  'sessions/',
+  'logs/',
+  'checkpoints/',
+  'settings.local.json',
+] as const;
+
+/** What the write did, so the caller can say it without re-deriving it. */
+export type TRuntimeDataIgnoreOutcome = 'created' | 'updated' | 'unchanged';
+
+/**
+ * Write `.robota/.gitignore` rather than touching the project's root `.gitignore`.
+ *
+ * Nested, so the patterns are relative to the directory they govern and live beside the data; git
+ * reads it exactly the same way. Targeted, so `.robota/settings.json` and `.robota/agents/` stay
+ * tracked — a blanket `.robota/` would hide reviewable project configuration along with the
+ * transcripts. And a merge rather than an overwrite, so running `init` twice is a no-op and a line
+ * the user added by hand survives.
+ */
+export function writeRuntimeDataIgnore(
+  reader: IWorkspaceProjectReader,
+  mutation: IWorkspaceProjectMutation,
+): TRuntimeDataIgnoreOutcome {
+  const existing = reader.readText(IGNORE_PATH, 'inspect runtime data ignore rules');
+  const lines = existing === undefined ? [] : existing.split('\n');
+  const present = new Set(lines.map((line) => line.trim()));
+  const missing = RUNTIME_DATA_IGNORE_ENTRIES.filter((entry) => !present.has(entry));
+  if (existing !== undefined && missing.length === 0) return 'unchanged';
+
+  const body =
+    existing === undefined
+      ? [HEADER, ...RUNTIME_DATA_IGNORE_ENTRIES].join('\n')
+      : [
+          ...lines.filter((line, index) => index < lines.length - 1 || line !== ''),
+          ...missing,
+        ].join('\n');
+  mutation.writeBytes(
+    IGNORE_PATH,
+    new TextEncoder().encode(`${body}\n`),
+    'initialize runtime data ignore rules',
+  );
+  return existing === undefined ? 'created' : 'updated';
+}

--- a/packages/agent-cli/src/remote-control/host-identity.ts
+++ b/packages/agent-cli/src/remote-control/host-identity.ts
@@ -8,8 +8,10 @@
  * `~/.robota` means control of the host process, which IS the agent. The device pins this host's PUBLIC key
  * at first pair and verifies it on every reconnect (rogue-host defense).
  */
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
+
+import { ensureOwnerOnlyDirectory } from '@robota-sdk/agent-core/node';
 import { dirname, join } from 'node:path';
 
 import {
@@ -89,7 +91,10 @@ export async function loadOrCreateHostIdentity(
 
   const keyPair = await generateIdentityKeyPair(true);
   const file: IHostIdentityFile = { version: 1, keyPair: await exportKeyPairJwk(keyPair) };
-  mkdirSync(dirname(filePath), { recursive: true });
+  // SEC-020: `~/.robota` was created with no mode, so it came out 0755 and every local account
+  // could enumerate the host identity, trusted devices and session records it holds. The file
+  // itself is written `wx` with 0600 and is never rewritten, so it needs no tightening.
+  ensureOwnerOnlyDirectory(dirname(filePath));
   try {
     writeFileSync(filePath, JSON.stringify(file, null, 2), { mode: 0o600, flag: 'wx' });
   } catch (cause) {

--- a/packages/agent-cli/src/remote-control/trusted-device-store.ts
+++ b/packages/agent-cli/src/remote-control/trusted-device-store.ts
@@ -8,8 +8,10 @@
  * trust store must surface, never be silently read as an empty allow-list that would force every device to
  * re-pair or, worse, mask tampering.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
+
+import { ensureOwnerOnlyDirectory, tightenExistingFile } from '@robota-sdk/agent-core/node';
 import { dirname, join } from 'node:path';
 
 /** One enrolled device. `publicKey` is a base64url SPKI; timestamps are ISO-8601 strings supplied by the caller. */
@@ -61,7 +63,11 @@ function readFile(filePath: string): ITrustedDeviceFile {
 }
 
 function writeFile(filePath: string, file: ITrustedDeviceFile): void {
-  mkdirSync(dirname(filePath), { recursive: true });
+  // SEC-020: the directory was created with no mode, and this file IS rewritten — `mode` applies
+  // only at creation, so a trusted-device list an older version left at 0644 stayed readable by
+  // every local account through every later pairing.
+  ensureOwnerOnlyDirectory(dirname(filePath));
+  tightenExistingFile(filePath);
   writeFileSync(filePath, JSON.stringify(file, null, 2), { mode: 0o600 });
 }
 

--- a/packages/agent-core/docs/SPEC.md
+++ b/packages/agent-core/docs/SPEC.md
@@ -264,6 +264,49 @@ graph. The import path is where the Node dependency becomes legible.
 | `canonicalizePath`            | function | `@robota-sdk/agent-core/node` | Realpath-resolve a path, tolerating a not-yet-created tail so `Write`/`Edit` targets still resolve                               |
 | `resolveTrustedExecutionRoot` | function | `@robota-sdk/agent-core/node` | Validate that an execution authority is a non-empty absolute, existing, traversable directory and return its canonical real path |
 
+### Owner-Only Store Public API (SEC-020)
+
+The SSOT for "create this directory or file so only its owner can read it", for every host store
+under `~/.robota` and a project's `.robota` — session records and logs, settings, device
+credentials. Measured under umask 022 before this existed: a fresh sessions directory came out 0755
+and its records 0644, and `~/.robota` itself was 0755.
+
+Three facts about the Node API make the naive form wrong, and the module exists because each of them
+had already produced a defect here:
+
+- **`mkdirSync(path, { recursive: true, mode })` does not set the mode of a directory that already
+  exists.** It returns successfully and adopts whatever is there — measured on a log directory
+  pre-created at 0777, which stayed 0777 while its records were 0600. Another account could not read
+  a record, and could unlink and replace one, and could enumerate every session id.
+- **`writeFileSync(path, data, { mode })` applies the mode only when the file is CREATED.** A record
+  an older version left at 0644 keeps 0644 through every later save.
+- **Creating wide and tightening afterwards leaves a window** in which the full record is on disk
+  readable. The atomic write therefore carries the mode from creation with `wx` and never chmods
+  after, so a mutation that removes the mode is caught rather than masked.
+
+Create, set the mode, then VERIFY — and the verification is the load-bearing third step, not a
+belt-and-braces one. The IO seams exist so the condition it alone catches, a filesystem that accepts
+`chmod` and ignores it, is reachable from a test.
+
+Windows cannot express owner-only through `chmod`; inherited NTFS ACLs govern instead.
+`ownerOnlyGuarantee()` reports which guarantee is in force rather than making the POSIX claim
+everywhere, and a project-local `.robota` inside a world-writable directory on Windows is NOT
+protected by this module.
+
+Exported from **`@robota-sdk/agent-core/node`** (CORE-028) for the same reason as path containment:
+these read and write the filesystem.
+
+| Export                      | Kind      | Import from                   | Description                                                                           |
+| --------------------------- | --------- | ----------------------------- | ------------------------------------------------------------------------------------- |
+| `ensureOwnerOnlyDirectory`  | function  | `@robota-sdk/agent-core/node` | Create a directory, set it to 0700 whether or not it existed, and refuse if it is not |
+| `writeOwnerOnlyFile`        | function  | `@robota-sdk/agent-core/node` | Replace a file atomically through a temp file that is 0600 from creation              |
+| `tightenExistingFile`       | function  | `@robota-sdk/agent-core/node` | Narrow a file an older version left readable; a no-op on a path that does not exist   |
+| `ownerOnlyGuarantee`        | function  | `@robota-sdk/agent-core/node` | Which guarantee this platform can make — `posix-mode` or `windows-acl`                |
+| `OwnerOnlyModeError`        | class     | `@robota-sdk/agent-core/node` | Raised when a path cannot be made owner-only; never swallowed into a weaker mode      |
+| `OWNER_ONLY_FILE_MODE`      | constant  | `@robota-sdk/agent-core/node` | `0o600`                                                                               |
+| `OWNER_ONLY_DIRECTORY_MODE` | constant  | `@robota-sdk/agent-core/node` | `0o700`                                                                               |
+| `IOwnerOnlyIo`              | interface | `@robota-sdk/agent-core/node` | Injected create/chmod/stat seams, so the verification's own failure path is testable  |
+
 ### Permission Argument Registry Public API (CORE-030)
 
 Which argument a tool's permission patterns are scoped to. The gate resolved this from a hardcoded

--- a/packages/agent-core/src/node.ts
+++ b/packages/agent-core/src/node.ts
@@ -17,4 +17,14 @@ export {
   isPathInside,
   resolveTrustedExecutionRoot,
 } from './utils/path-containment.js';
+export type { IOwnerOnlyIo } from './utils/owner-only-store.js';
+export {
+  OWNER_ONLY_DIRECTORY_MODE,
+  OWNER_ONLY_FILE_MODE,
+  OwnerOnlyModeError,
+  ensureOwnerOnlyDirectory,
+  ownerOnlyGuarantee,
+  tightenExistingFile,
+  writeOwnerOnlyFile,
+} from './utils/owner-only-store.js';
 export { CommandExecutor, HttpExecutor } from './hooks/executors/index.js';

--- a/packages/agent-core/src/utils/owner-only-store.test.ts
+++ b/packages/agent-core/src/utils/owner-only-store.test.ts
@@ -1,0 +1,194 @@
+/**
+ * SEC-020 (issue #2021) — the owner-only host store, asserted against a real filesystem.
+ *
+ * Every case sets a PERMISSIVE umask explicitly. A test that inherits a restrictive umask passes
+ * whether or not the mode was requested, which is the accidental-green shape this repository keeps
+ * finding: the assertion holds either way, so it asserts nothing.
+ */
+
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  OWNER_ONLY_DIRECTORY_MODE,
+  OWNER_ONLY_FILE_MODE,
+  OwnerOnlyModeError,
+  ensureOwnerOnlyDirectory,
+  ownerOnlyGuarantee,
+  tightenExistingFile,
+  writeOwnerOnlyFile,
+} from './owner-only-store.js';
+
+const PERMISSIVE_UMASK = 0o022;
+
+let root: string;
+let previousUmask: number;
+
+beforeEach(() => {
+  previousUmask = process.umask(PERMISSIVE_UMASK);
+  root = mkdtempSync(join(tmpdir(), 'owner-only-'));
+});
+
+afterEach(() => {
+  process.umask(previousUmask);
+});
+
+const mode = (path: string): number => statSync(path).mode & 0o7777;
+
+describe('SEC-020 — ensureOwnerOnlyDirectory', () => {
+  it('TC-01: creates a directory only its owner can enter, under a permissive umask', () => {
+    const target = join(root, 'sessions');
+    ensureOwnerOnlyDirectory(target);
+    expect(mode(target)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+
+  it('TC-02: TIGHTENS a directory that already exists at a wider mode', () => {
+    // `mkdirSync(path, { recursive: true, mode })` returns successfully on an existing directory
+    // WITHOUT touching its mode. This is the case the old `if (!existsSync) mkdirSync` skipped
+    // entirely, and it is the one an attacker creates by pre-making the directory.
+    const target = join(root, 'pre-existing');
+    mkdirSync(target);
+    chmodSync(target, 0o777);
+    expect(mode(target)).toBe(0o777);
+    ensureOwnerOnlyDirectory(target);
+    expect(mode(target)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+
+  it('TC-03: is idempotent', () => {
+    const target = join(root, 'twice');
+    ensureOwnerOnlyDirectory(target);
+    ensureOwnerOnlyDirectory(target);
+    expect(mode(target)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+
+  it('TC-04: creates missing parents, and every one of them is owner-only', () => {
+    const target = join(root, 'a', 'b', 'c');
+    ensureOwnerOnlyDirectory(target);
+    expect(mode(target)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+    expect(mode(join(root, 'a'))).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+
+  it('TC-05: refuses rather than proceeding when the target is not a directory', () => {
+    const target = join(root, 'a-file');
+    writeFileSync(target, 'x');
+    expect(() => ensureOwnerOnlyDirectory(target)).toThrow();
+  });
+});
+
+describe('SEC-020 — writeOwnerOnlyFile', () => {
+  it('TC-06: writes a record only its owner can read', () => {
+    const target = join(root, 'store', 'record.json');
+    writeOwnerOnlyFile(target, '{"a":1}');
+    expect(mode(target)).toBe(OWNER_ONLY_FILE_MODE);
+    expect(mode(join(root, 'store'))).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+
+  it('TC-07: REPLACES a file that already exists at a wider mode', () => {
+    // `writeFileSync(path, data, { mode })` applies the mode only when the file is CREATED, so a
+    // record an older version left at 0644 keeps 0644 through every later save.
+    const target = join(root, 'record.json');
+    writeFileSync(target, 'old');
+    chmodSync(target, 0o644);
+    writeOwnerOnlyFile(target, 'new');
+    expect(mode(target)).toBe(OWNER_ONLY_FILE_MODE);
+  });
+
+  it('TC-08: leaves no temp file behind on success', () => {
+    const target = join(root, 'record.json');
+    writeOwnerOnlyFile(target, 'x');
+    expect(existsSync(`${target}.${process.pid}.tmp`)).toBe(false);
+  });
+
+  it('TC-09: a temp path left at a wider mode is not adopted', () => {
+    // The window this closes: the bytes are on disk under the temp name before the rename, so a
+    // temp file created world-readable exposes the whole record even though the final path is 0600.
+    const target = join(root, 'record.json');
+    const temp = `${target}.${process.pid}.tmp`;
+    writeFileSync(temp, 'stale');
+    chmodSync(temp, 0o666);
+    writeOwnerOnlyFile(target, 'fresh');
+    expect(mode(target)).toBe(OWNER_ONLY_FILE_MODE);
+  });
+});
+
+describe('SEC-020 — tightenExistingFile', () => {
+  it('TC-10: narrows a file an older version left readable', () => {
+    const target = join(root, 'old.jsonl');
+    writeFileSync(target, 'line\n');
+    chmodSync(target, 0o644);
+    tightenExistingFile(target);
+    expect(mode(target)).toBe(OWNER_ONLY_FILE_MODE);
+  });
+
+  it('TC-11: is a no-op on a path that does not exist, and does not throw', () => {
+    expect(() => tightenExistingFile(join(root, 'absent'))).not.toThrow();
+  });
+
+  it('TC-12: leaves an already-owner-only file alone', () => {
+    const target = join(root, 'fine');
+    writeFileSync(target, 'x', { mode: OWNER_ONLY_FILE_MODE });
+    chmodSync(target, OWNER_ONLY_FILE_MODE);
+    tightenExistingFile(target);
+    expect(mode(target)).toBe(OWNER_ONLY_FILE_MODE);
+  });
+});
+
+describe('SEC-020 — the guarantee is named, not assumed', () => {
+  it('TC-13: Windows cannot express owner-only through chmod, and says so', () => {
+    // Asserted through the injected platform so the case runs on Linux CI. The point is that the
+    // module reports which guarantee is in force rather than making the POSIX claim everywhere —
+    // on win32 inherited NTFS ACLs govern, and a project-local `.robota` inside a world-writable
+    // directory is NOT protected by this module.
+    expect(ownerOnlyGuarantee('win32')).toBe('windows-acl');
+    expect(ownerOnlyGuarantee('linux')).toBe('posix-mode');
+    expect(ownerOnlyGuarantee('darwin')).toBe('posix-mode');
+  });
+
+  it('TC-14: OwnerOnlyModeError is the failure, not a weaker mode', () => {
+    expect(new OwnerOnlyModeError('x')).toBeInstanceOf(Error);
+    expect(new OwnerOnlyModeError('x').name).toBe('OwnerOnlyModeError');
+  });
+});
+
+describe('SEC-020 — verification, not hope', () => {
+  it('TC-29: a filesystem that silently ignores chmod is REFUSED, not used', () => {
+    // The condition the verification step exists for, and the only one create-then-chmod cannot
+    // reach on its own: `mkdir` succeeds, `chmod` returns without error, and the mode is still wide.
+    // Some network and FAT mounts behave exactly this way.
+    //
+    // Before this case existed, deleting the verification entirely changed no test result — the
+    // guard was present and unproven, which is the shape this repository keeps finding.
+    const target = join(root, 'ignores-chmod');
+    expect(() =>
+      ensureOwnerOnlyDirectory(target, {
+        makeDirectory: () => {
+          mkdirSync(target, { recursive: true });
+        },
+        setMode: () => {
+          /* the filesystem accepts the call and does nothing */
+        },
+        readMode: () => 0o777,
+      }),
+    ).toThrow(OwnerOnlyModeError);
+  });
+
+  it('TC-30: the refusal names the mode it found, so the message is actionable', () => {
+    const target = join(root, 'ignores-chmod-2');
+    try {
+      ensureOwnerOnlyDirectory(target, {
+        makeDirectory: () => {
+          mkdirSync(target, { recursive: true });
+        },
+        setMode: () => {},
+        readMode: () => 0o755,
+      });
+      expect.unreachable('the verification should have refused');
+    } catch (error) {
+      expect((error as Error).message).toContain('0755');
+      expect((error as Error).message).toContain(target);
+    }
+  });
+});

--- a/packages/agent-core/src/utils/owner-only-store.test.ts
+++ b/packages/agent-core/src/utils/owner-only-store.test.ts
@@ -192,3 +192,52 @@ describe('SEC-020 — verification, not hope', () => {
     }
   });
 });
+
+describe('SEC-020 — withinRoot tightens the ancestors the caller owns', () => {
+  it('TC-31: a store ROOT an older version left at 0755 is tightened, not only the leaf', () => {
+    // The defect review of PR #2224 found: `mkdirSync(path, { recursive: true, mode })` applies the
+    // mode only to the directories it CREATES, so a root that already existed keeps whatever it had
+    // while the sessions directory inside it came out 0700. On the restricted-workspace fallback no
+    // other writer runs, so nothing else would ever repair it.
+    const owned = join(root, 'store-root');
+    mkdirSync(owned);
+    chmodSync(owned, 0o755);
+    const leaf = join(owned, 'sessions');
+    ensureOwnerOnlyDirectory(leaf, { withinRoot: owned });
+    expect(mode(owned)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+    expect(mode(leaf)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+
+  it('TC-32: every segment between the root and the leaf is tightened', () => {
+    const owned = join(root, 'deep-root');
+    const middle = join(owned, 'a');
+    mkdirSync(middle, { recursive: true });
+    chmodSync(owned, 0o755);
+    chmodSync(middle, 0o777);
+    const leaf = join(middle, 'b');
+    ensureOwnerOnlyDirectory(leaf, { withinRoot: owned });
+    for (const path of [owned, middle, leaf]) {
+      expect(mode(path)).toBe(OWNER_ONLY_DIRECTORY_MODE);
+    }
+  });
+
+  it('TC-33: a withinRoot that is NOT an ancestor is refused, not silently ignored', () => {
+    // The guard that stops this module chmodding a directory nobody said it owns. Without it a
+    // caller could pass a home directory and this would narrow it.
+    const elsewhere = join(root, 'elsewhere');
+    const leaf = join(root, 'target', 'sessions');
+    mkdirSync(elsewhere, { recursive: true });
+    expect(() => ensureOwnerOnlyDirectory(leaf, { withinRoot: elsewhere })).toThrow(
+      OwnerOnlyModeError,
+    );
+  });
+
+  it('TC-34: without withinRoot only the leaf is touched — the parent is not this call to narrow', () => {
+    const parent = join(root, 'not-ours');
+    mkdirSync(parent);
+    chmodSync(parent, 0o755);
+    ensureOwnerOnlyDirectory(join(parent, 'leaf'));
+    expect(mode(parent)).toBe(0o755);
+    expect(mode(join(parent, 'leaf'))).toBe(OWNER_ONLY_DIRECTORY_MODE);
+  });
+});

--- a/packages/agent-core/src/utils/owner-only-store.ts
+++ b/packages/agent-core/src/utils/owner-only-store.ts
@@ -42,14 +42,14 @@
 
 import {
   chmodSync,
-  existsSync,
   mkdirSync,
   renameSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, isAbsolute, join, relative as relativePath, sep } from 'node:path';
 
 /** Owner read/write. Nothing for group, nothing for other. */
 export const OWNER_ONLY_FILE_MODE = 0o600;
@@ -92,6 +92,41 @@ export interface IOwnerOnlyIo {
   readonly readMode?: (target: string) => number;
 }
 
+export interface IEnsureOwnerOnlyOptions extends IOwnerOnlyIo {
+  /**
+   * An ANCESTOR of `directory` that the caller also owns, tightened along with every segment between
+   * them.
+   *
+   * Needed because `mkdirSync(path, { recursive: true, mode })` applies the mode only to the
+   * directories it CREATES. A store root an older version already made sits at whatever mode it was
+   * given and this call would leave it there — which is the module's own headline defect surviving
+   * one level up, on the very path it exists to protect. Found in review of PR #2224.
+   *
+   * It is a parameter rather than a walk up to some inferred boundary because WHICH ancestors belong
+   * to the caller is the caller's knowledge. This module must not guess that a parent is ours; it
+   * would eventually chmod someone's home directory.
+   */
+  readonly withinRoot?: string;
+}
+
+/** Every directory from `root` down to `target`, outermost first. `root` must be an ancestor. */
+function segmentsFromRoot(root: string, target: string): string[] {
+  const relative = relativePath(root, target);
+  if (relative.startsWith('..') || isAbsolute(relative)) {
+    throw new OwnerOnlyModeError(
+      `withinRoot ${root} is not an ancestor of ${target}, so this call cannot own the path between them.`,
+    );
+  }
+  const parts = relative.split(sep).filter((part) => part.length > 0);
+  const chain: string[] = [root];
+  let current = root;
+  for (const part of parts) {
+    current = join(current, part);
+    chain.push(current);
+  }
+  return chain;
+}
+
 function assertOwnerOnly(target: string, kind: 'directory' | 'file', io: IOwnerOnlyIo = {}): void {
   if (ownerOnlyGuarantee() !== 'posix-mode') return;
   const mode = (io.readMode ?? ((path: string) => statSync(path).mode & 0o7777))(target);
@@ -109,16 +144,28 @@ function assertOwnerOnly(target: string, kind: 'directory' | 'file', io: IOwnerO
  * The `chmod` is unconditional because `mkdir` does not touch an existing directory's mode, and the
  * `stat` afterwards is what turns two hopeful calls into a checked one.
  */
-export function ensureOwnerOnlyDirectory(directory: string, io: IOwnerOnlyIo = {}): void {
+export function ensureOwnerOnlyDirectory(
+  directory: string,
+  options: IEnsureOwnerOnlyOptions = {},
+): void {
   const makeDirectory =
-    io.makeDirectory ??
+    options.makeDirectory ??
     ((target: string, mode: number): void => {
       mkdirSync(target, { recursive: true, mode });
     });
-  const setMode = io.setMode ?? ((target: string, mode: number): void => chmodSync(target, mode));
+  const setMode =
+    options.setMode ?? ((target: string, mode: number): void => chmodSync(target, mode));
   makeDirectory(directory, OWNER_ONLY_DIRECTORY_MODE);
-  if (ownerOnlyGuarantee() === 'posix-mode') setMode(directory, OWNER_ONLY_DIRECTORY_MODE);
-  assertOwnerOnly(directory, 'directory', io);
+  // Every directory the caller declared it owns, not only the leaf. `mkdir` set the mode on what it
+  // CREATED; a root an older version left at 0755 was created by nobody here and would keep it.
+  const owned =
+    options.withinRoot === undefined
+      ? [directory]
+      : segmentsFromRoot(options.withinRoot, directory);
+  for (const target of owned) {
+    if (ownerOnlyGuarantee() === 'posix-mode') setMode(target, OWNER_ONLY_DIRECTORY_MODE);
+    assertOwnerOnly(target, 'directory', options);
+  }
 }
 
 /**
@@ -136,7 +183,12 @@ export function writeOwnerOnlyFile(filePath: string, content: string): void {
   // mid-write, its contents are meaningless, and — the part that matters here — `writeFileSync` does
   // not apply `mode` to a file that already exists, so reusing one at 0666 would put the whole
   // record on disk world-readable before the rename.
-  if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  //
+  // Removed with `force` rather than `if (exists) unlink`: checking and then acting on a path is a
+  // race, and the race is exploitable here — another process can create the path between the two
+  // calls, and the `wx` write below would then fail on a file this call believed it had cleared.
+  // CodeQL flagged the check-then-act form on PR #2224 and it was right to.
+  rmSync(temporaryPath, { force: true });
   // `wx` guarantees this call CREATES the file, which is the only condition under which `mode` is
   // applied. There is deliberately no `chmod` after it: tightening a file that was created wide
   // leaves a window in which the full record is readable, and a `chmod` here would make the mode

--- a/packages/agent-core/src/utils/owner-only-store.ts
+++ b/packages/agent-core/src/utils/owner-only-store.ts
@@ -1,0 +1,181 @@
+/**
+ * SEC-020 (issue #2021) — creating a host directory or file that only its owner can read.
+ *
+ * A host application persists session records, logs, settings and device credentials under a directory
+ * of its own choosing. They carry prompts, model output, tool results and, in the settings case,
+ * provider credentials. On a shared workstation or a CI host, every other local account reads them
+ * unless the mode says otherwise.
+ *
+ * WHERE that directory is belongs to the host, not here — this module knows only what has to be true
+ * of whatever path it is handed, which is what lets it be tested without a filesystem layout.
+ *
+ * ## Why this is one module and not a constant each caller repeats
+ *
+ * `0o600` and `0o700` were already spelled out in five separate files before this existed, and the
+ * repository had already learned — in `guarded-directory.ts`, for a pairing rendezvous — that the
+ * constants are the easy half. The load-bearing part is that **`mkdirSync(path, { mode })` does not
+ * set the mode of a directory that already exists.** `recursive: true` returns successfully and
+ * silently adopts whatever mode is there. A directory left at 0777 by an earlier version, by a
+ * shared CI checkout, or by another local user who pre-created it, becomes ours with no signal.
+ *
+ * Measured under umask 022 before this module existed: a session log directory pre-created at 0777
+ * stayed 0777 through `mkdirSync(dir, { recursive: true, mode: 0o700 })`, and its 0600 records were
+ * then removable and replaceable by any local account.
+ *
+ * The same holds for files. `writeFileSync(path, data, { mode })` applies the mode only when the
+ * file is CREATED; an existing 0644 record keeps 0644 forever, so a store written by an older
+ * version is never repaired by a newer one.
+ *
+ * So: create, then set the mode unconditionally, then VERIFY — and verification is what makes the
+ * first two checkable rather than hopeful. It is also the only step that catches an owner we did not
+ * expect, which `mkdir` and `chmod` between them cannot.
+ *
+ * ## Windows
+ *
+ * `chmodSync` on win32 toggles the read-only attribute and cannot express "owner only"; NTFS ACL
+ * inheritance governs instead, and a user's profile directory is not readable by other unprivileged
+ * accounts by default. The POSIX assertion is therefore not made there, and `ownerOnlyGuarantee()` reports which
+ * guarantee is in force so a caller — and a test — can state the platform's actual claim rather than
+ * assume the POSIX one everywhere. A store directory placed inside a world-writable parent on
+ * Windows is NOT protected by this module, and that is recorded rather than papered over.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+/** Owner read/write. Nothing for group, nothing for other. */
+export const OWNER_ONLY_FILE_MODE = 0o600;
+/** Owner read/write/traverse. The traverse bit is what keeps another account out of the directory. */
+export const OWNER_ONLY_DIRECTORY_MODE = 0o700;
+
+/** The bits that must be clear for the guarantee to hold: every group and other permission. */
+const FORBIDDEN_BITS = 0o077;
+
+/** Raised when a path cannot be made owner-only. Never swallowed into a weaker mode. */
+export class OwnerOnlyModeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OwnerOnlyModeError';
+  }
+}
+
+/**
+ * Which guarantee this platform can actually make.
+ *
+ * `posix-mode` — the mode bits are asserted after every create and every write.
+ * `windows-acl` — inherited NTFS ACLs govern; the POSIX assertion is not made and not claimed.
+ */
+export function ownerOnlyGuarantee(
+  platform: string = process.platform,
+): 'posix-mode' | 'windows-acl' {
+  return platform === 'win32' ? 'windows-acl' : 'posix-mode';
+}
+
+/**
+ * Seams for the failure paths, injected for the reason `guarded-directory.ts` states: a filesystem
+ * that silently ignores `chmod` is a real condition — some network and FAT mounts do exactly that —
+ * and it is the ONLY condition the verification step catches that create-then-chmod does not. Without
+ * a seam that case is unreachable from a test, and a guard no test can reach is a guard nobody knows
+ * is there. Measured: with these absent, deleting the verification entirely changed no test result.
+ */
+export interface IOwnerOnlyIo {
+  readonly makeDirectory?: (target: string, mode: number) => void;
+  readonly setMode?: (target: string, mode: number) => void;
+  readonly readMode?: (target: string) => number;
+}
+
+function assertOwnerOnly(target: string, kind: 'directory' | 'file', io: IOwnerOnlyIo = {}): void {
+  if (ownerOnlyGuarantee() !== 'posix-mode') return;
+  const mode = (io.readMode ?? ((path: string) => statSync(path).mode & 0o7777))(target);
+  if ((mode & FORBIDDEN_BITS) !== 0) {
+    throw new OwnerOnlyModeError(
+      `${kind} ${target} is mode 0${mode.toString(8)} after being set owner-only; ` +
+        'group or other permissions survived, so its contents are readable by another account.',
+    );
+  }
+}
+
+/**
+ * Ensure `directory` exists and only its owner can enter it.
+ *
+ * The `chmod` is unconditional because `mkdir` does not touch an existing directory's mode, and the
+ * `stat` afterwards is what turns two hopeful calls into a checked one.
+ */
+export function ensureOwnerOnlyDirectory(directory: string, io: IOwnerOnlyIo = {}): void {
+  const makeDirectory =
+    io.makeDirectory ??
+    ((target: string, mode: number): void => {
+      mkdirSync(target, { recursive: true, mode });
+    });
+  const setMode = io.setMode ?? ((target: string, mode: number): void => chmodSync(target, mode));
+  makeDirectory(directory, OWNER_ONLY_DIRECTORY_MODE);
+  if (ownerOnlyGuarantee() === 'posix-mode') setMode(directory, OWNER_ONLY_DIRECTORY_MODE);
+  assertOwnerOnly(directory, 'directory', io);
+}
+
+/**
+ * Replace `filePath` atomically with content only its owner can read.
+ *
+ * The temp file carries the mode from the moment it is created — writing it at the umask's default
+ * and tightening afterwards leaves a window in which the full content is world-readable on disk, and
+ * `rename` preserves whatever mode the temp file had. The `chmod` after the write is for the case
+ * where the temp path already existed at a wider mode.
+ */
+export function writeOwnerOnlyFile(filePath: string, content: string): void {
+  ensureOwnerOnlyDirectory(dirname(filePath));
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  // A stale temp file is REMOVED rather than reused. It can only come from a process that died
+  // mid-write, its contents are meaningless, and — the part that matters here — `writeFileSync` does
+  // not apply `mode` to a file that already exists, so reusing one at 0666 would put the whole
+  // record on disk world-readable before the rename.
+  if (existsSync(temporaryPath)) unlinkSync(temporaryPath);
+  // `wx` guarantees this call CREATES the file, which is the only condition under which `mode` is
+  // applied. There is deliberately no `chmod` after it: tightening a file that was created wide
+  // leaves a window in which the full record is readable, and a `chmod` here would make the mode
+  // above redundant — so a mutation that removed it would change nothing and the window would be
+  // untested. The assertion below is what proves the mode actually took.
+  writeFileSync(temporaryPath, content, {
+    encoding: 'utf8',
+    mode: OWNER_ONLY_FILE_MODE,
+    flag: 'wx',
+  });
+  try {
+    assertOwnerOnly(temporaryPath, 'file');
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // allow-fallback: the temp file may already be gone; the original error is the one to report.
+    }
+    throw error;
+  }
+  assertOwnerOnly(filePath, 'file');
+}
+
+/**
+ * Tighten a file that already exists — the repair path for a record an older version left at 0644.
+ *
+ * A no-op on a path that does not exist, because "there is nothing to tighten" and "we tightened it"
+ * are the same outcome for the caller, and throwing would make every writer branch on existence.
+ */
+export function tightenExistingFile(filePath: string): void {
+  if (ownerOnlyGuarantee() !== 'posix-mode') return;
+  let mode: number;
+  try {
+    mode = statSync(filePath).mode & 0o7777;
+  } catch {
+    return; // allow-fallback: nothing to tighten
+  }
+  if ((mode & FORBIDDEN_BITS) === 0) return;
+  chmodSync(filePath, OWNER_ONLY_FILE_MODE);
+  assertOwnerOnly(filePath, 'file');
+}

--- a/packages/agent-framework/src/config/node-host-settings-store.ts
+++ b/packages/agent-framework/src/config/node-host-settings-store.ts
@@ -1,5 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+
+import { ensureOwnerOnlyDirectory, tightenExistingFile } from '@robota-sdk/agent-core/node';
 
 import { SettingsParseError } from './settings-parse-error.js';
 import { createNodeHostSettingsSource } from './settings-source.js';
@@ -28,7 +30,11 @@ export function createNodeHostSettingsStore(
       }
     },
     write: (settings: TSettingsData): void => {
-      mkdirSync(dirname(path), { recursive: true });
+      // SEC-020: the directory was created with no mode, and `mode` on the write below applies
+      // only at creation — so the settings directory was 0755 and a file an older version left
+      // at 0644 stayed there through every rewrite.
+      ensureOwnerOnlyDirectory(dirname(path));
+      tightenExistingFile(path);
       writeFileSync(path, `${JSON.stringify(settings, null, 2)}\n`, {
         encoding: 'utf8',
         mode: 0o600,

--- a/packages/agent-framework/src/config/settings-io.ts
+++ b/packages/agent-framework/src/config/settings-io.ts
@@ -1,5 +1,7 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+
+import { ensureOwnerOnlyDirectory, tightenExistingFile } from '@robota-sdk/agent-core/node';
 
 import { SettingsParseError } from './settings-parse-error.js';
 
@@ -33,10 +35,15 @@ export function readSettings(path: string): TSettingsData {
  * SEC-003: settings files can hold a plaintext provider credential — `provider-settings.ts`
  * persists `apiKey` verbatim when `--api-key-env` is not used (and warns while doing it). A
  * default-umask create would leave that credential world-readable, so the file is created
- * owner-only. `mode` applies at creation; a settings file that already exists keeps its mode.
+ * owner-only. `mode` applies at creation, so a settings file an older version already wrote keeps
+ * its mode — which is why SEC-020 tightens it before the write rather than trusting `mode` alone.
  */
 export function writeSettings(path: string, settings: TSettingsData): void {
-  mkdirSync(dirname(path), { recursive: true });
+  // SEC-020: created with no mode at all, so the settings directory came out 0755 under umask 022
+  // and every account on the host could list what it holds. The file itself was already
+  // owner-only, but a rewrite leaves an older 0644 copy at 0644 — `mode` applies only at create.
+  ensureOwnerOnlyDirectory(dirname(path));
+  tightenExistingFile(path);
   writeFileSync(path, JSON.stringify(settings, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
 }
 

--- a/packages/agent-framework/src/interactive/session-persistence.ts
+++ b/packages/agent-framework/src/interactive/session-persistence.ts
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path';
+
 import { NodeSessionStore } from '@robota-sdk/agent-session';
 
 import { userPaths } from '../paths.js';
@@ -24,8 +26,11 @@ export function createProjectSessionStore(
 }
 
 /** Explicit host-filesystem session store. This does not establish project trust. */
-export function createNodeHostSessionStore(baseDirectory: string): IInteractiveSessionStore {
-  return new NodeSessionStore(baseDirectory);
+export function createNodeHostSessionStore(
+  baseDirectory: string,
+  ownedRoot?: string,
+): IInteractiveSessionStore {
+  return new NodeSessionStore(baseDirectory, ownedRoot);
 }
 
 /**
@@ -33,7 +38,12 @@ export function createNodeHostSessionStore(baseDirectory: string): IInteractiveS
  * there is no user-level replay-log directory, so it reads persisted records only.
  */
 export function createUserSessionStore(): IInteractiveSessionStore {
-  return new NodeSessionStore(userPaths().sessions);
+  // SEC-020: the user store root is passed as OWNED, so it is tightened along with the sessions
+  // directory inside it. This is the composition that knows the layout — `userPaths()` is here —
+  // and it is the path the restricted-workspace fallback takes, where no other writer may ever run
+  // to tighten the root on its behalf.
+  const sessions = userPaths().sessions;
+  return new NodeSessionStore(sessions, dirname(sessions));
 }
 
 export function listResumableSessionSummaries(

--- a/packages/agent-session/src/__tests__/sec-020-owner-only-session-records.test.ts
+++ b/packages/agent-session/src/__tests__/sec-020-owner-only-session-records.test.ts
@@ -151,3 +151,29 @@ describe('SEC-020 — NodeSessionLogSink', () => {
     expect(() => sink.append('s5', 'line\n')).not.toThrow();
   });
 });
+
+describe('SEC-020 — the store root the host declares it owns', () => {
+  it('TC-35: a root left at 0755 by an older version is tightened with the sessions directory', () => {
+    // Review of PR #2224: the leaf was 0700 and the directory above it was not, on exactly the path
+    // the change says matters most — the restricted-workspace fallback, where no settings or
+    // device-store write ever runs to tighten the root on the session store's behalf.
+    const owned = join(root, 'store-root');
+    mkdirSync(owned);
+    chmodSync(owned, 0o755);
+    const base = join(owned, 'sessions');
+    new NodeSessionStore(base, owned).save(record('d'));
+    expect(mode(owned)).toBe(OWNER_ONLY_DIRECTORY);
+    expect(mode(base)).toBe(OWNER_ONLY_DIRECTORY);
+  });
+
+  it('TC-36: without a declared root the store narrows only its own directory', () => {
+    // The adapter does not interpret its base directory as a trusted root and must not guess that a
+    // parent belongs to the product. Which ancestors are owned is composition's knowledge.
+    const parent = join(root, 'someone-elses');
+    mkdirSync(parent);
+    chmodSync(parent, 0o755);
+    new NodeSessionStore(join(parent, 'sessions')).save(record('e'));
+    expect(mode(parent)).toBe(0o755);
+    expect(mode(join(parent, 'sessions'))).toBe(OWNER_ONLY_DIRECTORY);
+  });
+});

--- a/packages/agent-session/src/__tests__/sec-020-owner-only-session-records.test.ts
+++ b/packages/agent-session/src/__tests__/sec-020-owner-only-session-records.test.ts
@@ -1,0 +1,153 @@
+/**
+ * SEC-020 (issue #2021) — a session record is not readable by another account on the host.
+ *
+ * These assert the MODE ON DISK after the real writers run, which is how the defect was measured in
+ * the first place. Asserting that a helper was called would be a claim about source text, and the
+ * defect was never that no mode was requested — `NodeSessionLogSink` requested 0700 and got 0777,
+ * because `mkdirSync` does not touch a directory that already exists.
+ *
+ * Every case sets a permissive umask explicitly: under a restrictive one these pass whether the mode
+ * is requested or not.
+ */
+
+import { createHash } from 'node:crypto';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { NodeSessionLogSink } from '../session-log-sinks.js';
+import { NodeSessionStore } from '../session-store.js';
+
+import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-transport';
+
+const PERMISSIVE_UMASK = 0o022;
+const OWNER_ONLY_FILE = 0o600;
+const OWNER_ONLY_DIRECTORY = 0o700;
+
+let root: string;
+let previousUmask: number;
+
+beforeEach(() => {
+  previousUmask = process.umask(PERMISSIVE_UMASK);
+  root = mkdtempSync(join(tmpdir(), 'sec-020-'));
+});
+
+afterEach(() => {
+  process.umask(previousUmask);
+});
+
+const mode = (path: string): number => statSync(path).mode & 0o7777;
+
+/** The sink refuses any reference whose digest is not the exact content address. */
+const createSha = (serialized: string): string =>
+  createHash('sha256').update(serialized).digest('hex');
+
+function record(id: string): IInteractiveSessionRecord {
+  const now = new Date().toISOString();
+  return {
+    id,
+    cwd: root,
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+  } as unknown as IInteractiveSessionRecord;
+}
+
+describe('SEC-020 — NodeSessionStore', () => {
+  it('TC-15: a fresh store is 0700 and its records 0600 under umask 022', () => {
+    // Measured before this change: 0755 and 0644.
+    const base = join(root, 'sessions');
+    new NodeSessionStore(base).save(record('a'));
+    expect(mode(base)).toBe(OWNER_ONLY_DIRECTORY);
+    expect(mode(join(base, 'a.json'))).toBe(OWNER_ONLY_FILE);
+  });
+
+  it('TC-16: a sessions directory pre-created at 0777 is tightened, not adopted', () => {
+    const base = join(root, 'sessions');
+    mkdirSync(base);
+    chmodSync(base, 0o777);
+    new NodeSessionStore(base).save(record('b'));
+    expect(mode(base)).toBe(OWNER_ONLY_DIRECTORY);
+  });
+
+  it('TC-17: a record an older version left at 0644 is narrowed on the next save', () => {
+    const base = join(root, 'sessions');
+    const store = new NodeSessionStore(base);
+    store.save(record('c'));
+    chmodSync(join(base, 'c.json'), 0o644);
+    store.save(record('c'));
+    expect(mode(join(base, 'c.json'))).toBe(OWNER_ONLY_FILE);
+  });
+
+  it('TC-18: resume still works — save, load, list and delete are unchanged', () => {
+    // A permission change that breaks resume is not a fix. This is the half the mode assertions
+    // cannot see.
+    const store = new NodeSessionStore(join(root, 'sessions'));
+    store.save(record('keep'));
+    expect(store.load('keep')?.id).toBe('keep');
+    expect(store.list().map((entry) => entry.id)).toEqual(['keep']);
+    store.delete('keep');
+    expect(store.load('keep')).toBeUndefined();
+  });
+});
+
+describe('SEC-020 — NodeSessionLogSink', () => {
+  it('TC-19: a log directory pre-created at 0777 is tightened', () => {
+    // The measured case: the sink asked for 0700 and got 0777, because `mkdirSync` with
+    // `recursive: true` succeeds on an existing directory without touching its mode. Records were
+    // 0600 the whole time, so another account could not READ one — it could unlink and replace it,
+    // and could list every session id.
+    const logs = join(root, 'logs');
+    mkdirSync(logs);
+    chmodSync(logs, 0o777);
+    new NodeSessionLogSink(logs).append('s1', '{"a":1}\n');
+    expect(mode(logs)).toBe(OWNER_ONLY_DIRECTORY);
+    expect(mode(join(logs, 's1.jsonl'))).toBe(OWNER_ONLY_FILE);
+  });
+
+  it('TC-20: a log an older version left at 0644 is narrowed before the next append', () => {
+    const logs = join(root, 'logs');
+    const sink = new NodeSessionLogSink(logs);
+    sink.append('s2', 'one\n');
+    chmodSync(join(logs, 's2.jsonl'), 0o644);
+    sink.append('s2', 'two\n');
+    expect(mode(join(logs, 's2.jsonl'))).toBe(OWNER_ONLY_FILE);
+    expect(readFileSync(join(logs, 's2.jsonl'), 'utf8')).toBe('one\ntwo\n');
+  });
+
+  it('TC-21: the content-addressed payload directory and its files are owner-only', () => {
+    const logs = join(root, 'logs');
+    const sink = new NodeSessionLogSink(logs);
+    const serialized = '{"payload":true}';
+    const sha256 = createSha(serialized);
+    const reference = sink.writeJson('s3', sha256, serialized);
+    expect(mode(join(logs, 's3.payloads'))).toBe(OWNER_ONLY_DIRECTORY);
+    expect(mode(join(logs, reference.relativePath))).toBe(OWNER_ONLY_FILE);
+  });
+
+  it('TC-22: an existing payload is not rewritten, but IS tightened', () => {
+    // `flag: 'wx'` correctly declines to rewrite content-addressed bytes. Its mode is a different
+    // question, and nothing else would ever repair a payload an older version wrote at 0644.
+    const logs = join(root, 'logs');
+    const sink = new NodeSessionLogSink(logs);
+    const serialized = '{"payload":true}';
+    const sha256 = createSha(serialized);
+    const reference = sink.writeJson('s4', sha256, serialized);
+    const path = join(logs, reference.relativePath);
+    chmodSync(path, 0o644);
+    sink.writeJson('s4', sha256, serialized);
+    expect(mode(path)).toBe(OWNER_ONLY_FILE);
+    expect(readFileSync(path, 'utf8')).toBe(serialized);
+  });
+
+  it('TC-23: a log directory that cannot be made owner-only disables logging rather than using it', () => {
+    // Fail closed. A diagnostic sink must not kill the session, and it must not fall back to a
+    // directory any account can read.
+    const blocked = join(root, 'not-a-directory');
+    writeFileSync(blocked, 'x');
+    const sink = new NodeSessionLogSink(blocked);
+    expect(() => sink.append('s5', 'line\n')).not.toThrow();
+  });
+});

--- a/packages/agent-session/src/session-log-sinks.ts
+++ b/packages/agent-session/src/session-log-sinks.ts
@@ -1,16 +1,19 @@
 import { createHash } from 'node:crypto';
-import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { appendFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { createLogger } from '@robota-sdk/agent-core';
+import {
+  OWNER_ONLY_FILE_MODE,
+  ensureOwnerOnlyDirectory,
+  tightenExistingFile,
+} from '@robota-sdk/agent-core/node';
 
 import { assertSafeSessionId } from './session-id.js';
 
 import type { IExternalPayloadReference } from './session-logger.js';
 
 const logger = createLogger('NodeSessionLogSink');
-const OWNER_ONLY_FILE_MODE = 0o600;
-const OWNER_ONLY_DIR_MODE = 0o700;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
 
 function assertContentAddress(sha256: string, serialized: string): void {
@@ -55,10 +58,17 @@ export class NodeSessionLogSink implements ISessionLogSink, IExternalPayloadSink
 
   constructor(private readonly logDirectory: string) {
     try {
-      mkdirSync(logDirectory, { recursive: true, mode: OWNER_ONLY_DIR_MODE });
+      // SEC-020: `mkdirSync(dir, { recursive: true, mode })` does NOT set the mode of a directory
+      // that already exists — it returns successfully and adopts whatever is there. Measured: a log
+      // directory pre-created at 0777 stayed 0777 while its records were written 0600, which means
+      // another local account could not read a record but could unlink and replace one, and could
+      // enumerate every session id.
+      ensureOwnerOnlyDirectory(logDirectory);
       this.enabled = true;
     } catch (error) {
-      // allow-fallback: session logging is diagnostic and must not disable the session.
+      // allow-fallback: session logging is diagnostic and must not disable the session. It now also
+      // disables on a directory that cannot be made owner-only, which is the correct direction: no
+      // log is better than a log any account can read or replace.
       this.enabled = false;
       logger.warn('session log directory could not be created — session logging is disabled', {
         logDirectory,
@@ -70,27 +80,32 @@ export class NodeSessionLogSink implements ISessionLogSink, IExternalPayloadSink
   append(sessionId: string, text: string): void {
     assertSafeSessionId(sessionId);
     if (!this.enabled) return;
-    appendFileSync(join(this.logDirectory, `${sessionId}.jsonl`), text, {
-      mode: OWNER_ONLY_FILE_MODE,
-    });
+    const path = join(this.logDirectory, `${sessionId}.jsonl`);
+    // SEC-020: `mode` on a write applies only when the file is CREATED, so a log an older version
+    // left at 0644 keeps 0644 for its whole life however many times it is appended to. Tightening
+    // first is the repair path for a store written before this change.
+    tightenExistingFile(path);
+    appendFileSync(path, text, { mode: OWNER_ONLY_FILE_MODE });
   }
 
   writeJson(sessionId: string, sha256: string, serialized: string): IExternalPayloadReference {
     const reference = createSessionLogExternalPayloadReference(sessionId, sha256, serialized);
     const payloadDirectoryName = `${sessionId}.payloads`;
     if (this.enabled) {
-      mkdirSync(join(this.logDirectory, payloadDirectoryName), {
-        recursive: true,
-        mode: OWNER_ONLY_DIR_MODE,
-      });
+      ensureOwnerOnlyDirectory(join(this.logDirectory, payloadDirectoryName));
+      const payloadPath = join(this.logDirectory, reference.relativePath);
       try {
-        writeFileSync(join(this.logDirectory, reference.relativePath), serialized, {
+        writeFileSync(payloadPath, serialized, {
           encoding: 'utf8',
           mode: OWNER_ONLY_FILE_MODE,
           flag: 'wx',
         });
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        // SEC-020: the payload is content-addressed, so an existing file already holds these exact
+        // bytes and `wx` correctly declines to rewrite it. Its MODE is a different question — one
+        // written by an older version is 0644 and nothing else would ever repair it.
+        tightenExistingFile(payloadPath);
       }
     }
     return reference;

--- a/packages/agent-session/src/session-store.ts
+++ b/packages/agent-session/src/session-store.ts
@@ -6,16 +6,10 @@
  * The store directory is created on first write if it does not exist.
  */
 
-import {
-  readFileSync,
-  writeFileSync,
-  existsSync,
-  mkdirSync,
-  unlinkSync,
-  readdirSync,
-  renameSync,
-} from 'fs';
+import { readFileSync, existsSync, unlinkSync, readdirSync } from 'fs';
 import { join } from 'path';
+
+import { ensureOwnerOnlyDirectory, writeOwnerOnlyFile } from '@robota-sdk/agent-core/node';
 
 import { assertSafeSessionId } from './session-id.js';
 
@@ -37,11 +31,17 @@ export class NodeSessionStore implements IInteractiveSessionStore {
     this.baseDir = baseDir;
   }
 
-  /** Ensure the storage directory exists */
+  /**
+   * Ensure the storage directory exists AND that only its owner can enter it (SEC-020).
+   *
+   * The `existsSync` guard this replaces is the whole defect. It skipped the case that matters: a
+   * directory some earlier version, a shared CI checkout, or another local user left at a wider
+   * mode was adopted as ours with no signal. Measured under umask 022 before this change, a fresh
+   * sessions directory came out 0755 and its records 0644 — and a directory pre-created at 0777
+   * stayed 0777.
+   */
   private ensureDir(): void {
-    if (!existsSync(this.baseDir)) {
-      mkdirSync(this.baseDir, { recursive: true });
-    }
+    ensureOwnerOnlyDirectory(this.baseDir);
   }
 
   /**
@@ -62,19 +62,16 @@ export class NodeSessionStore implements IInteractiveSessionStore {
    * Bytes go to a same-directory temp file first, then move into place with rename —
    * a crash mid-write can therefore never leave a truncated JSON where the previous
    * record used to be. Same-directory is load-bearing: cross-device rename is a copy.
+   *
+   * SEC-020: the atomic write now comes from `writeOwnerOnlyFile`, which carries the mode from the
+   * moment the temp file is created. The hand-rolled version here wrote it at the umask's default
+   * and let `rename` carry that mode to the final path, so every record was 0644 — and even setting
+   * the mode after the write would leave a window in which the full transcript was world-readable
+   * on disk.
    */
   save(session: IInteractiveSessionRecord): void {
     this.ensureDir();
-    const finalPath = this.filePath(session.id);
-    const tempPath = `${finalPath}.${process.pid}.tmp`;
-    const serialized = JSON.stringify(session, null, 2);
-    writeFileSync(tempPath, serialized, 'utf-8');
-    try {
-      renameSync(tempPath, finalPath);
-    } catch (error) {
-      unlinkSync(tempPath);
-      throw error;
-    }
+    writeOwnerOnlyFile(this.filePath(session.id), JSON.stringify(session, null, 2));
   }
 
   /**

--- a/packages/agent-session/src/session-store.ts
+++ b/packages/agent-session/src/session-store.ts
@@ -26,9 +26,19 @@ import type {
  */
 export class NodeSessionStore implements IInteractiveSessionStore {
   private readonly baseDir: string;
+  private readonly ownedRoot: string | undefined;
 
-  constructor(baseDir: string) {
+  /**
+   * @param baseDir the directory holding the records.
+   * @param ownedRoot an ancestor of `baseDir` the HOST also owns, tightened along with it (SEC-020).
+   *   Optional because this adapter does not interpret its base directory as a trusted root and must
+   *   not guess that a parent belongs to the product — which of them do is composition's knowledge.
+   *   Omitting it leaves a store root an older version created at whatever mode it was given, which
+   *   is what review of PR #2224 found: the leaf was 0700 and the directory above it was not.
+   */
+  constructor(baseDir: string, ownedRoot?: string) {
     this.baseDir = baseDir;
+    this.ownedRoot = ownedRoot;
   }
 
   /**
@@ -41,7 +51,10 @@ export class NodeSessionStore implements IInteractiveSessionStore {
    * stayed 0777.
    */
   private ensureDir(): void {
-    ensureOwnerOnlyDirectory(this.baseDir);
+    ensureOwnerOnlyDirectory(
+      this.baseDir,
+      this.ownedRoot === undefined ? {} : { withinRoot: this.ownedRoot },
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #2021.

## Measured, not read

Run under umask 022 against the real classes:

| writer | directory | records |
| --- | --- | --- |
| `NodeSessionStore` | **0755** | **0644** |
| `NodeSessionLogSink`, directory pre-made 0777 | **0777** (retained) | 0600 |
| the user store directory itself | **0755** | 0600 |

## Three causes, one shape

1. **No mode requested at all.** The store called `mkdirSync` with no mode and wrote its temp file with none either, so the umask decided and the rename carried 0644 to the record.
2. **`mkdirSync(path, { recursive: true, mode })` does not set the mode of a directory that already exists.** It returns successfully and adopts whatever is there. This repository had already written that down — in `guarded-directory.ts`, for a pairing rendezvous — and had not applied it anywhere else. A 0777 log directory means another account cannot *read* a 0600 record and **can unlink and replace one**, and can enumerate every session id.
3. **`writeFileSync(path, data, { mode })` applies the mode only when the file is CREATED.** Every 0600 above is a mode that was right on the day the file was first written and is never repaired.

## The direction is backwards where it matters most

The project-local path already writes 0600/0700 through the workspace-authority writer. The store with no modes at all is the **fallback taken when project access is `restricted`** — that is, when trust could *not* be established. The less trusted the workspace, the weaker the persistence.

## The fix

One primitive in `agent-core` beside `path-containment.ts`, which already imports `node:fs` — placement by ownership, not by consumer count. **Create, set the mode unconditionally, then verify.** The third step is what makes the first two checkable rather than hopeful, and it is the only one that catches a directory someone else pre-created.

`robota init` writes a nested `.robota/.gitignore`: targeted so reviewable settings stay tracked, merged so a second init is a no-op and a hand-added line survives, and written **before** the overwrite prompt because the path that reaches that prompt is exactly the one where transcripts are already in the tree.

Project memory is deliberately **not** ignored — it is the same kind of artefact this repository checks in on purpose, and ignoring it by default would make that choice for every user. Stated in the module so the omission is not read as an oversight.

## Two mutants survived their first run, and both were defects in this work

**Neutering the mode verification changed no test result.** Every case that reached it was already caught by `mkdir` or `chmod` throwing, so the check was present and unproven — the shape #2181 and #2215 are about. Fixed by adding the injected IO seams `guarded-directory.ts` already documents the need for; two cases now drive a filesystem that accepts `chmod` and ignores it, which is what some network and FAT mounts do.

**Removing the mode from the temp-file creation also changed nothing**, because the write set it *and* chmodded afterwards. The redundancy was the bug: tightening after the write leaves a window in which the whole record is on disk readable. The `chmod` is gone, the write uses `wx` so `mode` is guaranteed to apply, and the verification proves it took.

| mutant | agent-core red | agent-session red |
| --- | --- | --- |
| remove the unconditional directory `chmod` | 1 | 2 |
| neuter the mode verification | 2 | 0 |
| remove the mode from the temp-file creation | 4 | 4 |
| always report the Windows guarantee | 6 | 4 |
| remove `tightenExistingFile` from the log append | 0 | 1 |

Each applied with `agent-core` **rebuilt** first — the session tests resolve the primitive through the package build, so a source mutation is invisible to them without it.

## Verification

- The same probe that measured the defect now reports store **0700 / 0600**, and a log directory pre-created at 0777 **tightened to 0700**.
- 1180 + 341 + 1508 + 428 tests green across `agent-core`, `agent-session`, `agent-framework`, `agent-cli`.
- Workspace typecheck clean, lint 0 errors, `pnpm harness:scan` 141 passed / 2 skipped.
- `regression-red-proof` locally: `red-proof-ok (assertion-fail)` on the store, the log sink and the init command.

## Windows

`chmod` cannot express owner-only there; inherited NTFS ACLs govern. `ownerOnlyGuarantee()` reports which guarantee is in force rather than making the POSIX claim everywhere, and a store directory placed inside a world-writable parent on Windows is **not** protected by this module. Recorded rather than papered over.

## Not in scope, cited rather than changed

`agent-provider-openai`'s payload logger, `dag-adapters-local` and `local-peer-registry` share causes 2 and 3 and are not session records.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY
