### PR TITLE
fix(config): a corrupt settings layer is an error, not an absence (CONFIG-002)

### DIFF
--- a/.agents/tasks/CONFIG-002-config-loader-silently-drops-corrupt-settings-and-writers-produce-a-shape-it-rejects.md
+++ b/.agents/tasks/CONFIG-002-config-loader-silently-drops-corrupt-settings-and-writers-produce-a-shape-it-rejects.md
@@ -6,6 +6,7 @@ priority: high
 urgency: soon
 area: packages/agent-framework, packages/agent-cli
 depends_on: []
+issue: https://github.com/woojubb/robota/issues/2023
 ---
 
 # CONFIG-002: the loader and its writers disagree, and corruption silently widens permissions
@@ -36,11 +37,68 @@ model choice bricks every subsequent session against that file.
   (`src/index.ts:600`), documented (SPEC:282). `packages/agent-framework/src/config/config-loader.ts:169-173`
   — that exact shape makes `loadConfig` throw `'Legacy flat "provider" settings are not supported…'`.
 
+## Measurement (issue #2023, re-derived at `2a76b3869`)
+
+Issue #2023 was opened nine days after this record and names ONE file. The record's own evidence is
+two sites. Enumerating from code instead of from either text finds **12 parse sites over
+settings/policy/permission documents**, and the two axes the issue's title names must be judged
+separately, because a site can be one without the other:
+
+```
+parse sites ............ 12   @2a76b3869
+fail open ............... 5   @2a76b3869   (every one carries an allow-fallback marker)
+silently drop ........... 4   @2a76b3869
+validate shape .......... 4   @2a76b3869
+```
+
+`dag-cli/session/session-gate.ts` is the case that proves the axes are distinct: it fails open on a
+malformed `DAG_SESSION_PERMISSIONS` and writes a warning to stderr. Open, and not silent.
+
+**All five fail-opens are recorded decisions, not accidents** — each carries an `allow-fallback`
+marker with a stated reason: "likely a crash during write", "must not crash CLI startup", "to allow
+recovery", "open access is the safe default", "disables the feature gracefully". Every reason is an
+availability argument, and none of them mentions that the document being dropped is a security
+control. The decision was made; the consequence was not weighed in it.
+
+### The sharpest form: one file, two readers, opposite verdicts
+
+`config-loader.ts` and `command-api/provider/provider-merge.ts` both call `readSettingsSourceText`
+over the same `TSettingsSource` — the same files on disk. On a corrupt one:
+
+- `config-loader` caught and returned `undefined`, so the layer was dropped;
+- `provider-merge` catches and throws `SettingsParseError`.
+
+**The same corrupt file was fatal or ignored depending on which path reached it**, with both owners
+inside `agent-framework`, four directories apart, over one shared reader. Issue #2023 predicts this
+in the abstract ("different configuration owners may behave inconsistently if they parse files
+separately"); it is concrete, and it is between two modules that already share the reader.
+
+That also sharpens what "shape validation" means here. `loadConfig` DOES validate shape, with Zod,
+and fails closed on it — but corrupt JSON returned `undefined` and was filtered out one line before
+`safeParse` ran. **The fail-open path routed around the fail-closed one inside a single function.**
+
+### Corrected: three claims of an earlier reconnaissance pass that were wrong
+
+Recorded because the numbers were reported before they were checked, and a wrong measurement that
+survives is worse than none:
+
+- "10 parse sites" — the query returned 12 at both `81a4ab97c` and `2a76b3869`. Two sites were
+  dropped from the write-up without being mentioned.
+- "none of the sites validates shape" — four do, and for three others `TSettingsData` is
+  `Record<string, TUniversalValue>`, an open map with no shape to validate. That was counting the
+  absence of something those sites are not supposed to have.
+- A cited path that does not exist (`config/provider/provider-merge.ts`; the file is under
+  `command-api/`).
+
 ## Direction
 
-1. Make `readJsonFile` in `config-loader.ts` throw `SettingsParseError` (already defined in this
-   directory) on a corrupt EXISTING file, matching `settings-io.ts` — never silently skip. A missing
-   file stays missing; a corrupt file is an error, per CLI-069.
+1. **DONE (issue #2023).** `readJsonSource` in `config-loader.ts` throws `SettingsParseError` on a
+   corrupt EXISTING file, matching `settings-io.ts` — never silently skip. A missing file stays
+   missing; a corrupt file is an error, per CLI-069. An existing but EMPTY file is corrupt too:
+   `settings-io.readSettings` reaches `JSON.parse('')` and throws for the same file, so "empty is
+   missing" was this loader disagreeing with its neighbour rather than a considered policy. No
+   product path writes an empty settings file — `robota init` always writes `JSON.stringify(...)`
+   — so failing closed there costs nothing that existed.
 2. Make `updateModelInSettings`'s no-`currentProvider` branch synthesize a `currentProvider` +
    `providers` entry (or throw) instead of writing the legacy shape.
 

--- a/packages/agent-framework/src/config/__tests__/config-loader-corrupt-layer.test.ts
+++ b/packages/agent-framework/src/config/__tests__/config-loader-corrupt-layer.test.ts
@@ -22,7 +22,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { loadConfig } from '../config-loader.js';
-import { SettingsParseError } from '../settings-io.js';
+import { SettingsParseError } from '../settings-parse-error.js';
 import { createNodeHostSettingsSource } from '../settings-source.js';
 
 const roots: string[] = [];

--- a/packages/agent-framework/src/config/__tests__/config-loader-corrupt-layer.test.ts
+++ b/packages/agent-framework/src/config/__tests__/config-loader-corrupt-layer.test.ts
@@ -1,0 +1,96 @@
+/**
+ * CONFIG-002 (issue #2023) — a corrupt settings layer is an error, not an absence.
+ *
+ * `readJsonSource` returned `undefined` for a file it could not parse, and `loadConfig` skips a
+ * layer whose raw value is `undefined`. So a corrupt layer never reached `SettingsSchema`: shape
+ * validation is fail-closed and the JSON step beneath it was fail-open, which meant the fail-open
+ * path routed around the fail-closed one INSIDE one function.
+ *
+ * The consequence is the reason this is filed as security rather than tidiness. `toResolvedConfig`
+ * reads `merged.permissions?.deny ?? DEFAULTS.permissions.deny`, and that default is `[]` — so a
+ * project settings file that carried a deny list and then got truncated came back as a config with
+ * NO deny list, and nothing said so.
+ *
+ * Every case here drives the real `loadConfig` over real sources. Calling `readJsonSource` directly
+ * would prove the reader throws and say nothing about whether the loader still swallows it.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { loadConfig } from '../config-loader.js';
+import { SettingsParseError } from '../settings-io.js';
+import { createNodeHostSettingsSource } from '../settings-source.js';
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'robota-config-002-'));
+  roots.push(root);
+  return root;
+}
+
+/** A host settings source backed by a real file, which is what the loader reads in production. */
+function hostSourceWith(contents: string): ReturnType<typeof createNodeHostSettingsSource> {
+  const root = tempRoot();
+  mkdirSync(join(root, '.robota'), { recursive: true });
+  const path = join(root, '.robota', 'settings.json');
+  writeFileSync(path, contents, 'utf8');
+  return createNodeHostSettingsSource('user', path);
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('CONFIG-002: a corrupt layer is an error, not an absence', () => {
+  it('throws SettingsParseError for a layer that is not JSON', async () => {
+    const source = hostSourceWith('{"permissions": {"deny": ["Bash(rm -rf');
+
+    await expect(loadConfig([source])).rejects.toThrow(SettingsParseError);
+  });
+
+  it('names the file it could not read, so the operator can find it', async () => {
+    const source = hostSourceWith('not json at all');
+
+    await expect(loadConfig([source])).rejects.toThrow(/settings\.json/);
+  });
+
+  it('treats an EXISTING but empty file as corrupt, matching settings-io', async () => {
+    // `readSettings` in the same directory reaches `JSON.parse('')` and throws, so "empty is
+    // missing" was the loader disagreeing with its own neighbour about one file. A crash during
+    // write is exactly how a settings file becomes empty, and that is the moment the deny list
+    // matters most.
+    const source = hostSourceWith('   \n');
+
+    await expect(loadConfig([source])).rejects.toThrow(SettingsParseError);
+  });
+
+  it('leaves a genuinely MISSING file missing — absence is still absence', async () => {
+    const root = tempRoot();
+    const source = createNodeHostSettingsSource('user', join(root, '.robota', 'settings.json'));
+
+    const config = await loadConfig([source]);
+    expect(config.permissions.deny).toEqual([]);
+  });
+
+  it('does not lose a deny list to a corrupt sibling layer', async () => {
+    // The defect stated as the user meets it: a readable layer carrying a deny rule, and a corrupt
+    // one beside it. Before this, the corrupt layer vanished and the merge produced a config whose
+    // deny list came from DEFAULTS — empty — with no error anywhere.
+    const good = hostSourceWith('{"permissions":{"deny":["Bash(rm -rf /)"]}}');
+    const corrupt = hostSourceWith('{"permissions":{"deny":[');
+
+    await expect(loadConfig([good, corrupt])).rejects.toThrow(SettingsParseError);
+  });
+
+  it('still loads a well-formed layer, so the refusal is about corruption and not about reading', async () => {
+    const source = hostSourceWith('{"permissions":{"deny":["Bash(rm -rf /)"]}}');
+
+    const config = await loadConfig([source]);
+    expect(config.permissions.deny).toEqual(['Bash(rm -rf /)']);
+  });
+});

--- a/packages/agent-framework/src/config/config-loader.ts
+++ b/packages/agent-framework/src/config/config-loader.ts
@@ -16,6 +16,7 @@ import {
   type TEnvResolvedSettings,
   type IResolvedConfig,
 } from './config-types.js';
+import { SettingsParseError } from './settings-parse-error.js';
 import { readSettingsSourceText } from './settings-source.js';
 
 import type { TSettingsSource } from './settings-source.js';
@@ -41,17 +42,35 @@ const DEFAULTS: IResolvedConfig = {
  */
 function readJsonSource(source: TSettingsSource): unknown {
   const content = readSettingsSourceText(source, 'load configuration settings');
+  // A file that is not there was never a layer. Absence stays absence — that is the ONLY case that
+  // may answer `undefined`, because it is the only one where nothing was lost.
   if (content === undefined) return undefined;
+
   const raw = content.trim();
   if (raw.length === 0) {
-    // Empty file — likely from a crash during write. Treat as missing.
-    return undefined;
+    // An existing but empty file is corrupt, not absent. `settings-io.readSettings` in this
+    // directory reaches `JSON.parse('')` and throws for the same file, so treating empty as missing
+    // was this loader disagreeing with its neighbour rather than a considered policy — and a crash
+    // during write is precisely how a settings file becomes empty.
+    throw new SettingsParseError(source.displayName, 'the settings file is empty');
   }
+
   try {
     return JSON.parse(raw) as unknown;
-  } catch {
-    // allow-fallback: corrupt config JSON (likely a crash during write) is treated as missing config
-    return undefined;
+  } catch (error) {
+    // CONFIG-002 / issue #2023. This returned `undefined`, and `loadConfig` skips a layer whose raw
+    // value is `undefined` — so a corrupt layer never reached `SettingsSchema`. Shape validation is
+    // fail-closed; this step was fail-open; and the fail-open path therefore routed around the
+    // fail-closed one inside a single function.
+    //
+    // The direction is what makes it a security defect rather than a lost setting:
+    // `toResolvedConfig` resolves `merged.permissions?.deny ?? DEFAULTS.permissions.deny`, and that
+    // default is `[]`. A truncated project settings file that had carried a deny list came back as
+    // a config with none, and no caller could tell that from a file which never had one.
+    throw new SettingsParseError(
+      source.displayName,
+      error instanceof Error ? error.message : String(error),
+    );
   }
 }
 


### PR DESCRIPTION
Refs #2023. Implements Direction 1 of the pre-existing record `CONFIG-002` (2026-08-13), which predates the issue by nine days and cited it zero times — the two were never linked.

## What was wrong

`readJsonSource` returned `undefined` for a settings file it could not parse, and `loadConfig` skips a layer whose raw value is `undefined`. So a corrupt layer never reached `SettingsSchema`.

**Shape validation is fail-closed; the JSON step beneath it was fail-open. The fail-open path routed around the fail-closed one inside a single function** — `safeParse` throws on a bad shape, one line after the corrupt layer has already been filtered out.

The consequence is why the issue files this as security rather than as a lost setting. `toResolvedConfig` resolves:

```ts
deny: merged.permissions?.deny ?? DEFAULTS.permissions.deny   // DEFAULTS.permissions.deny === []
```

A project `settings.json` carrying a deny list, truncated by a crash during write, came back as a config with **no deny list** — indistinguishable from a file that never had a rule.

## What changed

`readJsonSource` throws `SettingsParseError` on a corrupt existing file, matching `settings-io.readSettings` four directories away.

**An existing but empty file fails too**, and that decision is by consistency rather than preference: `settings-io.readSettings` reaches `JSON.parse('')` and throws for the same file, so "empty is missing" was this loader disagreeing with its neighbour. Checked before changing it — no product path writes an empty settings file, `robota init` always writes `JSON.stringify(...)`.

**A missing file still answers `undefined`.** Absence is the one case where nothing was lost, and the only one that may still be silent.

## Measurement behind it, re-derived at `2a76b3869`

The issue names one file; the record's evidence is two sites. Enumerating from code finds **12**, and the issue's title names two axes that have to be judged separately:

```
parse sites ............ 12   fail open ... 5   silently drop ... 4   validate shape ... 4
```

`dag-cli/session/session-gate.ts` is why the axes must stay apart: it fails open on a malformed `DAG_SESSION_PERMISSIONS` **and writes a warning to stderr**. Open, and not silent.

**All five fail-opens are recorded decisions, not accidents** — each carries an `allow-fallback` marker. The stated reasons are "likely a crash during write", "must not crash CLI startup", "to allow recovery", "open access is the safe default", "disables the feature gracefully". Every one is an availability argument, and **not one mentions that the document being dropped is a security control.**

### One file, two readers, opposite verdicts

`config-loader.ts` and `command-api/provider/provider-merge.ts` both call `readSettingsSourceText` over the same `TSettingsSource`. On a corrupt file, one returned `undefined` and the other throws `SettingsParseError`. **The same file was fatal or ignored depending on which path reached it**, with both owners inside `agent-framework` over one shared reader. The issue predicts this in the abstract; this is the concrete instance.

## Verification

Red proof is its own commit: **4 of 6 cases fail** against the old loader. The 2 that pass are controls — a missing file stays missing, a well-formed layer still loads.

Three mutants, each with an applied-check confirming the mutation was in the tree:

| mutant | result |
| --- | --- |
| corrupt JSON restored to returning `undefined` | red |
| empty file restored to being treated as missing | red |
| a **missing** file made to throw as well | red |

The third is the one worth keeping. Four of six cases assert a refusal, so **a loader that refused everything would satisfy all four** — the controls are what stop the fix from being wrong in the opposite direction.

144 scans pass, agent-framework 1546 / agent-cli 430 / agent-command 295 / agent-session 369 tests pass, `pnpm typecheck` 0, `pnpm lint` **exit 0** (read by exit code, not the summary line).

## Deliberately not in this PR

- **`updateModelInSettings`**, the other half of CONFIG-002 — it writes a legacy flat `provider` shape the loader rejects. Real, recorded, and not what #2023 is about. Left on the record.
- **`mergeSettings` replacing a lower layer's `deny` wholesale** — found while measuring, verified, and **not this issue**: it fires with two entirely well-formed documents, so nothing here would fix it and fixing it would not fix this. It is the same class as #2024 and is assigned to that lane, which is also already editing that function.

## Corrections carried in the record

Three claims from my own earlier reconnaissance were wrong and are recorded as such: a site count of "10" when the query returned 12, "none of the sites validates shape" when four do (and three others have no shape to validate), and a cited path that does not exist. The record says so rather than quietly carrying the corrected numbers.
