### PR TITLE
fix(harness): run the lint-warning ceiling on every pull request (issue #1984)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,24 @@ jobs:
         if: env.PRODUCT_APPLICABLE == 'true'
         run: pnpm harness:verify -- --base-ref origin/${{ github.base_ref }} --skip-build --skip-record-check --skip-repository-check harness-tests
 
+      # issue #1984 — the lint-warning CEILING runs on EVERY pull request, not only the promotion.
+      #
+      # The ceiling is `--max-warnings` on the root `lint` script, and until this step existed the
+      # only CI path that executed it was `release-grade verification`, which is required on pull
+      # requests to `main` and therefore runs once per promotion. Measured 2026-08-23: 111 warnings
+      # had accumulated across 42 commits with every develop pull request green, and the first thing
+      # to notice was a promotion that could not merge. A ratchet nothing turns is a number.
+      #
+      # It lives HERE and not in `harness:scan`: that scan runs on every pre-push and a full
+      # workspace lint is minutes, which `scan-lint-warning-ratchet.mjs` rejects for that reason. CI
+      # has the time and the pre-push path does not. `quality` is already a required context on
+      # develop, so this gates without a ruleset change.
+      #
+      # `--cache` is deliberate and load-bearing for the runtime; the count it reports is unaffected.
+      - name: Lint-warning ceiling
+        if: env.PRODUCT_APPLICABLE == 'true'
+        run: pnpm lint
+
       # INFRA-037: build-contracts is the ONE scan that reads packages/*/dist (validates that declared
       # main/types/exports paths resolve to built files) and silently no-ops without dist. It stays in
       # `quality` (which restores dist above) so its coverage is preserved; the other 47 scans + the

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:coverage:packages": "pnpm --filter \"./packages/**\" run --if-present test:coverage",
     "test:coverage:apps": "pnpm --filter \"./apps/**\" run --if-present test:coverage",
     "typecheck": "pnpm run -r --workspace-concurrency=-1 --if-present typecheck",
-    "lint": "eslint packages apps --ext .ts,.tsx --cache --max-warnings 2092",
+    "lint": "eslint packages apps --ext .ts,.tsx --cache --max-warnings 2203",
     "lint:fix": "eslint packages apps --ext .ts,.tsx --cache --fix && prettier --write .",
     "lint:fix:staged": "scripts/harness/with-repo-lock.sh pnpm exec lint-staged",
     "dev": "pnpm run -r --if-present dev",

--- a/scripts/harness/ci-mirror-map.mjs
+++ b/scripts/harness/ci-mirror-map.mjs
@@ -161,6 +161,12 @@ export const CI_STAGES = [
     why: 'THE package test suites, lint and scoped typecheck — the gates verify-like-ci omitted entirely (INFRA-056)',
   },
   {
+    name: 'lint-ceiling',
+    needsBuildOutput: false,
+    mirrors: [{ job: 'quality', steps: ['Lint-warning ceiling'] }],
+    why: 'the WORKSPACE count against `--max-warnings`, which `affected-verify` cannot see: it lints only the affected scopes, so a warning added in one package is invisible to a ceiling that counts all of them (issue #1984)',
+  },
+  {
     name: 'binary-e2e',
     needsBuildOutput: true,
     mirrors: [{ job: 'quality', steps: ['Binary e2e (agent-cli bintests, dist-dependent)'] }],

--- a/scripts/harness/lint-warning-baseline.json
+++ b/scripts/harness/lint-warning-baseline.json
@@ -1,3 +1,3 @@
 {
-  "warnings": 2092
+  "warnings": 2203
 }

--- a/scripts/harness/scan-lint-warning-ratchet.mjs
+++ b/scripts/harness/scan-lint-warning-ratchet.mjs
@@ -19,8 +19,15 @@
  *   "lint": "eslint packages apps --ext .ts,.tsx --cache --max-warnings <N>"
  *
  * That script is part of `harness:verify:release` (asserted by `check-release-governance.mjs`), and
- * `release-grade verification` is a REQUIRED context on every pull request to `main`. So the ceiling
- * is enforced on the promotion path by the tool itself.
+ * `release-grade verification` is a REQUIRED context on every pull request to `main`, and the
+ * `quality` job runs the same script on every pull request to `develop` (issue #1984). So the
+ * ceiling is enforced by the tool itself on BOTH paths.
+ *
+ * It was the promotion path alone until 2026-08-23, and the cost of that is the reason the second
+ * one exists: 111 warnings accumulated across 42 commits with every develop pull request green, and
+ * the first thing to notice was a promotion that could not merge. A gate that runs once per release
+ * reports a number nobody can act on — by the time it speaks, the additions are spread across
+ * dozens of merged commits and no author is left to attribute them to.
  *
  * WHAT THIS SCAN IS FOR. A number written into a script is a hand-maintained second source, and this
  * repository has spent whole items removing those. So the ceiling is checked against the tree:
@@ -32,7 +39,8 @@
  * WHAT IT DOES NOT DO, stated rather than discovered: it does not run eslint. A full workspace lint
  * is minutes, and `harness:scan` runs on every pre-push — putting it here would move a required
  * gate onto a path that must stay fast. The COUNT is measured by the lint script itself, on the
- * release path; this scan governs the CEILING that script carries.
+ * lint script itself, on the release path AND on every develop pull request; this scan governs the
+ * CEILING that script carries.
  *
  * Exit code 0 = the ceiling is present and matches its baseline, 1 = otherwise.
  */
@@ -118,7 +126,7 @@ function main() {
   // declaring one. Found by doing exactly that.
   console.log(
     `lint-warning-ratchet scan passed (ceiling ${ceiling}, at baseline; enforced by ` +
-      '`--max-warnings` on the release path, not by this scan).',
+      '`--max-warnings` on the release path and on every develop pull request, not by this scan).',
   );
 }
 

--- a/scripts/harness/verify-like-ci.mjs
+++ b/scripts/harness/verify-like-ci.mjs
@@ -556,6 +556,10 @@ const STAGE_RUNNERS = {
   build: runBuild,
   'scan-suite': runScanSuite,
   'affected-verify': runAffectedVerify,
+  // The workspace count against the ceiling. `affected-verify` lints only the affected scopes, so a
+  // warning it reports is a warning in ITS packages — the number the ceiling governs is the sum over
+  // all of them, and only a whole-workspace run produces it (issue #1984).
+  'lint-ceiling': async () => ({ code: await run('pnpm', ['lint']) }),
   'binary-e2e': async () => ({
     code: await run('pnpm', ['--filter', '@robota-sdk/agent-cli', 'test:bin']),
   }),


### PR DESCRIPTION
Closes the blocker that stopped today's promotion. Approved by the owner before the work started.

## What happened

`release-grade verification` failed on the promotion to `main`: **2203 warnings against a `--max-warnings` ceiling of 2092**, exit 1, zero errors.

The ceiling is `--max-warnings` on the root `lint` script, and the only CI path that executed it was `release-grade verification` — required on pull requests to `main`, therefore run **once per promotion**. So 111 warnings accumulated across 42 commits with every develop pull request green, and the first thing to notice was a promotion that could not merge.

That is issue #1984 (*"the ratchet's only CI execution path is the promotion job, so it has never run on a pull request"*) and issue #2175 (*"develop is 1 warning over its own ceiling, and only the main-promotion path will find out"*) arriving exactly as written. #2175 saw the first single warning of the 111.

> A gate that runs once per release reports a number nobody can act on. By the time it speaks, the additions are spread across dozens of merged commits and no author is left to attribute them to — the count arrives as a fact about the repository rather than as a finding about a change.

## Two halves, and the second is what pays for the first

**The ceiling is re-frozen at the measured 2203.** On its own that is the thing a ratchet must not do: the governing rule is that the baseline may fall and must never rise without a deliberate re-freeze, and a re-freeze with nothing else in it is just the number moving. Raising a ceiling at the moment it first catches something is how a ratchet stops being one.

**So the same change makes it run on every pull request to develop.** From here, a warming count is a finding on the pull request that added it, while its author still holds the change.

## Why the `quality` job

`pnpm harness:scan` runs on every pre-push and a full workspace lint is minutes — the ratchet scan rejects putting it there for exactly that reason, and that reasoning still holds. CI has the time the pre-push path does not. `quality` is already a required context on develop, so this gates **without a ruleset change**.

## Two things the harness refused, both correctly

**`ci-mirror-map`'s anti-drift test blocked the first push.** The new required step was claimed by no `verify-like-ci` stage and declared as no plumbing. Its message is the reason it matters — *leaving a required step unanswered means "I ran the CI-equivalent check" covers less than it claims.* A mirror that omits a gate is the same defect as a gate that does not run, one layer over: both produce a green about a smaller question than the reader believes.

Declared as a **stage**, not plumbing, because it is a gate. And it is not redundant with `affected-verify`, which is the objection a reader reaches for: that stage lints the **affected scopes**, so the warnings it reports are the warnings in its packages. The ceiling governs the sum over all of them, and only a whole-workspace run produces that number — a warning added in one package is invisible to a scoped lint and counted by the ceiling.

**The ratchet scan's own docstring said the ceiling is enforced "on the promotion path"**, and its passing message said "on the release path, not by this scan". Both were true this morning and this change makes them false, so both are corrected here — the same rule this fleet applied to five documents on another leaf today.

## Cost, stated rather than discovered

`verify-like-ci` now runs a whole-workspace lint, so the local mirror is minutes slower. That is the cost of the gate being real, and the three lanes were told before this was pushed rather than left to find it as a slowdown.

## Not in this change

Reducing the 2203. `943` are `@typescript-eslint/ban-types` and `624` are `no-magic-numbers`, which split by rule into mechanical passes rather than one sweep across every lane's in-flight work. Filed separately.

## Verification

```
pnpm lint                                          -> exit 0 at the new ceiling
node scripts/harness/scan-lint-warning-ratchet.mjs -> passes, ceiling 2203 at baseline
pnpm harness:scan                                  -> 141 passed, 2 skipped, 0 failed
pnpm exec vitest run scripts/harness/__tests__/ci-mirror-map.test.mjs -> 51 passed
```

The count was measured on `f8f344eb8` with `eslint ... -f json`, summing `warningCount` across 1949 files, rather than read off a summary line.

Refs issue #1984, issue #2175

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fmnzs5W63fCNLiG4xEJLY
