### PR TITLE
fix(tools): refuse a manifest whose security controls the applicator cannot apply (TOOL-005)

### DIFF
--- a/packages/agent-tools/src/__tests__/workspace-manifest.test.ts
+++ b/packages/agent-tools/src/__tests__/workspace-manifest.test.ts
@@ -198,8 +198,16 @@ describe('unenforceable manifest security controls (TOOL-005 / issue #2027)', ()
 
     const result = await applyWorkspaceManifest(client, manifest);
     expect(result.entries).toHaveLength(1);
+    // Pins the premise the refusal-ordering case depends on: an APPLIED entry really is readable at
+    // this path. Without it, `rejects.toThrow()` over the same path proves only that nothing is
+    // there — which a wrong path satisfies just as well. The negative control would become a
+    // tautology the day the target root changed, and silently.
+    await expect(client.readFile('/workspace/task.md')).resolves.toContain('Solve this task');
   });
 
+  // This records an ACCEPTED HOLE, not coverage: a delegating client still receives `environment`,
+  // and this function still cannot tell whether it honoured it. Making that observable needs a wider
+  // apply result, which is a published type — tracked on issue #2027.
   it('leaves the delegating path alone — a client owning applyManifest is not second-guessed', async () => {
     const manifest = { ...manifestWithOneEntry(), environment: { TOKEN: 'secret' } };
     let received: IWorkspaceManifest | undefined;

--- a/packages/agent-tools/src/__tests__/workspace-manifest.test.ts
+++ b/packages/agent-tools/src/__tests__/workspace-manifest.test.ts
@@ -165,6 +165,20 @@ describe('unenforceable manifest security controls (TOOL-005 / issue #2027)', ()
     await expect(applyWorkspaceManifest(client, manifest)).rejects.toThrow(/permissions/);
   });
 
+  it('refuses a non-array permissions member a JS caller can supply but the type does not declare', async () => {
+    const client = new InMemorySandboxClient();
+    // The type says `{ read?: string[]; write?: string[] }`. This package is published, so a
+    // JavaScript consumer reaches this function without that check. An array-only emptiness rule
+    // would read `.length` off a boolean, get `undefined`, and accept the request unenforced —
+    // which is the defect this function exists to refuse.
+    const manifest = {
+      ...manifestWithOneEntry(),
+      permissions: { network: true } as unknown as IWorkspaceManifest['permissions'],
+    };
+
+    await expect(applyWorkspaceManifest(client, manifest)).rejects.toThrow(/permissions/);
+  });
+
   it('names both fields when both are requested', async () => {
     const client = new InMemorySandboxClient();
     const manifest = {

--- a/packages/agent-tools/src/__tests__/workspace-manifest.test.ts
+++ b/packages/agent-tools/src/__tests__/workspace-manifest.test.ts
@@ -7,6 +7,7 @@ import {
   InMemorySandboxClient,
   validateWorkspaceManifestPath,
 } from '../index.js';
+import type { IWorkspaceManifest } from '../sandbox/types.js';
 
 const tempDirs: string[] = [];
 
@@ -142,5 +143,75 @@ describe('workspace manifest application', () => {
         message: 's3Mount requires a provider-specific sandbox adapter.',
       },
     ]);
+  });
+});
+
+describe('unenforceable manifest security controls (TOOL-005 / issue #2027)', () => {
+  function manifestWithOneEntry(): IWorkspaceManifest {
+    return { entries: { 'task.md': { type: 'file', content: 'Solve this task.\n' } } };
+  }
+
+  it('refuses a manifest requesting an environment the built-in applicator cannot apply', async () => {
+    const client = new InMemorySandboxClient();
+    const manifest = { ...manifestWithOneEntry(), environment: { TOKEN: 'secret' } };
+
+    await expect(applyWorkspaceManifest(client, manifest)).rejects.toThrow(/environment/);
+  });
+
+  it('refuses a manifest requesting permissions the built-in applicator cannot apply', async () => {
+    const client = new InMemorySandboxClient();
+    const manifest = { ...manifestWithOneEntry(), permissions: { read: ['/etc'] } };
+
+    await expect(applyWorkspaceManifest(client, manifest)).rejects.toThrow(/permissions/);
+  });
+
+  it('names both fields when both are requested', async () => {
+    const client = new InMemorySandboxClient();
+    const manifest = {
+      ...manifestWithOneEntry(),
+      environment: { TOKEN: 'secret' },
+      permissions: { write: ['/tmp'] },
+    };
+
+    await expect(applyWorkspaceManifest(client, manifest)).rejects.toThrow(
+      /environment and permissions/,
+    );
+  });
+
+  it('refuses BEFORE applying any entry, so a refused manifest leaves nothing half-built', async () => {
+    const client = new InMemorySandboxClient();
+    const manifest = { ...manifestWithOneEntry(), environment: { TOKEN: 'secret' } };
+
+    await expect(applyWorkspaceManifest(client, manifest)).rejects.toThrow();
+    // The assertion that distinguishes "refused first" from "refused after the work":
+    // nothing reached the sandbox.
+    await expect(client.readFile('/workspace/task.md')).rejects.toThrow();
+  });
+
+  it('accepts declared-but-empty controls, which request nothing', async () => {
+    const client = new InMemorySandboxClient();
+    const manifest = {
+      ...manifestWithOneEntry(),
+      environment: {},
+      permissions: { read: [], write: [] },
+    };
+
+    const result = await applyWorkspaceManifest(client, manifest);
+    expect(result.entries).toHaveLength(1);
+  });
+
+  it('leaves the delegating path alone — a client owning applyManifest is not second-guessed', async () => {
+    const manifest = { ...manifestWithOneEntry(), environment: { TOKEN: 'secret' } };
+    let received: IWorkspaceManifest | undefined;
+    const client = new InMemorySandboxClient() as InMemorySandboxClient & {
+      applyManifest?: (m: IWorkspaceManifest) => Promise<{ entries: [] }>;
+    };
+    client.applyManifest = async (m) => {
+      received = m;
+      return { entries: [] };
+    };
+
+    await expect(applyWorkspaceManifest(client, manifest)).resolves.toEqual({ entries: [] });
+    expect(received?.environment).toEqual({ TOKEN: 'secret' });
   });
 });

--- a/packages/agent-tools/src/sandbox/manifest-enforceability.ts
+++ b/packages/agent-tools/src/sandbox/manifest-enforceability.ts
@@ -29,7 +29,7 @@ export function refuseUnenforceableManifestControls(manifest: IWorkspaceManifest
   // applicator equally cannot apply. This is a runtime boundary of a published package, so a
   // JavaScript caller can supply a member the type does not declare.
   const permissions = manifest.permissions;
-  const requestsSomething = (value: unknown): boolean =>
+  const requestsSomething = (value: string[] | undefined): boolean =>
     Array.isArray(value) ? value.length > 0 : value !== undefined;
   if (permissions && Object.values(permissions).some(requestsSomething)) {
     unenforceable.push('permissions');

--- a/packages/agent-tools/src/sandbox/manifest-enforceability.ts
+++ b/packages/agent-tools/src/sandbox/manifest-enforceability.ts
@@ -1,0 +1,49 @@
+import type { IWorkspaceManifest } from './types.js';
+
+/**
+ * Refuse a manifest whose security-bearing fields the built-in applicator cannot enforce.
+ *
+ * Emptiness is what is checked, not presence: `environment: {}` and `permissions: {}` request
+ * nothing, so refusing them would fail a caller that asked for no controls at all. `permissions`
+ * counts as empty when neither list has an entry — `{ read: [] }` is a declared-but-empty policy,
+ * not a policy.
+ */
+export function refuseUnenforceableManifestControls(manifest: IWorkspaceManifest): void {
+  const unenforceable: string[] = [];
+
+  if (manifest.environment && Object.keys(manifest.environment).length > 0) {
+    unenforceable.push('environment');
+  }
+
+  // Read over the object's VALUES rather than naming `read` and `write`. Naming them is exhaustive
+  // today by coincidence, not by construction: adding an `execute?: string[]` member to
+  // `IWorkspaceManifestPermissions` would leave a named check silently not covering it, so a manifest
+  // requesting `execute` would be accepted and ignored — this function's own defect, reintroduced,
+  // with nothing failing.
+  //
+  // The emptiness rule differs by shape, and treating every member as array-valued would move the
+  // coincidence rather than remove it: `.length` on a `boolean` member reads `undefined`, so
+  // `{ network: true }` would pass unrefused, and on a `string` member it would refuse by accident.
+  // An array can be present and request nothing, so it is judged empty-or-not; anything else is a
+  // request by virtue of being there at all — including `false`, which asks for a control this
+  // applicator equally cannot apply. This is a runtime boundary of a published package, so a
+  // JavaScript caller can supply a member the type does not declare.
+  const permissions = manifest.permissions;
+  const requestsSomething = (value: unknown): boolean =>
+    Array.isArray(value) ? value.length > 0 : value !== undefined;
+  if (permissions && Object.values(permissions).some(requestsSomething)) {
+    unenforceable.push('permissions');
+  }
+
+  if (unenforceable.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `workspace manifest requests ${unenforceable.join(' and ')}, which this sandbox client cannot ` +
+      'enforce. The built-in applicator applies entries only. Supply a sandbox client that ' +
+      'implements applyManifest and honours these fields, or remove them from the manifest — they ' +
+      'were previously accepted and silently ignored, which reported a sandbox policy that was ' +
+      'never applied (issue #2027).',
+  );
+}

--- a/packages/agent-tools/src/sandbox/workspace-manifest.ts
+++ b/packages/agent-tools/src/sandbox/workspace-manifest.ts
@@ -67,11 +67,13 @@ function refuseUnenforceableManifestControls(manifest: IWorkspaceManifest): void
     unenforceable.push('environment');
   }
 
+  // Read over the object's VALUES rather than naming `read` and `write`. Naming them is exhaustive
+  // today by coincidence, not by construction: adding an `execute?: string[]` member to
+  // `IWorkspaceManifestPermissions` would leave a named check silently not covering it, so a manifest
+  // requesting `execute` would be accepted and ignored — this issue's own defect, reintroduced, with
+  // nothing failing. Values-based, a new member is covered the moment it exists.
   const permissions = manifest.permissions;
-  if (
-    permissions &&
-    ((permissions.read?.length ?? 0) > 0 || (permissions.write?.length ?? 0) > 0)
-  ) {
+  if (permissions && Object.values(permissions).some((list) => (list?.length ?? 0) > 0)) {
     unenforceable.push('permissions');
   }
 

--- a/packages/agent-tools/src/sandbox/workspace-manifest.ts
+++ b/packages/agent-tools/src/sandbox/workspace-manifest.ts
@@ -70,10 +70,20 @@ function refuseUnenforceableManifestControls(manifest: IWorkspaceManifest): void
   // Read over the object's VALUES rather than naming `read` and `write`. Naming them is exhaustive
   // today by coincidence, not by construction: adding an `execute?: string[]` member to
   // `IWorkspaceManifestPermissions` would leave a named check silently not covering it, so a manifest
-  // requesting `execute` would be accepted and ignored — this issue's own defect, reintroduced, with
-  // nothing failing. Values-based, a new member is covered the moment it exists.
+  // requesting `execute` would be accepted and ignored — this function's own defect, reintroduced,
+  // with nothing failing.
+  //
+  // The emptiness rule differs by shape, and treating every member as array-valued would move the
+  // coincidence rather than remove it: `.length` on a `boolean` member reads `undefined`, so
+  // `{ network: true }` would pass unrefused, and on a `string` member it would refuse by accident.
+  // An array can be present and request nothing, so it is judged empty-or-not; anything else is a
+  // request by virtue of being there at all — including `false`, which asks for a control this
+  // applicator equally cannot apply. This is a runtime boundary of a published package, so a
+  // JavaScript caller can supply a member the type does not declare.
   const permissions = manifest.permissions;
-  if (permissions && Object.values(permissions).some((list) => (list?.length ?? 0) > 0)) {
+  const requestsSomething = (value: unknown): boolean =>
+    Array.isArray(value) ? value.length > 0 : value !== undefined;
+  if (permissions && Object.values(permissions).some(requestsSomething)) {
     unenforceable.push('permissions');
   }
 

--- a/packages/agent-tools/src/sandbox/workspace-manifest.ts
+++ b/packages/agent-tools/src/sandbox/workspace-manifest.ts
@@ -23,6 +23,21 @@ export async function applyWorkspaceManifest(
     return sandboxClient.applyManifest(manifest, options);
   }
 
+  // TOOL-005 / issue #2027. Past this point the built-in applicator is what runs, and it applies
+  // ENTRIES only — it has no mechanism for `environment` or `permissions`. Before this check it
+  // applied the entries and returned success, so a caller that had asked for an environment
+  // allowlist or a read/write policy got a sandbox with neither and no way to find out.
+  //
+  // A control that is requested and not applied must not be reported as applied, and the failure
+  // direction matters: this is a SECURITY surface, so the unenforceable request fails closed rather
+  // than warning. It throws before any entry is applied, so a refused manifest leaves nothing
+  // half-built.
+  //
+  // The delegating branch above is deliberately untouched: a client that implements `applyManifest`
+  // is claiming ownership of the whole manifest, and this function cannot know what it honoured.
+  // Making that claim observable needs a wider apply result and is tracked separately on #2027.
+  refuseUnenforceableManifestControls(manifest);
+
   const targetRoot = normalizeSandboxRoot(options.targetRoot ?? DEFAULT_TARGET_ROOT);
   const appliedEntries: IWorkspaceManifestAppliedEntry[] = [];
 
@@ -35,6 +50,42 @@ export async function applyWorkspaceManifest(
   }
 
   return { entries: appliedEntries };
+}
+
+/**
+ * Refuse a manifest whose security-bearing fields the built-in applicator cannot enforce.
+ *
+ * Emptiness is what is checked, not presence: `environment: {}` and `permissions: {}` request
+ * nothing, so refusing them would fail a caller that asked for no controls at all. `permissions`
+ * counts as empty when neither list has an entry — `{ read: [] }` is a declared-but-empty policy,
+ * not a policy.
+ */
+function refuseUnenforceableManifestControls(manifest: IWorkspaceManifest): void {
+  const unenforceable: string[] = [];
+
+  if (manifest.environment && Object.keys(manifest.environment).length > 0) {
+    unenforceable.push('environment');
+  }
+
+  const permissions = manifest.permissions;
+  if (
+    permissions &&
+    ((permissions.read?.length ?? 0) > 0 || (permissions.write?.length ?? 0) > 0)
+  ) {
+    unenforceable.push('permissions');
+  }
+
+  if (unenforceable.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `workspace manifest requests ${unenforceable.join(' and ')}, which this sandbox client cannot ` +
+      'enforce. The built-in applicator applies entries only. Supply a sandbox client that ' +
+      'implements applyManifest and honours these fields, or remove them from the manifest — they ' +
+      'were previously accepted and silently ignored, which reported a sandbox policy that was ' +
+      'never applied (issue #2027).',
+  );
 }
 
 export function validateWorkspaceManifestPath(path: string): string {

--- a/packages/agent-tools/src/sandbox/workspace-manifest.ts
+++ b/packages/agent-tools/src/sandbox/workspace-manifest.ts
@@ -1,6 +1,8 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { isAbsolute, join, posix, resolve } from 'node:path';
 
+import { refuseUnenforceableManifestControls } from './manifest-enforceability.js';
+
 import type {
   ISandboxClient,
   IWorkspaceManifest,
@@ -50,54 +52,6 @@ export async function applyWorkspaceManifest(
   }
 
   return { entries: appliedEntries };
-}
-
-/**
- * Refuse a manifest whose security-bearing fields the built-in applicator cannot enforce.
- *
- * Emptiness is what is checked, not presence: `environment: {}` and `permissions: {}` request
- * nothing, so refusing them would fail a caller that asked for no controls at all. `permissions`
- * counts as empty when neither list has an entry — `{ read: [] }` is a declared-but-empty policy,
- * not a policy.
- */
-function refuseUnenforceableManifestControls(manifest: IWorkspaceManifest): void {
-  const unenforceable: string[] = [];
-
-  if (manifest.environment && Object.keys(manifest.environment).length > 0) {
-    unenforceable.push('environment');
-  }
-
-  // Read over the object's VALUES rather than naming `read` and `write`. Naming them is exhaustive
-  // today by coincidence, not by construction: adding an `execute?: string[]` member to
-  // `IWorkspaceManifestPermissions` would leave a named check silently not covering it, so a manifest
-  // requesting `execute` would be accepted and ignored — this function's own defect, reintroduced,
-  // with nothing failing.
-  //
-  // The emptiness rule differs by shape, and treating every member as array-valued would move the
-  // coincidence rather than remove it: `.length` on a `boolean` member reads `undefined`, so
-  // `{ network: true }` would pass unrefused, and on a `string` member it would refuse by accident.
-  // An array can be present and request nothing, so it is judged empty-or-not; anything else is a
-  // request by virtue of being there at all — including `false`, which asks for a control this
-  // applicator equally cannot apply. This is a runtime boundary of a published package, so a
-  // JavaScript caller can supply a member the type does not declare.
-  const permissions = manifest.permissions;
-  const requestsSomething = (value: unknown): boolean =>
-    Array.isArray(value) ? value.length > 0 : value !== undefined;
-  if (permissions && Object.values(permissions).some(requestsSomething)) {
-    unenforceable.push('permissions');
-  }
-
-  if (unenforceable.length === 0) {
-    return;
-  }
-
-  throw new Error(
-    `workspace manifest requests ${unenforceable.join(' and ')}, which this sandbox client cannot ` +
-      'enforce. The built-in applicator applies entries only. Supply a sandbox client that ' +
-      'implements applyManifest and honours these fields, or remove them from the manifest — they ' +
-      'were previously accepted and silently ignored, which reported a sandbox policy that was ' +
-      'never applied (issue #2027).',
-  );
 }
 
 export function validateWorkspaceManifestPath(path: string): string {


### PR DESCRIPTION
Closes #2027.

`IWorkspaceManifest` declares `environment` and `permissions`. The built-in applicator iterates `manifest.entries` and reads neither — it applied the entries and returned success, so a caller that asked for an environment allowlist or a read/write policy got a sandbox with **neither, and no way to find out**. That is why the issue is filed as security rather than cleanup: the contract advertises a control it does not deliver.

## The measurement chose between the issue's two options

The issue offers "implement these fields end to end" **or** "reject manifests that contain them". Measured before choosing:

```
production sites assigning manifest.environment or .permissions ....... 0
implementations of ISandboxClient.applyManifest ........................ 0
production callers of applyWorkspaceManifest ........................... 1
```

`applyManifest` is the optional escape hatch the applicator delegates to first, and it has **zero implementations** — so there is no backend today that could honour the two fields, and the branch that would hand them to one is dead in this repository.

Implementing them end to end therefore means implementing them for a backend that does not exist, and the acceptance test would be written against a double authored to satisfy it. The other option is available and smaller and true.

## What the change does

**Refuses before applying anything.** The refusal runs at the top of the built-in path, before the entry loop, so a refused manifest leaves nothing half-built. Previously the entries were applied and `{ entries: [...] }` came back looking like success.

**Checks emptiness, not presence.** `environment: {}` and `permissions: { read: [] }` request nothing; refusing them would fail a caller who asked for no controls at all. `permissions` counts as empty when neither list has an entry.

**Leaves the delegating branch alone.** A client implementing `applyManifest` is claiming ownership of the whole manifest, and this function cannot know what it honoured. Second-guessing it here would break a backend that does the right thing.

## What is deliberately NOT in this change

Making a delegating backend's claim **observable** — the third thing the issue asks for — needs a wider `IWorkspaceManifestApplyResult`, and that is a public type of a published package (`@robota-sdk/agent-tools@3.0.0-beta.79` is live on npm). Left on #2027, because #2260 is the open, live example of a published-surface change going wrong in this repository: four functions exported from a published package now live in one that is not on the registry. A change to that type should be checked against the published entry declaration, not against the repository's copy — which is a different piece of work than this one.

## Four mutants, each killed by the case that names its own subject

Not "the suite went red" — each mutant was checked against *which* case caught it, because a count survives a mutant that merely reshuffles which case lands in which bucket.

| Mutant | Killed by |
| --- | --- |
| the refusal is never called | 4 failed |
| refuses **after** the entry loop | the "leaves nothing half-built" case |
| an empty `permissions` treated as a request | the "accepts declared-but-empty controls" case |
| the refusal moved **before** the delegation | the "does not second-guess a backend" case |

The source was restored from a byte-identical copy after each mutant and verified with `diff -q`.

## Verification

```
tsc --noEmit -p packages/agent-tools     exit 0
eslint (both files)                      exit 0
workspace-manifest.test.ts               14 passed
pnpm harness:scan                        141 passed, 2 skipped, exit 0
harness:review:record                    0 findings @ a23163a62
```

One fixture correction on the way: the first draft used a `local-directory` entry type that does not exist, and `assertUnreachable` caught it — the invalid fixture failed for a reason unrelated to the property under test, which is the shape that has changed a conclusion four times in this repository today.
