### PR TITLE
docs(spec): record five GATE-COMPLETE verdicts on the wave-1 ARCH leaves

### DIFF
--- a/.agents/spec-docs/todo/ARCH-103-move-execution-contracts-to-their-domain-owner.md
+++ b/.agents/spec-docs/todo/ARCH-103-move-execution-contracts-to-their-domain-owner.md
@@ -202,3 +202,55 @@ were both settled before this leaf:
   illegal until ARCH-101, which landed the owner's layer ruling. It is now a declared downward edge.
 
 Nothing here decides which family belongs to which owner — that is ARCH-100's, merged and unchanged.
+
+### [GATE-COMPLETE] — 🔴 NON-COMPLIANCE | 2026-08-24
+
+**Status remains:** approved (`.agents/spec-docs/todo/`)
+
+**Violation:** the ordering check for GATE-COMPLETE fails on both limbs, and the work this pipeline
+was supposed to authorize has already shipped.
+
+- **Prior gate absent.** `gate-catalogue.md` § Prior-gate map requires a recorded **GATE-VERIFY PASS**
+  before GATE-COMPLETE. This Evidence Log contains exactly two entries — `[GATE-WRITE] ✅ PASS
+2026-08-23` and `[GATE-APPROVAL] ✅ PASS 2026-08-23`. There is **no GATE-IMPLEMENT entry and no
+  GATE-VERIFY entry**. Two gates in the pipeline were skipped, not one.
+- **Input state wrong.** GATE-COMPLETE expects `verifying` / `active/`. The frontmatter reads
+  `status: approved` and the file sits in `todo/` — the state GATE-APPROVAL leaves behind, i.e. the
+  document never left the approval step.
+- **Authorized-work-already-done.** GATE-IMPLEMENT is the verdict that implementation may _start_.
+  Implementation is merged: `bd50f8b28` "feat(interface): move execution contracts to their domain
+  owner (ARCH-103)" (PR #2203), dated 2026-08-23, verified an ancestor of `origin/develop` via
+  `git merge-base --is-ancestor`. `packages/agent-interface-execution` exists on disk. Passing
+  GATE-COMPLETE now would not be judging the pipeline; it would be backdating two verdicts that were
+  never rendered — the definition of a bypassed gate.
+
+**Corroborating irregularities observed while establishing the above (not the deciding finding):**
+
+- The spec has **no `## Tasks` section at all** (sections present: Problem, Prior Art Research,
+  Architecture Review Checklist, Alternatives Considered, Decision, Completion Criteria, Test Plan,
+  User Execution Test Scenarios, Evidence Log). GATE-WRITE § Structure requires one, and GATE-IMPLEMENT
+  requires the tasks-file path be recorded in it. The GATE-WRITE PASS entry does not mention the
+  Structure criterion at all — an unanswered criterion, which the catalogue treats as NON-COMPLIANCE on
+  the next run.
+- The GATE-WRITE entry states on its face: "Judged by: self-assessment … Not a `backlog-gate-guard`
+  verdict — no guardian agent was dispatched." The only prior evidence for the upstream gate is
+  author-recorded, not an independent guardian verdict.
+- All six TC-01…TC-06 checkboxes in `## Completion Criteria` are `[ ]` unchecked, and the paired task
+  record `.agents/tasks/ARCH-103-move-execution-contracts-to-their-domain-owner.md` carries
+  `status: in-progress` with all six of its task items `[ ]` unchecked — while the implementation is
+  merged. (The claim that an uncommitted change moves that task to `completed/` with `status: done`
+  does not hold in this clone: `git status --porcelain` shows only
+  `.agents/evals/lessons/auto-lessons.md` and `.agents/evals/lessons/weekly-digest.md` modified.)
+
+Per the ordering rule, GATE-COMPLETE's own criteria were **not** evaluated — a gate judged out of order
+is meaningless, and a per-TC evidence pass here would manufacture the record the skipped gates should
+have produced.
+
+**Required action:** not this gate's call to make, and not resolvable by re-running GATE-COMPLETE.
+The skipped `GATE-IMPLEMENT` and `GATE-VERIFY` are **outside GATE-COMPLETE's remit to judge** — this
+gate may only observe that they are missing and refuse. Resolution belongs to the orchestrator
+(`backlog-pipeline` / `backlog-execution-orchestrator`): either reconstruct the pipeline honestly with
+each gate dated when it is actually run and labelled as retrospective, or reject the item and record
+the merged-without-gates state as the process finding it is. Whichever is chosen, the missing
+`## Tasks` section must be authored and the TC checkboxes and task record brought into agreement with
+the shipped code before GATE-COMPLETE can be run at all.

--- a/.agents/spec-docs/todo/ARCH-104-move-command-contracts-to-their-domain-owner.md
+++ b/.agents/spec-docs/todo/ARCH-104-move-command-contracts-to-their-domain-owner.md
@@ -177,3 +177,63 @@ were both settled before this leaf:
   ARCH-101, which landed the owner's layer ruling.
 
 Nothing here decides which family belongs to which owner — that is ARCH-100's, merged and unchanged.
+
+### [GATE-COMPLETE] — 🔴 NON-COMPLIANCE | 2026-08-24
+
+**Status remains:** approved
+
+**Violation:** the ordering check fails on both limbs, and the work this pipeline gates has already
+shipped.
+
+- **Prior gate absent.** GATE-COMPLETE's prior gate is GATE-VERIFY (gate-catalogue § Prior-gate map).
+  This Evidence Log contains exactly two entries — `[GATE-WRITE]` (2026-08-23) and `[GATE-APPROVAL]`
+  (2026-08-23). There is no `[GATE-IMPLEMENT]` and no `[GATE-VERIFY]` entry, PASS, FAIL or otherwise.
+  Two gates were skipped, not one.
+- **Input state wrong.** GATE-COMPLETE expects `status: verifying` in `.agents/spec-docs/active/`.
+  Frontmatter reads `status: approved` and the file sits in `.agents/spec-docs/todo/` — the
+  GATE-APPROVAL output state, unchanged since 2026-08-23.
+- **The gated work is already merged.** GATE-IMPLEMENT is the verdict that implementation may START.
+  Implementation landed on `develop` as `0c9c9fd59` "feat(interface): move command contracts to their
+  domain owner (ARCH-104)" (PR #2209), creating `packages/agent-interface-command` with 109 files rewired
+  across 9 consumer packages. Two later leaves (`c621e4d49` ARCH-105, `22152ef9d` ARCH-106) have since
+  built on it. Passing GATE-COMPLETE now would not be judging the gate; it would be writing a
+  2026-08-24 PASS over a pipeline whose implement-authorisation gate never ran and can no longer be
+  run against an unstarted tree. That is backdating, and it is refused.
+
+**Not evaluated:** this gate's own criteria (TC-01…TC-06 verification entries, Test Plan references,
+`## Tasks` pointer, active-task completion). The guardian charter halts the run at a failed ordering
+check; evaluating them would manufacture the record the skipped gates were supposed to produce.
+Recorded only as ordering context, not as criterion verdicts: the spec has **no `## Tasks` section at
+all** (sections present: Problem, Prior Art Research, Architecture Review Checklist, Alternatives
+Considered, Decision, Completion Criteria, Test Plan, User Execution Test Scenarios, Evidence Log), and
+all six TC-N checkboxes in `## Completion Criteria` are `[ ]`.
+
+**Two collateral findings surfaced while checking prior evidence:**
+
+1. `[GATE-WRITE]` self-declares "Judged by: self-assessment against `.agents/specs/gate-catalogue.md`
+   § GATE-WRITE. Not a `backlog-gate-guard` verdict." A gate's own author is not its guardian, so the
+   one recorded PASS that precedes GATE-APPROVAL is not independent evidence. Its GATE-WRITE
+   "Structure" criterion (Tasks section present) is also contradicted by the file: no `## Tasks`
+   section exists, and the entry does not mention the item.
+2. The paired task record `.agents/tasks/ARCH-104-move-command-contracts-to-their-domain-owner.md` is
+   `status: in-progress` in `.agents/tasks/`, with all six of its completion criteria unchecked. The
+   reported uncommitted move to `completed/` with `status: done` is **not present in this clone** —
+   `git status --porcelain` on `develop` shows only `.agents/evals/lessons/auto-lessons.md` and
+   `.agents/evals/lessons/weekly-digest.md` modified.
+
+**Expired criterion — cannot be treated as met.** The task's fifth criterion,
+"`agent-interface-transport` stays declared at layer 1 — it still holds the session family", was true
+when `0c9c9fd59` landed: `contract-family-owner-map.md` at that commit reads "**`agent-interface-transport`
+is at layer 1 TODAY.**" It is no longer true. The same document on `develop` now reads
+"**`agent-interface-transport` is at layer 2 TODAY**", because `22152ef9d` (ARCH-106) closed
+issue #2110 and moved the session family out — the very condition the criterion was scoped
+by ("until issue #2110"). An expired criterion is not a met criterion: the gate asks whether the document demonstrably
+satisfies it, and the observable it names no longer exists to be observed. It is also not a FAIL of
+the implementation, which did retain layer 1 at the time. The correct handling is a criterion
+re-statement pinned to `0c9c9fd59` (or an explicit superseded-by-ARCH-106 note), decided by whoever
+owns the criteria — not a guardian ticking a box against a fact that has moved.
+
+**Required action:** not this guardian's call to sequence, but the record cannot be closed by this
+gate. Resolution requires the orchestrator to rule on a pipeline whose GATE-IMPLEMENT and GATE-VERIFY
+cannot be honestly recorded after the fact, and the layer-1 criterion to be re-stated or marked
+superseded before any completion verdict is attempted.

--- a/.agents/spec-docs/todo/ARCH-105-extract-analytics-contracts-to-their-reporting-owner.md
+++ b/.agents/spec-docs/todo/ARCH-105-extract-analytics-contracts-to-their-reporting-owner.md
@@ -191,3 +191,45 @@ before this leaf:
   ARCH-101.
 
 Nothing here decides which family belongs to which owner — that is ARCH-100's, merged and unchanged.
+
+### [GATE-COMPLETE] — 🔴 NON-COMPLIANCE | 2026-08-24
+
+**Status remains:** approved
+
+**Violation:** The ordering check for GATE-COMPLETE fails on both halves, and the work this pipeline
+was supposed to authorize has already shipped.
+
+- **Missing prior gate.** `gate-catalogue.md` § Prior-gate map requires GATE-VERIFY to show PASS
+  before GATE-COMPLETE runs. This Evidence Log contains exactly two entries — `[GATE-WRITE] ✅ PASS |
+2026-08-23` and `[GATE-APPROVAL] ✅ PASS | 2026-08-23`. There is no GATE-VERIFY entry, and no
+  GATE-IMPLEMENT entry either, so the missing predecessor is itself missing a predecessor.
+- **Wrong input state.** The gate expects `verifying` / `active/`. Frontmatter reads `status:
+approved` and the file sits in `.agents/spec-docs/todo/` — the state GATE-APPROVAL left it in, two
+  transitions back.
+- **Work already performed without its authorizing gate.** GATE-IMPLEMENT is the verdict that
+  implementation may _start_. Implementation is merged: `c621e4d49` ("feat(interface): extract
+  analytics contracts to their reporting owner (ARCH-105)" (PR #2214), 2026-08-23), verified an ancestor
+  of HEAD, creating `packages/agent-interface-analytics/` (`src/usage-contracts.ts`, 123 lines),
+  removing 111 lines from `packages/agent-interface-transport/src/session-contracts.ts` and 7 barrel
+  exports from its `src/index.ts`, and rewiring 4 consumer packages. A gate that authorizes a start
+  cannot be recorded after the finish; that entry would be a backdate, not a judgement.
+
+**Not adjudicated:** GATE-COMPLETE's own criteria were deliberately not evaluated, per the
+guardian ordering rule (evaluate ordering first; on failure, name the missing gate and stop). For the
+record, two of them are independently observable and would not have carried a PASS: all six TC-01…
+TC-06 boxes in `## Completion Criteria` are unchecked `[ ]` with no `[GATE-COMPLETE: TC-N]` evidence
+entries, and the spec has no `## Tasks` section at all (section list: Problem, Prior Art Research,
+Architecture Review Checklist, Alternatives Considered, Decision, Completion Criteria, Test Plan,
+User Execution Test Scenarios, Evidence Log), so no active task path is named.
+
+**Working-tree note:** the paired task record
+`.agents/tasks/ARCH-105-extract-analytics-contracts-to-their-reporting-owner.md` reads `status:
+in-progress` with 0 of 5 completion criteria checked, and `git status --porcelain` reports it clean.
+An uncommitted change in another clone is not evidence available to this gate.
+
+**Required action:** Not this guardian's call to sequence, but the record cannot be repaired by
+re-running GATE-COMPLETE. The pipeline owner must decide how a spec whose implementation merged ahead
+of its GATE-IMPLEMENT verdict is reconciled — the choice is between a recorded, dated
+out-of-order-execution finding that the later gates then judge against the shipped state, and
+rejection of the spec document — per `spec-workflow.md` HARD GATE and
+`backlog-execution-orchestrator` Phase 5.

--- a/.agents/spec-docs/todo/ARCH-106-move-session-contracts-to-the-runtime-owner.md
+++ b/.agents/spec-docs/todo/ARCH-106-move-session-contracts-to-the-runtime-owner.md
@@ -193,3 +193,34 @@ this leaf:
   so it is reviewable as a decision rather than as diff noise.
 
 Nothing here decides which family belongs to which owner — that is ARCH-100's, merged and unchanged.
+
+### [GATE-COMPLETE] — 🔴 NON-COMPLIANCE | 2026-08-24
+
+**Status remains:** approved (`.agents/spec-docs/todo/`)
+**Violation:** Ordering check failed on both halves, so this gate's own criteria were not reached.
+
+- **Missing prior gate.** `gate-catalogue.md` § Prior-gate map requires GATE-VERIFY PASS before
+  GATE-COMPLETE. The Evidence Log records exactly two entries — `[GATE-WRITE]` (2026-08-23) and
+  `[GATE-APPROVAL]` (2026-08-23). There is no `[GATE-IMPLEMENT]` entry and no `[GATE-VERIFY]` entry.
+  Two gates, not one, are absent.
+- **Wrong input state.** GATE-COMPLETE expects `verifying` / `active/`. Frontmatter reads
+  `status: approved` and the file sits in `todo/` — the state GATE-APPROVAL leaves behind, i.e. the
+  document never entered implementation on the record.
+- **Work this gate chain was to authorize has already shipped.** `packages/agent-interface-session`
+  exists on `develop`; commit `22152ef9d` "feat(interface): move session contracts to the runtime
+  owner (ARCH-106)" (PR #2217, 2026-08-23) is an ancestor of HEAD, and `4ed80522b` (ARCH-107, PR #2220)
+  already builds on it. GATE-IMPLEMENT is the verdict that implementation may _start_; issuing it
+  after the merge would be backdating, not judging. It is outside GATE-COMPLETE's remit either way —
+  a guardian applies one gate per run and cannot supply a predecessor's verdict.
+- **Corroborating tree state (not the deciding finding).** The paired task
+  `.agents/tasks/ARCH-106-move-session-contracts-to-the-runtime-owner.md` is `status: in-progress`
+  with 0 of 5 checklist items `[x]`; the spec has no `## Tasks` section at all, so no task path is
+  recorded where GATE-IMPLEMENT requires it; all six TC-N boxes are `[ ]` and the log holds zero
+  `[GATE-COMPLETE: TC-N]` entries. Judged against this working tree only; an uncommitted change in
+  another clone is not evidence here.
+
+**Required action:** Not a re-run of this gate. The pipeline owner must reconcile the record with the
+merged reality — decide whether ARCH-106 is closed out by a retrospective correction that is labelled
+as one (never a PASS-shaped GATE-IMPLEMENT entry dated after `22152ef9d`), or rejected and re-filed.
+Only once the document legitimately reads `verifying` with a GATE-VERIFY PASS may GATE-COMPLETE be
+invoked. No status change, no folder move and no content fix was made by this run.

--- a/.agents/spec-docs/todo/ARCH-107-move-mobility-contracts-to-the-session-mobility-owner.md
+++ b/.agents/spec-docs/todo/ARCH-107-move-mobility-contracts-to-the-session-mobility-owner.md
@@ -185,3 +185,52 @@ edge under ARCH-101.
 The layer change to 0 is not a new decision either — it is the state ARCH-106's corrected rule
 predicts once mobility leaves, and it is separated into its own commit so it stays reviewable as a
 decision.
+
+### [GATE-COMPLETE] — 🔴 NON-COMPLIANCE | 2026-08-24
+
+**Status remains:** approved
+
+**Violation:** The ordering check failed on both of its parts, so GATE-COMPLETE's own criteria were not
+evaluated.
+
+- **Missing prior gate.** The gate catalogue's prior-gate map requires **GATE-VERIFY = PASS** before
+  GATE-COMPLETE. The Evidence Log above holds exactly two entries — `[GATE-WRITE]` and
+  `[GATE-APPROVAL]`. There is no `[GATE-IMPLEMENT]` entry and no `[GATE-VERIFY]` entry. Two gates are
+  missing, not one.
+- **Wrong input state.** GATE-COMPLETE expects `status: verifying` in `.agents/spec-docs/active/`. This
+  document is `status: approved` in `.agents/spec-docs/todo/`. Status and folder agree with each other,
+  but they are the state expected as _input to GATE-IMPLEMENT_ — two transitions upstream.
+
+**Work this gate never authorized has already shipped.** Verified in-tree, not taken on report:
+
+- `packages/agent-interface-session-mobility` exists on `origin/develop`.
+- `4ed80522b feat(interface): move mobility contracts to the session-mobility owner (ARCH-107) (#2220)`
+  is merged.
+- A dependent follow-on leaf is merged on top of it:
+  `c1dd93768 refactor(interface): narrow the transport owner to what it owns (ARCH-108) (#2244)`.
+
+GATE-IMPLEMENT is the verdict that implementation may **start**. It was never run, and the
+implementation has since merged — which is the `NON-COMPLIANCE trigger` named under GATE-APPROVAL
+("implementation work was started before this gate ran") applied to the gate after it.
+
+**The missing gates are outside this gate's remit.** GATE-COMPLETE judges TC-N verification evidence
+against a document that GATE-VERIFY has already passed. It cannot stand in for GATE-IMPLEMENT or
+GATE-VERIFY, and it cannot authorize retroactively: a PASS recorded here would not be a judgement of
+those two gates, it would be a **backdating** of them — writing `verifying → done` over a document that
+never entered `in-progress`. That is the one thing a gate must never do, so this halts here.
+
+**Paired task record contradicts completion** (judged as this working tree holds it, unmodified —
+`git status` reports it clean): `.agents/tasks/ARCH-107-move-mobility-contracts-to-the-session-mobility-owner.md`
+is `status: in-progress` with **0 of 4 tasks checked**. An uncommitted change in a different clone is
+not evidence in this one.
+
+**Incidental, not the deciding basis** (recorded so a later run does not read this entry as clearing
+them): the spec has **no `## Tasks` section at all**, so no active task path is named; all 5 TC-N
+boxes are `[ ]`; and there are **0** `[GATE-COMPLETE: TC-N]` entries. Each is independently fatal to
+GATE-COMPLETE, but none was reached — the ordering check decided this run.
+
+**Required action:** Not resolvable by re-running this gate, and not by editing this document. The
+gap between the recorded pipeline state and the merged tree is a process breach that needs an owner
+decision — reconstruct the skipped GATE-IMPLEMENT/GATE-VERIFY record against the merged commit, or
+close this item out under the Rejection Action. Routing that decision belongs to the orchestrator,
+not to this guardian.


### PR DESCRIPTION
Five `backlog-gate-guard` invocations, one per document, GATE-COMPLETE on ARCH-103 through ARCH-107. Five NON-COMPLIANCE verdicts. This pull request is those verdicts written to the documents they judge — nothing else. No status changed, no document moved, no content under judgement edited.

The user authorized the guardian runs; `backlog-execution.md` reserves the verdict for that agent and forbids it to the actor that did the work, and this session did none of the ARCH-103..108 work.

## What five independent runs found, separately

Each verified the merge commit itself rather than taking it on report.

| Spec | Merged as | Gates recorded | State |
| --- | --- | --- | --- |
| ARCH-103 | `bd50f8b28` (PR #2203) | WRITE, APPROVAL | `approved` / `todo/` |
| ARCH-104 | `0c9c9fd59` (PR #2209) | WRITE, APPROVAL | `approved` / `todo/` |
| ARCH-105 | `c621e4d49` (PR #2214) | WRITE, APPROVAL | `approved` / `todo/` |
| ARCH-106 | `22152ef9d` (PR #2217) | WRITE, APPROVAL | `approved` / `todo/` |
| ARCH-107 | `4ed80522b` (PR #2220) | WRITE, APPROVAL | `approved` / `todo/` |

The ordering check fails on both limbs every time. `GATE-VERIFY` has no entry — and neither does its own predecessor `GATE-IMPLEMENT`, so, in one verdict's words, *"the missing predecessor is itself missing a predecessor."* The state is exactly what GATE-APPROVAL leaves behind, which means that **on the record none of these documents ever entered implementation**, while the work is merged and ARCH-108 is built on top of it.

Each verdict states why re-running the gate cannot repair this: GATE-IMPLEMENT is the verdict that implementation may **start**, it cannot be issued honestly about work that shipped, so there is no PASS for GATE-COMPLETE to inherit. A guardian may observe a missing prior gate and refuse on it; it may not adjudicate or absolve one. Routing — retrospective correction labelled as one, or rejection — is issue #2266.

## Why the verdicts are worth committing rather than just acting on

The reason these five reached this state is that **nothing read what the documents already said about themselves.** Every GATE-WRITE entry here discloses, on its own face, that it is not a guardian verdict. The disclosure was already in the tree and no mechanism consumed it. A verdict that is not recorded is in the same position, so these are recorded.

They are also the first `GATE VERDICT` lines to reach the `spec-docs` tree at all. Across 308 spec documents and 1578 `### [GATE-…]` entries there are 12 `Judged by:` lines, and every one of them says self-assessment.

## One correction made to the guards' own text

Six references the guards quoted out of commit subjects were bare `#NNNN`, which `reference-kind-qualified` refuses — and two `#2110` references were separated from the word "issue" by a line wrap, so the qualifier was there and unreadable, a regex treating the newline as a separator.

Each is now qualified, and **each kind was checked against GitHub rather than inferred from its shape**: #2203, #2209, #2214, #2217 and #2220 are pull requests, #2110 is an issue. The scan's own passing message is explicit that it cannot do this part —

> It checks that a reference says WHICH it is, not that the kind it names is correct — deciding that needs a live GitHub read.

— so the scan going green and the labels being right are two different claims, and only the second one matters to a reader.

## Verification

```
pnpm harness:scan                     143 scans, exit 0
scan-reference-kind-qualified         exit 0, 3048 documents examined
pnpm harness:review:record            0 findings @ 474a0614a
```

The scan was first read as passing off a summary line while the pipeline's exit status came from `tail`. Re-run under `set -o pipefail` it was exit 1, and `reference-kind-qualified` was the failure fixed above.
