### PR TITLE
fix(transport): a reconnect peer is a candidate, not a registry entry (issue #2043)

### DIFF
--- a/packages/agent-cli/src/remote-control/__tests__/remote-control-e3.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/remote-control-e3.test.ts
@@ -8,12 +8,33 @@ import {
 import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
 import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
 import type { IHostReconnectConfig, ISignalingClient } from '@robota-sdk/agent-transport-webrtc';
-import type { TransportRegistry } from '@robota-sdk/agent-transport';
+import { TransportRegistry } from '@robota-sdk/agent-transport';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import type { IHostIdentity } from '../host-identity.js';
 import { RemoteControlController } from '../remote-control-controller.js';
 import type { ITrustedDeviceRecord, ITrustedDeviceStore } from '../trusted-device-store.js';
+
+/**
+ * The REAL registry, not `{ register: () => {} }`.
+ *
+ * Issue #2043: these suites used to stub `register` with a no-op, which removed the one rule the
+ * reconnect path breaks — `register` refuses a duplicate `transport.name`, and every
+ * `WebRtcTransport` is named `webrtc`. A double whose refusal is the defect cannot fail on it, so
+ * the reconnect tests passed while every reconnect registration threw in production.
+ *
+ * Constructed with a temp settings path: the registry only reads it for saved transport config, and
+ * an absent file means "no saved config", which is what these tests want.
+ */
+function realRegistry(): TransportRegistry {
+  return new TransportRegistry(
+    join(mkdtempSync(join(tmpdir(), 'robota-rc-registry-')), 'settings.json'),
+  );
+}
 
 /**
  * REMOTE-012 E3 TC-05/08 — the controller wires a reconnect config from the host identity + trusted-device
@@ -46,7 +67,7 @@ function build(
 } {
   const captured: { reconnect?: IHostReconnectConfig } = {};
   const controller = new RemoteControlController({
-    registry: { register: () => {} } as unknown as TransportRegistry,
+    registry: realRegistry(),
     readRelayUrl: () => 'ws://127.0.0.1:9999',
     readClientUrl: () => 'https://remote.example/',
     getSession: () => stubSession(),
@@ -63,6 +84,12 @@ function build(
       captured.reconnect = reconnect;
       return {
         name: 'webrtc',
+        // Issue #2043: the real `WebRtcTransport` declares `lifecycle: { kind: 'service' }` and has no
+        // `waitForCompletion`, and `TransportRegistry.register` refuses a transport whose shape
+        // disagrees. This stub omitted it and nothing noticed, because `register` was a no-op double
+        // — the `as unknown as` cast hid the missing member from the compiler, and the no-op hid it
+        // from the runtime.
+        lifecycle: { kind: 'service' as const },
         defaultEnabled: false,
         attach: vi.fn(),
         start: vi.fn().mockResolvedValue(undefined),
@@ -124,7 +151,7 @@ describe('RemoteControlController E3 wiring (REMOTE-012)', () => {
   it('with no store configured, listDevices is empty and reconnect config is absent', async () => {
     const captured: { reconnect?: IHostReconnectConfig } = {};
     const controller = new RemoteControlController({
-      registry: { register: () => {} } as unknown as TransportRegistry,
+      registry: realRegistry(),
       readRelayUrl: () => 'ws://127.0.0.1:9999',
       readClientUrl: () => 'https://remote.example/',
       getSession: () => stubSession(),
@@ -139,6 +166,8 @@ describe('RemoteControlController E3 wiring (REMOTE-012)', () => {
         captured.reconnect = reconnect;
         return {
           name: 'webrtc',
+          // See the note on the sibling stub above: `lifecycle` was missing here too.
+          lifecycle: { kind: 'service' as const },
           defaultEnabled: false,
           attach: vi.fn(),
           start: vi.fn().mockResolvedValue(undefined),

--- a/packages/agent-cli/src/remote-control/__tests__/remote-control-e4.test.ts
+++ b/packages/agent-cli/src/remote-control/__tests__/remote-control-e4.test.ts
@@ -8,12 +8,33 @@ import {
 import type { IConfigurableTransport } from '@robota-sdk/agent-interface-transport';
 import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
 import type { ISignalingClient } from '@robota-sdk/agent-transport-webrtc';
-import type { TransportRegistry } from '@robota-sdk/agent-transport';
+import { TransportRegistry } from '@robota-sdk/agent-transport';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import type { IHostIdentity } from '../host-identity.js';
 import { RemoteControlController } from '../remote-control-controller.js';
 import type { ITrustedDeviceRecord, ITrustedDeviceStore } from '../trusted-device-store.js';
+
+/**
+ * The REAL registry, not `{ register: () => {} }`.
+ *
+ * Issue #2043: these suites used to stub `register` with a no-op, which removed the one rule the
+ * reconnect path breaks — `register` refuses a duplicate `transport.name`, and every
+ * `WebRtcTransport` is named `webrtc`. A double whose refusal is the defect cannot fail on it, so
+ * the reconnect tests passed while every reconnect registration threw in production.
+ *
+ * Constructed with a temp settings path: the registry only reads it for saved transport config, and
+ * an absent file means "no saved config", which is what these tests want.
+ */
+function realRegistry(): TransportRegistry {
+  return new TransportRegistry(
+    join(mkdtempSync(join(tmpdir(), 'robota-rc-registry-')), 'settings.json'),
+  );
+}
 
 /**
  * REMOTE-013 E4 TC-04/05 (host) — the controller reconnect orchestration with fakes (no werift): first-pair
@@ -55,6 +76,11 @@ function memoryStore(): ITrustedDeviceStore {
 function fakeTransport(): IConfigurableTransport<IInteractiveSession> {
   return {
     name: 'webrtc',
+    // Issue #2043: `TransportRegistry.register` refuses a transport whose lifecycle shape disagrees
+    // with its `waitForCompletion` presence. This omitted `lifecycle` and nothing noticed, because
+    // `register` was stubbed to a no-op — the cast below hid it from the compiler and the no-op hid
+    // it from the runtime.
+    lifecycle: { kind: 'service' as const },
     defaultEnabled: false,
     attach: vi.fn(),
     start: vi.fn().mockResolvedValue(undefined),
@@ -81,8 +107,9 @@ function setup(store: ITrustedDeviceStore, identity: IHostIdentity) {
     off: vi.fn(),
     getMessages: () => [],
   });
+  const registry = realRegistry();
   const controller = new RemoteControlController({
-    registry: { register: () => {} } as unknown as TransportRegistry,
+    registry,
     readRelayUrl: () => 'ws://relay',
     readClientUrl: () => 'https://client/',
     getSession: () => session,
@@ -124,7 +151,7 @@ function setup(store: ITrustedDeviceStore, identity: IHostIdentity) {
       return transport;
     },
   });
-  return { controller, created, rendezvouses, ceilings, session };
+  return { controller, created, rendezvouses, ceilings, session, registry };
 }
 
 describe('RemoteControlController E4 reconnect (REMOTE-013)', () => {
@@ -177,6 +204,64 @@ describe('RemoteControlController E4 reconnect (REMOTE-013)', () => {
 
     expect(store.get('dev-1')?.reconnectCounter).toBe(2); // resync-on-success: used(1) + 1
     expect(ceilings).toHaveLength(0); // ceiling cancelled on reconnect
+    expect(controller.getStatus()).toEqual({ state: 'paired' });
+  });
+
+  it('a drop leaves exactly one webrtc entry — candidates are not registered (issue #2043)', async () => {
+    const store = memoryStore();
+    const { controller, created, registry } = setup(store, await hostIdentity());
+    await controller.enable();
+    (created[0].reconnect as { onEnroll: (id: string, spki: string) => void }).onEnroll(
+      'dev-1',
+      'spki',
+    );
+    created[0].hooks.onPaired({ sessionKey: generatePairingSecret().secret });
+    await waitForSeed(store, 'dev-1');
+
+    created[0].hooks.onDropped?.();
+    await new Promise((r) => setTimeout(r, 25));
+
+    // A drop opens TWO reconnect rooms while the original entry is still present. Registering each
+    // candidate threw `Duplicate transport name: webrtc` out of a callback nothing observed, so the
+    // suite stayed green on its assertions while six rejections went unhandled. The count is the
+    // observable that distinguishes "not registered" from "registered and the throw was swallowed".
+    expect(registry.getAll().filter((e) => e.transport.name === 'webrtc')).toHaveLength(1);
+    expect(created.length).toBeGreaterThan(1); // rooms really were opened
+
+    // The entry count alone does not distinguish "never registered" from "register threw", because a
+    // throw leaves the count at one too. What separates them is whether the candidates became
+    // USABLE: `register` ran before `attach`/`start`, so a throw there left every candidate created
+    // and never attached — the reconnect rooms existed and no device could be served by them.
+    for (const candidate of created.slice(1)) {
+      expect(candidate.transport.attach).toHaveBeenCalled();
+      expect(candidate.transport.start).toHaveBeenCalled();
+    }
+  });
+
+  it('promotion swaps the registry entry to the winner, not the abandoned peer (issue #2043)', async () => {
+    const store = memoryStore();
+    const { controller, created, registry } = setup(store, await hostIdentity());
+    await controller.enable();
+    (created[0].reconnect as { onEnroll: (id: string, spki: string) => void }).onEnroll(
+      'dev-1',
+      'spki',
+    );
+    created[0].hooks.onPaired({ sessionKey: generatePairingSecret().secret });
+    await waitForSeed(store, 'dev-1');
+
+    const original = created[0].transport;
+    created[0].hooks.onDropped?.();
+    await new Promise((r) => setTimeout(r, 25));
+    const seed = (store.get('dev-1') as ITrustedDeviceRecord).reconnectSeed as string;
+    const room1 = await deriveReconnectRendezvous(seed, 1);
+    const winner = created.slice(1).find((c) => c.rendezvous === room1)!;
+    winner.hooks.onPaired();
+
+    // Without the swap the entry keeps naming a peer the controller abandoned, so `stopAll` at
+    // shutdown stops that one and never reaches the peer actually serving the session.
+    const entry = registry.getAll().find((e) => e.transport.name === 'webrtc');
+    expect(entry?.transport).toBe(winner.transport);
+    expect(entry?.transport).not.toBe(original);
     expect(controller.getStatus()).toEqual({ state: 'paired' });
   });
 

--- a/packages/agent-cli/src/remote-control/remote-control-controller.ts
+++ b/packages/agent-cli/src/remote-control/remote-control-controller.ts
@@ -345,7 +345,6 @@ export class RemoteControlController {
     );
     this.reconnectPeers.push(peer);
     this.reconnectSignalings.push(signaling);
-    this.deps.registry.register(peer);
     peer.attach(session);
     void peer.start().catch(() => undefined);
   }
@@ -372,6 +371,7 @@ export class RemoteControlController {
     }
     this.reconnectPeers = [];
     this.reconnectSignalings = [];
+    this.deps.registry.replace(winner); // #2043: the entry must name the live instance
     this.transport = winner;
     this.signaling = winnerSignaling;
     this.status = { state: 'paired' };

--- a/packages/agent-transport/src/transport-registry-errors.ts
+++ b/packages/agent-transport/src/transport-registry-errors.ts
@@ -1,0 +1,50 @@
+/**
+ * The typed errors `TransportRegistry` raises, separated from the registry itself.
+ *
+ * Constructing an error with a stable `name`, a `code` and non-enumerable causes is its own job: the
+ * shape is a contract consumers match on, and it changes for reasons that have nothing to do with
+ * how entries are held or started. Split out when the registry reached its size limit — this is the
+ * seam that was already there rather than a cut made to fit.
+ */
+
+import type {
+  ITransportStartupError,
+  TTransportConfigurationErrorCode,
+} from '@robota-sdk/agent-interface-transport';
+
+/** A transport that is unknown to the registry, or known and not configurable. */
+export function configurationError(
+  transportName: string,
+  code: TTransportConfigurationErrorCode,
+): Error {
+  return Object.assign(new Error(`Transport ${transportName} is ${code}.`), {
+    name: 'TransportConfigurationError' as const,
+    code,
+    transportName,
+  });
+}
+
+/**
+ * A transport that threw while starting, carrying what rollback did afterwards.
+ *
+ * `cause` and `rollbackCauses` are non-enumerable so a structured log of this error does not spill
+ * the originals, while a reader who asks for them still gets them.
+ */
+export function startupError(
+  transportName: string,
+  cause: unknown,
+  rollbackErrors: ITransportStartupError['rollbackErrors'],
+  rollbackCauses: readonly unknown[],
+): ITransportStartupError {
+  const error = Object.assign(new Error(`Transport ${transportName} failed during startup.`), {
+    name: 'TransportStartupError' as const,
+    transportName,
+    rollbackErrors: Object.freeze([...rollbackErrors]),
+  });
+  Object.defineProperty(error, 'cause', { value: cause, enumerable: false });
+  Object.defineProperty(error, 'rollbackCauses', {
+    value: Object.freeze([...rollbackCauses]),
+    enumerable: false,
+  });
+  return error;
+}

--- a/packages/agent-transport/src/transport-registry.ts
+++ b/packages/agent-transport/src/transport-registry.ts
@@ -1,23 +1,18 @@
 /** Transport lifecycle registry with optional settings capability per entry. */
 
-import { readSettings, writeSettings, type TSettingsData } from '@robota-sdk/agent-framework';
-
+import { configurationError, startupError } from './transport-registry-errors.js';
 import { TransportRunGeneration } from './transport-run-generation.js';
+import { TransportSettingsView } from './transport-settings-view.js';
 
 import type { IDestroyResult, TUniversalValue } from '@robota-sdk/agent-core';
 import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
 import type {
-  IConfigurableTransport,
-  ITransportAdapter,
   ITransportCompletionRecord,
-  ITransportConfig,
   ITransportEntry,
   ITransportFailureRecord,
   ITransportRunnerAdapter,
-  ITransportStartupError,
   TConfigurableTransport,
   TTransportAdapter,
-  TTransportConfigurationErrorCode,
 } from '@robota-sdk/agent-interface-transport';
 
 interface IRegistryEntry {
@@ -37,38 +32,11 @@ function isRunnerTransport(
   return transport.lifecycle.kind === 'runner';
 }
 
-function configurationError(transportName: string, code: TTransportConfigurationErrorCode): Error {
-  return Object.assign(new Error(`Transport ${transportName} is ${code}.`), {
-    name: 'TransportConfigurationError' as const,
-    code,
-    transportName,
-  });
-}
-
-function startupError(
-  transportName: string,
-  cause: unknown,
-  rollbackErrors: ITransportStartupError['rollbackErrors'],
-  rollbackCauses: readonly unknown[],
-): ITransportStartupError {
-  const error = Object.assign(new Error(`Transport ${transportName} failed during startup.`), {
-    name: 'TransportStartupError' as const,
-    transportName,
-    rollbackErrors: Object.freeze([...rollbackErrors]),
-  });
-  Object.defineProperty(error, 'cause', { value: cause, enumerable: false });
-  Object.defineProperty(error, 'rollbackCauses', {
-    value: Object.freeze([...rollbackCauses]),
-    enumerable: false,
-  });
-  return error;
-}
-
 type TRegistryState = 'idle' | 'starting' | 'active' | 'stopping';
 
 export class TransportRegistry {
   private readonly entries = new Map<string, IRegistryEntry>();
-  private readonly settingsPath: string;
+  private readonly settings: TransportSettingsView;
   private generation: TransportRunGeneration | undefined;
   private state: TRegistryState = 'idle';
   private startOperation: Promise<void> | undefined;
@@ -79,13 +47,11 @@ export class TransportRegistry {
     { readonly transportName: string; readonly cause: unknown } | undefined;
 
   constructor(settingsPath: string) {
-    this.settingsPath = settingsPath;
+    this.settings = new TransportSettingsView(settingsPath);
   }
 
-  register(transport: TTransportAdapter<IInteractiveSession>): void {
-    if (this.entries.has(transport.name)) {
-      throw new Error(`Duplicate transport name: ${transport.name}`);
-    }
+  /** The lifecycle/shape agreement every entry must satisfy, on the way in and on a replace. */
+  private assertRegisterableShape(transport: TTransportAdapter<IInteractiveSession>): void {
     const hasCompletion =
       'waitForCompletion' in transport && typeof transport.waitForCompletion === 'function';
     if (
@@ -96,6 +62,37 @@ export class TransportRegistry {
         `Transport ${transport.name} has an invalid ${transport.lifecycle.kind} shape.`,
       );
     }
+  }
+
+  register(transport: TTransportAdapter<IInteractiveSession>): void {
+    if (this.entries.has(transport.name)) {
+      throw new Error(`Duplicate transport name: ${transport.name}`);
+    }
+    this.assertRegisterableShape(transport);
+    this.entries.set(transport.name, {
+      transport,
+      configurable: isConfigurableTransport(transport) ? transport : undefined,
+    });
+  }
+
+  /**
+   * Swap the adapter registered under `transport.name` for a new instance of the same name.
+   *
+   * Narrower than an unregister: the name must ALREADY be registered and the count cannot change, so
+   * `stopAll` keeps its promise to reach everything. An entry is a claim about WHICH instance is
+   * live, and reconnect makes it false (issue #2043).
+   *
+   * Returns nothing and stops nothing: every caller that abandons an adapter already stops it on the
+   * path that abandoned it, and a registry that stopped it here would do so at a moment the caller
+   * did not choose.
+   */
+  replace(transport: TTransportAdapter<IInteractiveSession>): void {
+    if (!this.entries.has(transport.name)) {
+      throw new Error(
+        `Cannot replace transport ${transport.name}: no transport is registered under that name.`,
+      );
+    }
+    this.assertRegisterableShape(transport);
     this.entries.set(transport.name, {
       transport,
       configurable: isConfigurableTransport(transport) ? transport : undefined,
@@ -103,13 +100,13 @@ export class TransportRegistry {
   }
 
   getAll(): ITransportEntry<IInteractiveSession>[] {
-    const saved = this.readTransportSettings();
+    const saved = this.settings.readAll();
     return [...this.entries.values()].flatMap(({ configurable }) =>
       configurable
         ? [
             {
               transport: configurable,
-              config: this.resolveConfig(configurable, saved[configurable.name]),
+              config: this.settings.resolve(configurable, saved[configurable.name]),
             },
           ]
         : [],
@@ -117,31 +114,21 @@ export class TransportRegistry {
   }
 
   getEnabled(): TTransportAdapter<IInteractiveSession>[] {
-    const saved = this.readTransportSettings();
+    const saved = this.settings.readAll();
     return [...this.entries.values()].flatMap(({ transport, configurable }) => {
       if (!configurable) return [transport];
-      return this.resolveConfig(configurable, saved[transport.name]).enabled ? [transport] : [];
+      return this.settings.resolve(configurable, saved[transport.name]).enabled ? [transport] : [];
     });
   }
 
   async setEnabled(name: string, enabled: boolean): Promise<void> {
     this.requireConfigurable(name);
-    const settings = readSettings(this.settingsPath);
-    const transports = (settings.transports ?? {}) as TSettingsData;
-    const entry = (transports[name] ?? {}) as TSettingsData;
-    transports[name] = { ...entry, enabled } as TSettingsData;
-    settings.transports = transports;
-    writeSettings(this.settingsPath, settings);
+    this.settings.setEnabled(name, enabled);
   }
 
   async setOptions(name: string, options: Record<string, TUniversalValue>): Promise<void> {
     this.requireConfigurable(name);
-    const settings = readSettings(this.settingsPath);
-    const transports = (settings.transports ?? {}) as TSettingsData;
-    const entry = (transports[name] ?? {}) as TSettingsData;
-    transports[name] = { ...entry, options: options as TSettingsData } as TSettingsData;
-    settings.transports = transports;
-    writeSettings(this.settingsPath, settings);
+    this.settings.setOptions(name, options);
   }
 
   async startAll(session: IInteractiveSession): Promise<void> {
@@ -279,21 +266,5 @@ export class TransportRegistry {
     if (!entry) throw configurationError(name, 'unknown-transport');
     if (!entry.configurable) throw configurationError(name, 'not-configurable');
     return entry.configurable;
-  }
-
-  private resolveConfig(
-    transport: TConfigurableTransport<IInteractiveSession>,
-    saved?: TSettingsData,
-  ): ITransportConfig {
-    const enabled = (saved?.enabled as boolean | undefined) ?? transport.defaultEnabled;
-    const options = (saved?.options as Record<string, TUniversalValue> | undefined) ?? {};
-    return { enabled, options };
-  }
-
-  private readTransportSettings(): Record<string, TSettingsData> {
-    const settings = readSettings(this.settingsPath);
-    const raw = settings.transports;
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
-    return raw as Record<string, TSettingsData>;
   }
 }

--- a/packages/agent-transport/src/transport-settings-view.ts
+++ b/packages/agent-transport/src/transport-settings-view.ts
@@ -1,0 +1,74 @@
+/**
+ * The persisted transport-config half of the registry, separated from the entry table.
+ *
+ * `TransportRegistry` does two jobs that only share a constructor argument: it holds WHICH adapters
+ * exist and orchestrates their start/stop, and it reads and writes what the user saved ABOUT them.
+ * The second one owns a settings path, a file format and a defaulting rule, and none of that is a
+ * fact about the entry table.
+ *
+ * They were one 299-line file, one line under the anti-monolith limit, so the next addition had to
+ * split something. This is the seam that was already there rather than a cut made to fit.
+ */
+
+import { readSettings, writeSettings, type TSettingsData } from '@robota-sdk/agent-framework';
+
+import type { TUniversalValue } from '@robota-sdk/agent-core';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
+import type {
+  ITransportConfig,
+  TConfigurableTransport,
+} from '@robota-sdk/agent-interface-transport';
+
+/** Reads and writes the `transports` section of one settings file. */
+export class TransportSettingsView {
+  private readonly settingsPath: string;
+
+  constructor(settingsPath: string) {
+    this.settingsPath = settingsPath;
+  }
+
+  /** Every saved transport section, keyed by transport name. `{}` when absent or malformed. */
+  readAll(): Record<string, TSettingsData> {
+    const settings = readSettings(this.settingsPath);
+    const raw = settings.transports;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+    return raw as Record<string, TSettingsData>;
+  }
+
+  /**
+   * What a transport's config resolves to, given what was saved for it.
+   *
+   * The transport's own `defaultEnabled` is the fallback, so a transport nobody has configured
+   * answers with its declared default rather than with `false`.
+   */
+  resolve(
+    transport: TConfigurableTransport<IInteractiveSession>,
+    saved?: TSettingsData,
+  ): ITransportConfig {
+    const enabled = (saved?.enabled as boolean | undefined) ?? transport.defaultEnabled;
+    const options = (saved?.options as Record<string, TUniversalValue> | undefined) ?? {};
+    return { enabled, options };
+  }
+
+  /** Persist `enabled` for one transport, leaving its other saved keys untouched. */
+  setEnabled(name: string, enabled: boolean): void {
+    this.mutate(name, (entry) => ({ ...entry, enabled }) as TSettingsData);
+  }
+
+  /** Persist `options` for one transport, leaving its other saved keys untouched. */
+  setOptions(name: string, options: Record<string, TUniversalValue>): void {
+    this.mutate(
+      name,
+      (entry) => ({ ...entry, options: options as TSettingsData }) as TSettingsData,
+    );
+  }
+
+  private mutate(name: string, next: (entry: TSettingsData) => TSettingsData): void {
+    const settings = readSettings(this.settingsPath);
+    const transports = (settings.transports ?? {}) as TSettingsData;
+    const entry = (transports[name] ?? {}) as TSettingsData;
+    transports[name] = next(entry);
+    settings.transports = transports;
+    writeSettings(this.settingsPath, settings);
+  }
+}


### PR DESCRIPTION
Closes #2043.

`TransportRegistry.register` refuses a duplicate `transport.name`, and `WebRtcTransport.name` is the class constant `'webrtc'`. Remote-control reconnect registered **every candidate peer** while the original entry was still present, and a single drop opens **two** rooms — so it threw `Duplicate transport name: webrtc` every time.

**Measured, not argued:** the mutant that restores the registration produces **ten unhandled rejections** and every assertion still passes. That is the defect's whole signature — it throws, nothing observes it, and the suite reports green.

There is also **no unregister** anywhere in the registry, so even a registration that had succeeded could never be undone for the losing rooms.

## Two changes, and neither is "make the name unique"

A per-instance name would let the registration succeed and leave the registry accumulating entries it cannot release. The model conflict is real: the registry holds **one long-lived adapter per transport kind**; reconnect produces **several short-lived candidates per generation**.

**Candidates are no longer registered.** This controller starts each peer out of band and stops every one of them itself — in `onReconnected` for the losers, in `teardown` for all. Registration bought them nothing they did not already have.

**Promotion swaps the entry instead.** `replace` requires the name to already be registered and cannot change the entry count, so `stopAll` keeps its promise to reach everything it started, while the entry stops naming a peer the controller abandoned. It returns nothing and stops nothing: `onDropped` already stops the outgoing peer before this runs.

## The three test doubles are gone, and they were hiding two things

```
remote-control-e3.test.ts:49    registry: { register: () => {} }
remote-control-e3.test.ts:127   registry: { register: () => {} }
remote-control-e4.test.ts:85    registry: { register: () => {} }
```

**The one rule reconnect breaks, replaced with a no-op.** The reconnect suite passed while every reconnect registration threw in production — a double whose refusal *is* the defect cannot fail on it.

Using the real registry immediately surfaced a **second** thing they had hidden: the stub transports declare no `lifecycle`, which `register` also refuses. The `as unknown as` cast kept that from the compiler while the no-op kept it from the runtime.

## Both mutants die on the case that names them

| Mutant | Killed by |
| --- | --- |
| register each candidate again | *"a drop leaves exactly one webrtc entry"* |
| drop the promotion swap | *"promotion swaps the registry entry to the winner"* |

**The first assertion is deliberately not the entry count.** A throw leaves the count at one too, so counting cannot tell "never registered" from "registered and the throw was swallowed". What separates them is whether each candidate became **usable** — `register` ran before `attach`/`start`, so a throw there left every candidate created and never attached.

## `file-size` refused the first attempt, and splitting is what it asks for

340 lines against a 300 limit. Two responsibilities were already sitting in that file and both left: **persisted transport config** (`transport-settings-view.ts`) and **typed error construction** (`transport-registry-errors.ts`). The registry is **276 lines** now — below where it started.

## One measurement error of mine, recorded because it nearly became a false report

While checking the lint ceiling I reported that `develop` itself exceeded it. It does not. `git stash` without `-u` had left my own untracked new files in the tree, so the "develop" measurement was contaminated by the change I was measuring against it. Re-run with `-u`: develop is **2203**, exactly at the ceiling, and this branch is **2201** — two below, because the split removed four unused type imports.

## Verification

```
tsc                      0 in both packages
vitest                   206 files, 1659 tests, exit 0
pnpm harness:scan        142 passed, 2 skipped, exit 0
pnpm lint                exit 0 at 2201 (ceiling 2203; develop is 2203)
harness:review:record    0 findings @ 5ab7b3ecf
```
