### PR TITLE
docs(rules): state what a zero finding count obliges, and that one item has one owner

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -490,6 +490,66 @@ comment (or the PR description):
 No CONFIRMED/PLAUSIBLE finding may be left silently unaddressed. **Only after all findings are resolved**
 may the PR be merged.
 
+### One issue, one PR, one session (mandatory)
+
+**A GitHub issue and a pull request each have exactly ONE owning session while work on it is open.**
+No second session edits that branch, pushes to that PR, or starts work on that issue.
+
+This is not the One-Branch-At-A-Time rule above. That bounds how many branches a CLONE holds; this
+bounds how many SESSIONS touch one unit of work, and neither implies the other.
+
+**The orchestrator keeps the assignment list and reads it before assigning.** Ownership is not
+derivable from the issue tracker: an open issue and an unowned issue look identical there. Re-deriving
+"what is unassigned" from a list of what is open is how one item gets handed out twice.
+
+- An assignment without a named owner is not an assignment.
+- A session that finds work already owned reports it to the owner and does not act.
+- Releasing ownership is explicit and one-directional.
+
+**Why it is quiet:** the collision is not in the file system, so nothing local refuses it. Two sessions
+can hold disjoint branches, pass every hook, and discover at rebase time that they solved the same
+problem twice — or that one silently reverted the other's reasoning while resolving a clean merge.
+
+Enforced by: nothing — ownership exists only in the orchestrator's assignment list. A clone can see
+which branches exist and which issues are open; it cannot see who was TOLD to do what, and the two
+sessions in a collision each look correct locally. The only thing that has caught it is a session
+asking before acting.
+
+Case: [PROC-013](https://github.com/woojubb/robota/issues/2283).
+
+### `ACTIONABLE FINDINGS: 0` ends the loop — it does not start a merge
+
+**Zero findings obliges exactly one thing: STOP EDITING.** It is not a signal to merge, not a
+deadline, and not a reason to hurry.
+
+**Advice arriving alongside a zero count is not a finding.** A reviewer may add SHOULD or CONSIDER
+notes on a diff it has just passed. Those are input for a FUTURE pull request. Acting on them
+re-opens the diff, producing a new head, a new round, and new advice on the new code — a loop with no
+terminal condition, because each fix creates the surface the next round reads.
+
+**Merging is a separate judgement, made once, without urgency.**
+
+- **Green checks are not authorization.** A person or orchestrator decides; a state does not.
+- **Do not race the base.** Aiming at speed is what puts a merge in a race with base moves,
+  concurrent merges and stale verdicts. If the base moves, rebase and re-verify — that is not an edit
+  and does not restart the finding loop.
+- **Round count is not the condition.** A loop is not wrong because it is long; it is wrong when it
+  is editing a pull request that reported clean.
+
+**An override supplied every time is not an override.** The hatch exists for a push whose reason the
+hook cannot see. Reaching for it repeatedly is the signal that the reason has stopped being examined,
+and nothing counts repeated use.
+
+**If no more issues can be found, there is nothing left to fix.**
+
+Enforced by: `pre-push-check` for the half a machine can decide — it refuses a push into an open pull
+request whose latest reviewer verdict reports `ACTIONABLE FINDINGS: 0`, because there is then nothing
+for that push to resolve. The rest is not mechanizable here: whether to merge, and when, is a
+judgement about a state the repository can observe but not evaluate, and a check that merged on green
+would be the automation this section exists to refuse.
+
+Case: [PROC-013](https://github.com/woojubb/robota/issues/2283).
+
 ### An open PR's diff is frozen except to resolve a finding
 
 **Open a PR only when the unit of work is complete.** An open PR is a merge invitation: it may be

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ The most-hit refusals, in imperative form. Reasoning lives in [git-branch.md](.a
 - **Record a local review before the first push**: `pnpm harness:review:record --findings <n>`.
 - **A merge needs**: CI green, a reviewer verdict quoting the _exact_ current base and head, `ACTIONABLE FINDINGS: 0`, and every review thread **answered and resolved** — fixing a finding is not answering it.
 - **Cut branches from a freshly-fetched `origin/develop`**, one at a time.
-- **An open PR's diff is frozen** except to resolve a reported finding.
+- **An open PR's diff is frozen** except to resolve a reported finding. `ACTIONABLE FINDINGS: 0` means STOP EDITING, not "merge now" — advice arriving with a zero count is input for a FUTURE PR, and one issue/PR is owned by exactly one session ([git-branch.md](.agents/rules/git-branch.md)).
 - **Never enumerate files in a way that follows symlinks** (`find -L`, `grep -R`, `rg --follow`): in a pnpm workspace it reaches the dependency store, where a write is invisible to `git status` and to every scan.
 - **Never wait in the foreground** — a `sleep` budget over 60s, or a loop polling a remote status. Run it in the background, or use `Monitor`.
 


### PR DESCRIPTION
Two invariants that were missing. The case that produced them is issue #2283 (PROC-013); the rule links to it rather than retelling it.

## What happened, in numbers

PR #2235 ran **22 review rounds over two days**. Measured from the pull request, not from anyone's account of it:

```
reviewer verdicts .......................... 24
  ACTIONABLE FINDINGS: 0 ................... 23
findings actually recorded on the PR ....... 1 MUST, 3 SHOULD
commits .................................... 34
base moves ................................. 7
`pr-finding-resolution-loop` runs logged .... 0
PRE_PUSH_ALLOW_UNREVIEWED supplied ......... 24 of 42 pushes
```

The gate was satisfied from round 4. Every round after that edited a pull request that had already been passed.

## `ACTIONABLE FINDINGS: 0` ends the loop

Nothing said what a zero count **obliges**. The frozen-diff rule and `pre-push-check` both existed and both worked — the hook refused correctly 24 times and was overridden 24 times. What was missing is the sentence that makes the refusal legible: **advice arriving alongside a zero count is not a finding.** It is input for a future pull request, and acting on it re-opens the diff, producing a new head, a new round, and new advice on the new code. That loop has no terminal condition because each fix creates the surface the next round reads.

Also stated, because each was a wrong turn taken while diagnosing this:

- **Green is not authorization.** A person or orchestrator decides; a state does not.
- **Do not race the base.** Aiming at speed is what puts a merge in a race with base moves. A moved base means rebase and re-verify — not an edit, and it does not restart the loop.
- **Round count is not the condition.** A long loop is not wrong; a loop editing a clean pull request is.
- **An override supplied every time is not an override.**

## One issue, one PR, one session

Not the One-Branch-At-A-Time rule — that bounds branches per clone; this bounds sessions per unit of work, and neither implies the other.

The operative half is about the orchestrator, because that is where the failure was: **ownership is not derivable from the tracker.** An open issue and an unowned issue look identical there. Re-deriving "what is unassigned" from a list of what is open is how one item was handed out twice — the lanes were each correctly holding one item.

## Both declare their enforcement, because the repository refused the first draft

`new-rule-declares-enforcement` blocked the push, and its demand is the right one — a rule says how it is enforced, or says it is not and why. Silence is what a reader cannot tell from enforcement.

```
One issue, one PR, one session
  Enforced by: nothing — ownership exists only in the orchestrator's assignment list. A clone
  can see which branches exist and which issues are open; it cannot see who was TOLD to do what,
  and the two sessions in a collision each look correct locally.

ACTIONABLE FINDINGS: 0 ends the loop
  Enforced by: `pre-push-check` for the half a machine can decide. The rest — whether to merge,
  and when — is a judgement about a state the repository can observe but not evaluate, and a
  check that merged on green would be the automation this section exists to refuse.
```

## What is deliberately NOT added

**No new mechanism.** The rule, the hook and the owning skill all existed and all worked. A fourth mechanism on top of three working ones would repeat the error being recorded. An earlier draft of this change proposed a round-count ceiling with an invented threshold; that is a proxy in the place of the real condition and it was dropped.

`AGENTS.md` gains one clause on the line that already owns the frozen-diff rule and **no new line** — its size ratchet refused a first attempt at two, correctly: a routing document routes.

## Verification

```
pnpm harness:scan                        145 passed, exit 0
new-rule-declares-enforcement            exit 0, 2 new rule sections, each declares
rule-case-narrative                      exit 0 (the case moved to issue #2283)
reference-kind-qualified                 exit 0
routing-document-size                    exit 0 (AGENTS.md back at its frozen 112)
scan-new-rule-declares-enforcement.test  22 passed
harness:review:record                    0 findings @ 06e17b902
```
