### PR TITLE
feat(harness): resolve a cited task-record path instead of trusting it (HARNESS-118)

### DIFF
--- a/.agents/memory/no-fake-in-src.md
+++ b/.agents/memory/no-fake-in-src.md
@@ -15,4 +15,4 @@ sanctioned occurrence with `// allow-fake: <reason>` (reason-less anti-rot). Rul
 [code-quality.md](../rules/code-quality.md) Development Patterns. Correct fix for a hit: rename to what it IS
 (`InMemory…`/`Manual…`/`Recording…`/`Scripted…`) OR move the test double under a `testing/` subpath exported via
 `./testing` (the `@robota-sdk/agent-core/testing` `scripted-provider` precedent). Sibling of the No-Fallback floor
-([[no-fallback-gate]]). Pre-existing debt is allowlisted in the scan + tracked by `.agents/tasks/HARNESS-033-fake-in-src-sweep.md`.
+([[no-fallback-gate]]). Pre-existing debt is allowlisted in the scan + tracked by `.agents/tasks/completed/HARNESS-033-fake-in-src-sweep.md`.

--- a/.agents/memory/selfhost-roadmap-progress.md
+++ b/.agents/memory/selfhost-roadmap-progress.md
@@ -39,7 +39,7 @@ The phase notes below are the record of how it got there, not its current state:
   Neutrality held for these two highest-drift primitives — WHO delegates / WHO speaks next is caller-injected, and
   the standing `orchestration-neutrality` floor stays clean. **All five named primitives now implemented** (30 tests).
 - **GATE-VERIFY + GATE-COMPLETE PASSED** — spec moved `active/` → `.agents/spec-docs/done/`, `status: done`,
-  `completed: 2026-07-17`; task archived to `.agents/tasks/completed/SELFHOST-001.md`. All 6 Completion Criteria
+  `completed: 2026-07-17`; task archived to `.agents/archive/task-breakdowns/completed/SELFHOST-001.md`. All 6 Completion Criteria
   `[x]` with per-TC evidence; User-Execution done-gate passed via a public-SDK-usage scenario (UET-01, exit 0,
   all 5 primitives run — script in `scratch/src/`, INFRA-023). **SELFHOST-001 is DONE.**
 - **B3 extraction trigger** (deferred): when a second implementer family lands (a dag-\* adapter), move BOTH the

--- a/.agents/spec-docs/active/INFRA-104-promotion-carries-closing-keywords-to-main.md
+++ b/.agents/spec-docs/active/INFRA-104-promotion-carries-closing-keywords-to-main.md
@@ -266,7 +266,7 @@ the next promotion rather than executed here.
 
 ## Tasks
 
-- [ ] `.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md` — 생성됨 (TC-01…TC-10 전부 Plan 항목으로 존재)
+- [ ] `.agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md` — 생성됨 (TC-01…TC-10 전부 Plan 항목으로 존재)
 
 ## Evidence Log
 
@@ -315,7 +315,7 @@ checked against the document; the deviation is in who ran the gate, not in wheth
 
 **Status upgrade:** approved → in-progress
 
-- Tasks file created: `.agents/tasks/INFRA-104-promotion-carries-closing-keywords-to-main.md`
+- Tasks file created: `.agents/tasks/completed/INFRA-104-promotion-carries-closing-keywords-to-main.md`
   (frontmatter `status: in-progress`, `created: 2026-08-18`, `priority: high`, `urgency: now`).
 - Its path is recorded in the `## Tasks` section above.
 - Its `## Plan` carries one task per TC-N — TC-01 through TC-10, ten items, matching the ten Completion

--- a/.agents/spec-docs/rejected/ARCH-036-child-process-runner-drops-builtin-agents.md
+++ b/.agents/spec-docs/rejected/ARCH-036-child-process-runner-drops-builtin-agents.md
@@ -145,7 +145,7 @@ None
 - `scripts/harness/scan-subagent-runner-deps-parity.mjs`
 - `scripts/harness/run-all-scans.mjs`
 - `scripts/harness/__tests__/scan-subagent-runner-deps-parity.test.mjs`
-- `.agents/tasks/ARCH-036-child-process-runner-drops-builtin-agents.md`
+- `.agents/tasks/completed/ARCH-036-child-process-runner-drops-builtin-agents.md`
 
 ## Completion Criteria
 
@@ -233,7 +233,7 @@ Durable engineering artifacts backing the same behavior:
 
 ## Tasks
 
-- [ ] `.agents/tasks/ARCH-036-child-process-runner-drops-builtin-agents.md` — problem record exists;
+- [ ] `.agents/tasks/completed/ARCH-036-child-process-runner-drops-builtin-agents.md` — problem record exists;
       implementation begins after GATE-APPROVAL
 
 ## Evidence Log

--- a/.agents/spec-docs/rejected/ARCH-037-published-contract-hygiene-from-the-arch-audit.md
+++ b/.agents/spec-docs/rejected/ARCH-037-published-contract-hygiene-from-the-arch-audit.md
@@ -178,7 +178,7 @@ None
 - `scripts/harness/run-all-scans.mjs`
 - `scripts/harness/__tests__/scan-barrel-parameter-exports.test.mjs`
 - `.changeset/arch-037-published-contract-hygiene.md`
-- `.agents/tasks/ARCH-037-published-contract-hygiene-from-the-arch-audit.md`
+- `.agents/tasks/completed/ARCH-037-published-contract-hygiene-from-the-arch-audit.md`
 
 ## Completion Criteria
 
@@ -225,7 +225,7 @@ Engineering evidence: `pnpm typecheck` across the workspace, `pnpm harness:scan`
 
 ## Tasks
 
-- [ ] `.agents/tasks/ARCH-037-published-contract-hygiene-from-the-arch-audit.md` — problem record
+- [ ] `.agents/tasks/completed/ARCH-037-published-contract-hygiene-from-the-arch-audit.md` — problem record
       created; implementation begins after GATE-APPROVAL
 
 ## Evidence Log

--- a/.agents/spec-docs/rejected/HARNESS-104-spec-public-surface-section-parser-is-not-hierarchical.md
+++ b/.agents/spec-docs/rejected/HARNESS-104-spec-public-surface-section-parser-is-not-hierarchical.md
@@ -184,7 +184,7 @@ None
 - `scripts/harness/spec-surface-baseline.json`
 - `scripts/harness/__tests__/check-spec-public-surface.test.mjs`
 - `packages/agent-core/docs/SPEC.md`
-- `.agents/tasks/HARNESS-104-spec-public-surface-section-parser-is-not-hierarchical.md`
+- `.agents/tasks/completed/HARNESS-104-spec-public-surface-section-parser-is-not-hierarchical.md`
 
 ## Completion Criteria
 
@@ -230,7 +230,7 @@ nested subsections the flat parser was reading as public API).
 
 ## Tasks
 
-- [ ] `.agents/tasks/HARNESS-104-spec-public-surface-section-parser-is-not-hierarchical.md` — problem
+- [ ] `.agents/tasks/completed/HARNESS-104-spec-public-surface-section-parser-is-not-hierarchical.md` — problem
       record created; implementation begins after GATE-APPROVAL
 
 ## Evidence Log

--- a/.agents/spec-docs/rejected/INFRA-102-node-version-single-valued-across-the-workspace.md
+++ b/.agents/spec-docs/rejected/INFRA-102-node-version-single-valued-across-the-workspace.md
@@ -186,7 +186,7 @@ None
 - `scripts/harness/scan-node-version-single-valued.mjs`
 - `scripts/harness/run-all-scans.mjs`
 - `scripts/harness/__tests__/scan-node-version-single-valued.test.mjs`
-- `.agents/tasks/INFRA-102-node-version-is-not-single-valued-across-the-workspace.md`
+- `.agents/tasks/completed/INFRA-102-node-version-is-not-single-valued-across-the-workspace.md`
 
 ## Completion Criteria
 
@@ -236,7 +236,7 @@ including the drifted-literal, circular-`extends`, and examined-count reset case
 
 ## Tasks
 
-- [ ] `.agents/tasks/INFRA-102-node-version-is-not-single-valued-across-the-workspace.md` — problem
+- [ ] `.agents/tasks/completed/INFRA-102-node-version-is-not-single-valued-across-the-workspace.md` — problem
       record created; implementation begins after GATE-APPROVAL
 
 ## Evidence Log

--- a/.agents/specs/background-task-layer.md
+++ b/.agents/specs/background-task-layer.md
@@ -2,7 +2,7 @@
 
 Status: Proposed
 Created: 2026-04-30
-Source research: `.agents/tasks/completed/CLI-BL-024-background-task-layer-research.md`
+Source research: `.agents/archive/task-breakdowns/completed/CLI-BL-024-background-task-layer-research.md`
 Related spec: `.agents/specs/subagent-process-manager.md`
 
 ## Scope

--- a/.agents/specs/subagent-process-manager.md
+++ b/.agents/specs/subagent-process-manager.md
@@ -2,7 +2,7 @@
 
 Status: Proposed
 Created: 2026-04-30
-Source research: `.agents/tasks/completed/CLI-BL-019-subagent-process-manager-research.md`
+Source research: `.agents/archive/task-breakdowns/completed/CLI-BL-019-subagent-process-manager-research.md`
 Common runtime layer: `.agents/specs/background-task-layer.md`
 
 ## Scope

--- a/.agents/tasks/HARNESS-052-vacuous-green-sweep.md
+++ b/.agents/tasks/HARNESS-052-vacuous-green-sweep.md
@@ -457,7 +457,7 @@ in `## Test Plan`.
 
 ## References
 
-- `.agents/tasks/HARNESS-051-dead-code-satisfies-architecture-gate.md` — records the same class
+- `.agents/tasks/completed/HARNESS-051-dead-code-satisfies-architecture-gate.md` — records the same class
   from SEC-005's angle: the vacuously-satisfied `agent-server-boundary` gate, the test-file
   `no-unused-vars` exemption that hid the assertion-free tests, and `verify-change.mjs`'s `passed`
   field that is structurally always `true`. Not duplicated here.

--- a/.agents/tasks/HARNESS-118-citations-of-a-task-record-path-are-not-re-derived-when-the-record-moves-is-rena.md
+++ b/.agents/tasks/HARNESS-118-citations-of-a-task-record-path-are-not-re-derived-when-the-record-moves-is-rena.md
@@ -1,0 +1,103 @@
+---
+title: 'HARNESS-118: citations of a task record path are not re-derived when the record moves, is renamed, or its ID is reused'
+issue: https://github.com/woojubb/robota/issues/2248
+status: todo
+created: 2026-08-23
+priority: medium
+urgency: soon
+area: harness
+depends_on: []
+---
+
+# HARNESS-118: citations of a task record path are not re-derived when the record moves, is renamed, or its ID is reused
+
+## Objective
+
+A citation of a task-record path is a fact about where a file is. Completing a record moves it from
+the live folder into `completed/`, which makes every such citation false, and nothing says so. The
+same happens when a record is renamed (the slug is part of the path), when it is archived out of
+the tasks tree entirely, and when an ID is reused for a different subject.
+
+## What was measured before designing
+
+`git grep` over tracked files finds 1779 citations of a `.agents/tasks/` path across 401 files.
+**That number is not the problem size.** Three corrections, each of which changes the answer:
+
+1. **Test fixtures are not citations.** 90 are strings inside harness tests — deliberately absent
+   ids, and traversal payloads aimed at the enumerator. A scan counting these measures its own
+   fixtures.
+2. **Resolution must be by ID and slug, not by exact path.** Most citations name
+   `.agents/tasks/<ID>.md` while records are `<ID>-<slug>.md`, so exact-path matching reports a
+   file that exists as missing.
+3. **Frozen history is not a live claim.** `.agents/archive/`, `.design/`, `.agents/daily-reports/`
+   and `.agents/spec-docs/done/` hold the bulk — 607 stale and 363 unresolvable in
+   `spec-docs/done/` alone. A completed document recording where a record was AT THE TIME is
+   history; rewriting it destroys the record instead of fixing it.
+
+**On the surface that makes live claims — rules, skills, specs, memory, active/draft spec-docs, live
+task records, scripts — there are 22 false citations, 20 after excluding two format examples.**
+
+## The two cases that decide the design
+
+Both were found by checking classifications rather than accepting them, and both would be made
+WORSE by a resolver that matches on ID alone.
+
+**`.agents/rules/operational.md:52` — a format example using a live ID.** It sits in a fence under
+"**File naming:** `{ID}-{slug}.md`. The slug says what the item is about, in words:" and names
+CORE-014 with the slug `shutdown-drops-in-flight-work`. `git log --all --diff-filter=A` over
+`*CORE-014*` returns exactly one path ever added: `CORE-014-stateless-run-mode.md`. **No file with
+that slug has existed at any commit** — an example demonstrating that a slug says what an item is
+about uses a slug that says what no item was ever about, under an ID that means something else.
+
+**`DIST-002-release-artifact-verification.md`, cited by two harness scripts — the right slug under
+the wrong ID.** The record with that slug is `.agents/tasks/DIST-005-release-artifact-verification.md`
+(`title: Nothing verifies a published release artifact — the macOS downloads do not open`). DIST-002
+is a live ID belonging to `spec-docs/done/DIST-002-bun-binary-release-workflow.md`. **An ID-based
+resolver sends this citation to the Bun-binary document** — confidently and silently.
+
+These are the two ends of one axis: there the ID is live and the slug fabricated; here the slug is
+live and the ID belongs to someone else. **A broken link is noticed by a human; a resolved wrong
+link is not.** That asymmetry is why `conflict` exists as an outcome and is never auto-repaired.
+
+## Plan
+
+- [ ] TC-01 — the scan resolves by ID **and** slug and reports four distinct outcomes: `moved`
+      (both match, folder differs), `renamed` (ID matches, slug extends), `conflict` (ID and slug
+      resolve to different records, or one resolves and the other does not), `dangling` (neither).
+- [ ] TC-02 — `conflict` fires on `DIST-002-release-artifact-verification.md`, asserted by name.
+- [ ] TC-03 — `conflict` fires on the `CORE-014` example, asserted by name.
+- [ ] TC-04 — history is excluded as a citation SOURCE and INCLUDED as a resolution TARGET. Asserted
+      on `SELFHOST-008-P6`, which exists only in `.agents/archive/` and `spec-docs/done/`: excluding
+      it from resolution reports `dangling`, which is the wrong answer and the more alarming one.
+- [ ] TC-05 — a fenced format example is not read as a citation; `CHILD-001-description.md` in
+      `.agents/tasks/README.md` stays silent.
+- [ ] TC-06 — the 12 mechanical `moved` repairs are applied and the scan then reports zero `moved`.
+- [ ] TC-07 — the `CORE-014` example is made unresolvable rather than repointed, and a rule is
+      stated: an example must not use a live ID.
+- [ ] TC-08 — MUTANT: collapsing the `conflict` branch into `moved` must go RED. This is the one
+      that matters — such a scan is green on the whole tree while doing the exact damage the scan
+      exists to prevent, and deleting the resolver does not catch it.
+- [ ] TC-09 — MUTANT: deleting the resolver must go RED on every one of the 20 known cases, not
+      merely on the tree as a whole.
+- [ ] TC-10 — MUTANT: replacing the live-surface directory list with an empty corpus must go RED. A
+      scan whose corpus silently excludes its subject passes identically to one that works.
+- [ ] TC-11 — `run-all-scans` green; the new scan declares what it examined.
+- [ ] TC-12 — `pnpm lint` checked by EXIT CODE, not by the summary line (issue #1984 / PR #2246).
+
+## Not in scope
+
+The 6 `dangling` citations get a comment on issue #2248, not a guess. Re-pointing a citation by
+inference is how the `CORE-014` example reached its current state.
+
+`.agents/memory/agent-run-capability-verification.md` calls SELFHOST-008-P6 a "Concrete open fix"
+while P6 exists only as a completed spec-doc and an archived breakdown. That is a claim about
+STATUS, not about a path, and it is filed separately. That file is also owned by another lane's
+memory-mirroring branch and is excluded from this PR's repairs to avoid a collision.
+
+## Test Plan
+
+The scan is `scripts/harness/` with its cases driven from the real tree rather than fixtures, since
+every one of the four outcomes was discovered in the real tree and no fixture would have produced
+`conflict`. Gate commands: `node scripts/harness/run-all-scans.mjs`, `pnpm lint` (exit code),
+`pnpm typecheck`, and the three mutants above run individually with an applied-check confirming the
+mutation is in the tree before the result is read.

--- a/.agents/tasks/REL-024-changeset-fixed-group-covers-13-of-30-packages.md
+++ b/.agents/tasks/REL-024-changeset-fixed-group-covers-13-of-30-packages.md
@@ -33,7 +33,7 @@ does, because no scan reads the config against the rule.
 ## Why this is filed rather than fixed in passing
 
 Found while classifying the release impact of ARCH-030
-(`.agents/tasks/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md`), whose changeset
+(`.agents/tasks/completed/ARCH-030-outbound-protocol-replies-bypass-carrier-delivery-boundary.md`), whose changeset
 classifies `agent-transport-protocol` as `major` and its two dependents as `patch`. That classification is
 what the semver table forces once the config is taken as the operative artifact, and it is correct for that
 item. The disagreement it exposes is monorepo-wide and pre-existing: ARCH-030 neither caused it nor is the

--- a/scripts/harness/__tests__/scan-task-path-citations.test.mjs
+++ b/scripts/harness/__tests__/scan-task-path-citations.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * HARNESS-118 — the tree-side half: which documents are in scope, and the size the pass line reports.
+ *
+ * What a citation MEANS is pinned in `task-path-citation.test.mjs`, beside the module that decides
+ * it. This file covers the parts only the scan owns.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyCitation, indexRecords } from '../task-path-citation.mjs';
+import {
+  OUTCOME_ORDER,
+  collectCitations,
+  examinedDocumentCount,
+  findStaleCitations,
+} from '../scan-task-path-citations.mjs';
+
+const TASKS = ['.agents', 'tasks'].join('/') + '/';
+const ARCHIVE = ['.agents', 'archive', 'task-breakdowns', 'completed'].join('/') + '/';
+
+/** A tree of record paths, indexed the way the scan indexes the real one. */
+function tree(...files) {
+  const present = new Set(files);
+  return { index: indexRecords(files), exists: (file) => present.has(file) };
+}
+
+describe('the declared size', () => {
+  it('counts each document READ, exactly — not the size of the list it walked', () => {
+    // A collection size and a traversal count agree until a read throws, which is the one moment
+    // the number is load-bearing. An exact expectation, because every over-count satisfies a bound.
+    expect(collectCitations('no citations here\n').length).toBe(0);
+    expect(
+      collectCitations(`a line citing ${TASKS}A-001-thing.md\nand ${TASKS}B-002-other.md here\n`)
+        .length,
+    ).toBe(2);
+  });
+
+  it('does not read a fenced block as a citation', () => {
+    // The naming-format example in the tasks README is the reason: an id nothing resolves, shown to
+    // demonstrate the shape. A scan cannot tell it from a citation, and neither can a reader — which
+    // is why the rule is that an example must not use a live id.
+    const fenced = ['before', '```', `${TASKS}A-001-thing.md`, '```', 'after'].join('\n');
+    expect(collectCitations(fenced)).toEqual([]);
+  });
+
+  it('reports the line each citation sits on', () => {
+    const text = ['first', `see ${TASKS}A-001-thing.md`].join('\n');
+    expect(collectCitations(text)).toEqual([{ line: 2, cited: `${TASKS}A-001-thing.md` }]);
+  });
+
+  it('reports EXACTLY the number of documents it read', () => {
+    const t = tree(`${TASKS}completed/A-001-thing.md`);
+    const docs = {
+      'a.md': `see ${TASKS}A-001-thing.md`,
+      'b.md': 'nothing here',
+      'c.md': `also ${TASKS}A-001-thing.md`,
+    };
+    findStaleCitations(Object.keys(docs), t.index, t.exists, (file) => docs[file]);
+    expect(examinedDocumentCount()).toBe(3);
+  });
+
+  it('does NOT count a document it could not read', () => {
+    // The one case where a collection size and a traversal count disagree, and the case where the
+    // number matters: a skipped read must lower the reported coverage, not be absorbed by it.
+    const t = tree(`${TASKS}completed/A-001-thing.md`);
+    findStaleCitations(['ok.md', 'unreadable.md'], t.index, t.exists, (file) => {
+      if (file === 'unreadable.md') throw new Error('EACCES');
+      return `see ${TASKS}A-001-thing.md`;
+    });
+    expect(examinedDocumentCount()).toBe(1);
+  });
+
+  it('starts from zero on a SECOND run rather than accumulating', () => {
+    // A counter that accumulates reports the sum of every run in the process and rises
+    // monotonically, so it reads as growing coverage no matter what the last run examined.
+    const t = tree(`${TASKS}completed/A-001-thing.md`);
+    const docs = { 'a.md': `see ${TASKS}A-001-thing.md`, 'b.md': 'nothing' };
+    findStaleCitations(Object.keys(docs), t.index, t.exists, (file) => docs[file]);
+    expect(examinedDocumentCount()).toBe(2);
+    findStaleCitations(['a.md'], t.index, t.exists, (file) => docs[file]);
+    expect(examinedDocumentCount()).toBe(1);
+  });
+});
+
+describe('every declared outcome is producible', () => {
+  // The axis TC-08 did not cover. Collapsing `conflict` into `moved` was caught; a declared outcome
+  // that NO input produces was not, because nothing asked the question. `renamed` was in this list,
+  // in the resolver's documentation and in the record's TC-01, and unreachable — with every gate
+  // green. The fixtures below are the answer to "name an input that produces this".
+  const PRODUCES = {
+    conflict: () => {
+      const t = tree(`${TASKS}completed/CORE-014-stateless-run-mode.md`);
+      return classifyCitation(`${TASKS}CORE-014-invented-slug.md`, t.index, t.exists);
+    },
+    dangling: () => {
+      const t = tree(`${TASKS}B-002-other.md`);
+      return classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    },
+    archived: () => {
+      const t = tree(`${ARCHIVE}A-001-thing.md`);
+      return classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    },
+    moved: () => {
+      const t = tree(`${TASKS}completed/A-001-thing.md`);
+      return classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    },
+    renamed: () => {
+      const t = tree(`${TASKS}A-001-thing-with-more-words.md`);
+      return classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    },
+  };
+
+  it('the reported order and the producible set are the SAME set, both directions', () => {
+    // One direction alone is half a check: an outcome nothing produces is a false promise, and an
+    // outcome produced but never grouped is a finding printed under no heading.
+    expect([...OUTCOME_ORDER].sort()).toEqual(Object.keys(PRODUCES).sort());
+  });
+
+  it.each(OUTCOME_ORDER)('an input exists that produces %s', (outcome) => {
+    expect(PRODUCES[outcome]().outcome).toBe(outcome);
+  });
+});

--- a/scripts/harness/__tests__/task-path-citation.test.mjs
+++ b/scripts/harness/__tests__/task-path-citation.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * HARNESS-118 — the resolver, beside the module it pins.
+ *
+ * The classification is the whole product. A scan that finds every stale citation and calls each of
+ * them repairable does MORE damage than one that finds none, because it repairs a citation to a
+ * document nobody named. So these pin outcomes BY NAME, never by count: a count survives a mutant
+ * that merely moves a case from one bucket to another, and that is the mutant that mattered — it
+ * left the whole tree green.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyCitation,
+  indexRecords,
+  isHistorySource,
+  parseRecordName,
+} from '../task-path-citation.mjs';
+
+const TASKS = ['.agents', 'tasks'].join('/') + '/';
+const ARCHIVE = ['.agents', 'archive', 'task-breakdowns', 'completed'].join('/') + '/';
+
+/** A tree of record paths, indexed the way the scan indexes the real one. */
+function tree(...files) {
+  const present = new Set(files);
+  return { index: indexRecords(files), exists: (file) => present.has(file) };
+}
+
+describe('parsing a record name', () => {
+  it('splits a single-segment domain', () => {
+    expect(parseRecordName('CORE-014-stateless-run-mode.md')).toEqual({
+      id: 'CORE-014',
+      slug: 'stateless-run-mode',
+    });
+  });
+
+  it('splits a MULTI-segment domain, which is why the id pattern is not [A-Z]+-\\d+', () => {
+    expect(parseRecordName('CLI-BL-024-provider-configuration-ux.md')).toEqual({
+      id: 'CLI-BL-024',
+      slug: 'provider-configuration-ux',
+    });
+  });
+
+  it('reads a bare id as a record with no slug', () => {
+    expect(parseRecordName('INFRA-018.md')).toEqual({ id: 'INFRA-018', slug: '' });
+  });
+
+  it('is not fooled by a name that is not a record', () => {
+    expect(parseRecordName('README.md')).toBeNull();
+  });
+});
+
+describe('the four outcomes', () => {
+  it('exact — the file is where the citation says', () => {
+    const t = tree(`${TASKS}A-001-thing.md`);
+    expect(classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists).outcome).toBe('exact');
+  });
+
+  it('moved — completed within the tasks tree', () => {
+    const t = tree(`${TASKS}completed/A-001-thing.md`);
+    const verdict = classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    expect(verdict.outcome).toBe('moved');
+    expect(verdict.actual).toBe(`${TASKS}completed/A-001-thing.md`);
+  });
+
+  it('archived — the record left the tasks tree entirely', () => {
+    // The bucket that was empty until history was included as a resolution target. Without this,
+    // four real citations report as missing for the least alarming reason there is: they finished.
+    const t = tree(`${ARCHIVE}A-001-thing.md`);
+    const verdict = classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    expect(verdict.outcome).toBe('archived');
+    expect(verdict.actual).toBe(`${ARCHIVE}A-001-thing.md`);
+  });
+
+  it('dangling — neither axis resolves', () => {
+    const t = tree(`${TASKS}B-002-other.md`);
+    expect(classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists).outcome).toBe('dangling');
+  });
+});
+
+describe('conflict — the outcome that must never be repaired', () => {
+  it('fires when the ID is live and the slug was never real (the CORE-014 shape)', () => {
+    // Repointing this at the live ID would hand a reader a document about something else, with a
+    // resolved link vouching for it.
+    const t = tree(`${TASKS}completed/CORE-014-stateless-run-mode.md`);
+    const verdict = classifyCitation(
+      `${TASKS}CORE-014-shutdown-drops-in-flight-work.md`,
+      t.index,
+      t.exists,
+    );
+    expect(verdict.outcome).toBe('conflict');
+    expect(verdict.actual).toBeUndefined();
+  });
+
+  it('fires when the slug is live under someone else’s ID (the DIST-002 shape)', () => {
+    const t = tree(
+      `${TASKS}DIST-005-release-artifact-verification.md`,
+      `${TASKS}completed/DIST-002-bun-binary-release-workflow.md`,
+    );
+    const verdict = classifyCitation(
+      `${TASKS}DIST-002-release-artifact-verification.md`,
+      t.index,
+      t.exists,
+    );
+    expect(verdict.outcome).toBe('conflict');
+    expect(verdict.id).toContain(`${TASKS}completed/DIST-002-bun-binary-release-workflow.md`);
+    expect(verdict.slug).toContain(`${TASKS}DIST-005-release-artifact-verification.md`);
+  });
+
+  it('does NOT guess when one ID carries two archived subjects', () => {
+    // CLI-BL-019 and CLI-BL-024 are each two different subjects in the archive. An ID-only resolver
+    // picks one of two and is right by luck half the time, which is not right.
+    const t = tree(
+      `${ARCHIVE}CLI-BL-019-streaming-rendering-optimization.md`,
+      `${ARCHIVE}CLI-BL-019-subagent-process-manager-research.md`,
+    );
+    const verdict = classifyCitation(
+      `${TASKS}completed/CLI-BL-019-subagent-process-manager-research.md`,
+      t.index,
+      t.exists,
+    );
+    expect(verdict.outcome).toBe('archived');
+    expect(verdict.actual).toBe(`${ARCHIVE}CLI-BL-019-subagent-process-manager-research.md`);
+  });
+
+  it('a bare-id citation against two subjects is a conflict, not a coin flip', () => {
+    const t = tree(
+      `${ARCHIVE}CLI-BL-019-streaming-rendering-optimization.md`,
+      `${ARCHIVE}CLI-BL-019-subagent-process-manager-research.md`,
+    );
+    const verdict = classifyCitation(`${TASKS}CLI-BL-019.md`, t.index, t.exists);
+    expect(verdict.outcome).toBe('conflict');
+    expect(verdict.actual).toBeUndefined();
+    expect(verdict.id).toHaveLength(2);
+  });
+});
+
+describe('history is a target, not a source', () => {
+  it('excludes a completed spec-doc as a citation SOURCE', () => {
+    expect(isHistorySource('.agents/spec-docs/done/X-001-thing.md')).toBe(true);
+    expect(isHistorySource('.agents/archive/task-breakdowns/completed/X-001.md')).toBe(true);
+    expect(isHistorySource('.agents/daily-reports/2026-07-17.md')).toBe(true);
+  });
+
+  it('keeps a live rule, spec and script as citation sources', () => {
+    expect(isHistorySource('.agents/rules/operational.md')).toBe(false);
+    expect(isHistorySource('.agents/spec-docs/active/X-001-thing.md')).toBe(false);
+    expect(isHistorySource('scripts/harness/scan-anything.mjs')).toBe(false);
+  });
+
+  it('a SPEC-DOC never answers "where is the record"', () => {
+    // Same class of confident wrong answer as ID-only matching: a spec-doc shares the ID and is a
+    // different document. Where only a spec-doc survives, dangling is the honest answer.
+    const t = tree('.agents/spec-docs/active/A-001-thing.md');
+    expect(classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists).outcome).toBe('dangling');
+  });
+});
+
+describe('renamed — the outcome an earlier version documented but could never return', () => {
+  it('reports a slug that gained a word IN PLACE as renamed, not moved', () => {
+    // The directory is unchanged; only the file name differs. Reporting this as `moved` says the
+    // record went somewhere it did not go, and `moved` was all this branch could produce.
+    const t = tree(`${TASKS}A-001-thing-with-more-words.md`);
+    const verdict = classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists);
+    expect(verdict.outcome).toBe('renamed');
+    expect(verdict.actual).toBe(`${TASKS}A-001-thing-with-more-words.md`);
+  });
+
+  it('still says moved when the rename ALSO changed directory', () => {
+    // The directory is what a repair has to change, so it decides first.
+    const t = tree(`${TASKS}completed/A-001-thing-with-more-words.md`);
+    expect(classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists).outcome).toBe('moved');
+  });
+
+  it('still says archived when the rename ALSO left the tasks tree', () => {
+    const t = tree(`${ARCHIVE}A-001-thing-with-more-words.md`);
+    expect(classifyCitation(`${TASKS}A-001-thing.md`, t.index, t.exists).outcome).toBe('archived');
+  });
+
+  it('a bare-id citation whose record has a slug is renamed when the directory holds', () => {
+    const t = tree(`${TASKS}A-001-thing.md`);
+    expect(classifyCitation(`${TASKS}A-001.md`, t.index, t.exists).outcome).toBe('renamed');
+  });
+});

--- a/scripts/harness/examined-adoption-baseline.json
+++ b/scripts/harness/examined-adoption-baseline.json
@@ -82,6 +82,7 @@
     "symlink-following-enumeration",
     "task-archival",
     "task-frontmatter-fields",
+    "task-path-citations",
     "temp-dir-owner",
     "test-plans",
     "test-selection-tolerance",

--- a/scripts/harness/measurement-provenance-pending.json
+++ b/scripts/harness/measurement-provenance-pending.json
@@ -43,6 +43,7 @@
     "scripts/harness/scan-spec-user-execution-section.mjs",
     "scripts/harness/scan-symlink-following-enumeration.mjs",
     "scripts/harness/scan-task-frontmatter-fields.mjs",
+    "scripts/harness/scan-task-path-citations.mjs",
     "scripts/harness/scan-temp-dir-owner.mjs",
     "scripts/harness/scan-tool-classification.mjs",
     "scripts/harness/scan-transport-conformance.mjs",

--- a/scripts/harness/named-artifact-baseline.json
+++ b/scripts/harness/named-artifact-baseline.json
@@ -65,7 +65,7 @@
   "scripts/harness/scan-named-artifact-resolves.mjs -> scan-x.mjs",
   "scripts/harness/scan-named-artifact-resolves.mjs -> src/ghost.ts",
   "scripts/harness/scan-named-artifact-resolves.mjs -> test.ts",
-  "scripts/harness/scan-no-fake-in-src.mjs -> .agents/tasks/HARNESS-033-fake-in-src-sweep.md",
+  "scripts/harness/scan-no-fake-in-src.mjs -> .agents/tasks/completed/HARNESS-033-fake-in-src-sweep.md",
   "scripts/harness/scan-review-token-supply.mjs -> src/github/token.ts",
   "scripts/harness/scan-test-selection-tolerance.mjs -> shell-resolver.test.ts",
   "scripts/harness/scan-unearned-done-claims.mjs -> cli-provider-profile-naming-research.md",

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -455,6 +455,13 @@ export const SCAN_COMMANDS = [
     name: 'reference-kind-qualified',
     command: ['node', 'scripts/harness/scan-reference-kind-qualified.mjs'],
   },
+  // HARNESS-118. A cited task-record path is a fact that a lifecycle move makes false in silence.
+  // Resolution is by ID AND slug, because an ID-only resolver answers three cases in this tree with
+  // a confident wrong document, and a resolved wrong link is one nobody questions.
+  {
+    name: 'task-path-citations',
+    command: ['node', 'scripts/harness/scan-task-path-citations.mjs'],
+  },
   // INFRA-127. A rule catalogue's row IS the unit of obligation, so a row short of the columns its
   // header declares renders with rule text missing and nothing said. Six of 92 entries were in that
   // state when this landed.

--- a/scripts/harness/scan-build-tooling-scope.mjs
+++ b/scripts/harness/scan-build-tooling-scope.mjs
@@ -74,7 +74,7 @@ const FILE_TOKEN = /^\.?[\w][\w./-]*\.(?:mjs|cjs|js|ts|mts|cts|sh|json|ya?ml)$/;
 /** Docs-only paths used to pin that zero scopes remains reachable and passing (R4). */
 export const DOCS_ONLY_CONTROL = [
   'README.md',
-  '.agents/tasks/INFRA-060-ci-yml-job-by-job-audit.md',
+  '.agents/tasks/completed/INFRA-060-ci-yml-job-by-job-audit.md',
   'docs/plans/example.md',
 ];
 

--- a/scripts/harness/scan-no-fake-in-src.mjs
+++ b/scripts/harness/scan-no-fake-in-src.mjs
@@ -35,7 +35,7 @@ const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
 /**
  * Documented allowlist of PRE-EXISTING test-double-named shipped files (mirrors the `conflict-markers` scan's
  * allowlist convention). These predate this floor and are tracked for relocation/rename by
- * `.agents/tasks/HARNESS-033-fake-in-src-sweep.md` — remove each entry as HARNESS-033 fixes it. A NEW file
+ * `.agents/tasks/completed/HARNESS-033-fake-in-src-sweep.md` — remove each entry as HARNESS-033 fixes it. A NEW file
  * with a `Fake*`/`Mock*`/`Stub*` declaration is NOT on this list and therefore FAILS. Normalized to `/`.
  */
 // HARNESS-033 emptied this baseline: the dag-adapters-local test-support ports were relocated to the

--- a/scripts/harness/scan-task-path-citations.mjs
+++ b/scripts/harness/scan-task-path-citations.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+/**
+ * HARNESS-118 (issue #2248) — a citation of a task-record path is re-derived, not trusted.
+ *
+ * ## Why this is not a ratchet
+ *
+ * Measured before it was written: 1,779 citations across 401 tracked files, of which the LIVE
+ * surface — rules, skills, specs, memory, active/draft spec-docs, live task records, scripts —
+ * carries 22, and 20 after excluding two format examples. A flat gate is affordable here precisely
+ * because history is out of scope: `.agents/spec-docs/done/` alone holds 607 stale citations, and a
+ * completed document recording where a record was AT THE TIME is a record, not a defect. Rewriting
+ * it would destroy the thing it is for.
+ *
+ * The corpus is therefore the finding-shaped risk in this scan, not the resolver. A corpus that
+ * silently excluded the live surface would pass identically to one that works, which is why the
+ * mutant that empties `LIVE_SOURCES` is part of the verification and not an afterthought.
+ *
+ * ## What it will not do
+ *
+ * It never repairs a `conflict`. See `task-path-citation.mjs` for why an ID-only resolver is worse
+ * than no resolver: it turns a link a human would notice is broken into one nobody will question.
+ *
+ * Exit 0 = every live citation resolves to where it says, 1 = otherwise.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { enumerateFiles } from './enumerate-files.mjs';
+import { classifyCitation, indexRecords, isHistorySource } from './task-path-citation.mjs';
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/** Documents and code whose citations are LIVE CLAIMS a reader acts on. */
+const LIVE_SOURCES = [
+  '.agents/rules/',
+  '.agents/skills/',
+  '.agents/specs/',
+  '.agents/spec-docs/',
+  '.agents/memory/',
+  '.agents/tasks/',
+  'scripts/',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'CONTRIBUTING.md',
+];
+
+/** A test's fixture is not a citation: it names a record that is supposed not to exist. */
+const NOT_A_CITATION = [/\/__tests__\//, /\.test\.(ts|mjs|js)$/, /(^|\/)node_modules\//];
+
+const CITATION = /\.agents\/tasks\/[A-Za-z0-9._/-]+\.md/g;
+
+/**
+ * Every outcome this scan can report, most serious first — and the list a test holds it to.
+ *
+ * Exported as DATA on purpose. A declared outcome that no code path produces is a claim about
+ * behaviour nothing holds: `renamed` sat in this list, in the resolver's doc comment and in the task
+ * record's TC-01 while the branch that should have produced it fell through to `moved`, and every
+ * gate was green. Deriving the list from the source with a regex would not have caught it either —
+ * a derivation narrows with the thing it derives from, so both sides shrink together and the
+ * equation still holds. A literal list does not narrow itself.
+ */
+export const OUTCOME_ORDER = ['conflict', 'dangling', 'archived', 'moved', 'renamed'];
+
+/**
+ * Citations a PERSON must resolve, exempt from the gate and REPORTED on every pass.
+ *
+ * An exemption that prints nothing is a suppression: the finding stops being visible at exactly the
+ * moment it stops being urgent. Each entry carries the reason it cannot be mechanical, and the pass
+ * line names how many are outstanding.
+ *
+ * Two shapes are here. The first is a SENTENCE that contradicts the repair.
+ *
+ * Both of these read "미생성" — not yet created — beside a path that now resolves to a COMPLETED,
+ * archived record. Repointing them yields a well-formed, resolvable, confident falsehood: a reader
+ * following the link finds finished work under a sentence telling them it does not exist. That is
+ * strictly worse than the stale path, and it is the failure `--fix` cannot see, because the tool
+ * reads the path and a reader reads the claim around it.
+ *
+ * They are exempt from the SCAN, not resolved: each needs someone to decide whether the work
+ * happened, and then correct the sentence or the record. Filed as part of issue #2248.
+ */
+// Assembled rather than written literally: this file is itself in the scanned corpus, and a literal
+// path here would be read as a citation of its own. Excluding the scan's source instead would carve
+// a hole in the corpus, which is the one thing this scan must not do quietly.
+const TASKS_DIR = ['.agents', 'tasks'].join('/') + '/';
+const SENTENCE_CONTRADICTS_REPAIR = [
+  {
+    file: '.agents/spec-docs/draft/HARNESS-017-dispatch-determinism-and-firing-measurement.md',
+    cited: `${TASKS_DIR}INFRA-018.md`,
+    outcome: 'archived',
+    why: 'the sentence reads 미생성 — not yet created — beside a completed, archived record',
+  },
+  {
+    file: '.agents/spec-docs/rejected/RESUME-001-session-resume-context-verification.md',
+    cited: `${TASKS_DIR}RESUME-001.md`,
+    outcome: 'archived',
+    why: 'the sentence reads 미생성 — not yet created — beside a completed, archived record',
+  },
+  // The second shape is a CONFLICT: the ID and the slug lead to different records, so no repair can
+  // be derived. These are the cases this scan exists to surface, and surfacing them is all it does.
+  {
+    file: 'scripts/harness/scan-release-verification-gate.mjs',
+    cited: `${TASKS_DIR}DIST-002-release-artifact-verification.md`,
+    outcome: 'conflict',
+    why: 'slug belongs to DIST-005, the ID to an unrelated Bun-binary spec-doc; which is intended is a decision, not a lookup',
+  },
+  {
+    file: 'scripts/harness/verify-macos-release-artifacts.sh',
+    cited: `${TASKS_DIR}DIST-002-release-artifact-verification.md`,
+    outcome: 'conflict',
+    why: 'same conflict as the gate script, and the surrounding prose says DIST-002 too — renumbering one without the other would be worse',
+  },
+  {
+    file: '.agents/memory/agent-run-capability-verification.md',
+    cited: `${TASKS_DIR}SELFHOST-008-P6-surface-wiring-and-agent-run-verification.md`,
+    outcome: 'conflict',
+    why: 'the document calls a completed item an open fix; that is a status claim, filed as issue #2262',
+  },
+];
+
+/**
+ * The exemption for this citation, if its outcome is still the one the exemption excuses.
+ *
+ * An exemption PINS an outcome. Excusing a path instead would make the scan blind to the very
+ * distinction it exists for: measured here, a mutant collapsing `conflict` into `moved` left the
+ * whole tree green, because every conflict in the tree is exempt and a path-keyed exemption skipped
+ * them before their classification mattered. Pinning the outcome turns that mutant red — a
+ * reclassified citation is no longer the finding anyone signed off.
+ */
+function exemptionFor(file, cited, outcome) {
+  return SENTENCE_CONTRADICTS_REPAIR.find(
+    (one) => one.file === file && one.cited === cited && one.outcome === outcome,
+  );
+}
+
+/**
+ * A fenced block demonstrating the naming FORMAT is not a citation.
+ *
+ * The tasks README already gets this right: it demonstrates the shape with an id nothing can
+ * resolve — `CHILD-001-description.md` — allow-missing-artifact: an example that must not resolve. An example that uses a LIVE id is indistinguishable from a citation to this scan and
+ * to a reader both, which is the rule the `operational.md` case established.
+ */
+function citationLines(text) {
+  const lines = text.split('\n');
+  const out = [];
+  let fenced = false;
+  for (const [index, line] of lines.entries()) {
+    if (/^\s*```/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) continue;
+    for (const match of line.matchAll(CITATION)) out.push({ line: index + 1, cited: match[0] });
+  }
+  return out;
+}
+
+let examinedDocuments = 0;
+
+/**
+ * How many documents the last run actually OPENED.
+ *
+ * Incremented where the read happens, not taken from `sources.length`. The two agree until a read
+ * throws and the file is skipped — the one moment the number is load-bearing, and the moment a
+ * collection size would still report full coverage. Reset at the start of each run so a second run
+ * in one process reports its own size rather than the sum.
+ */
+export function examinedDocumentCount() {
+  return examinedDocuments;
+}
+
+/** Every citation in one document, with the line it sits on. Exported for the counter's test. */
+export function collectCitations(text) {
+  return citationLines(text);
+}
+
+export function liveSources(files) {
+  return files.filter(
+    (file) =>
+      LIVE_SOURCES.some((prefix) => file.startsWith(prefix)) &&
+      !isHistorySource(file) &&
+      !NOT_A_CITATION.some((pattern) => pattern.test(file)),
+  );
+}
+
+/**
+ * Walk the live documents and classify every citation each one carries.
+ *
+ * Separated from `main` so the counter can be asserted against a fixture of KNOWN size. A counter
+ * only reachable through a whole-tree run can be asserted against a bound, and every over-count —
+ * including one that counts a document twice — satisfies a bound.
+ */
+export function findStaleCitations(sources, index, exists, readDocument) {
+  examinedDocuments = 0;
+  const findings = [];
+  const matchedExemptions = new Set();
+  for (const file of sources) {
+    let text;
+    try {
+      text = readDocument(file);
+    } catch {
+      // A document that cannot be read was NOT examined, and the count must say so.
+      continue;
+    }
+    examinedDocuments += 1;
+    for (const { line, cited } of citationLines(text)) {
+      const verdict = classifyCitation(cited, index, exists);
+      if (verdict.outcome === 'exact') continue;
+      const exemption = exemptionFor(file, cited, verdict.outcome);
+      if (exemption) {
+        matchedExemptions.add(exemption);
+        continue;
+      }
+      findings.push({ file, line, cited, ...verdict });
+    }
+  }
+  return { findings, matchedExemptions };
+}
+
+function main() {
+  const files = enumerateFiles(['*']).filter((file) => existsSync(path.join(WORKSPACE_ROOT, file)));
+  const index = indexRecords(files);
+  const present = new Set(files);
+  const exists = (file) => present.has(file);
+
+  const { findings, matchedExemptions } = findStaleCitations(
+    liveSources(files),
+    index,
+    exists,
+    (file) => readFileSync(path.join(WORKSPACE_ROOT, file), 'utf-8'),
+  );
+
+  if (process.argv.includes('--fix')) {
+    // REPAIRABLE means the ID and the slug agree on one record. `conflict` is excluded by
+    // construction, not by a filter that could be relaxed later: repairing a citation whose two
+    // axes disagree picks a document the citation never named, and does it with the authority of a
+    // tool. That is the defect this scan exists to prevent, so --fix must not be able to cause it.
+    const repairable = findings.filter(
+      (one) => (one.outcome === 'moved' || one.outcome === 'archived') && one.actual,
+    );
+    const byFile = new Map();
+    for (const one of repairable) {
+      if (!byFile.has(one.file)) byFile.set(one.file, []);
+      byFile.get(one.file).push(one);
+    }
+    for (const [file, group] of byFile) {
+      const full = path.join(WORKSPACE_ROOT, file);
+      let text = readFileSync(full, 'utf-8');
+      // Substitute the cited path where it stands. Rebuilding the line would take whatever else
+      // shares it — a lesson this repository has paid for more than once.
+      for (const one of group) text = text.split(one.cited).join(one.actual);
+      writeFileSync(full, text, 'utf-8');
+      console.log(`fixed ${group.length} citation(s) in ${file}`);
+    }
+    const refused = findings.length - repairable.length;
+    if (refused > 0) {
+      console.log(
+        `refused to repair ${refused} citation(s): a conflict or an unresolvable path needs a ` +
+          'person, and guessing is how one of them got this way.',
+      );
+    }
+    return;
+  }
+
+  console.log(
+    `::examined:: ${examinedDocuments} live document(s) read, ${index.byId.size} work-item id(s)`,
+  );
+
+  // An exemption that stops matching is not a success. Measured: a mutant that made the resolver
+  // answer `exact` for everything produced zero findings and left the scan green — every exemption
+  // silently unmatched. Asserting them makes the corpus and the resolver both falsifiable, because
+  // a scan that has stopped seeing its own known findings has stopped working.
+  const unmatched = SENTENCE_CONTRADICTS_REPAIR.filter((one) => !matchedExemptions.has(one));
+  if (unmatched.length > 0) {
+    console.error(
+      `\n- [stale exemption] ${unmatched.length} exemption(s) no longer match a finding. Either ` +
+        'the citation was fixed — drop the row in the SAME change — or the scan stopped seeing it:',
+    );
+    for (const one of unmatched)
+      console.error(`    ${one.file}\n      ${one.cited} [${one.outcome}]`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (findings.length === 0) {
+    console.log(
+      'task-path-citations scan passed. It re-derives each cited task-record path from the tree ' +
+        'by ID AND slug; history is excluded as a citation source and included as a resolution ' +
+        'target, because a completed record still exists.',
+    );
+    console.log(
+      `${SENTENCE_CONTRADICTS_REPAIR.length} citation(s) are exempt and still OUTSTANDING — each ` +
+        'needs a person, and none is repairable by this tool:',
+    );
+    for (const one of SENTENCE_CONTRADICTS_REPAIR) {
+      console.log(`  ${one.file}\n    ${one.cited} — ${one.why}`);
+    }
+    return;
+  }
+
+  const order = OUTCOME_ORDER;
+  for (const outcome of order) {
+    const group = findings.filter((one) => one.outcome === outcome);
+    if (group.length === 0) continue;
+    console.error(`\n- [${outcome}] ${group.length} citation(s):`);
+    for (const one of group) {
+      console.error(`    ${one.file}:${one.line}`);
+      console.error(`      cites  ${one.cited}`);
+      if (one.outcome === 'conflict') {
+        console.error(`      the ID resolves to   ${one.id?.join(', ') || '— nothing —'}`);
+        console.error(`      the slug resolves to ${one.slug?.join(', ') || '— nothing —'}`);
+        console.error(
+          '      NOT repairable automatically: the two axes disagree, so any repair picks a ' +
+            'document the citation did not name.',
+        );
+      } else {
+        console.error(`      actual ${one.actual}`);
+      }
+    }
+  }
+  console.error(
+    `\ntask-path-citations: ${findings.length} live citation(s) do not resolve to where they say.`,
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  main();
+}

--- a/scripts/harness/task-path-citation.mjs
+++ b/scripts/harness/task-path-citation.mjs
@@ -1,0 +1,172 @@
+/**
+ * HARNESS-118 (issue #2248) — resolve a cited task-record path against the tree.
+ *
+ * A citation of a task-record path is a FACT about where a file is, and four ordinary events make
+ * it false without anyone saying so: the record is completed (`git mv` into `completed/`), it is
+ * renamed (the slug is part of the path), it is archived out of `.agents/tasks/` entirely, or its
+ * ID is reused for a different subject.
+ *
+ * ## Why resolution is by ID *and* slug
+ *
+ * Matching on ID alone is worse than not resolving, because it produces a confident wrong answer
+ * where a broken link would have produced a noticed one. Three cases in this tree, reached from
+ * three directions:
+ *
+ *   - `CORE-014-shutdown-drops-in-flight-work.md` (allow-missing-artifact: the SUBJECT is that no
+ *     commit ever added this slug) — the ID is live and the slug was never real. The only CORE-014
+ *     file ever added is the stateless-run-mode record.
+ *   - `DIST-002-release-artifact-verification.md` (allow-missing-artifact: the SUBJECT is an id and
+ *     a slug that disagree) — the slug is live, under someone else's ID. It belongs to DIST-005;
+ *     DIST-002 is a Bun-binary release workflow.
+ *   - `CLI-BL-024` and `CLI-BL-019` — one ID, two archived subjects each. An ID-only resolver picks
+ *     one of two and is right by luck half the time, which is not right.
+ *
+ * So a disagreement between the two axes is the FINDING (`conflict`), never something to resolve
+ * past. It is the outcome this module exists for, and the only one that must never be auto-repaired.
+ */
+
+import path from 'node:path';
+
+/** `DOMAIN-NNN` at the start of a record basename, allowing multi-segment domains (`CLI-BL-024`). */
+const ID_PATTERN = /^([A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*-\d+(?:-P\d+)?)(?:-(.+))?$/;
+
+/** Directories whose documents are FROZEN HISTORY: excluded as a citation source. */
+const HISTORY_SOURCES = [
+  '.agents/archive/',
+  '.design/',
+  '.agents/daily-reports/',
+  '.agents/spec-docs/done/',
+  '.agents/tasks/completed/',
+];
+
+/**
+ * Directories searched when RESOLVING a citation.
+ *
+ * History is excluded as a source and INCLUDED as a target, and the two lists must not be shared.
+ * A completed record still exists — reporting it as missing is the most alarming verdict available
+ * for the least alarming cause, and four citations in this tree are in exactly that position.
+ *
+ * Only TASK RECORDS resolve a task-record citation. `.agents/spec-docs/` is deliberately absent: a
+ * spec-doc is a different document with the same ID, and answering "where is the record" with a
+ * spec-doc is the same class of confident wrong answer that ID-only matching produces. Where only a
+ * spec-doc survives, the honest answers are `conflict` and `dangling`, and both are here.
+ */
+const RESOLUTION_ROOTS = ['.agents/tasks/', '.agents/archive/task-breakdowns/'];
+
+/** Split a record basename into its work-item ID and slug. Returns null when it is not a record. */
+export function parseRecordName(basename) {
+  const stem = basename.endsWith('.md') ? basename.slice(0, -3) : basename;
+  const match = ID_PATTERN.exec(stem);
+  if (!match) return null;
+  return { id: match[1], slug: match[2] ?? '' };
+}
+
+/** Whether a citing file is frozen history rather than a live claim. */
+export function isHistorySource(file) {
+  return HISTORY_SOURCES.some((prefix) => file.startsWith(prefix));
+}
+
+/** Every candidate record the tree holds, indexed by ID and by slug. */
+export function indexRecords(files) {
+  const byId = new Map();
+  const bySlug = new Map();
+  for (const file of files) {
+    if (!RESOLUTION_ROOTS.some((root) => file.startsWith(root))) continue;
+    if (!file.endsWith('.md')) continue;
+    const parsed = parseRecordName(path.basename(file));
+    if (!parsed) continue;
+    if (!byId.has(parsed.id)) byId.set(parsed.id, []);
+    byId.get(parsed.id).push({ file, ...parsed });
+    if (parsed.slug) {
+      if (!bySlug.has(parsed.slug)) bySlug.set(parsed.slug, []);
+      bySlug.get(parsed.slug).push({ file, ...parsed });
+    }
+  }
+  return { byId, bySlug };
+}
+
+/**
+ * Classify one cited path.
+ *
+ * `exact` — the file is where the citation says.
+ * `moved` — same ID and slug, different directory under `.agents/tasks/`.
+ * `archived` — same ID and slug, but the record left `.agents/tasks/` for the archive.
+ * `renamed` — the ID resolves and the cited slug is a prefix of the record's (or absent).
+ * `conflict` — the ID and the slug lead to DIFFERENT records, or one leads somewhere and the other
+ *   leads elsewhere. Never repaired automatically.
+ * `dangling` — neither axis resolves.
+ */
+export function classifyCitation(cited, index, exists) {
+  if (exists(cited)) return { outcome: 'exact', actual: cited };
+
+  const parsed = parseRecordName(path.basename(cited));
+  if (!parsed) return { outcome: 'dangling', actual: undefined };
+
+  const byId = index.byId.get(parsed.id) ?? [];
+  const bySlug = parsed.slug ? (index.bySlug.get(parsed.slug) ?? []) : [];
+
+  // The slug is the stronger axis: it names the subject, and a subject does not change identity
+  // when an ID is reassigned. Where both resolve and disagree, that disagreement IS the answer.
+  const idFiles = new Set(byId.map((entry) => entry.file));
+  const slugFiles = new Set(bySlug.map((entry) => entry.file));
+
+  if (idFiles.size > 0 && slugFiles.size > 0) {
+    const agreed = [...slugFiles].filter((file) => idFiles.has(file));
+    if (agreed.length === 0) {
+      return { outcome: 'conflict', actual: undefined, id: [...idFiles], slug: [...slugFiles] };
+    }
+    return { ...placement(cited, agreed[0]), actual: agreed[0] };
+  }
+
+  // Only the slug resolves: the ID in the citation belongs to nobody, or to someone else entirely.
+  if (slugFiles.size > 0) {
+    const other = index.byId.get(parsed.id);
+    if (other && other.length > 0) {
+      return {
+        outcome: 'conflict',
+        actual: undefined,
+        id: other.map((e) => e.file),
+        slug: [...slugFiles],
+      };
+    }
+    return { outcome: 'conflict', actual: undefined, id: [], slug: [...slugFiles] };
+  }
+
+  // Only the ID resolves. A cited slug that the record does not carry is a fabricated slug, not a
+  // rename — `CORE-014-shutdown-drops-in-flight-work` is the case, and repointing it would make a
+  // false citation look verified.
+  if (idFiles.size > 0) {
+    if (!parsed.slug) {
+      // A bare-id citation carries no slug to disambiguate with, so one ID holding two subjects has
+      // no answer here. Taking the first is the coin flip this module exists to refuse — right half
+      // the time, and confident either way.
+      if (idFiles.size > 1)
+        return { outcome: 'conflict', actual: undefined, id: [...idFiles], slug: [] };
+      return { ...placement(cited, byId[0].file), actual: byId[0].file };
+    }
+    const extending = byId.filter((entry) => entry.slug.startsWith(parsed.slug));
+    if (extending.length === 1)
+      return { ...placement(cited, extending[0].file), actual: extending[0].file };
+    return { outcome: 'conflict', actual: undefined, id: [...idFiles], slug: [] };
+  }
+
+  return { outcome: 'dangling', actual: undefined };
+}
+
+/**
+ * Which of the three placement outcomes a resolved record is.
+ *
+ * The directory decides first, because that is what a repair has to change. `renamed` is what is
+ * left when the directory did NOT change and only the file name did — a real case (a slug gains a
+ * word), and one an earlier version of this file could not report: the branch that should have
+ * produced it fell through to this function, so `renamed` existed in the prose, in the output-group
+ * list, and nowhere in the returned values. A documented outcome no input can produce is a claim
+ * about behaviour that nothing holds to.
+ */
+function placement(cited, actual) {
+  const wasTask = cited.startsWith('.agents/tasks/');
+  const isTask = actual.startsWith('.agents/tasks/');
+  if (wasTask && !isTask) return { outcome: 'archived' };
+  if (path.dirname(cited) === path.dirname(actual)) return { outcome: 'renamed' };
+  return { outcome: 'moved' };
+}


### PR DESCRIPTION
Closes #2248.

## What

A citation of a task-record path is a fact about where a file is. Completing a record, renaming it, or archiving it makes that fact false and nothing says so. This re-derives every such citation on the live surface from the tree.

## Resolution is by ID *and* slug, and that is the whole design

Matching on ID alone is **worse than not resolving**, because it turns a link a human would notice is broken into one nobody will question. Three cases in this tree, reached from three directions:

| citation | the ID leads to | the slug leads to |
| --- | --- | --- |
| `CORE-014-shutdown-drops-in-flight-work.md` | a live record about *stateless run mode* | nothing — **no commit ever added this slug** |
| `DIST-002-release-artifact-verification.md` | an unrelated Bun-binary spec-doc | `DIST-005-release-artifact-verification.md` |
| `CLI-BL-019` / `CLI-BL-024` | **two archived subjects each** | the one that was meant |

So a disagreement between the axes is the **finding** (`conflict`), never something to resolve past — and `--fix` cannot repair one by construction, not by a filter someone could relax later.

## Measured before designing, because the raw number is not the problem size

`git grep` finds **1779** citations across **401** files. Three corrections each change the answer:

1. **Test fixtures are not citations** — 90 are strings inside harness tests. A scan counting them measures its own fixtures.
2. **Resolution must be by ID and slug** — most citations name `<ID>.md` while records are `<ID>-<slug>.md`, so exact-path matching reports files that exist as missing.
3. **Frozen history is not a live claim** — `spec-docs/done/` alone holds 607 stale citations. A completed document recording where a record was *at the time* is a record, not a defect.

**Live surface: 22 citations, 20 excluding two format examples.** 16 repaired here.

## Two findings the plan did not predict

**The `dangling` bucket is empty.** The four citations that looked unresolvable — `INFRA-018`, `RESUME-001`, `CLI-BL-024-…`, `CLI-BL-019-…` — are records that were completed and archived out of the tasks tree. Without history as a resolution **target**, the scan reports them missing: the most alarming verdict available, for the least alarming cause. History is excluded as a citation *source* and included as a resolution *target*, and the two roles deliberately do not share a list.

**Two repairs had to be reverted because the path was right and the sentence was wrong.** Both read "미생성" — *not yet created* — beside a record that is completed and archived. Repairing the path yields a well-formed, resolvable, confident falsehood: a reader follows the link and finds finished work under a sentence telling them it does not exist. That is strictly worse than the stale path, and `--fix` cannot see it, because the tool reads the path and a reader reads the claim around it. They are exempt and **printed on every pass** — an exemption that prints nothing is a suppression.

## The mutants are the deliverable, and two of them found real defects

- **`conflict` collapsed into `moved` → left the whole tree GREEN.** Every conflict in the tree was exempt, and the exemptions were keyed by *path*, so they skipped those citations before classification mattered. **An exemption now pins the outcome it excuses**; a reclassified citation is no longer the finding anyone signed off. Now red.
- **Resolver answers `exact` for everything → also left the tree green**, with all five exemptions silently unmatched. **An unmatched exemption now fails the scan.** Now red.
- **Live corpus emptied → red.** Caught by the scan and *not* by the unit tests: the corpus is a tree-level property and no unit test walks the tree. Stating that rather than claiming coverage it does not have.
- **History removed as a resolution target → red.**

A third defect came from the fixture test rather than a mutant: a bare-ID citation against an ID holding two subjects took the first match — the coin flip this module refuses. Now a `conflict`.

## Verification

143 scans pass (1 skipped), 4886 harness tests pass, `pnpm lint` **exit 0** at the 2203 ceiling — checked by exit code, not the summary line. `examined-adoption-baseline.json` re-frozen in this change. The declared size is incremented where the read happens rather than taken from the list length; the two agree until a read throws, which is the one moment the number is load-bearing.

## Left for a person, deliberately

Five citations are exempt and reported: two sentence-contradictions above, the two `DIST-002` conflicts (the surrounding prose says DIST-002 too, so renumbering one without the other would be worse), and one memory document calling a completed item an open fix — filed as #2262, and owned by another lane's branch.
