### PR TITLE
feat(transport): let the outbound boundary be asked about backpressure (ARCH-030)

### DIFF
--- a/packages/agent-transport-protocol/src/__tests__/outbound-delivery.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/outbound-delivery.test.ts
@@ -331,3 +331,76 @@ describe('reply families that resolve after the carrier disconnected (ARCH-030)'
     expect(probe.failures).toHaveLength(1);
   });
 });
+
+/**
+ * ARCH-030 / issue #1734 — the boundary can be ASKED about backpressure, and never invents an answer.
+ *
+ * `deliver` returning is not delivery: both carriers hand this boundary a fire-and-forget sink, so a
+ * frame that has "been sent" may be sitting in a socket buffer the boundary cannot see. Before this,
+ * a non-reading peer — the contract case the issue names — was not observable at all, and any budget
+ * built here would have counted what the boundary HANDED OVER rather than what the peer had not read.
+ *
+ * These pin the two things that make the number worth having: it comes from the carrier, and
+ * "cannot say" is distinguishable from "nothing pending".
+ */
+describe('outbound backpressure reporting (ARCH-030 / issue #1734)', () => {
+  it('reports the carrier own reading, not a count the boundary kept', () => {
+    let carrierPending = 0;
+    const deliver = createOutboundDelivery(
+      () => {
+        // The carrier accepted it and has NOT written it — exactly the state the boundary cannot see
+        // by counting its own calls.
+        carrierPending += 100;
+      },
+      () => undefined,
+      () => carrierPending,
+    );
+
+    expect(deliver.pendingBytes()).toBe(0);
+    deliver({ type: 'protocol_error', message: 'x' } as never);
+    deliver({ type: 'protocol_error', message: 'y' } as never);
+    expect(deliver.pendingBytes()).toBe(200);
+  });
+
+  it('a peer that stops reading makes the number grow while every deliver still returns', () => {
+    let carrierPending = 0;
+    const deliver = createOutboundDelivery(
+      () => {
+        carrierPending += 10;
+      },
+      () => undefined,
+      () => carrierPending,
+    );
+
+    for (let i = 0; i < 50; i += 1) deliver({ type: 'protocol_error', message: 'x' } as never);
+
+    // Nothing threw and nothing reported a failure — which is the whole point: a non-reading peer is
+    // indistinguishable from a healthy one through `deliver` alone.
+    expect(deliver.pendingBytes()).toBe(500);
+  });
+
+  it('answers `undefined` — not 0 — when the carrier supplied no reading', () => {
+    const deliver = createOutboundDelivery(
+      () => undefined,
+      () => undefined,
+    );
+
+    // `0` would let "unknown" satisfy any threshold later placed on this number, which is the defect
+    // a budget over the wrong quantity would reintroduce.
+    expect(deliver.pendingBytes()).toBeUndefined();
+    expect(deliver.pendingBytes()).not.toBe(0);
+  });
+
+  it('re-reads at call time, so a value that changes underneath is not captured once', () => {
+    let carrierPending = 7;
+    const deliver = createOutboundDelivery(
+      () => undefined,
+      () => undefined,
+      () => carrierPending,
+    );
+
+    expect(deliver.pendingBytes()).toBe(7);
+    carrierPending = 0; // the peer drained
+    expect(deliver.pendingBytes()).toBe(0);
+  });
+});

--- a/packages/agent-transport-protocol/src/outbound-delivery.ts
+++ b/packages/agent-transport-protocol/src/outbound-delivery.ts
@@ -44,6 +44,22 @@ declare const outboundDeliveryBrand: unique symbol;
  */
 export type TOutboundDeliver = ((message: TServerMessage) => void) & {
   readonly [outboundDeliveryBrand]: true;
+
+  /**
+   * Bytes this carrier has ACCEPTED and not yet written to the peer — or `undefined` when it cannot
+   * say.
+   *
+   * `deliver` returning is not delivery. Both carriers hand this boundary a fire-and-forget sink, so
+   * a frame that has "been sent" may be sitting in a socket buffer the boundary cannot see. Anything
+   * this boundary counted itself would be a count of what it HANDED OVER, which is a different
+   * quantity from what the peer has not read — and a budget over the wrong quantity reports a
+   * healthy connection for a peer that stopped reading (ARCH-030 / issue #1734).
+   *
+   * `undefined` is deliberately not `0`. A carrier that cannot report backpressure and a carrier with
+   * nothing pending are different states, and collapsing them would let "unknown" satisfy any
+   * threshold placed on this number.
+   */
+  readonly pendingBytes: () => number | undefined;
 };
 
 /**
@@ -63,10 +79,13 @@ export type TDeliveryErrorHandler = (error: Error, event: TServerMessage['type']
  * @param send - the carrier's raw sink. May throw; that is what makes it raw.
  * @param onDeliveryError - the carrier's failure policy, invoked at most once. A handler that itself
  *   throws is isolated: a diagnostic cannot reverse an already-committed session operation.
+ * @param pendingBytes - the carrier's own backpressure reading. Optional because not every carrier
+ *   has one; omitted, the boundary answers `undefined` rather than inventing a number.
  */
 export function createOutboundDelivery(
   send: (message: TServerMessage) => void,
   onDeliveryError: TDeliveryErrorHandler,
+  pendingBytes?: () => number | undefined,
 ): TOutboundDeliver {
   let closed = false;
   const deliver = (message: TServerMessage): void => {
@@ -88,5 +107,7 @@ export function createOutboundDelivery(
       }
     }
   };
-  return deliver as TOutboundDeliver;
+  return Object.assign(deliver, {
+    pendingBytes: (): number | undefined => pendingBytes?.(),
+  }) as TOutboundDeliver;
 }

--- a/packages/agent-transport-webrtc/src/channel-delivery.ts
+++ b/packages/agent-transport-webrtc/src/channel-delivery.ts
@@ -12,9 +12,16 @@ import { createOutboundDelivery } from '@robota-sdk/agent-transport-protocol';
 
 import type { TOutboundDeliver } from '@robota-sdk/agent-transport-protocol';
 
-/** The slice of `RTCDataChannel` an outbound boundary needs — `send`, and nothing else. */
+/**
+ * The slice of `RTCDataChannel` an outbound boundary needs.
+ *
+ * `bufferedAmount` is optional because the slice is structural — a test double may omit it — but a
+ * real `RTCDataChannel` always has it, so the production path reports a real number rather than a
+ * placeholder (ARCH-030 / issue #1734).
+ */
 export interface IDataChannelSink {
   send: (data: string) => void;
+  readonly bufferedAmount?: number;
 }
 
 /**
@@ -30,5 +37,8 @@ export function createChannelDelivery(
   return createOutboundDelivery(
     (message) => channel.send(JSON.stringify(message)),
     (error, event) => onDeliveryError(error, event),
+    // Read at CALL time, not captured: `bufferedAmount` is a live property and a value read once
+    // would answer with the backpressure of the moment the boundary was built.
+    () => channel.bufferedAmount,
   );
 }

--- a/packages/agent-transport-ws/src/ws-session-delivery.ts
+++ b/packages/agent-transport-ws/src/ws-session-delivery.ts
@@ -27,6 +27,9 @@ export class WsSessionDelivery {
     this.deliver = createOutboundDelivery(
       (message) => this.rawSend(message),
       () => this.close(),
+      // ARCH-030 / issue #1734: the socket's own count of what it has accepted and not yet written.
+      // Read at call time — it changes underneath.
+      () => this.socket.bufferedAmount,
     );
   }
 


### PR DESCRIPTION
Part of #1734 (ARCH-030). The reopened scope asks this boundary to own slow-consumer budgets — queue/byte/time limits, an `accepted | queued | refused` result, an overflow policy. **This is the step that has to come first, and the measurement is why.**

## The measurement that decides the design

At `9a9d34c93`:

```
bufferedAmount in production source ......... 0 occurrences
carriers handing the boundary a sink ........ 2, both fire-and-forget
```

So **`deliver` returning is not delivery.** A frame that has "been sent" may be sitting in a socket buffer the boundary cannot see.

A budget built on that today would count **what the boundary handed over**, which is a different quantity from **what the peer has not read**. It would report a healthy connection for a peer that stopped reading — which is the contract case the issue names. And its acceptance test could only be written by mocking the boundary's own counter, proving a counter against itself.

## What this change does

The carrier reports, the boundary relays, **nothing yet decides**.

- `TOutboundDeliver` gains `pendingBytes(): number | undefined`.
- WebSocket and WebRTC pass their own `bufferedAmount`.

Additive: no existing caller changes and no return type moves. If the budget design later goes another way, the signal is still correct.

## Two decisions, each the difference between a real number and a decorative one

**`undefined` is not `0`.** A carrier that cannot report backpressure and a carrier with nothing pending are different states. Collapsing them would let *"unknown"* satisfy any threshold later placed on this number — the same shape as a guard whose input cannot vary.

**The reading is taken at call time, not captured at build time.** It is a live property; a value read once answers with the backpressure of the moment the boundary was constructed.

## Mutants, each killed by the case that names its subject

| Mutant | Killed by |
| --- | --- |
| `pendingBytes?.() ?? 0` — unknown collapses to zero | *"answers `undefined` — not 0"* |
| the reading captured once at build time | *"re-reads at call time"* + both growth cases |

## Deliberately not in this change

**The `accepted | queued | refused` vocabulary.** It changes a branded callable's return type across roughly 48 invocation points in three modules, and this repository already decided the opposite once on flattening a reason to `"refused"` — `packages/agent-cli/src/remote-control/local-peer-admission.ts` records that the rejection reason is carried through verbatim *"rather than flattened"*. That argument deserves its own change, and it is cheaper to make with a real signal to point at than with a number the boundary invented.

**The budgets themselves**, for the same reason: a threshold is only as good as the quantity under it.

## Verification

```
tsc                  0 in agent-transport-protocol, -ws, -webrtc
vitest               363 tests pass across the three packages
pnpm harness:scan    143 passed, 2 skipped, exit 0
pnpm lint            exit 0
harness:review:record  0 findings @ 7e0c4d1aa
```
