### PR TITLE
fix(config): a project settings layer can no longer delete a user's hooks (CONFIG-003)

### DIFF
--- a/.agents/tasks/CONFIG-003-deep-merge-replaces-hooks-wholesale-and-transports-is-a-dead-resolved-field.md
+++ b/.agents/tasks/CONFIG-003-deep-merge-replaces-hooks-wholesale-and-transports-is-a-dead-resolved-field.md
@@ -65,3 +65,58 @@ file (same for the `preset` key).
   gone.
 - Cleanup: remove the fixture hooks.
 - Evidence (fill in after implementation): logs showing both hooks executed.
+
+## Direction item 1, hooks and taskContext — delivered 2026-08-24
+
+`mergeSettings` now merges `hooks` **per lifecycle event**, appending each layer's groups in layer
+order, and merges `taskContext` field-wise. A later layer can ADD hooks and can never REMOVE one it
+did not declare.
+
+**Why per-event and not per-object.** Replacing the `PreToolUse` array wholesale is exactly as fatal
+as replacing the whole `hooks` object, so an object-level merge would have looked like a fix and left
+the same hole one level down. The same-event case is pinned by its own test.
+
+**Why user-first ordering.** `runHooks` returns on the first `deny`, so a surviving user guard blocks
+regardless of position — but ordering decides which hook gets to speak for non-deny decisions, and
+the higher-trust layer should be the one that does.
+
+**The codebase already knew.** `plugins/plugin-hooks-merger.ts`'s `mergeHooksIntoConfig` composes
+plugin hooks with config hooks by concatenating per event, and always has. Settings-layer hooks were
+the only hook composition in the package that replaced instead of merging.
+
+Red-first, as the Test Plan above requires — all three fail on the property itself without the fix:
+
+```
+expected undefined to be 'user-guard'                       ← the guard was deleted
+expected [ { matcher: 'Bash' } ] to have a length of 2       ← the same-event group was replaced
+expected undefined to be false                              ← the user's taskContext.enabled was erased
+```
+
+`mergeSettings`/`mergeHooks`/`mergeProviders` moved to `config/config-merge.ts`: the loader READS and
+RESOLVES, while what a later layer may do to an earlier one is a different question — and the one
+with the security boundary in it.
+
+The SPEC's "Higher layers override lower layers via deep merge" now states the hooks exception where
+that claim is made, including that deliberate user-level _disable_ semantics are not defined and were
+not invented inside a merge function.
+
+### What this does NOT deliver
+
+- **`transports`** (Direction item 2). Wholesale replacement is real but reaches no consumer:
+  `toResolvedConfig` never populates it, so the merge behaviour of a field nothing reads was left
+  alone rather than "fixed" invisibly. The delete-or-populate decision is still open.
+- **`preset` routing**, same item.
+- **`permissions.allow` / `.deny`.** Measured while here and NOT changed: both are field-level
+  replacements (`layer.permissions?.deny ?? merged.permissions?.deny`), so a project layer declaring
+  `deny` erases the user's. That is a **deliberate** line somebody wrote, unlike the hooks case which
+  fell out of a spread, so it needs an argument rather than a correction — and `allow` needs a
+  different argument from `deny`, because unioning a restriction is safe while unioning a grant is
+  not. Raised separately.
+- **Provenance diagnostics** and **explicit disable semantics** from issue #2024's acceptance list.
+  Both are design decisions; this change deliberately makes neither.
+
+### Issue #2024 is the same defect, narrower
+
+Issue #2024 (2026-08-22) records the `hooks` half of this record (2026-08-13) with a reproduction and
+an acceptance list. This record owns it — it is earlier and names all three fields. Issue #2024's acceptance
+criteria are folded in above, and it closes when this record delivers.

--- a/packages/agent-framework/docs/SPEC.md
+++ b/packages/agent-framework/docs/SPEC.md
@@ -2174,6 +2174,10 @@ Settings are loaded with a 6-file precedence model (lowest priority first). `.ro
 
 The `.claude/settings.json` layers provide Claude Code compatibility — settings written by Claude Code are automatically picked up by Robota. Higher layers override lower layers via deep merge. `$ENV:VAR` substitution is applied after merge for provider API keys.
 
+**`hooks` is the exception, and it is a security boundary rather than a merge preference (CONFIG-003).** Hooks are merged **per lifecycle event**, with each layer's groups appended in layer order. A higher layer can therefore ADD hooks and can never REMOVE one it did not declare. Without this, a project `.robota/settings.json` declaring any single hook replaced the entire user-global `hooks` object — a repository could disable a user's `PreToolUse` guard by declaring an unrelated `PostToolUse` automation. Project layers are read only for a workspace the user has marked trusted, but trusting a workspace is not the same as intending it to remove your own guards.
+
+Deliberate user-level disable semantics are NOT defined: there is no way to express "turn that hook off from a later layer", and the merge deliberately does not invent one.
+
 Provider resolution order:
 
 1. `currentProvider` plus `providers[currentProvider]`

--- a/packages/agent-framework/src/__tests__/config-loader.test.ts
+++ b/packages/agent-framework/src/__tests__/config-loader.test.ts
@@ -456,6 +456,64 @@ describe('loadConfig', () => {
     expect(config.defaultTrustLevel).toBe('full');
   });
 
+  it('CONFIG-003: a project hook does not delete the user-global PreToolUse guard', async () => {
+    // The defect: `hooks` fell through mergeSettings' top-level spread, so ANY later layer that
+    // declared hooks replaced the whole object. A repository could disable a user's security guard
+    // by declaring an unrelated event — a lower-trust layer removing a higher-trust control, with
+    // nothing in normal output saying so.
+    writeJson(join(userDir, 'settings.json'), {
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'user-guard' }] }],
+      },
+    });
+    writeJson(join(projectDir, 'settings.json'), {
+      hooks: {
+        PostToolUse: [{ matcher: '', hooks: [{ type: 'command', command: 'project-automation' }] }],
+      },
+    });
+    const config = await loadConfig(cwd);
+
+    // The guard is still there. This is the security property; everything else here is shape.
+    expect(config.hooks?.PreToolUse?.[0]?.hooks?.[0]).toMatchObject({ command: 'user-guard' });
+    // And the project's own hook was added rather than swapped in.
+    expect(config.hooks?.PostToolUse?.[0]?.hooks?.[0]).toMatchObject({
+      command: 'project-automation',
+    });
+  });
+
+  it("CONFIG-003: a project hook on the SAME event is appended after the user's, not instead of it", async () => {
+    // The same-event case is the one a per-object merge would still get wrong: replacing
+    // `PreToolUse` wholesale is exactly as fatal as replacing `hooks` wholesale, and only a
+    // per-event concatenation survives it. User first, because `runHooks` returns on the first
+    // `deny` and the user's guard should be the one that gets to say it.
+    writeJson(join(userDir, 'settings.json'), {
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'user-guard' }] }],
+      },
+    });
+    writeJson(join(projectDir, 'settings.json'), {
+      hooks: {
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'project-hook' }] }],
+      },
+    });
+    const config = await loadConfig(cwd);
+
+    expect(config.hooks?.PreToolUse).toHaveLength(2);
+    expect(config.hooks?.PreToolUse?.[0]?.hooks?.[0]).toMatchObject({ command: 'user-guard' });
+    expect(config.hooks?.PreToolUse?.[1]?.hooks?.[0]).toMatchObject({ command: 'project-hook' });
+  });
+
+  it('CONFIG-003: a project taskContext.dir does not silently re-enable an injection the user turned off', async () => {
+    // Same wholesale-replacement defect, without the security framing: `taskContext` is
+    // `{ enabled?, dir? }`, so a project setting only `dir` erased the user's `enabled: false`.
+    writeJson(join(userDir, 'settings.json'), { taskContext: { enabled: false } });
+    writeJson(join(projectDir, 'settings.json'), { taskContext: { dir: '.agents/tasks' } });
+    const config = await loadConfig(cwd);
+
+    expect(config.taskContext?.enabled).toBe(false);
+    expect(config.taskContext?.dir).toBe('.agents/tasks');
+  });
+
   it('hooks from .claude/settings.json are loaded and merged', async () => {
     writeJson(join(claudeProjectDir, 'settings.json'), {
       hooks: {

--- a/packages/agent-framework/src/__tests__/e2e-scenarios.test.ts
+++ b/packages/agent-framework/src/__tests__/e2e-scenarios.test.ts
@@ -294,7 +294,7 @@ describe('E2E: Hook configuration to execution', () => {
       },
     };
 
-    // 2. Create local settings with a Read hook (should override)
+    // 2. Create local settings with a Read hook (CONFIG-003: ADDS, does not replace)
     const localSettings = {
       hooks: {
         PreToolUse: [
@@ -315,10 +315,18 @@ describe('E2E: Hook configuration to execution', () => {
     // 3. Load config
     const config = await loadConfig(projectDir);
 
-    // 4. Verify local settings take precedence
+    // 4. CONFIG-003: both survive, in layer order.
+    //
+    // This test asserted length 1 and called itself "should merge". The title was right and the
+    // assertion pinned the defect: `hooks` fell through mergeSettings' top-level spread, so the
+    // later layer replaced the whole object and the base Bash hook vanished. Two project layers
+    // rather than user-vs-project makes the trust gap smaller, not the behaviour different — and
+    // there is no way to express "remove that hook", so replacement was never an override anyone
+    // asked for. It was the only thing a spread could do.
     expect(config.hooks).toBeDefined();
-    expect(config.hooks!.PreToolUse).toHaveLength(1);
-    expect(config.hooks!.PreToolUse![0]!.matcher).toBe('Read');
+    expect(config.hooks!.PreToolUse).toHaveLength(2);
+    expect(config.hooks!.PreToolUse![0]!.matcher).toBe('Bash');
+    expect(config.hooks!.PreToolUse![1]!.matcher).toBe('Read');
   });
 });
 

--- a/packages/agent-framework/src/__tests__/filesystem-smoke.test.ts
+++ b/packages/agent-framework/src/__tests__/filesystem-smoke.test.ts
@@ -441,7 +441,7 @@ describe('Filesystem smoke: hook config loading', () => {
       },
     };
 
-    // Local settings override hooks entirely
+    // Local settings ADD hooks (CONFIG-003 — they used to replace them entirely)
     const localSettings = {
       hooks: {
         PreToolUse: [
@@ -462,9 +462,11 @@ describe('Filesystem smoke: hook config loading', () => {
     const config = await loadConfig(projectDir);
 
     expect(config.hooks).toBeDefined();
-    expect(config.hooks!.PreToolUse).toHaveLength(1);
-    // Local should win — matcher is "Read", not "Bash"
-    expect(config.hooks!.PreToolUse![0]!.matcher).toBe('Read');
+    // CONFIG-003: both layers' groups survive, earlier first. The previous assertion required the
+    // base hook to be gone, under a title that said "merge".
+    expect(config.hooks!.PreToolUse).toHaveLength(2);
+    expect(config.hooks!.PreToolUse![0]!.matcher).toBe('Bash');
+    expect(config.hooks!.PreToolUse![1]!.matcher).toBe('Read');
   });
 
   it('should load provider settings from .claude/settings.json', async () => {

--- a/packages/agent-framework/src/config/config-loader.ts
+++ b/packages/agent-framework/src/config/config-loader.ts
@@ -9,6 +9,7 @@
  *   5. .claude/settings.json         (project, Claude Code compat)
  *   6. .claude/settings.local.json   (project-local, highest priority)
  */
+import { mergeSettings } from './config-merge.js';
 import {
   SettingsSchema,
   type TSettings,
@@ -115,59 +116,6 @@ function resolveProviderCredentialEnvRefs<TProvider extends { apiKey?: string }>
     apiKey: resolveEnvRef(provider.apiKey),
     ...(wasReference && { apiKeyEnv: provider.apiKey.slice(ENV_PREFIX.length) }),
   };
-}
-
-/**
- * Deep-merge settings objects. Later entries in the array win.
- * Arrays are replaced (not concatenated) so that project settings
- * fully override user settings for list-type fields.
- */
-function mergeSettings(layers: TEnvResolvedSettings[]): TEnvResolvedSettings {
-  return layers.reduce<TEnvResolvedSettings>((merged, layer) => {
-    return {
-      ...merged,
-      ...layer,
-      provider:
-        merged.provider !== undefined || layer.provider !== undefined
-          ? { ...merged.provider, ...layer.provider }
-          : undefined,
-      permissions:
-        merged.permissions !== undefined || layer.permissions !== undefined
-          ? {
-              allow: layer.permissions?.allow ?? merged.permissions?.allow,
-              deny: layer.permissions?.deny ?? merged.permissions?.deny,
-            }
-          : undefined,
-      env: {
-        ...(merged.env ?? {}),
-        ...(layer.env ?? {}),
-      },
-      providers:
-        merged.providers !== undefined || layer.providers !== undefined
-          ? mergeProviders(merged.providers, layer.providers)
-          : undefined,
-      enabledPlugins:
-        merged.enabledPlugins !== undefined || layer.enabledPlugins !== undefined
-          ? { ...(merged.enabledPlugins ?? {}), ...(layer.enabledPlugins ?? {}) }
-          : undefined,
-      extraKnownMarketplaces: layer.extraKnownMarketplaces ?? merged.extraKnownMarketplaces,
-      autoCompactThreshold: layer.autoCompactThreshold ?? merged.autoCompactThreshold,
-    };
-  }, {});
-}
-
-function mergeProviders(
-  base: TEnvResolvedSettings['providers'],
-  override: TEnvResolvedSettings['providers'],
-): TEnvResolvedSettings['providers'] {
-  const result: NonNullable<TEnvResolvedSettings['providers']> = { ...(base ?? {}) };
-  for (const [name, profile] of Object.entries(override ?? {})) {
-    result[name] = {
-      ...result[name],
-      ...profile,
-    };
-  }
-  return result;
 }
 
 function resolveProvider(merged: TEnvResolvedSettings): IResolvedConfig['provider'] {

--- a/packages/agent-framework/src/config/config-merge.ts
+++ b/packages/agent-framework/src/config/config-merge.ts
@@ -1,0 +1,116 @@
+/**
+ * Settings-layer composition: how a later layer combines with an earlier one.
+ *
+ * Split out of `config-loader.ts` by CONFIG-003. The loader's job is to READ layers and RESOLVE the
+ * result; deciding what a later layer may do to an earlier one is a different question, and it is
+ * the one with a security boundary in it — `mergeHooks` is why a project cannot delete a user's
+ * guard. Keeping that decision in a file named for it means the next reader of "can a project
+ * override X" has somewhere to look.
+ */
+
+import type { TEnvResolvedSettings } from './config-types.js';
+
+/**
+ * Deep-merge settings objects. Later entries in the array win.
+ *
+ * Arrays are replaced (not concatenated) so that project settings fully override user settings for
+ * list-type fields — with ONE exception, stated here because the previous version of this comment
+ * described two behaviours and the function performed three.
+ *
+ * **`hooks` is merged per event, never replaced (CONFIG-003).** It is not a list-type field: it is an
+ * object keyed by lifecycle event, so it fell through the top-level spread and neither documented
+ * rule covered it. A project settings layer declaring one `PostToolUse` hook therefore deleted
+ * every user-global hook, including `PreToolUse` security guards — a lower-trust layer
+ * silently removing a higher-trust control. The layers are user-then-project, so concatenating each
+ * event's groups in layer order keeps the user's guards present and first; `runHooks` returns on the
+ * first `deny`, so a surviving guard still blocks whatever a later group would have permitted.
+ *
+ * A project layer can therefore ADD hooks and can never REMOVE one it did not declare. Deliberate
+ * user-level disable semantics are not part of this: there is no way to express "turn that off" yet,
+ * and inventing one here would be a policy decision made inside a merge function.
+ */
+export function mergeSettings(layers: TEnvResolvedSettings[]): TEnvResolvedSettings {
+  return layers.reduce<TEnvResolvedSettings>((merged, layer) => {
+    return {
+      ...merged,
+      ...layer,
+      provider:
+        merged.provider !== undefined || layer.provider !== undefined
+          ? { ...merged.provider, ...layer.provider }
+          : undefined,
+      permissions:
+        merged.permissions !== undefined || layer.permissions !== undefined
+          ? {
+              allow: layer.permissions?.allow ?? merged.permissions?.allow,
+              deny: layer.permissions?.deny ?? merged.permissions?.deny,
+            }
+          : undefined,
+      env: {
+        ...(merged.env ?? {}),
+        ...(layer.env ?? {}),
+      },
+      providers:
+        merged.providers !== undefined || layer.providers !== undefined
+          ? mergeProviders(merged.providers, layer.providers)
+          : undefined,
+      enabledPlugins:
+        merged.enabledPlugins !== undefined || layer.enabledPlugins !== undefined
+          ? { ...(merged.enabledPlugins ?? {}), ...(layer.enabledPlugins ?? {}) }
+          : undefined,
+      extraKnownMarketplaces: layer.extraKnownMarketplaces ?? merged.extraKnownMarketplaces,
+      autoCompactThreshold: layer.autoCompactThreshold ?? merged.autoCompactThreshold,
+      hooks:
+        merged.hooks !== undefined || layer.hooks !== undefined
+          ? mergeHooks(merged.hooks, layer.hooks)
+          : undefined,
+      taskContext:
+        merged.taskContext !== undefined || layer.taskContext !== undefined
+          ? { ...merged.taskContext, ...layer.taskContext }
+          : undefined,
+    };
+  }, {});
+}
+
+/**
+ * Merge two hooks objects by event, keeping the earlier layer's groups first.
+ *
+ * **The same operation already existed one module away.** `plugin-hooks-merger.ts`'s
+ * `mergeHooksIntoConfig` composes plugin hooks with config hooks by concatenating per event, and has
+ * done so all along. Settings-layer hooks were the only hook composition in this package that
+ * replaced instead of merging — the codebase knew the answer and this path did not use it.
+ *
+ * It is not reused directly: that helper is typed against a loose local `IHookGroup` and orders
+ * plugin groups first by design, where this needs `THooksConfig` and the user's layer first.
+ *
+ * Concatenation rather than replacement is the whole security property: the earlier layer is the
+ * user's, and a hook it declared must still be there after a later layer adds its own. Duplicates
+ * are kept and both run — a repeated guard costs an extra execution, while dropping one on a
+ * key-collision guess would be this defect again in a smaller form.
+ */
+function mergeHooks(
+  base: TEnvResolvedSettings['hooks'],
+  override: TEnvResolvedSettings['hooks'],
+): TEnvResolvedSettings['hooks'] {
+  const result: NonNullable<TEnvResolvedSettings['hooks']> = { ...(base ?? {}) };
+  for (const [event, groups] of Object.entries(override ?? {})) {
+    if (groups === undefined) continue;
+    const key = event as keyof NonNullable<TEnvResolvedSettings['hooks']>;
+    const existing = result[key];
+    result[key] = existing === undefined ? [...groups] : [...existing, ...groups];
+  }
+  return result;
+}
+
+function mergeProviders(
+  base: TEnvResolvedSettings['providers'],
+  override: TEnvResolvedSettings['providers'],
+): TEnvResolvedSettings['providers'] {
+  const result: NonNullable<TEnvResolvedSettings['providers']> = { ...(base ?? {}) };
+  for (const [name, profile] of Object.entries(override ?? {})) {
+    result[name] = {
+      ...result[name],
+      ...profile,
+    };
+  }
+  return result;
+}


### PR DESCRIPTION
Delivers the `hooks` half of CONFIG-003. Issue #2024 records the same defect, narrower; it closes when
that record delivers.

## The defect

`mergeSettings` handled 7 of the 14 settings fields explicitly and let the other 7 fall through a
top-level spread. `hooks` was one of them, so **any layer that declared hooks replaced the whole
object**: a project settings file declaring one `PostToolUse` automation silently deleted every
user-global hook, including `PreToolUse` security guards. A lower-trust layer removing a
higher-trust control, with nothing in normal output saying so.

## The function documented two behaviours and performed three

```
Deep-merge settings objects. Later entries in the array win.
Arrays are replaced (not concatenated) so that project settings
fully override user settings for list-type fields.
```

**`hooks` is not a list-type field.** It is an object keyed by lifecycle event. Neither the deep-merge
rule nor the stated array exception covered it — the behaviour fell out of the spread. The SPEC made
the same promise (*"Higher layers override lower layers via deep merge"*) and carried the same gap;
it now states the exception where the claim is made.

That answers whether this was intent or accident, without guessing: **the code contradicts its own
comment.**

## Per event, not per object

Replacing the `PreToolUse` array wholesale is exactly as fatal as replacing the `hooks` object, so an
object-level merge would have **looked like a fix and left the same hole one level down**. The
same-event case has its own test.

User groups come first: `runHooks` returns on the first `deny`, so a surviving guard blocks
regardless of position — but ordering decides which hook speaks for non-deny decisions, and the
higher-trust layer should be the one that does.

A later layer can therefore ADD and can never REMOVE what it did not declare. **Deliberate
user-level disable semantics are not defined**, and this change does not invent them inside a merge
function.

## The codebase already knew

`plugins/plugin-hooks-merger.ts`'s `mergeHooksIntoConfig` composes plugin hooks with config hooks by
concatenating per event, and always has. **Settings-layer hooks were the only hook composition in the
package that replaced instead of merging.** Not reused directly — that helper is typed against a
loose local `IHookGroup` and orders plugin groups first by design — but recorded, because the answer
existed one module away.

## `taskContext`, same defect without the security framing

`{ enabled?, dir? }`, so a project setting only `dir` erased a user's `enabled: false` — silently
re-enabling an injection the user turned off. Now merged field-wise.

## Two existing tests pinned the replacement, and are changed deliberately

| Test | Title says | Asserted |
| ---- | ---------- | -------- |
| `e2e-scenarios` | "should **merge** hooks from `.claude/settings.json` and `.claude/settings.local.json`" | the base hook is gone |
| `filesystem-smoke` | "should **merge** `.claude/settings.local.json` over `.claude/settings.json`" | the base hook is gone |

Their own comments say *"should override"* and *"Local should win"*. **The titles were right and the
assertions pinned the defect.** Both layers there are project-side, which makes the trust gap smaller
but not the behaviour different — and since nothing can express "remove that hook", replacement was
never an override anyone asked for. It was the only thing a spread could do.

## Red-first, and each failure checked to be the property

```
expected undefined to be 'user-guard'                    ← the guard was deleted
expected [ { matcher: 'Bash' } ] to have a length of 2    ← the same-event group was replaced
expected undefined to be false                            ← the user's taskContext.enabled was erased
```

Not incidental errors. A red that means something else proves nothing.

## Not delivered here — stated rather than left implied

- **`transports`**: wholesale-replaced, but `toResolvedConfig` never populates it, so the merge
  behaviour of a field nothing reads was left alone rather than "fixed" invisibly. The
  delete-or-populate decision (CONFIG-003 item 2) stays open.
- **`preset` routing**, same item.
- **`permissions.allow` / `.deny`**: also field-level replacements, so a project layer declaring
  `deny` erases the user's. **Somebody wrote that line deliberately**, unlike the hooks case which
  fell out of a spread, so it needs an argument rather than a correction — and `allow` needs a
  *different* argument from `deny`, because unioning a restriction is safe while unioning a grant is
  not. Raised separately.
- **Provenance diagnostics** and **explicit disable semantics** from #2024's acceptance list. Both
  are design decisions; this change makes neither.

## Structure

Layer composition moved to `config/config-merge.ts` after `file-size` fired at 301/300 — split by
responsibility rather than by shaving comments. The loader READS layers and RESOLVES the result;
what a later layer may do to an earlier one is a different question, and the one with a security
boundary in it.

## Verification

`pnpm harness:verify-like-ci` exit 0 (12 stages) on base `312e8682a`; 144 scans; 4898 + 1142 tests.
