### PR TITLE
docs(tasks): PROC-015 is delivered and its record is archived

### DIFF
--- a/.agents/tasks/completed/PROC-015-an-issue-s-resolution-is-delegated-to-a-host-feature-that-never-fires-on-the-int.md
+++ b/.agents/tasks/completed/PROC-015-an-issue-s-resolution-is-delegated-to-a-host-feature-that-never-fires-on-the-int.md
@@ -1,8 +1,9 @@
 ---
 title: "PROC-015: an issue's resolution is delegated to a host feature that never fires on the integration branch"
 issue: https://github.com/woojubb/robota/issues/2289
-status: in-progress
+status: done
 created: 2026-08-24
+completed: 2026-08-25
 priority: medium
 urgency: soon
 area: .agents/rules, .agents/skills


### PR DESCRIPTION
The two amendments landed on `develop` as `14b48921163c634efbd1e77608731b94105fa003` (PR #2290). This closes the record's own lifecycle, which the delivering pull request left at `in-progress`.

- `status: done` with `completed: 2026-08-25`, and the `git mv` to `completed/` — in this one commit, which is the atomic pair the lifecycle requires. They were initially split: the frontmatter edit was never staged before `git mv` recorded the rename from the index, so the first commit carried the move alone. Amended rather than followed up, because the two landing separately is exactly what the invariant forbids.
- No user-execution scenario gate applies. The delivery is rule and skill text with no runnable user-facing behavior; `Not applicable` with its reason was written into the record before implementation, not supplied afterwards to clear a gate.

**The step this Task added has now been applied to the Task's own issue.** Issue #2289 was closed on the merge to `develop`, with the delivering commit named in the closing comment and each acceptance point checked against what the remote tree holds rather than against the pull request's description. That was the first live use of `post-merge-cycle` step 2.

Verification: `pnpm harness:scan` — 143 passed, 2 skipped, 0 failed, including `backlog-placement` and `task-archival`, which are the two that own this transition.

Refs issue #2289