### PR TITLE
fix(harness): keyed lists refuse a second entry for a key they already hold (issue #2042)

### DIFF
--- a/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
+++ b/scripts/harness/__tests__/scan-named-mechanism-resolves.test.mjs
@@ -20,6 +20,19 @@ import { collectNamedMechanismFindings, MATCHERS } from '../scan-named-mechanism
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../..');
 
+describe('the matcher table is well-formed', () => {
+  // Issue #2042. `MATCHERS` is looked up with `.find((m) => m.kind === kind)`, which returns the
+  // first and never looks again, so a duplicate `kind` leaves a matcher — pattern, resolver and
+  // hint — that no input can ever reach. The check asks EXISTENCE; the property is UNIQUENESS.
+  //
+  // Same shape as `CI_STAGES`'s `stage names are unique` and `SCAN_COMMANDS`'s
+  // `registers every scan exactly once`; this repository already answers this question twice.
+  it('declares every kind exactly once — a second matcher is unreachable', () => {
+    const kinds = MATCHERS.map((matcher) => matcher.kind);
+    expect(new Set(kinds).size).toBe(kinds.length);
+  });
+});
+
 describe('scan-named-mechanism-resolves', () => {
   it('is registered in run-all-scans.mjs', () => {
     const runner = readFileSync(

--- a/scripts/harness/__tests__/scan-release-sweep-coverage.test.mjs
+++ b/scripts/harness/__tests__/scan-release-sweep-coverage.test.mjs
@@ -128,6 +128,22 @@ describe('R2 reachability — the pre-fix, hand-maintained shape', () => {
   });
 });
 
+describe('the exclusion list is well-formed', () => {
+  // Issue #2042. `EXCLUSIONS` is read through `.some((e) => e.script === script)`, which is
+  // satisfied by one entry and never looks for a second — so a duplicate `script` puts a reason in
+  // the file that nothing will ever read, wearing the same authoritative face as the one that
+  // governs. The check asks EXISTENCE; the property is UNIQUENESS.
+  //
+  // An assertion rather than a Map, because the second entry is dropped before anyone sees it —
+  // unlike NOT_MIRRORED, whose duplicates are printed to the user and so are refused structurally.
+  // The shape follows `CI_STAGES`'s `stage names are unique` and `SCAN_COMMANDS`'s
+  // `registers every scan exactly once`, which is what this repository already does twice.
+  it('excludes every script exactly once — a second entry is a reason nobody reads', () => {
+    const scripts = EXCLUSIONS.map((entry) => entry.script);
+    expect(new Set(scripts).size).toBe(scripts.length);
+  });
+});
+
 describe('R0 vacuity', () => {
   it('fails when it discovers no test scripts at all, rather than reporting a complete sweep', () => {
     const root = baseRoot({

--- a/scripts/harness/ci-mirror-map.mjs
+++ b/scripts/harness/ci-mirror-map.mjs
@@ -197,7 +197,7 @@ export const CI_STAGES = [
  * `relevance` is a KEY the runner evaluates, not prose. A `relevantWhen` sentence with no code
  * behind it would describe a condition nobody computes — a smaller version of the same defect.
  */
-export const NOT_MIRRORED = [
+const NOT_MIRRORED_ENTRIES = [
   {
     context: 'regression-red-proof (enforcing: accidental-green only)',
     reason:
@@ -246,6 +246,50 @@ export const NOT_MIRRORED = [
       'no local equivalent — push and read the check, or query it directly: gh api "repos/<owner>/<repo>/code-scanning/alerts?pr=<n>&state=open" --paginate  (note --paginate: a single page silently truncates, which is how a 40-high backlog once read as clean)',
   },
 ];
+
+/**
+ * The same entries, keyed by context — and the reason the list above is not the export.
+ *
+ * A duplicate `context` used to be undetectable. `scan-required-check-local-reachability.mjs` reads
+ * this through `new Set(...)`, which collapses one; the tests read it through `.find()`, which
+ * returns the first and never looks again. Neither is wrong about what it asks — both ask EXISTENCE,
+ * and the property is UNIQUENESS.
+ *
+ * The runtime path is what makes an assertion insufficient here. `annotateNotMirrored` maps over
+ * every entry and `renderSummary` prints every one, so a duplicate reaches the USER as one required
+ * check excused twice, in two different voices, with nothing saying which governs. `CI_STAGES` and
+ * `SCAN_COMMANDS` are guarded by a test because their duplicates are collapsed before anyone sees
+ * them; this one is not, so it refuses at construction.
+ *
+ * Refusing HERE rather than in a test is deliberate: a test has to be run, and this throws the
+ * moment any consumer imports the module. Issue #2042.
+ */
+function keyByContext(entries) {
+  const byContext = new Map();
+  for (const entry of entries) {
+    const existing = byContext.get(entry.context);
+    if (existing) {
+      throw new Error(
+        `ci-mirror-map: NOT_MIRRORED declares \`${entry.context}\` twice. A required check cannot ` +
+          'have two reasons for being un-mirrorable — verify-like-ci prints both and names neither ' +
+          `as governing. First reason: ${existing.reason.slice(0, 80)}… Second: ${entry.reason.slice(0, 80)}…`,
+      );
+    }
+    byContext.set(entry.context, entry);
+  }
+  return byContext;
+}
+
+/** Required contexts this entry point cannot reproduce, keyed by context. Insertion-ordered. */
+export const NOT_MIRRORED_BY_CONTEXT = keyByContext(NOT_MIRRORED_ENTRIES);
+
+/**
+ * The entries as a list, for the consumers that iterate rather than look up.
+ *
+ * Derived from the Map, so it cannot disagree with it — a second array would be a second place for
+ * the same fact, which is what this change removes.
+ */
+export const NOT_MIRRORED = [...NOT_MIRRORED_BY_CONTEXT.values()];
 
 /** The relevance keys the runner knows how to evaluate. */
 export const RELEVANCE_KEYS = ['manifest-or-lockfile', 'code', 'guarded-workflow'];


### PR DESCRIPTION
Closes #2042.

## The repository already knew, one constant away

`scripts/harness/run-all-scans.mjs`'s test is titled **"registers every scan exactly once — a
duplicate runs twice and reports twice"**. `scripts/harness/ci-mirror-map.mjs`'s neighbouring
`CI_STAGES` carries **"stage names are unique"**.

`NOT_MIRRORED`, declared in that same file, had neither — and a duplicate in it is precisely the
defect the first title describes.

## Three lists, three different duplicates, two repairs

Every consumer asked **existence** where the property is **uniqueness**. One entry satisfies "is
there an entry for this key", and `.find()` returns the first, so a second sits in the file wearing
the same authoritative face as the one that governs.

What differs is where the second entry ends up:

| List | Read through | The duplicate | Repair |
| ---- | ------------ | ------------- | ------ |
| `NOT_MIRRORED` | `new Set(…)`, `.find`, **`.map`** | **printed to the user** | refuses at construction |
| `EXCLUSIONS` | `.some` | silently dropped | uniqueness assertion |
| `MATCHERS` | `.find` | silently dropped | uniqueness assertion |

**`NOT_MIRRORED` is the one that reaches a human.** `verify-like-ci.mjs` maps over every entry and
the summary loop prints every one, so a duplicate shows the reader one required check excused twice,
in two different voices, with nothing saying which governs. A visible contradiction has to be made
impossible rather than merely detected — and a throw at module load fires for every consumer without
waiting for a test to be run.

The issue's body says the second entry is *"a reason nobody will ever read"*. That is true of
`.find()` and false of the runtime path, and the difference is what makes an assertion insufficient
here. Recorded as a comment on the issue.

**`EXCLUSIONS` and `MATCHERS` get an assertion each**, in the shape this repository already uses
twice. Inventing a third form for a defect it has solved before would be the worse choice.

## Measured, not assumed — and wrong twice on the way

```
scripts/harness exported keyed constant lists ......... 28
  read for existence (new Set(.map) / .find / .some) ...  5
    already guarded ....................................  2   CI_STAGES, SCAN_COMMANDS
    repaired here ......................................  3
```

`ISSUE_LINK_PATTERNS` and `NON_CRITERIA_HEADINGS` were excluded: they are unkeyed regex arrays, where
duplication has no defined meaning. Counting them would have been the same defect this PR fixes.

**A regex over each constant's name reported `CI_STAGES` and `SCAN_COMMANDS` as guarded, then as
unguarded, and both readings were wrong.** They are guarded, by tests titled after the *property*
rather than the constant — neither title nor first line contains the identifier. A search by name
cannot find what does not write the name down. Filed on #2234, because the better a test is named,
the less findable it is by identifier.

## Each repair falsified individually

A duplicate was inserted into each list, fully valid in every other field, and each was confirmed to
be refused **on its own**, not through one aggregate count that a bucket-shuffling mutant survives:

```
NOT_MIRRORED   import throws, quoting both reasons
EXCLUSIONS     1 test fails — "excludes every script exactly once"
MATCHERS       1 test fails — "declares every kind exactly once"
```

**An earlier probe of mine went red and proved nothing.** Its duplicate carried
`relevance: 'always'`, absent from `RELEVANCE_KEYS`, so a content assertion fired — and `.find()`
surfaced it only because I had inserted it first. Reported as-is, that red would have concluded
"duplicates are caught". The opposite was true.

> When a probe goes red, nothing is proven until you check that the reason it went red is the
> property the probe was asking about.

The probes were **re-run after rebasing** rather than reused: a probe result is about the tree it ran
on.

## Verification

`pnpm harness:verify-like-ci` exit 0 on base `1d7e10d30`; 143 scans; 4867 + 1142 harness tests.
