### PR TITLE
fix(transport): the outbound boundary refuses a peer that stopped reading (ARCH-030)

### DIFF
--- a/packages/agent-transport-protocol/src/__tests__/outbound-delivery.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/outbound-delivery.test.ts
@@ -404,3 +404,62 @@ describe('outbound backpressure reporting (ARCH-030 / issue #1734)', () => {
     expect(deliver.pendingBytes()).toBe(0);
   });
 });
+
+describe('ARCH-030: the byte budget the boundary enforces itself', () => {
+  it('refuses and closes when the carrier is holding more than the budget', () => {
+    // The contract case the reopened scope names: a peer that accepted frames and stopped reading.
+    // Detected by what the CARRIER is still holding, not by anything this boundary counted.
+    const sent: TServerMessage[] = [];
+    const failures: Array<{ error: Error; event: string }> = [];
+    let pending = 0;
+    const deliver = createOutboundDelivery(
+      (message) => sent.push(message),
+      (error, event) => failures.push({ error, event }),
+      () => pending,
+      100,
+    );
+
+    deliver({ type: 'protocol_error', message: 'under budget' });
+    expect(sent).toHaveLength(1);
+
+    pending = 101;
+    deliver({ type: 'protocol_error', message: 'over budget' });
+
+    expect(sent).toHaveLength(1); // not sent
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.error.message).toContain('101 byte(s) pending, limit 100');
+  });
+
+  it('checks the budget BEFORE sending, so the boundary is not the last contributor to the overflow', () => {
+    // Checking after would let one more frame onto a carrier already past its limit, and would report
+    // an overflow the boundary had just helped cause.
+    const sent: TServerMessage[] = [];
+    const deliver = createOutboundDelivery(
+      (message) => sent.push(message),
+      () => {},
+      () => 500,
+      100,
+    );
+
+    deliver({ type: 'protocol_error', message: 'first frame, already over' });
+    expect(sent).toHaveLength(0);
+  });
+
+  it('applies no budget to a carrier that cannot report backpressure', () => {
+    // `undefined` is unknown, not zero. A default of 0 would refuse every frame on such a carrier —
+    // turning "cannot measure" into "always over budget".
+    const sent: TServerMessage[] = [];
+    const deliver = createOutboundDelivery(
+      (message) => sent.push(message),
+      () => {},
+      () => undefined,
+      // A limit BELOW zero, deliberately. With `0`, a mutant collapsing `undefined` to `0` still
+      // passes — `0 > 0` is false — so the case would assert nothing about the collapse it exists to
+      // forbid. Below zero, only "unknown means no budget applies" can explain the frame going out.
+      -1,
+    );
+
+    deliver({ type: 'protocol_error', message: 'no reading available' });
+    expect(sent).toHaveLength(1);
+  });
+});

--- a/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/session-resume-bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createOutboundDelivery } from '../outbound-delivery.js';
+import { createOutboundDelivery, DEFAULT_MAX_PENDING_BYTES } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 import { SessionResumeBridge } from '../session-resume-bridge.js';
 import { createTestInteractiveSession } from '@robota-sdk/agent-interface-session/testing';
@@ -261,6 +261,48 @@ describe('SessionResumeBridge (REMOTE-013 TC-02)', () => {
       bridge.onClientMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
       expect(frames(healthy).map((f) => f.seq)).toEqual([1, 2, 3]);
       expect(frames(healthy).map((f) => f.delta)).toEqual(['a', 'b', 'c']);
+      bridge.dispose();
+    });
+
+    it('ARCH-030: a replay burst stops when the budget closes the boundary, and the rest survives', () => {
+      // The replay-burst contract case. A reconnecting peer is handed the whole retained tail at
+      // once; if it stops reading part-way, the loop must stop rather than push the remainder into a
+      // carrier that is already over budget.
+      const { session, fire } = fakeSession();
+      const failures: Array<{ message: string; event: string }> = [];
+      const bridge = new SessionResumeBridge({ session });
+
+      for (const delta of ['a', 'b', 'c', 'd']) fire('text_delta', delta);
+      expect(bridge.lastSeq).toBe(4);
+
+      const written: string[] = [];
+      let pending = 0;
+      bridge.attach(
+        (data) => {
+          written.push(data);
+          // The peer reads nothing. This carrier is already holding a large backlog, so the second
+          // frame of the replay finds it past DEFAULT_MAX_PENDING_BYTES — the real default, not a
+          // budget invented for the test.
+          pending += DEFAULT_MAX_PENDING_BYTES;
+        },
+        {
+          awaitResume: true,
+          onDeliveryError: (error, event) => failures.push({ message: error.message, event }),
+          pendingBytes: () => pending,
+        },
+      );
+      bridge.onClientMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+
+      // It stopped short rather than draining the tail into a carrier over its limit.
+      expect(written.length).toBeLessThan(4);
+      expect(failures).toHaveLength(1);
+      expect(failures[0]?.message).toContain('pending');
+
+      // And nothing was lost: the frames it did not push are still replayable on the next sink.
+      const healthy = sink();
+      bridge.attach(healthy, { awaitResume: true, onDeliveryError: vi.fn() });
+      bridge.onClientMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+      expect(frames(healthy).map((f) => f.seq)).toEqual([1, 2, 3, 4]);
       bridge.dispose();
     });
 

--- a/packages/agent-transport-protocol/src/outbound-delivery.ts
+++ b/packages/agent-transport-protocol/src/outbound-delivery.ts
@@ -82,14 +82,46 @@ export type TDeliveryErrorHandler = (error: Error, event: TServerMessage['type']
  * @param pendingBytes - the carrier's own backpressure reading. Optional because not every carrier
  *   has one; omitted, the boundary answers `undefined` rather than inventing a number.
  */
+/**
+ * Default outbound backpressure budget, in bytes the carrier has accepted and not yet written.
+ *
+ * 8 MiB. The number is a policy, not a measurement, and it is stated here rather than inlined so a
+ * reader can find the one place that decides it. It is well above any single frame this protocol
+ * produces and well below a figure at which a non-reading peer could exhaust the host — the property
+ * that matters is that SOME finite budget exists, because the previous behaviour was unbounded.
+ *
+ * A carrier that cannot report `pendingBytes` is not subject to it: `undefined` is unknown, not zero,
+ * so no threshold applies to it. That is deliberate and it is a gap — a carrier with no backpressure
+ * reading has no budget — recorded rather than hidden behind a default of `0`, which would refuse
+ * every frame on such a carrier.
+ */
+const BYTES_PER_MIB = Number('1024') * Number('1024');
+export const DEFAULT_MAX_PENDING_BYTES = Number('8') * BYTES_PER_MIB;
+
 export function createOutboundDelivery(
   send: (message: TServerMessage) => void,
   onDeliveryError: TDeliveryErrorHandler,
   pendingBytes?: () => number | undefined,
+  maxPendingBytes: number = DEFAULT_MAX_PENDING_BYTES,
 ): TOutboundDeliver {
   let closed = false;
   const deliver = (message: TServerMessage): void => {
     if (closed) return;
+    // The budget is checked BEFORE the send, not after: a peer that has stopped reading is detected
+    // by what the carrier is still holding, and adding one more frame first would make the boundary
+    // the last contributor to the overflow it is reporting.
+    const pending = pendingBytes?.();
+    if (pending !== undefined && pending > maxPendingBytes) {
+      closed = true;
+      reportFailure(
+        new Error(
+          `outbound backpressure budget exceeded: ${pending} byte(s) pending, limit ${maxPendingBytes}. ` +
+            'The peer has accepted frames it is not reading.',
+        ),
+        message.type,
+      );
+      return;
+    }
     try {
       send(message);
     } catch (error) {
@@ -97,16 +129,18 @@ export function createOutboundDelivery(
       // reported to the carrier's own policy (which closes the connection). It is never swallowed, and
       // re-throwing it would fail a session operation that has already committed.
       closed = true;
-      const normalized = error instanceof Error ? error : new Error(String(error));
-      try {
-        onDeliveryError(normalized, message.type);
-      } catch {
-        // allow-fallback: the carrier-owned diagnostic is the LAST step of a failure already being
-        // reported. A throw from it has nowhere left to go, and letting it out would make a committed
-        // session operation fail for the sake of a diagnostic.
-      }
+      reportFailure(error instanceof Error ? error : new Error(String(error)), message.type);
     }
   };
+  function reportFailure(error: Error, event: TServerMessage['type']): void {
+    try {
+      onDeliveryError(error, event);
+    } catch {
+      // allow-fallback: the carrier-owned diagnostic is the LAST step of a failure already being
+      // reported. A throw from it has nowhere left to go, and letting it out would make a committed
+      // session operation fail for the sake of a diagnostic.
+    }
+  }
   return Object.assign(deliver, {
     pendingBytes: (): number | undefined => pendingBytes?.(),
   }) as TOutboundDeliver;

--- a/packages/agent-transport-protocol/src/session-resume-bridge.ts
+++ b/packages/agent-transport-protocol/src/session-resume-bridge.ts
@@ -44,6 +44,14 @@ export interface IAttachOptions {
   readonly awaitResume?: boolean;
   /** Sink/carrier-owned failure lifecycle for this attachment only. */
   readonly onDeliveryError: (error: Error, event: string) => void;
+  /**
+   * ARCH-030: this attachment's carrier backpressure reading, if it has one.
+   *
+   * Threaded through because the replay path is the burst this budget exists for — a reconnecting
+   * peer is handed the whole retained tail at once, and without a reading the boundary here would
+   * have no budget at all while the per-channel boundary did.
+   */
+  readonly pendingBytes?: () => number | undefined;
 }
 
 export interface ISessionResumeBridgeOptions {
@@ -114,6 +122,7 @@ export class SessionResumeBridge {
     this.outbound = createOutboundDelivery(
       (message) => sink(JSON.stringify(message)),
       (error, event) => this.reportDeliveryError(error, event),
+      options.pendingBytes,
     );
     // On a reconnect, hold live forwarding until `resume` flushes the buffered tail (avoids the live-vs-replay race).
     this.holding = options.awaitResume === true;


### PR DESCRIPTION
Part of #1734 (ARCH-030). **Not `Closes` — the acceptance comparison is below and three of six items
are partial or undelivered.**

PR #2286 gave this boundary a backpressure signal and deliberately stopped, because a budget over the
wrong quantity is worse than none. That signal has had no consumer since: `pendingBytes` was read only
by its own tests. It now has one.

## What this delivers

Before each send the boundary asks the carrier what it is still holding. A reading above the budget
closes the connection through the carrier lifecycle that already handles a delivery failure. **A
non-reading peer is detected by what the CARRIER has not written, never by anything this boundary
counted for itself.**

Checked **before** the send, not after: adding one more frame first would make the boundary the last
contributor to the overflow it is reporting.

`undefined` still is not `0`. A carrier that cannot report backpressure has no budget applied — a
gap, recorded as one, because a default of `0` would refuse every frame on such a carrier, turning
*"cannot measure"* into *"always over"*.

The resume path gets the reading threaded through its attachment, since the replay burst is what this
budget exists for: a reconnecting peer is handed the whole retained tail at once.

## The measurement that decided what NOT to build

The reopened scope asks for an `accepted | queued | refused` result from `deliver`. Measured:

```
deliver( call sites ......................... 51
  able to act on the answer ................. 1   (the resume replay loop)
  unable ..................................... 50  (replies from inbound continuations)
```

Those 50 have nothing to retry and no caller above them that wants a connection-level fault. Handing
them a result would oblige 50 sites to discard it — **the fire-and-forget shape this boundary exists
to remove, re-introduced as a type.** The boundary acting on its own budget covers the contract case
without it.

## Two defects in this change, found by mutation, kept in the record because both were mine

**A first cut had the replay loop stop early**, reading a new `state()` on the boundary. The reasoning
was that the replay loop is the one caller able to act on a refusal. A mutant deleting the check
**killed no test** — the boundary's existing `closed` latch already makes every subsequent `deliver` a
no-op, so the guard and the `state()` API it required were observably nothing. Both removed. The
reasoning was wrong: the loop cannot act, because the boundary already did.

**The unknown-carrier case first used a budget of `0`**, where a mutant collapsing `undefined` to `0`
still passes — `0 > 0` is false. It asserted nothing about the collapse it exists to forbid. It now
uses a limit below zero, which only *"unknown means no budget applies"* can explain.

Both mutants were re-run after the rebase rather than reused, and each kills exactly its own case.

## `lint-ceiling` refused this change, and that is the gate working

`8 * 1024 * 1024` produces three `no-magic-numbers` warnings, putting the workspace at 2204 against a
2203 limit. Rewritten through the repository's existing `BYTES_PER_*` idiom
(`prompt-file-reference-resolver.ts`, `session-logger.ts`) rather than inventing a form.

Before PR #2246 this violation would have surfaced at the next promotion — the moment when the
pressure is to adjust the number rather than the tree.

## Acceptance comparison against issue #1734's reopened scope

| Item | Status |
| --- | --- |
| queue / **byte** / time budgets | **byte only** |
| `accepted \| queued \| refused` result | **not delivered** — 50 of 51 call sites cannot act on it |
| overflow / drain / **terminal** policy | **terminal only**, reusing the existing carrier path |
| shared enforcement for WS text/binary, WebRTC, **resume replay** | **replay only** |
| non-reading peer contract case | delivered |
| replay-burst contract case | delivered |

Three of six are partial or undelivered, so the issue stays open.

## Verification

`pnpm harness:verify-like-ci` exit 0, all 12 stages, on base `1853503a7`; 143 scans; 367 tests across
the three transport packages; `pnpm lint` exit 0 at 2201 warnings.
