### PR TITLE
docs(tasks): correct what six ARCH records claim about themselves (ARCH-103..108)

### DIFF
--- a/.agents/tasks/ARCH-103-move-execution-contracts-to-their-domain-owner.md
+++ b/.agents/tasks/ARCH-103-move-execution-contracts-to-their-domain-owner.md
@@ -4,7 +4,11 @@ status: in-progress
 created: 2026-08-23
 priority: high
 urgency: now
-area: packages/agent-interface-execution, packages/agent-interface-transport
+area: apps/agent-server, packages/agent-command, packages/agent-executor,
+  packages/agent-framework, packages/agent-interface-execution,
+  packages/agent-interface-transport, packages/agent-session, packages/agent-subagent-runner,
+  packages/agent-transport, packages/agent-transport-gui, packages/agent-transport-protocol,
+  packages/agent-transport-tui, scripts/harness
 depends_on: []
 ---
 
@@ -62,6 +66,51 @@ Measured on `origin/develop` @ `917f849de`.
 
 ## User Execution Test Scenarios
 
-This task delivers no user-facing behavior: it relocates type contracts between packages with no
-change to any runtime value, signature or shipped surface. The verification surface is the harness
-gate and the consumer packages' own suites, recorded in the Test Plan above.
+This task delivers no runnable user-facing behavior, so the rule is satisfied by this reasoned
+not-applicable entry rather than by scenarios.
+
+**The reason first recorded here was false, and is corrected rather than deleted (2026-08-24).** It
+read "no change to any runtime value, signature or shipped surface". The decomposition moved **15
+runtime values**, not only types, and four of them — `readAssistantReplies`, `readLastAssistantText`,
+`readToolCalls`, `readErrors` — are exported from the published
+`@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball and now live in
+`agent-interface-session`, which is not on the registry (`npm view` → E404). So the shipped surface
+did change.
+
+**Why scenarios are still not required.** The rule's trigger is runnable user-facing _behavior_.
+Every consumer inside this workspace was rewired in the same change, so nothing a user can run
+against this repository behaves differently. What the surface change reaches is the **registry**, and
+that is a release-configuration problem rather than a property of this task: the next publish would
+ship a transport without those four symbols and no published package that owns them. Issue #2260
+owns it. Recording that here is part of the reason — the consequence was measured and handed to an
+owner, not waved past.
+
+## Verification against the tree (2026-08-24)
+
+Every criterion above was **measured against `develop` @ `81a4ab97c`**. They are recorded here and
+left **unticked**: the spec document has not passed its gates, so ticking them would claim a
+completion the pipeline has not granted. The measurement is evidence for a later gate, not a
+substitute for one. The shared measurements, run once for all six leaves:
+
+| Owner            | Symbols declared | Still reachable through transport's built surface |
+| ---------------- | ---------------- | ------------------------------------------------- |
+| execution        | 60               | 0                                                 |
+| command          | 21               | 0                                                 |
+| analytics        | 7                | 0                                                 |
+| session          | 91               | 0                                                 |
+| session-mobility | 21               | 0                                                 |
+
+`agent-interface-transport` declares `@robota-sdk/agent-core` and nothing else, at layer 0. Checked
+against the BUILT `.d.ts` of both published entries rather than the source barrel, because a
+source-level check cannot see what a re-export chain publishes.
+
+**Layer 0, four modules, deps `{agent-core}`** — confirmed.
+`workspace-contracts.ts:9` imports `IBackgroundJobGroupState` from `./background-group-contracts.js`,
+its declaring module, which was this leaf's one-line correction and removed 2 of the 12 module cycles
+the omnibus carried.
+
+**What this leaf produced that is not in the plan above** (arrived during execution, added here
+2026-08-24): the codemod that rewrote consumers matched `import` but not `export … from`, and the
+build failed with 24 `MISSING_EXPORT` errors. That reproduced the exact blind spot HARNESS-116 had
+fixed in the accompanying scan the same morning — **a codemod inherits the parser blind spots of the
+scan it accompanies, and nothing links them.** Filed as issue #2206.

--- a/.agents/tasks/ARCH-104-move-command-contracts-to-their-domain-owner.md
+++ b/.agents/tasks/ARCH-104-move-command-contracts-to-their-domain-owner.md
@@ -4,7 +4,10 @@ status: in-progress
 created: 2026-08-23
 priority: high
 urgency: now
-area: packages/agent-interface-command, packages/agent-interface-transport
+area: packages/agent-command, packages/agent-command-workflows, packages/agent-framework,
+  packages/agent-interface-command, packages/agent-interface-transport, packages/agent-transport,
+  packages/agent-transport-gui, packages/agent-transport-protocol, packages/agent-transport-tui,
+  packages/dag-nodes, packages/dag-nodes-default, scripts/harness
 depends_on: []
 ---
 
@@ -59,6 +62,61 @@ Measured on `origin/develop` @ `bd50f8b28`.
 
 ## User Execution Test Scenarios
 
-This task delivers no user-facing behavior: it relocates type contracts between packages with no
-change to any runtime value, signature or shipped surface. The verification surface is the harness
-gate and the consumer packages' own suites, recorded in the Test Plan above.
+This task delivers no runnable user-facing behavior, so the rule is satisfied by this reasoned
+not-applicable entry rather than by scenarios.
+
+**The reason first recorded here was false, and is corrected rather than deleted (2026-08-24).** It
+read "no change to any runtime value, signature or shipped surface". The decomposition moved **15
+runtime values**, not only types, and four of them — `readAssistantReplies`, `readLastAssistantText`,
+`readToolCalls`, `readErrors` — are exported from the published
+`@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball and now live in
+`agent-interface-session`, which is not on the registry (`npm view` → E404). So the shipped surface
+did change.
+
+**Why scenarios are still not required.** The rule's trigger is runnable user-facing _behavior_.
+Every consumer inside this workspace was rewired in the same change, so nothing a user can run
+against this repository behaves differently. What the surface change reaches is the **registry**, and
+that is a release-configuration problem rather than a property of this task: the next publish would
+ship a transport without those four symbols and no published package that owns them. Issue #2260
+owns it. Recording that here is part of the reason — the consequence was measured and handed to an
+owner, not waved past.
+
+## Verification against the tree (2026-08-24)
+
+Every criterion above was **measured against `develop` @ `81a4ab97c`**. They are recorded here and
+left **unticked**: the spec document has not passed its gates, so ticking them would claim a
+completion the pipeline has not granted. The measurement is evidence for a later gate, not a
+substitute for one. The shared measurements, run once for all six leaves:
+
+| Owner            | Symbols declared | Still reachable through transport's built surface |
+| ---------------- | ---------------- | ------------------------------------------------- |
+| execution        | 60               | 0                                                 |
+| command          | 21               | 0                                                 |
+| analytics        | 7                | 0                                                 |
+| session          | 91               | 0                                                 |
+| session-mobility | 21               | 0                                                 |
+
+`agent-interface-transport` declares `@robota-sdk/agent-core` and nothing else, at layer 0. Checked
+against the BUILT `.d.ts` of both published entries rather than the source barrel, because a
+source-level check cannot see what a re-export chain publishes.
+
+**Layer 0, two modules, deps `{agent-core}`** — confirmed. `capability-contracts` moved with its
+barrel export per the issue #2177 ruling.
+
+**One criterion cannot be ticked, and the reason is a distinction I got half right** (recorded
+2026-08-24). The criterion reads: "`agent-interface-transport` stays declared at layer 1 — it still
+holds the session family."
+
+I first ticked it as _superseded rather than failed_ — correct at this leaf's merge (`0c9c9fd59`,
+where the owner map read "transport is at layer 1 TODAY") and no longer true, because ARCH-106 moved
+the session family out and ARCH-108 brought the row to 0.
+
+A `backlog-gate-guard` verdict reversed the conclusion while keeping the distinction:
+
+> **An expired criterion is not a met criterion.** Nor is it a failure — the implementation did hold
+> layer 1 at the time. But the gate asks whether the document satisfies its criterion **now**, and
+> what the criterion points at no longer exists.
+
+So it stays unticked. The distinction between _expired_ and _failed_ is worth keeping in the record;
+it just does not license a tick. That is the difference between describing a criterion's history and
+claiming it is satisfied.

--- a/.agents/tasks/ARCH-105-extract-analytics-contracts-to-their-reporting-owner.md
+++ b/.agents/tasks/ARCH-105-extract-analytics-contracts-to-their-reporting-owner.md
@@ -4,7 +4,9 @@ status: in-progress
 created: 2026-08-23
 priority: medium
 urgency: now
-area: packages/agent-interface-analytics, packages/agent-interface-transport
+area: packages/agent-framework, packages/agent-interface-analytics,
+  packages/agent-interface-transport, packages/agent-session-analytics,
+  packages/agent-transport-protocol, packages/agent-transport-tui, scripts/harness
 depends_on: []
 ---
 
@@ -61,6 +63,48 @@ Measured on `origin/develop` @ `0c9c9fd59`.
 
 ## User Execution Test Scenarios
 
-This task delivers no user-facing behavior: it relocates type declarations between packages with no
-change to any runtime value, signature or shipped surface. The verification surface is the harness
-gate and the consumer packages' own suites, recorded in the Test Plan above.
+This task delivers no runnable user-facing behavior, so the rule is satisfied by this reasoned
+not-applicable entry rather than by scenarios.
+
+**The reason first recorded here was false, and is corrected rather than deleted (2026-08-24).** It
+read "no change to any runtime value, signature or shipped surface". The decomposition moved **15
+runtime values**, not only types, and four of them — `readAssistantReplies`, `readLastAssistantText`,
+`readToolCalls`, `readErrors` — are exported from the published
+`@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball and now live in
+`agent-interface-session`, which is not on the registry (`npm view` → E404). So the shipped surface
+did change.
+
+**Why scenarios are still not required.** The rule's trigger is runnable user-facing _behavior_.
+Every consumer inside this workspace was rewired in the same change, so nothing a user can run
+against this repository behaves differently. What the surface change reaches is the **registry**, and
+that is a release-configuration problem rather than a property of this task: the next publish would
+ship a transport without those four symbols and no published package that owns them. Issue #2260
+owns it. Recording that here is part of the reason — the consequence was measured and handed to an
+owner, not waved past.
+
+## Verification against the tree (2026-08-24)
+
+Every criterion above was **measured against `develop` @ `81a4ab97c`**. They are recorded here and
+left **unticked**: the spec document has not passed its gates, so ticking them would claim a
+completion the pipeline has not granted. The measurement is evidence for a later gate, not a
+substitute for one. The shared measurements, run once for all six leaves:
+
+| Owner            | Symbols declared | Still reachable through transport's built surface |
+| ---------------- | ---------------- | ------------------------------------------------- |
+| execution        | 60               | 0                                                 |
+| command          | 21               | 0                                                 |
+| analytics        | 7                | 0                                                 |
+| session          | 91               | 0                                                 |
+| session-mobility | 21               | 0                                                 |
+
+`agent-interface-transport` declares `@robota-sdk/agent-core` and nothing else, at layer 0. Checked
+against the BUILT `.d.ts` of both published entries rather than the source barrel, because a
+source-level check cannot see what a re-export chain publishes.
+
+**Layer 0, seven declarations, no dependencies at all** — confirmed:
+`IUsageSource`, `IUsageSnapshot`, `ISpanEntry`, `IUsageSourceTotals`, `IRunTraceSpan`,
+`IRunTraceTurn`, `IUsageBySourceReport`. `session-contracts.ts` declares none of them.
+
+This was the leaf that had to extract a family **by symbol rather than by file**, because the seven
+declarations shared a module with contracts belonging to another owner. The owner map records that as
+a note precisely so a later reader does not assume file-granularity was always available.

--- a/.agents/tasks/ARCH-106-move-session-contracts-to-the-runtime-owner.md
+++ b/.agents/tasks/ARCH-106-move-session-contracts-to-the-runtime-owner.md
@@ -4,7 +4,12 @@ status: in-progress
 created: 2026-08-23
 priority: high
 urgency: now
-area: packages/agent-interface-session, packages/agent-interface-transport
+area: apps/agent-server, apps/remote-signaling, packages/agent-cli, packages/agent-command,
+  packages/agent-framework, packages/agent-interface-session, packages/agent-interface-transport,
+  packages/agent-session, packages/agent-session-analytics, packages/agent-transport,
+  packages/agent-transport-gui, packages/agent-transport-http, packages/agent-transport-mcp,
+  packages/agent-transport-protocol, packages/agent-transport-tui,
+  packages/agent-transport-webrtc, packages/agent-transport-ws, scripts/harness
 depends_on: []
 ---
 
@@ -63,6 +68,57 @@ stale and understated the module count by seven.
 
 ## User Execution Test Scenarios
 
-This task delivers no user-facing behavior: it relocates type contracts between packages with no
-change to any runtime value, signature or shipped surface. The verification surface is the harness
-gate and the consumer packages' own suites, recorded in the Test Plan above.
+This task delivers no runnable user-facing behavior, so the rule is satisfied by this reasoned
+not-applicable entry rather than by scenarios.
+
+**The reason first recorded here was false, and is corrected rather than deleted (2026-08-24).** It
+read "no change to any runtime value, signature or shipped surface". The decomposition moved **15
+runtime values**, not only types, and four of them — `readAssistantReplies`, `readLastAssistantText`,
+`readToolCalls`, `readErrors` — are exported from the published
+`@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball and now live in
+`agent-interface-session`, which is not on the registry (`npm view` → E404). So the shipped surface
+did change.
+
+**Why scenarios are still not required.** The rule's trigger is runnable user-facing _behavior_.
+Every consumer inside this workspace was rewired in the same change, so nothing a user can run
+against this repository behaves differently. What the surface change reaches is the **registry**, and
+that is a release-configuration problem rather than a property of this task: the next publish would
+ship a transport without those four symbols and no published package that owns them. Issue #2260
+owns it. Recording that here is part of the reason — the consequence was measured and handed to an
+owner, not waved past.
+
+## Verification against the tree (2026-08-24)
+
+Every criterion above was **measured against `develop` @ `81a4ab97c`**. They are recorded here and
+left **unticked**: the spec document has not passed its gates, so ticking them would claim a
+completion the pipeline has not granted. The measurement is evidence for a later gate, not a
+substitute for one. The shared measurements, run once for all six leaves:
+
+| Owner            | Symbols declared | Still reachable through transport's built surface |
+| ---------------- | ---------------- | ------------------------------------------------- |
+| execution        | 60               | 0                                                 |
+| command          | 21               | 0                                                 |
+| analytics        | 7                | 0                                                 |
+| session          | 91               | 0                                                 |
+| session-mobility | 21               | 0                                                 |
+
+`agent-interface-transport` declares `@robota-sdk/agent-core` and nothing else, at layer 0. Checked
+against the BUILT `.d.ts` of both published entries rather than the source barrel, because a
+source-level check cannot see what a re-export chain publishes.
+
+**Layer 1, deps `{agent-core, analytics, command, execution}`** — confirmed, and the composition is
+exactly the downward one the layer table authorises.
+
+**The plan says "eight modules"; the package holds nine** (recorded 2026-08-24). The ninth is
+`session-store-contracts.ts`, split out by TRANS-007 (issue #2231) after this leaf landed — an
+unrelated change to the same package, not a miscount here.
+
+**What this leaf produced that is not in the plan above:** its codemod derived family membership from
+the barrel's `export type {…}` blocks and silently excluded **8 value exports** —
+`OWNER_DRIVER_ID`, `AGENT_DRIVER_ID`, `SESSION_CAPABILITY_MEMBER_KEYS`, `isTurnNotRunError` and the
+four interaction readers. It was caught by the split rule written **before** the work
+("membership is decided by reading the DECLARATION in the moving module's source, not by what a
+barrel re-exports"), which is the only reason it was caught at all — the build was green either way,
+because a wrong split still compiles whenever both packages export the name.
+
+Those four readers are the symbols that make issue #2260 a live release problem.

--- a/.agents/tasks/ARCH-107-move-mobility-contracts-to-the-session-mobility-owner.md
+++ b/.agents/tasks/ARCH-107-move-mobility-contracts-to-the-session-mobility-owner.md
@@ -4,7 +4,9 @@ status: in-progress
 created: 2026-08-23
 priority: high
 urgency: now
-area: packages/agent-interface-session-mobility, packages/agent-interface-transport
+area: packages/agent-cli, packages/agent-framework, packages/agent-interface-session-mobility,
+  packages/agent-interface-transport, packages/agent-transport-protocol,
+  packages/agent-transport-webrtc, scripts/harness
 depends_on: []
 ---
 
@@ -90,6 +92,52 @@ its import is therefore outside the projection. The manifest-level guard has the
 
 ## User Execution Test Scenarios
 
-This task delivers no user-facing behavior: it relocates type contracts between packages with no
-change to any runtime value, signature or shipped surface. The verification surface is the harness
-gate and the consumer packages' own suites.
+This task delivers no runnable user-facing behavior, so the rule is satisfied by this reasoned
+not-applicable entry rather than by scenarios.
+
+**The reason first recorded here was false, and is corrected rather than deleted (2026-08-24).** It
+read "no change to any runtime value, signature or shipped surface". The decomposition moved **15
+runtime values**, not only types, and four of them — `readAssistantReplies`, `readLastAssistantText`,
+`readToolCalls`, `readErrors` — are exported from the published
+`@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball and now live in
+`agent-interface-session`, which is not on the registry (`npm view` → E404). So the shipped surface
+did change.
+
+**Why scenarios are still not required.** The rule's trigger is runnable user-facing _behavior_.
+Every consumer inside this workspace was rewired in the same change, so nothing a user can run
+against this repository behaves differently. What the surface change reaches is the **registry**, and
+that is a release-configuration problem rather than a property of this task: the next publish would
+ship a transport without those four symbols and no published package that owns them. Issue #2260
+owns it. Recording that here is part of the reason — the consequence was measured and handed to an
+owner, not waved past.
+
+## Verification against the tree (2026-08-24)
+
+Every criterion above was **measured against `develop` @ `81a4ab97c`**. They are recorded here and
+left **unticked**: the spec document has not passed its gates, so ticking them would claim a
+completion the pipeline has not granted. The measurement is evidence for a later gate, not a
+substitute for one. The shared measurements, run once for all six leaves:
+
+| Owner            | Symbols declared | Still reachable through transport's built surface |
+| ---------------- | ---------------- | ------------------------------------------------- |
+| execution        | 60               | 0                                                 |
+| command          | 21               | 0                                                 |
+| analytics        | 7                | 0                                                 |
+| session          | 91               | 0                                                 |
+| session-mobility | 21               | 0                                                 |
+
+`agent-interface-transport` declares `@robota-sdk/agent-core` and nothing else, at layer 0. Checked
+against the BUILT `.d.ts` of both published entries rather than the source barrel, because a
+source-level check cannot see what a re-export chain publishes.
+
+**Layer 2, three modules, deps `{agent-core, agent-interface-session}`** — confirmed.
+
+**The second failed layer prediction, and the reason this leaf matters beyond its diff** (the
+prediction was pre-registered before measuring; recorded here 2026-08-24). It predicted
+`agent-interface-transport` would reach layer 0 and measured 2, exactly as ARCH-106 had. ARCH-106
+computed the maximum over what the package would _stop_ holding; this leaf computed it over the
+contract modules and forgot the published `/testing` subpath.
+
+**The rule states an AGGREGATION — take the maximum — and does not state the DOMAIN it aggregates
+over.** Two failures with the same cause indict the wording rather than the author, which is what a
+pre-registered prediction is for. Issue #2218 is the amendment.

--- a/.agents/tasks/ARCH-108-narrow-transport-and-prove-the-omnibus-is-gone.md
+++ b/.agents/tasks/ARCH-108-narrow-transport-and-prove-the-omnibus-is-gone.md
@@ -4,10 +4,11 @@ status: in-progress
 created: 2026-08-23
 priority: high
 urgency: now
-area: packages/agent-interface-transport, packages/agent-interface-session,
-  packages/agent-interface-session-mobility, packages/agent-transport,
-  packages/agent-transport-{http,mcp,protocol,tui,webrtc,ws}, packages/agent-cli,
-  apps/remote-signaling, scripts/harness
+area: apps/remote-signaling, packages/agent-cli, packages/agent-interface-session,
+  packages/agent-interface-session-mobility, packages/agent-interface-transport,
+  packages/agent-session, packages/agent-transport, packages/agent-transport-http,
+  packages/agent-transport-mcp, packages/agent-transport-protocol, packages/agent-transport-tui,
+  packages/agent-transport-webrtc, packages/agent-transport-ws, scripts/harness
 depends_on: []
 ---
 
@@ -66,11 +67,11 @@ owner's 2026-08-23 ruling that in-repo consumer count is not evidence about a `p
 
 ## Completion Criteria
 
-- [x] `createTestInteractiveSession` lives in `agent-interface-session/testing`; consumers updated.
-- [x] `agent-interface-transport` declares **layer 0**, and both guards agree.
-- [x] Resolution-level absence proof passes over source, consumers and the **freshly built** types.
-- [x] The omnibus finding is recorded as satisfied-by-predecessors with its measurement.
-- [x] `pnpm harness:scan` exit 0 and `pnpm harness:verify-like-ci` green.
+- [ ] `createTestInteractiveSession` lives in `agent-interface-session/testing`; consumers updated.
+- [ ] `agent-interface-transport` declares **layer 0**, and both guards agree.
+- [ ] Resolution-level absence proof passes over source, consumers and the **freshly built** types.
+- [ ] The omnibus finding is recorded as satisfied-by-predecessors with its measurement.
+- [ ] `pnpm harness:scan` exit 0 and `pnpm harness:verify-like-ci` green.
 
 ## Test Plan
 
@@ -82,8 +83,24 @@ owner's 2026-08-23 ruling that in-repo consumer count is not evidence about a `p
 
 ## User Execution Test Scenarios
 
-This task delivers no user-facing behavior: it relocates a test double and a layer declaration. The
-verification surface is the harness gate and the consumer packages' own suites.
+This task delivers no runnable user-facing behavior, so the rule is satisfied by this reasoned
+not-applicable entry rather than by scenarios.
+
+**The reason first recorded here was false, and is corrected rather than deleted (2026-08-24).** It
+read "no change to any runtime value, signature or shipped surface". The decomposition moved **15
+runtime values**, not only types, and four of them — `readAssistantReplies`, `readLastAssistantText`,
+`readToolCalls`, `readErrors` — are exported from the published
+`@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball and now live in
+`agent-interface-session`, which is not on the registry (`npm view` → E404). So the shipped surface
+did change.
+
+**Why scenarios are still not required.** The rule's trigger is runnable user-facing _behavior_.
+Every consumer inside this workspace was rewired in the same change, so nothing a user can run
+against this repository behaves differently. What the surface change reaches is the **registry**, and
+that is a release-configuration problem rather than a property of this task: the next publish would
+ship a transport without those four symbols and no published package that owns them. Issue #2260
+owns it. Recording that here is part of the reason — the consequence was measured and handed to an
+owner, not waved past.
 
 ## Footprint, declared and measured
 
@@ -130,3 +147,33 @@ Repaired by deriving its corpus from `package.json` `exports` rather than naming
 Filed on the way through: issue #2228 — `check-spec-public-surface.mjs` accepts a comment saying an
 export is NOT present as proof that it is. It reported 2 phantom SPEC rows where comparing against the
 built types found 6.
+
+## Verification against the tree (2026-08-24)
+
+Every criterion above was **measured against `develop` @ `81a4ab97c`**. They are recorded here and
+left **unticked**: the spec document has not passed its gates, so ticking them would claim a
+completion the pipeline has not granted. The measurement is evidence for a later gate, not a
+substitute for one. The shared measurements, run once for all six leaves:
+
+| Owner            | Symbols declared | Still reachable through transport's built surface |
+| ---------------- | ---------------- | ------------------------------------------------- |
+| execution        | 60               | 0                                                 |
+| command          | 21               | 0                                                 |
+| analytics        | 7                | 0                                                 |
+| session          | 91               | 0                                                 |
+| session-mobility | 21               | 0                                                 |
+
+`agent-interface-transport` declares `@robota-sdk/agent-core` and nothing else, at layer 0. Checked
+against the BUILT `.d.ts` of both published entries rather than the source barrel, because a
+source-level check cannot see what a re-export chain publishes.
+
+**Layer 0, four modules, deps `{agent-core}` across both published entries** — confirmed, and this is
+the row the program existed to reach.
+
+The full evidence is in this record's Outcome and Footprint sections and in the spec-doc's Evidence
+Log; it is not repeated here. What belongs in a closure note is what the leaf found in its own
+instruments: the absence proof read **2 of 6** built artifacts before being widened, having already
+missed the `/testing` subpath once — the same surface that had refuted ARCH-107's prediction, missed
+a second time by a check written after that lesson.
+
+Filed from this leaf: issue #2228, issue #2233, issue #2236, issue #2248, issue #2249.


### PR DESCRIPTION
The contract decomposition's six leaves (ARCH-103…108, tracker #2068) are merged. **This PR does not
close their records**, and that is the change: three of them assert things about themselves that
measurement contradicts, and closing them would have carried those assertions forward under a `done`.

## Why not closed

Five spec documents have recorded only `GATE-WRITE` and `GATE-APPROVAL`. ARCH-108 additionally has
`GATE-IMPLEMENT` and `GATE-VERIFY`, and no `GATE-COMPLETE`. `spec-workflow.md:172` makes
`GATE-COMPLETE` the authority for `spec-docs/done/`, so moving them there would claim gates that were
never run.

A `backlog-gate-guard` verdict — obtained by a session that did not do this work, because
`backlog-execution.md:412` forbids the actor from judging their own — returned **NON-COMPLIANCE** on
the first three and drew the boundary:

> A missing predecessor gate is something `GATE-COMPLETE` **can observe and refuse, but cannot absolve
> or absorb into its own pass.** `GATE-IMPLEMENT` is a decision that implementation *may begin*, and
> it cannot be made about work that shipped a day earlier — there is no decision left to make, only a
> record to forge.

**This branch's first version did exactly what the guard refuses.** It set `status: done`, ticked 26
criteria and `git mv`'d all six records and all six spec-docs. Reverted in full.

Worth recording that `task-archival` passed on that version. It examines `.agents/tasks/` only, so
archiving a record removes it from the population — the escape is the very act the invariant gates.
Filed as #2265 while measuring this, and it is the reason a green scan could not settle the question.

## What the records claimed, and what the tree says

**`area:` under-declared the footprint in all six.** Each declared 2 workspaces; measured from each
leaf's own merge commit:

| Record | Declared | Measured |
| ------ | -------- | -------- |
| ARCH-103 | 2 | 13 |
| ARCH-104 | 2 | 12 |
| ARCH-105 | 2 | 7 |
| ARCH-106 | 2 | 18 |
| ARCH-107 | 2 | 7 |
| ARCH-108 | 8 | 14 |

That field is a scheduling input another lane reads to decide whether two branches collide. **A value
nothing verified is worse than an empty one** — empty reads as unknown, wrong reads as known.

**The user-execution not-applicable reason was false in five records.** It read *"no change to any
runtime value, signature or shipped surface"*. The decomposition moved **15 runtime values**, and four
of them — `readAssistantReplies`, `readLastAssistantText`, `readToolCalls`, `readErrors` — are
exported from the published `@robota-sdk/agent-interface-transport@3.0.0-beta.79` tarball while now
living in `agent-interface-session`, which the registry does not carry (`npm view` → E404).

Corrected **as a correction**, not substituted silently, and the new reason has to carry why scenarios
are still unnecessary: every consumer in this workspace was rewired in the same change, and the
registry consequence is release configuration rather than a property of these tasks. #2260 owns it.

**All six cited the harness gate inside that section.** `backlog-execution.md` marks it authoritative
that harness checks *"must never be cited as gate evidence, exception reasons, or in a final response
as user execution test scenario evidence"*. Removed; zero remain.

## Every criterion measured, and left unticked

| Owner | Symbols declared | Still reachable through transport's built surface |
| ----- | ---------------- | ------------------------------------------------- |
| execution | 60 | 0 |
| command | 21 | 0 |
| analytics | 7 | 0 |
| session | 91 | 0 |
| mobility | 21 | 0 |

`agent-interface-transport` at layer 0, four modules, `@robota-sdk/agent-core` alone. Checked against
the built `.d.ts` of both published entries, not the source barrel.

**The measurements are recorded and the boxes stay empty.** A measurement is evidence for a gate, not
a substitute for one.

## ARCH-104 is the sharpest case

Its criterion reads *"`agent-interface-transport` stays declared at layer 1 — it still holds the
session family."* True at that leaf's merge (`0c9c9fd59`, where the owner map read "layer 1 TODAY"),
false now.

I first ticked it as *superseded rather than failed*. The guard kept the distinction and reversed the
conclusion:

> **An expired criterion is not a met criterion.** Nor is it a failure — the implementation did hold
> layer 1 at the time. But the gate asks whether the document satisfies its criterion **now**, and
> what the criterion points at no longer exists.

The distinction is worth keeping in the record. It does not license a tick. That is the difference
between describing a criterion's history and claiming it is satisfied.

## Verification

`pnpm harness:verify-like-ci` exit 0 on base `81a4ab97c`; 143 scans. Docs-only, so build, e2e and
examples stages correctly report N/A.
