### PR TITLE
fix(config): a project layer's deny no longer removes the user's (CONFIG-003)

### DIFF
--- a/.agents/tasks/CONFIG-003-deep-merge-replaces-hooks-wholesale-and-transports-is-a-dead-resolved-field.md
+++ b/.agents/tasks/CONFIG-003-deep-merge-replaces-hooks-wholesale-and-transports-is-a-dead-resolved-field.md
@@ -120,3 +120,46 @@ not invented inside a merge function.
 Issue #2024 (2026-08-22) records the `hooks` half of this record (2026-08-13) with a reproduction and
 an acceptance list. This record owns it — it is earlier and names all three fields. Issue #2024's acceptance
 criteria are folded in above, and it closes when this record delivers.
+
+## `permissions.deny` — delivered 2026-08-24
+
+**Not a new rule. The repository's rule, applied at the one site that disagreed.**
+
+`agent-core`'s `applyPresetToolLists` states and implements it for the preset layer:
+
+> the allowlist REPLACES … the denylist UNIONS — a denial is not weakened by a later layer that
+> forgot to repeat it.
+
+`permission-enforcer.ts:126` cites the same rule when it explains why a newly applied denial outranks
+an earlier "always allow". ARCH-040's completed record calls it **settled**.
+
+`mergeSettings` was the exception: `layer.permissions?.deny ?? merged.permissions?.deny` meant a
+project layer declaring ANY deny silently dropped every deny the user had configured. `deny` now
+unions, deduplicated and order-preserving to match `applyPresetToolLists`.
+
+**`allow` is deliberately unchanged, and that asymmetry is the rule rather than an oversight.** An
+allowlist states the complete permitted set, so a later, more specific layer supersedes it; unioning
+a GRANT would let a project widen what the user permitted — the same inverted trust direction the
+deny fix closes. A test now pins it, so a future change that unions `allow` for symmetry goes red.
+
+**What this was, versus the `hooks` half.** The hooks defect fell out of a top-level spread and the
+code contradicted its own comment. This line was written on purpose. What makes it wrong is not that
+nobody decided it, but that **the decision contradicts one the repository had already made
+elsewhere** — which is why it needed a citation rather than an argument.
+
+**Mitigation, stated because it bounds the severity without excusing it:** project settings sources
+are read only when `projectAccess.status === 'trusted'`. Trusting a workspace means the user trusts
+it to contribute settings; it does not mean they intended it to remove their own deny rules, and a
+trusted workspace is still a cloned repository.
+
+Each of the three tests is falsifiable by its own mutant, verified rather than assumed:
+
+```
+deny replaces (the defect)   → "expected [ 'Read(.env)' ] to include 'Bash(rm -rf *)'"
+union without dedup          → "expected [ 'Bash(rm -rf *)', …(2) ] to deeply equal [ … ]"
+allow unioned too            → "expected [ 'Bash(git *)', 'Read(**)' ] to deeply equal [ 'Read(**)' ]"
+```
+
+Only the first is red against `develop`; the other two are red against a mutant of this change, and
+are characterisation rather than regression tests. Stated because "three red-first tests" would have
+been the easier and wrong claim.

--- a/packages/agent-framework/src/__tests__/config-loader.test.ts
+++ b/packages/agent-framework/src/__tests__/config-loader.test.ts
@@ -185,6 +185,46 @@ describe('loadConfig', () => {
     expect(config.permissions.allow).toEqual(['Read(**)', 'Glob(**)']);
   });
 
+  it('CONFIG-003: a project deny rule does not remove a user-global deny rule', async () => {
+    // The repository's settled combine rule, applied at the one site that disagreed:
+    // `agent-core`'s applyPresetToolLists says "the denylist UNIONS — a denial is not weakened by a
+    // later layer that forgot to repeat it", and settings-layer merging did exactly that weakening.
+    // A project layer declaring ANY deny dropped every deny the user had configured.
+    writeJson(join(userDir, 'settings.json'), {
+      permissions: { deny: ['Bash(rm -rf *)'] },
+    });
+    writeJson(join(projectDir, 'settings.json'), {
+      permissions: { deny: ['Read(.env)'] },
+    });
+    const config = await loadConfig(cwd);
+
+    expect(config.permissions.deny).toContain('Bash(rm -rf *)');
+    expect(config.permissions.deny).toContain('Read(.env)');
+  });
+
+  it('CONFIG-003: a repeated deny rule is not duplicated', async () => {
+    // Order-preserving and deduplicated, matching applyPresetToolLists. A union that grew on every
+    // layer would turn a repeated rule into a longer list that means the same thing.
+    writeJson(join(userDir, 'settings.json'), { permissions: { deny: ['Bash(rm -rf *)'] } });
+    writeJson(join(projectDir, 'settings.json'), {
+      permissions: { deny: ['Bash(rm -rf *)', 'Read(.env)'] },
+    });
+    const config = await loadConfig(cwd);
+
+    expect(config.permissions.deny).toEqual(['Bash(rm -rf *)', 'Read(.env)']);
+  });
+
+  it('CONFIG-003: allow still REPLACES — the asymmetry is the rule, not an oversight', async () => {
+    // Deliberately NOT changed. An allowlist states the complete permitted set, so a later, more
+    // specific layer supersedes it; unioning a GRANT would let a project widen what the user
+    // permitted, which is the same inverted trust direction the deny fix closes.
+    writeJson(join(userDir, 'settings.json'), { permissions: { allow: ['Bash(git *)'] } });
+    writeJson(join(projectDir, 'settings.json'), { permissions: { allow: ['Read(**)'] } });
+    const config = await loadConfig(cwd);
+
+    expect(config.permissions.allow).toEqual(['Read(**)']);
+  });
+
   it('throws on invalid settings (Zod validation)', async () => {
     writeJson(join(projectDir, 'settings.json'), {
       defaultTrustLevel: 'INVALID_VALUE',

--- a/packages/agent-framework/src/config/config-merge.ts
+++ b/packages/agent-framework/src/config/config-merge.ts
@@ -41,8 +41,11 @@ export function mergeSettings(layers: TEnvResolvedSettings[]): TEnvResolvedSetti
       permissions:
         merged.permissions !== undefined || layer.permissions !== undefined
           ? {
+              // `allow` REPLACES: an allowlist states the complete permitted set, so a later, more
+              // specific layer supersedes the earlier answer. Unchanged — this already conformed.
               allow: layer.permissions?.allow ?? merged.permissions?.allow,
-              deny: layer.permissions?.deny ?? merged.permissions?.deny,
+              // `deny` UNIONS: a denial is not weakened by a later layer that forgot to repeat it.
+              deny: unionDeny(merged.permissions?.deny, layer.permissions?.deny),
             }
           : undefined,
       env: {
@@ -87,6 +90,36 @@ export function mergeSettings(layers: TEnvResolvedSettings[]): TEnvResolvedSetti
  * are kept and both run — a repeated guard costs an extra execution, while dropping one on a
  * key-collision guess would be this defect again in a smaller form.
  */
+/**
+ * Combine two denylists.
+ *
+ * **This is not a new rule — it is the repository's rule, applied at the one site that disagreed.**
+ * `agent-core`'s `applyPresetToolLists` states and implements it for the preset layer:
+ *
+ * > the allowlist REPLACES … the denylist UNIONS — a denial is not weakened by a later layer that
+ * > forgot to repeat it.
+ *
+ * `permission-enforcer.ts` cites the same rule when it explains why a newly applied denial outranks
+ * an earlier "always allow", and ARCH-040's record calls it settled. Settings-layer merging was the
+ * exception: `layer.permissions?.deny ?? merged.permissions?.deny` meant a project layer declaring
+ * ANY deny silently dropped every deny the user had configured — the lower-trust layer relaxing the
+ * higher-trust policy, which is the trust direction inverted.
+ *
+ * Unlike the `hooks` defect this file was created for, that line was written on purpose rather than
+ * falling out of a spread. What makes it wrong is not that nobody decided it, but that the decision
+ * contradicts the one the repository had already made elsewhere.
+ *
+ * Deduplicated and order-preserving, matching `applyPresetToolLists`.
+ */
+function unionDeny(
+  base: readonly string[] | undefined,
+  layer: readonly string[] | undefined,
+): string[] | undefined {
+  if (base === undefined) return layer === undefined ? undefined : [...layer];
+  if (layer === undefined) return [...base];
+  return [...new Set([...base, ...layer])];
+}
+
 function mergeHooks(
   base: TEnvResolvedSettings['hooks'],
   override: TEnvResolvedSettings['hooks'],


### PR DESCRIPTION
Delivers the `permissions` half of CONFIG-003. Issue #2024's other half — hooks — landed in #2279.

## The defect

```ts
deny: layer.permissions?.deny ?? merged.permissions?.deny,
```

A project settings layer declaring **any** deny silently dropped **every** deny the user had
configured. The lower-trust layer relaxing the higher-trust policy — the trust direction inverted.

## This is not a new rule, and that is the whole point

I had an argument prepared for why a restriction should compose by union. I did not need it. **The
repository settled this and wrote it down three times.**

`packages/agent-core/src/permissions/tool-list-patterns.ts` states it and implements it:

> - **the allowlist REPLACES** — it states the complete permitted set, so a later, more specific
>   layer supersedes the earlier answer;
> - **the denylist UNIONS** — a denial is not weakened by a later layer that forgot to repeat it.

`packages/agent-session/src/permission-enforcer.ts` cites the same rule when explaining why a newly
applied denial outranks an earlier "always allow". `ARCH-040`'s completed record calls it **settled**.

`mergeSettings` was the one site that disagreed. So this PR is a **citation, not a judgement**, and
what makes the line wrong is not that nobody decided it — somebody wrote it on purpose — but that the
decision contradicts one the repository had already made.

## `allow` is deliberately unchanged, and the asymmetry is the rule

The same settled rule says the allowlist REPLACES, and the current code already conforms. Unioning a
**grant** would let a project widen what the user permitted — the same inverted trust direction the
deny fix closes.

A test now pins it, so a future change that unions `allow` "for symmetry" goes red.

## How this differs from the hooks half of the same record

| | `hooks` (#2279) | `permissions.deny` (here) |
| --- | --- | --- |
| Origin | fell out of a top-level spread | a line somebody wrote on purpose |
| Evidence it is wrong | the code contradicted its own comment | the decision contradicts one made elsewhere |
| What it needed | a correction | a citation |

## Only one of the three tests is red-first, and saying so is the point

```
deny replaces (the defect)  →  red against develop:  expected [ 'Read(.env)' ] to include 'Bash(rm -rf *)'
union without dedup         →  green against develop, red against a mutant of this change
allow unioned too           →  green against develop, red against a mutant of this change
```

The dedup and allow-replaces tests **pass without the fix** — without a union there is nothing to
deduplicate, and the allow assertion asserts no change. They are characterisation tests, not
regression tests for this defect, and each was verified against its own mutant rather than counted as
proof it is not.

"Three red-first tests" would have been the easier claim and the wrong one. The mutants were also
**re-run after the rebase** rather than reused: a probe result is about the tree it ran on.

## Severity is bounded — stated, not used as an excuse

Project settings sources are read only when `projectAccess.status === 'trusted'`. That lowers the
severity considerably. It does not dispose of it: **trusting a workspace means trusting it to
contribute settings, not intending it to remove your own deny rules**, and a trusted workspace is
still a cloned repository.

## Verification

`pnpm harness:verify-like-ci` exit 0 (12 stages) on base `9a9d34c93`; 143 scans; 39 config-loader
tests.
