### PR TITLE
docs(rules): resolution happens on develop, and a registered item may be declined

### DIFF
--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -43,6 +43,55 @@ Every Task converted from an issue must cite its source issue. Conversion does n
 implementation; the issue remains open until the tracked work lands or receives an explicit terminal
 disposition. The `issue-to-backlog` skill owns the conversion procedure; this rule owns the boundary.
 
+## Registration is not authorization — an item may be declined
+
+**An issue being open does not oblige anyone to implement it.** Issues arrive here through many routes —
+an audit sweep, a review finding filed rather than absorbed, a scan's output, a passing observation
+during unrelated work — and those routes do not share a bar. Some carry a security defect; some carry a
+wording preference. A rule that every registered item must be worked would let the cheapest route to
+create work set the queue.
+
+So **picking an item up begins with a judgement, and the judgement may be to decline it.** The two
+outcomes are symmetric: proceed with reasons, or decline with reasons. Neither is the default, and
+"it is open, therefore I work it" is not a judgement.
+
+**A decline is closed, not left open.** An item judged not worth doing and left open is worse than either
+outcome — it stays in every count, is re-picked by the next session, and is re-judged from scratch each
+time. Close it, with the disposition recorded **on the issue**, where the next reader looks. A Task file
+that mirrors it takes the terminal status this file already defines (`wontfix`, `skipped`, `superseded`)
+with its date.
+
+**What a decline must contain**, because the grounds are the whole substance of it:
+
+- **What the item claims**, restated — a decline that does not first state the claim usually declines a
+  different, easier claim.
+- **Why it is not worth doing**, against something outside the decider's convenience: the defect does not
+  reproduce, the cost exceeds the harm, a merged change already resolved it, another open item subsumes
+  it, or the premise is factually wrong — and if wrong, which measurement shows it.
+- **What would reverse the decision.** A decline that nothing could change is a refusal to judge wearing
+  the clothes of a judgement. Anyone reopening the issue should be able to read this line and know what
+  to bring.
+
+**What is not a ground.** That the item is tedious, unfamiliar, large, poorly written, old, or filed by a
+route the decider dislikes. Those describe the decider, not the item. A large item is decomposed or
+declined on cost against harm — with the cost stated — never declined for being large.
+
+**Which declines are not the agent's to make alone.** Route by
+[Agent Decision Authority](#agent-decision-authority) below, with one addition that follows from what a
+decline destroys: an item asserting a **security or data-correctness defect** is not declined on agent
+authority. Being unable to reproduce it is a finding to report, not a disposition to apply — the
+difference between "this does not happen" and "I did not make it happen" is exactly what a second reader
+is for. Recommend the decline with its grounds and let the user decide.
+
+Enforced by: the record half only. `backlog-placement` refuses a terminal status without its
+`completed:` date, so a declined item cannot be archived undated, and `task-archival` refuses the
+half-finished move. The judgement itself is not mechanizable and no scan is claimed for it: whether the
+grounds are sound is the thing being asked, and a machine that could decide it would not need the rule.
+What that leaves is visible by construction — the grounds are written on the issue, so a wrong decline is
+readable rather than silent, and reopening costs one comment.
+
+Case: [PROC-015](https://github.com/woojubb/robota/issues/2289).
+
 ## Agent Decision Authority
 
 When a decision must be made during backlog work, the agent must first determine whether it falls

--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -550,6 +550,42 @@ would be the automation this section exists to refuse.
 
 Case: [PROC-013](https://github.com/woojubb/robota/issues/2283).
 
+### Work that reaches `develop` is resolved — and the closure is performed, not inferred
+
+**When a pull request lands on `develop`, the session that owns it closes the issue that work resolves,
+by hand, as a step of the post-merge sequence.** `develop` is where resolution happens. Promotion to
+`main` is a release action; it is not what makes an issue done, and an issue must not wait on it.
+
+**Do not delegate the closure to the host's closing keywords.** They fire only on a pull request whose
+base is the **default branch** — which no feature pull request here has — so a keyword on a `develop`
+pull request closes nothing and reads, to its author and to every later reader, as though it had.
+`scripts/harness/promotion-closes.mjs` owns that fact; this section exists because relying on it is what
+left delivered work sitting in the open queue. Write the keyword if you like — it costs nothing and it
+documents intent — but it is not the act, and a pull request body is not a closure.
+
+**Close what was delivered, and say what was not.** This is the reason the step is a judgement rather
+than a setting. A keyword closes an issue whole, so a pull request delivering part of one either closes
+undelivered acceptance criteria along with the delivered ones, or carries no keyword and closes nothing.
+An issue with acceptance criteria is closed only after the criteria are compared item by item; where some
+remain, the issue stays open and the comment records which, so that "addressed" and "satisfied" do not
+collapse into one state.
+
+**The closing comment names the delivering commit on `develop`.** An issue closed without that is closed
+on someone's memory — the next reader cannot tell which change is supposed to have resolved it, and
+cannot check.
+
+Enforced by: nothing — whether a merged change satisfies an issue is not decidable from the tree. When
+this was measured, 57 open issues were named by a merged `develop` pull request and almost every one of
+those mentions was
+`filed as`, `parent tracker`, or `Filed from this` — a merged pull request naming an issue is usually
+**registering** work, not delivering it. A machine that closed on mention would close the backlog the
+repository had just written down. What a machine can do is make the gap visible, never decide it. So the
+step is carried by [`post-merge-cycle`](../skills/post-merge-cycle/SKILL.md), which must report the
+closure — or the reason there was none — as part of its outcome contract, where an omission is a missing
+field rather than a silence.
+
+Case: [PROC-015](https://github.com/woojubb/robota/issues/2289).
+
 ### An open PR's diff is frozen except to resolve a finding
 
 **Open a PR only when the unit of work is complete.** An open PR is a merge invitation: it may be

--- a/.agents/skills/post-merge-cycle/SKILL.md
+++ b/.agents/skills/post-merge-cycle/SKILL.md
@@ -24,15 +24,16 @@ the outcome tokens it routes on, because those _are_ the mechanism.
   per-hop mandates); "`--delete-branch` is Prohibited in `gh pr merge`" (the ban, the confirm-merged
   precondition, and the four conditions under which a branch must NOT be deleted); "Delete Merged
   Branches" (the local/remote deletion mechanics, the ancestry precondition, never the integration
-  branches); "Post-Merge Branch Cycle" (churn discipline and the fresh-base requirement); "Clean Working
+  branches); "Work that reaches `develop` is resolved" (the closure is performed, not inferred, and what a
+  partial delivery does instead); "Post-Merge Branch Cycle" (churn discipline and the fresh-base requirement); "Clean Working
   Tree Before Every Commit and Push" (names the CI-equivalent verification entry point).
 - The `merge-verifier` agent definition in `.claude/agents/merge-verifier.md`.
 
 ## Input
 
-The merge just performed: the PR (or merge commit) and its target branch; whether this is one hop of a
-multi-hop flow and, if so, which hops remain; and whether the caller intends to continue working in this
-same working tree afterwards. That last one decides whether phase 3 runs at all — ask rather than assume,
+The merge just performed: the PR (or merge commit) and its target branch; **the issue this work resolves,
+or that there is none**; whether this is one hop of a multi-hop flow and, if so, which hops remain; and
+whether the caller intends to continue working in this same working tree afterwards. That last one decides whether phase 4 runs at all — ask rather than assume,
 because a caller working in a disposable isolated tree has no next branch to base.
 
 ## The state machine
@@ -51,16 +52,39 @@ and do not treat a host UI's "merged" label as the answer.
 The `FAIL` edge is absolute: a merge that did not land is exactly the case where deleting the source
 branch destroys the only copy of the work.
 
-### 2. Decide and perform branch deletion
+### 2. Close what the merge resolved
+
+The merge landed, so the work is resolved — `develop` is where that happens, and the issue does not wait
+for a promotion. Close it here, in this step, as an act.
+
+Do not look for the host to have closed it. The rule owns why: a closing keyword needs a pull request
+based on the default branch, and this one was not, so nothing fired. A closed-looking issue at this point
+was closed by someone, not by the merge.
+
+| Outcome                                     | Routes to                                                                                                             |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| the issue's criteria are all delivered      | close it with a comment naming the delivering commit on the integration branch, then advance to 3                     |
+| some criteria remain                        | **leave it open**, comment which were delivered and which were not, then advance to 3                                 |
+| the merge delivered no issue                | advance to 3 — recorded as "none", never as an empty step                                                             |
+| the merge names an issue it did not deliver | **leave it open** — a pull request that files, tracks, or cross-references an issue has not resolved it; advance to 3 |
+
+The last row is the failure this step is most likely to cause, and it is the opposite of the one it was
+added to fix. Most merged pull requests here name issues they are _registering_, not delivering. Read what
+the body says about the issue before acting on the fact that it mentions one.
+
+Where the issue carries acceptance criteria, compare them item by item. "This change addressed the topic"
+is not "this change satisfied the criteria", and only the second one closes an issue.
+
+### 3. Decide and perform branch deletion
 
 The rule lists the conditions under which a merged branch must **not** be deleted. Evaluate each against
 observable state — they are all decidable, not matters of taste — and route:
 
 | Outcome                                          | Routes to                                                                                                |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| every condition clear                            | delete local, then remote, then advance to 3                                                             |
-| any condition holds                              | **skip the deletion**, record which condition held and why, advance to 3                                 |
-| the ancestry precondition fails on remote delete | **do not delete**; surface it as a finding (the branch has commits the target does not) and advance to 3 |
+| every condition clear                            | delete local, then remote, then advance to 4                                                             |
+| any condition holds                              | **skip the deletion**, record which condition held and why, advance to 4                                 |
+| the ancestry precondition fails on remote delete | **do not delete**; surface it as a finding (the branch has commits the target does not) and advance to 4 |
 
 Order within the deletion itself is fixed by the rule: local first (its safe form refuses an unmerged
 branch, so it is a free second opinion), then the remote — and the remote only once the merge is confirmed,
@@ -69,7 +93,7 @@ which step 1 already established. Prune any worktree that was holding the branch
 Not deleting is a recorded outcome, not a silent one. A branch skipped here without a reason written down
 is how a backlog of stale branches accumulates.
 
-### 3. Reset onto a fresh base for the next branch
+### 4. Reset onto a fresh base for the next branch
 
 Run only when the caller continues in this working tree. The order matters and is the whole point of the
 phase:
@@ -85,19 +109,21 @@ phase:
 | Outcome                  | Routes to                                                                                                                           |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | base verification passes | **terminate** — the cycle is complete                                                                                               |
-| base verification fails  | return to step 3.1 and re-cut, **bounded at 2 attempts**                                                                            |
+| base verification fails  | return to step 4.1 and re-cut, **bounded at 2 attempts**                                                                            |
 | still failing after 2    | **terminate and escalate to the user** — a base that will not resolve is a repository-state problem, not something to keep retrying |
 
 ## Termination
 
 Terminate on any of: `merge-verifier` returning `FAIL`; the base-reset bound being exhausted; a caller
-with no next branch reaching the end of step 2; or any of the conditions the governing rules define as a
+with no next branch reaching the end of step 3; or any of the conditions the governing rules define as a
 stop. Those stop conditions are owned by the rules — do not restate them here.
 
 ## Outcome contract
 
-Report, per step: the landing verdict, whether the branch was deleted or which condition prevented it, and
-whether a fresh base was established. Aggregate "cleaned up" is not a report — the caller may be holding
+Report, per step: the landing verdict; **which issue was closed, or the reason none was** — `none`, or the
+criteria that remain; whether the branch was deleted or which condition prevented it; and whether a fresh
+base was established. The closure field is required, so a cycle that never reached it is a missing field
+rather than a silence. Aggregate "cleaned up" is not a report — the caller may be holding
 other work behind this cycle's completion.
 
 ## What This Skill Does NOT Do
@@ -109,6 +135,7 @@ other work behind this cycle's completion.
 | Perform the merge, or decide when to arm one   | the calling pipeline               |
 | Define what a clean tree or a green gate means | `.agents/rules/git-branch.md`      |
 | Judge the merged change's quality              | the code-review gate the rules own |
+| Decide whether an issue's criteria are met     | the session that owns the issue    |
 
 If you find yourself restating a rule here, stop — link the rule instead.
 

--- a/.agents/tasks/PROC-015-an-issue-s-resolution-is-delegated-to-a-host-feature-that-never-fires-on-the-int.md
+++ b/.agents/tasks/PROC-015-an-issue-s-resolution-is-delegated-to-a-host-feature-that-never-fires-on-the-int.md
@@ -1,0 +1,90 @@
+---
+title: "PROC-015: an issue's resolution is delegated to a host feature that never fires on the integration branch"
+issue: https://github.com/woojubb/robota/issues/2289
+status: in-progress
+created: 2026-08-24
+priority: medium
+urgency: soon
+area: .agents/rules, .agents/skills
+depends_on: []
+---
+
+# PROC-015: an issue's resolution is delegated to a host feature that never fires on the integration branch
+
+## Objective
+
+Make the closure of an issue an explicit act by the session that delivered it, at the moment the work
+reaches `develop` — instead of an inference the host draws from a keyword on a pull request that does not
+target the branch the keyword needs.
+
+## The measurement this rests on
+
+`scripts/harness/promotion-closes.mjs` records the mechanism: GitHub's closing keywords fire only on a
+pull request whose base is the **default branch**. Every feature pull request in this repository targets
+`develop`, so no merge into `develop` has ever closed an issue.
+
+Measured on 2026-08-24 over the 120 most recent merged `develop` pull requests:
+
+| Measurement                                                   | Count |
+| ------------------------------------------------------------- | ----- |
+| body-level closing keywords (`closes` / `fixes` / `resolves`) | 87    |
+| of those, the named issue still open                          | 2     |
+| open issues merely _mentioned_ by a merged pull request       | 57    |
+| of those 57, the mention is a delivery rather than a filing   | ~0    |
+
+The last row is the one that matters, and it is why this Task does not propose a batch closure. The
+mention text is overwhelmingly `filed as #N`, `parent tracker #N`, `Filed from this: #N` — a merged pull
+request naming an issue is usually **registering future work**, not delivering it. A mechanism that closed
+every mentioned issue would close the backlog this repository had just written down.
+
+## Why a keyword cannot carry the judgement
+
+A keyword closes an issue **whole**. A pull request that delivers part of an issue therefore has two
+options, and both are wrong: carry the keyword and close undelivered acceptance criteria along with the
+delivered ones, or omit it and close nothing. Observed the same day on issue #2024, whose five acceptance
+criteria were delivered three-and-a-half by one pull request — had that pull request carried `Closes`, two
+undelivered criteria would have closed with it.
+
+An explicit step can close what was delivered **and say what was not**. That is the judgement the keyword
+has no way to express, and it is the reason this is a step and not a better-configured feature.
+
+## Plan
+
+- [x] Amend `.agents/rules/git-branch.md` — `develop` is where resolution happens, and the closure is
+      performed, not inferred.
+- [x] Add the closure step to the `post-merge-cycle` skill, positioned after the landing verdict and
+      before branch deletion.
+- [x] State the enforcement honestly, including what no machine can decide.
+- [x] Amend `.agents/rules/backlog-execution.md` — registration is not authorization; an item may be
+      declined with reasons, and a decline is closed rather than left open.
+
+## The second half: an open item is not an instruction
+
+Added to this Task on the owner's direction the same day, because it shares a cause with the first half.
+Closing an issue when work lands only helps if the queue is a list of things worth doing. Issues reach
+this repository through routes that do not share a bar — an audit sweep, a review finding filed rather
+than absorbed, a scan's output, an observation made during unrelated work. If every registered item must
+be worked, the cheapest route to create work sets the queue, and the cost of filing something trivial is
+paid by whoever picks it up.
+
+So picking an item up begins with a judgement that may go either way, and a decline is **closed** with
+its grounds written on the issue. Left open, a declined item stays in every count and is re-judged from
+scratch by the next session — the state this repository was already in.
+
+One asymmetry is written into the rule rather than left to taste: an item asserting a security or
+data-correctness defect is not declined on agent authority. "I could not reproduce it" and "it does not
+happen" are different claims, and only the second one is a disposition.
+
+## Test Plan
+
+- `pnpm harness:scan` — `new-rule-declares-enforcement` must accept the new rule section, and
+  `conflict-markers` must not report the new text as contradicting the promotion rule (they describe two
+  different acts and must read as such).
+- `pnpm harness:verify-like-ci` for the repository-wide gates.
+- Falsification: a rule section without its `Enforced by:` line must be REFUSED by the scan. Recorded as
+  a control arm so the scan's acceptance of the real section is not a vacuous green.
+
+## User Execution Test Scenarios
+
+Not applicable — a rule-and-skill change delivering no runnable user-facing behavior. The document checks
+belong to the Test Plan above, per `.agents/tasks/README.md`.


### PR DESCRIPTION
Two amendments with one cause: the queue did not reflect what was **done**, and it did not reflect what was **worth doing**.

## Why the queue did not reflect what was done

`scripts/harness/promotion-closes.mjs` records the mechanism — GitHub's closing keywords fire only on a pull request whose base is the **default branch**. Every feature pull request here targets `develop`, so no merge into `develop` has ever closed an issue. The closure had been deferred to a promotion, which is a release action on its own schedule, so delivered work sat in the open queue reading as unstarted.

Measured over the 120 most recent merged `develop` pull requests:

| Measurement                                                 | Count |
| ----------------------------------------------------------- | ----- |
| body-level closing keywords                                 | 87    |
| of those, the named issue still open                        | 2     |
| open issues merely *mentioned* by a merged pull request     | 57    |
| of those, mentions that are a delivery rather than a filing | ~0    |

The last row is why this change adds no bulk closure and no scan that closes on mention. The mention text is overwhelmingly `filed as #N`, `parent tracker #N`, `Filed from this: #N` — a merged pull request naming an issue is usually **registering** work. A machine that closed on mention would close the backlog the repository had just written down. That case is written into the skill as its own routing row, because it is the failure this step is most likely to cause and it is the opposite of the one it fixes.

So the closure becomes an act: **step 2 of `post-merge-cycle`**, after the landing verdict and before branch deletion, reported as a required field of the outcome contract.

A keyword also closes an issue **whole**. A pull request delivering part of an issue therefore either closes undelivered acceptance criteria along with the delivered ones, or carries no keyword and closes nothing. Observed the same day on issue #2024, whose five acceptance criteria were delivered three-and-a-half by one pull request. An explicit step closes what was delivered **and records what was not** — the judgement a keyword has no way to express, and the reason this is a step rather than a better-configured feature.

## Why the queue did not reflect what was worth doing

Registration is not authorization. Issues reach this repository by routes that do not share a bar — an audit sweep, a review finding filed rather than absorbed, a scan's output, an observation made during unrelated work. If every registered item must be worked, the cheapest route to create work sets the queue.

So picking an item up begins with a judgement that may go either way, and **a decline is closed**, with the claim restated, grounds outside the decider's convenience, and what would reverse the decision. Left open, a declined item stays in every count and is re-judged from scratch by the next session — which is the state the queue was already in.

One asymmetry is written in rather than left to taste: an item asserting a **security or data-correctness defect is not declined on agent authority**. "I could not reproduce it" and "it does not happen" are different claims, and only the second is a disposition.

## Enforcement, stated as what it is

`backlog-placement` and `task-archival` hold the record half — a declined item cannot be archived undated or half-moved. Whether a merged change satisfies an issue, and whether a decline is sound, are the questions being asked; a machine able to decide them would make the rule unnecessary. Both sections say so in the form the floor requires rather than implying a check that does not exist.

## Verification

- `pnpm harness:scan` — 145/145, including `conflict-markers` (the new text and the promotion rule describe two different acts and must read as such) and `rule-case-narrative`.
- **Falsification, both arms recorded.** Treatment: `new-rule-declares-enforcement` passes on the section as written. Control: the same section committed with its `Enforced by:` line removed → the scan **fails**, naming the section, exit 1. The first control attempt reported a pass; its commit had been refused by a hook and `HEAD` never moved, so the arm measured the treatment twice. Verified `HEAD` moved before trusting the second.
- Two defects were found by the local review and fixed before the first push: the enforcement declaration used `nothing mechanical,` where the floor's literal requires `nothing —`, and the rule body carried a bare date that `rule-case-narrative` counts as case narrative belonging in the linked record.

Refs issue #2289