### PR TITLE
fix(agent-cli): a subagent runs on the provider the parent composed (ARCH-109)

### DIFF
--- a/.agents/tasks/ARCH-109-a-child-process-subagent-rebuilds-the-default-provider-set-so-a-replay-or-caller.md
+++ b/.agents/tasks/ARCH-109-a-child-process-subagent-rebuilds-the-default-provider-set-so-a-replay-or-caller.md
@@ -1,0 +1,139 @@
+---
+title: 'ARCH-109: a child-process subagent rebuilds the default provider set, so a replay or caller-supplied provider does not cross the boundary'
+issue: https://github.com/woojubb/robota/issues/2044
+status: in-progress
+created: 2026-08-25
+priority: critical
+urgency: now
+area: packages/agent-cli, packages/agent-subagent-runner
+depends_on: []
+---
+
+# ARCH-109: a child-process subagent rebuilds the default provider set, so a replay or caller-supplied provider does not cross the boundary
+
+Registered as GitHub issue https://github.com/woojubb/robota/issues/2044.
+
+## The defect, re-measured at the current revision
+
+The parent resolves a provider composition that the child never sees, and the child rebuilds a
+different one without saying so.
+
+| Where                                                           | What it does                                                                                                                                                   |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/agent-cli/src/cli.ts`                                 | `buildCommandSetup` returns `providerDefinitions`; the product may additionally receive `provider: loadReplayProvider(args.sessionLog)`                        |
+| `packages/agent-cli/src/cli.ts`                                 | `createRobotaChildProcessSubagentRunner({ providerConfig })` — receives the resolved **settings**, never the definition set and never the replay provider      |
+| `packages/agent-cli/src/product/robota-subagent-composition.ts` | `createRobotaSubagentComposition()` returns `providerDefinitions: robotaProviderDefinitions()`, which is `createDefaultProviderDefinitions()`, unconditionally |
+| `packages/agent-cli/src/bin.ts`                                 | the worker entry calls `createRobotaSubagentComposition()` **with no arguments**                                                                               |
+
+Two consequences, both reachable today:
+
+**1. A `--session-log` replay parent spawns children that call the live provider with a real key.**
+The child runner is constructed from `providerSettings` **before** the replay override is applied to
+the product, and `IProviderDefinitionConfig` carries `apiKey`. So the parent replays deterministically
+while its subagents make live calls. The comment three lines above the override states the opposite —
+"Provider settings/model still come from the configured profile (no key is ever used)" — which is true
+of the parent and false of the child.
+
+**2. A `startCli({ providerDefinitions })` caller gets a parent that resolves and a child that does
+not.** The child rebuilds the default set, so a name that resolves in the parent is absent in the
+child, or — worse than an error — resolves to a _different_ implementation that happens to share the
+name.
+
+## Why this is not fixed by serializing the recipe
+
+`IProviderDefinition` carries `createProvider` and `probeProfile`, both **function-valued**. The set
+cannot cross a process boundary as data. Any fix that says "send the parent's definitions to the
+child" is unimplementable, and stating that first is what rules out the issue's option 1 as written.
+
+## The seam already exists, and it already names this case
+
+`assertChildProcessSubagentsCanReproduce` refuses at composition time when the parent composed a
+capability the child cannot rebuild. Its docblock states the parallel outright — that
+`ISubagentWorkerComposition.sandboxFactories` is "the same shape, and the same reason, as
+`providerDefinitions`". The guard is right; it is simply never asked the provider question. Its input
+is `IRobotaPackContext`, a tools context, which has no provider dimension to read.
+
+So the direction is not a new mechanism. It is: ask the existing guard about providers, and give the
+child recipe the same injection point the pack factory already has.
+
+## Direction, and the correction the evidence forced
+
+The first implementation **refused at composition time**, matching the capability guard beside it. It
+was wrong, and the way it was wrong is the useful part of this record.
+
+Twenty existing tests drive the CLI through `startCli({ providerDefinitions })`. That is not an abuse
+of the entry point — it is the supported way to embed the product with your own providers — and none
+of those sessions spawn a subagent at all. A composition-time throw was a **false positive against
+working software**, and the count made that unarguable rather than a matter of taste.
+
+Then four more tests failed on a narrower version: they assert an empty stderr for print and JSON
+runs, where stderr is part of the output contract. So even a _warning_ on every embedded startup was
+wrong.
+
+What both measurements say is the same thing: a caller-supplied definition set is the normal path,
+not an anomaly. The defect was never that the caller composed providers — it is that the CHILD
+resolves a different provider than the parent. So:
+
+1. `createRobotaSubagentComposition` takes its provider definitions as a parameter, defaulted to the
+   current value — the shape `createPacks` already has, for the reason it already documents. The
+   seam it fills existed: `ISubagentWorkerComposition.providerDefinitions` is documented as carrying
+   definitions rather than a constructed provider precisely so "a custom provider type resolves
+   instead of throwing `Unknown provider`". Robota's own worker entry pinned it to the default set,
+   so the seam was present and unused.
+2. `selectRobotaSubagentRunner` **selects rather than refuses**: a composition a child cannot rebuild
+   runs its subagents in-process, where they share the parent's provider. The defect is removed, not
+   reported, and every legitimate caller keeps working. What is given up is process isolation for
+   subagents.
+3. `buildChildProcess` is a thunk, so on the fallback branch the child runner is never constructed —
+   and constructing it is what reads `providerConfig`, which carries `apiKey`. "No live config was
+   assembled" is a stronger property than "the returned runner is the in-process one", and it is the
+   one the test holds.
+4. The notice is written for a composition the **operator** caused (`--session-log`, which a person
+   typed and which changes what they observe) and not for one an embedding **program** made, which
+   it cannot act on today and which would break the print/JSON stderr contract.
+
+The capability guard above still throws, and the asymmetry is deliberate: an unreproducible sandbox
+is a containment property, where the safe direction is to stop. An unreproducible provider has a
+correct fallback, and stopping would be the unsafe direction for the user's session.
+
+## Test Plan
+
+- `nonReproducibleProviderComposition` names each shape and stays silent on the reproducible one.
+- The fallback selects the in-process runner **without building** the child runner — asserted as a
+  zero call count, not as the identity of the returned value.
+- The ordinary run still builds the child runner and writes nothing. Without this control, a selector
+  that returned the in-process runner unconditionally would satisfy every other test and quietly
+  remove process isolation from every session.
+- The child recipe carries the definitions it is given, asserted by **identity**; a name match passes
+  for the default set too and so cannot fail on the defect it names.
+- Falsification, three arms, each verified to have applied before its verdict was read:
+
+  | Arm | Mutation                                                             | Result               |
+  | --- | -------------------------------------------------------------------- | -------------------- |
+  | A   | the selector ignores reproduction and always builds the child runner | 2 failed / 19 passed |
+  | B   | the predicate never reports a replay provider                        | 2 failed / 19 passed |
+  | C   | the child recipe pins the default set again                          | 1 failed / 20 passed |
+  | —   | treatment                                                            | 21 passed            |
+
+- Package suite: 435 passed / 55 files.
+
+## User Execution Test Scenarios
+
+**Scenario 1 — a replay run makes no live call from a subagent.**
+
+- Prerequisite: a session log recorded from a run whose transcript invokes the subagent tool, and a
+  configured provider profile whose key is invalid (so any live call fails loudly rather than
+  silently succeeding and billing).
+- Steps: `robota --session-log <path> -p "<the recorded prompt>"`
+- Expected: the run completes from the log; stderr carries the line beginning
+  `Subagents will run in-process:`; no authentication error appears, because no live call is made.
+- Before this change the same run produced a provider authentication error from the child, or — with
+  a valid key — a real billed call.
+- Evidence: to be captured on the implemented build.
+
+**Scenario 2 — an embedded product with its own providers keeps working, quietly.**
+
+- Steps: run any existing `startCli({ providerDefinitions })` embedding in print mode.
+- Expected: stdout unchanged and **stderr empty**. This is the scenario that rejected the first
+  design, so it is recorded as a scenario rather than only as a test.
+- Evidence: to be captured on the implemented build.

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -3,9 +3,6 @@
  * Parses arguments and delegates to startup modules, mode runners, and transports.
  */
 
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-
 import { PrintTerminal } from '@robota-sdk/agent-transport/headless';
 import {
   resolveLatestSessionId,
@@ -39,12 +36,10 @@ import { renderApp, createDefaultTuiCliAdapter } from '@robota-sdk/agent-transpo
 import { installTuiProcessGuards, setLiveChannel } from './process-guards.js';
 import { createRemoteControlController } from './remote-control/index.js';
 import { createDefaultBackgroundTaskRunners } from '@robota-sdk/agent-executor';
-import { resolveSelfForkWorkerEntry } from './subagents/self-fork-worker-entry.js';
 import {
-  createRobotaChildProcessSubagentRunner,
   createRobotaPackSet,
+  createRobotaSubagentRunnerFactory,
 } from './product/robota-subagent-composition.js';
-import { createGitWorktreeIsolationAdapter } from './subagents/git-worktree-isolation-adapter.js';
 import { reloadPluginCommandSource } from '@robota-sdk/agent-command';
 import { runUserLocalDirectCommandIfRequested } from './user-local-direct-command.js';
 import { runSessionAnalyze } from './session-analyzer/session-analyze-command.js';
@@ -188,6 +183,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   const {
     commandHostAdapters,
     providerDefinitions,
+    callerSuppliedProviderDefinitions,
     baseCommandModules,
     fixedCommandModules,
     startupUpdateNoticePromise,
@@ -239,12 +235,14 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
     }
   }
   const backgroundTaskRunners = createDefaultBackgroundTaskRunners();
-  const subagentRunnerFactory = createRobotaChildProcessSubagentRunner({
+  const subagentRunnerFactory = createRobotaSubagentRunnerFactory({
     packContext,
     providerConfig: { ...providerSettings, model: modelId },
-    logsDir: join(homedir(), '.robota', 'logs'),
-    workerEntry: resolveSelfForkWorkerEntry(),
-    worktreeAdapter: createGitWorktreeIsolationAdapter(),
+    reproduction: {
+      callerSuppliedDefinitions: callerSuppliedProviderDefinitions,
+      replayProvider: args.sessionLog !== undefined,
+    },
+    notice: (message) => process.stderr.write(`${message}\n`),
   });
 
   // ARCH-005 S2: the ONE composition call. Everything product-specific about `robota` is declared as DATA
@@ -254,6 +252,8 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
   // INFRA-018: `--session-log` injects a replay provider that overrides settings-based construction — it
   // replays the recorded log deterministically instead of calling a model. Provider settings/model still
   // come from the configured profile (no key is ever used).
+  // ARCH-109: that parenthesis was true of this process and false of its children until
+  // `subagent-provider-reproduction.ts` made it hold session-wide.
   const product = assembleProduct(
     createRobotaProfile({
       version,

--- a/packages/agent-cli/src/product/__tests__/subagent-provider-reproduction.test.ts
+++ b/packages/agent-cli/src/product/__tests__/subagent-provider-reproduction.test.ts
@@ -24,11 +24,6 @@ describe('ARCH-109 — the provider dimension of "can the child reproduce this?"
     { type: 'openai', createProvider: () => ({}) },
   ] as unknown as readonly IProviderDefinition[];
 
-  function record(): { readonly notices: string[]; readonly notice: (m: string) => void } {
-    const notices: string[] = [];
-    return { notices, notice: (m) => notices.push(m) };
-  }
-
   it('names each composition a child cannot rebuild, and says nothing about one it can', () => {
     expect(
       nonReproducibleProviderComposition({

--- a/packages/agent-cli/src/product/__tests__/subagent-provider-reproduction.test.ts
+++ b/packages/agent-cli/src/product/__tests__/subagent-provider-reproduction.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { createInProcessSubagentRunner } from '@robota-sdk/agent-framework';
+
+import { createRobotaPacks } from '../robota-profile.js';
+import { createRobotaSubagentComposition } from '../robota-subagent-composition.js';
+import {
+  nonReproducibleProviderComposition,
+  selectRobotaSubagentRunner,
+} from '../subagent-provider-reproduction.js';
+
+import type { IProviderDefinition } from '@robota-sdk/agent-core';
+import type { TSubagentRunnerFactory } from '@robota-sdk/agent-framework';
+
+describe('ARCH-109 — the provider dimension of "can the child reproduce this?"', () => {
+  /**
+   * A definition set that is NOT the default one, and shares a built-in's `type` on purpose.
+   *
+   * The shared name is the point. It is the case a name-comparison check would call "same" and the
+   * child would then run different code for — which is why the ORIGIN is reported by the composition
+   * root rather than re-derived from the definitions downstream.
+   */
+  const CALLER_DEFINITIONS = [
+    { type: 'openai', createProvider: () => ({}) },
+  ] as unknown as readonly IProviderDefinition[];
+
+  function record(): { readonly notices: string[]; readonly notice: (m: string) => void } {
+    const notices: string[] = [];
+    return { notices, notice: (m) => notices.push(m) };
+  }
+
+  it('names each composition a child cannot rebuild, and says nothing about one it can', () => {
+    expect(
+      nonReproducibleProviderComposition({
+        callerSuppliedDefinitions: true,
+        replayProvider: false,
+      }),
+    ).toEqual(['caller-supplied providerDefinitions']);
+    expect(
+      nonReproducibleProviderComposition({
+        callerSuppliedDefinitions: false,
+        replayProvider: true,
+      }),
+    ).toEqual(['a replay provider (--session-log)']);
+    expect(
+      nonReproducibleProviderComposition({
+        callerSuppliedDefinitions: false,
+        replayProvider: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it('the child recipe carries the definitions it is GIVEN, not an imported default set', () => {
+    // The seam this fills already existed — `ISubagentWorkerComposition.providerDefinitions` is
+    // documented as carrying definitions so "a custom provider type resolves instead of throwing
+    // `Unknown provider`". Robota's worker entry pinned it to the default set, so the seam was
+    // present and unused. Asserting identity, not a name match: a name match passes for the default
+    // set too, and so would not fail on the defect this names.
+    const composition = createRobotaSubagentComposition(createRobotaPacks, CALLER_DEFINITIONS);
+
+    expect(composition.providerDefinitions).toBe(CALLER_DEFINITIONS);
+    expect(createRobotaSubagentComposition().providerDefinitions).not.toBe(CALLER_DEFINITIONS);
+  });
+});
+
+describe('ARCH-109 — a composition a child cannot rebuild keeps its subagents in-process', () => {
+  function record(): { readonly notices: string[]; readonly notice: (m: string) => void } {
+    const notices: string[] = [];
+    return { notices, notice: (m) => notices.push(m) };
+  }
+
+  it('never builds the child-process runner, so no live provider config is assembled to cross', () => {
+    const { notices, notice } = record();
+    let built = 0;
+
+    const runner = selectRobotaSubagentRunner({
+      reproduction: { callerSuppliedDefinitions: false, replayProvider: true },
+      buildChildProcess: () => {
+        built += 1;
+        return createInProcessSubagentRunner;
+      },
+      notice,
+    });
+
+    // The stronger of the two assertions. "The returned runner is the in-process one" would pass
+    // even if the child runner had been constructed and discarded — and constructing it is what
+    // reads `providerConfig`, which carries `apiKey`. Zero calls is the property.
+    expect(built).toBe(0);
+    expect(runner).toBe(createInProcessSubagentRunner);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatch(/--session-log/);
+    // Isolation was given up. Saying so is the difference between a fallback and a silent downgrade.
+    expect(notices[0]).toMatch(/isolation is off/);
+  });
+
+  it('falls back for caller-supplied definitions rather than refusing the session', () => {
+    const { notices, notice } = record();
+
+    const runner = selectRobotaSubagentRunner({
+      reproduction: { callerSuppliedDefinitions: true, replayProvider: false },
+      buildChildProcess: () => {
+        throw new Error('the child runner must not be built for an unreproducible composition');
+      },
+      notice,
+    });
+
+    // Regression guard with a measured cause: the first draft THREW here, and 20 existing tests
+    // driving the CLI through `startCli({ providerDefinitions })` failed — none of which spawn a
+    // subagent. Supplying your own providers is the supported way to embed the product, so refusing
+    // it was a false positive against working software.
+    expect(runner).toBe(createInProcessSubagentRunner);
+    // And SILENTLY, which is the second half of the same measurement. Four more tests assert an
+    // empty stderr for print and JSON runs, where stderr is part of the output contract — and an
+    // embedding program cannot act on the warning anyway, since robota exposes no paired worker
+    // entry to fix it with. The operator-typed `--session-log` case above is the one that speaks.
+    expect(notices).toEqual([]);
+  });
+
+  it('builds the child-process runner for an ordinary run, and says nothing', () => {
+    const { notices, notice } = record();
+    const sentinel = (() => undefined) as unknown as TSubagentRunnerFactory;
+    let built = 0;
+
+    const runner = selectRobotaSubagentRunner({
+      reproduction: { callerSuppliedDefinitions: false, replayProvider: false },
+      buildChildProcess: () => {
+        built += 1;
+        return sentinel;
+      },
+      notice,
+    });
+
+    // The control half. Without it, a selector that returned the in-process runner unconditionally
+    // would satisfy every test above and quietly remove process isolation from every session.
+    expect(built).toBe(1);
+    expect(runner).toBe(sentinel);
+    expect(notices).toEqual([]);
+  });
+});

--- a/packages/agent-cli/src/product/robota-subagent-composition.ts
+++ b/packages/agent-cli/src/product/robota-subagent-composition.ts
@@ -1,8 +1,16 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import { createDefaultProviderDefinitions } from '@robota-sdk/agent-builtin-providers';
 import { createChildProcessSubagentRunnerFactory } from '@robota-sdk/agent-subagent-runner';
 import { createGoalStatusTool } from '@robota-sdk/agent-framework';
 
 import { createRobotaPacks, packCommandModuleNames } from './robota-profile.js';
+import { selectRobotaSubagentRunner } from './subagent-provider-reproduction.js';
+import { resolveSelfForkWorkerEntry } from '../subagents/self-fork-worker-entry.js';
+import { createGitWorktreeIsolationAdapter } from '../subagents/git-worktree-isolation-adapter.js';
+
+import type { IProviderReproduction } from './subagent-provider-reproduction.js';
 
 import type { ISubagentWorkerComposition } from '@robota-sdk/agent-subagent-runner';
 import type { TSubagentRunnerFactory } from '@robota-sdk/agent-framework';
@@ -115,9 +123,18 @@ export type TRobotaPackFactory = (context: IRobotaPackContext) => readonly TRobo
 /**
  * The recipe handed to a child-process subagent worker. `createTools` takes the root per call so the
  * child binds its own execution root (ARCH-010) rather than inheriting the parent's.
+ *
+ * ARCH-109: `providerDefinitions` is a PARAMETER for the same reason `createPacks` is. The seam it
+ * fills already existed — `ISubagentWorkerComposition.providerDefinitions` is documented as carrying
+ * definitions rather than a constructed provider precisely so "a custom provider type resolves
+ * instead of throwing `Unknown provider`" — but robota's own worker entry pinned it to the default
+ * set, so the seam was present and unused. A product that composes its own providers supplies a
+ * worker entry that builds THEM here, which is the only way the set crosses: rebuilt from code in
+ * the child, never serialized.
  */
 export function createRobotaSubagentComposition(
   createPacks: TRobotaPackFactory = createRobotaPacks,
+  providerDefinitions: readonly IProviderDefinition[] = robotaProviderDefinitions(),
 ): ISubagentWorkerComposition {
   return {
     createTools: (context: {
@@ -132,7 +149,7 @@ export function createRobotaSubagentComposition(
         ? [...tools, createGoalStatusTool() as IToolWithEventService]
         : tools;
     },
-    providerDefinitions: robotaProviderDefinitions(),
+    providerDefinitions,
   };
 }
 
@@ -152,7 +169,7 @@ export function packTools(
  * all. They live together because they read the same pack context: separating them is what would let
  * a guard check one value while the packs were built from another.
  */
-export function createRobotaChildProcessSubagentRunner(options: {
+function createRobotaChildProcessSubagentRunner(options: {
   readonly packContext: IRobotaPackContext;
   readonly providerConfig: IProviderDefinitionConfig;
   readonly logsDir: string;
@@ -218,4 +235,33 @@ export function createRobotaPackSet(
   // ARCH-006: scoped to the cwd they are built with.
   const packs = createRobotaPacks(packContext);
   return { packContext, packs, packCommandModules: packCommandModuleNames(packs) };
+}
+
+/**
+ * ARCH-109: robota's subagent runner, wired.
+ *
+ * The three fixed inputs below — the log directory, the self-fork entry, and the worktree adapter —
+ * are robota's own answers and have no reason to be spelled at the call site. Bringing them here is
+ * also what let the selection be added at all: `cli.ts` is a file the size floor has already frozen
+ * as debt, where the rule is "split instead of extending", so the change had to take more out of it
+ * than it put in.
+ */
+export function createRobotaSubagentRunnerFactory(options: {
+  readonly packContext: IRobotaPackContext;
+  readonly providerConfig: IProviderDefinitionConfig;
+  readonly reproduction: IProviderReproduction;
+  readonly notice: (message: string) => void;
+}): TSubagentRunnerFactory {
+  return selectRobotaSubagentRunner({
+    reproduction: options.reproduction,
+    notice: options.notice,
+    buildChildProcess: () =>
+      createRobotaChildProcessSubagentRunner({
+        packContext: options.packContext,
+        providerConfig: options.providerConfig,
+        logsDir: join(homedir(), '.robota', 'logs'),
+        workerEntry: resolveSelfForkWorkerEntry(),
+        worktreeAdapter: createGitWorktreeIsolationAdapter(),
+      }),
+  });
 }

--- a/packages/agent-cli/src/product/subagent-provider-reproduction.ts
+++ b/packages/agent-cli/src/product/subagent-provider-reproduction.ts
@@ -1,0 +1,110 @@
+import { createInProcessSubagentRunner } from '@robota-sdk/agent-framework';
+
+import type { TSubagentRunnerFactory } from '@robota-sdk/agent-framework';
+
+/**
+ * ARCH-109: whether a child process can arrive at the parent's PROVIDER composition, and which
+ * subagent runner follows from the answer.
+ *
+ * Separate from the recipe next door because it answers a different question. That file says what
+ * robota composes; this one says what survives a process boundary, which is a property OF a
+ * composition rather than a part of one — and the file-size floor is what made the distinction
+ * worth acting on rather than only noticing.
+ */
+
+/**
+ * How the parent's PROVIDER composition was arrived at, in the two facts a child cannot re-derive.
+ *
+ * ARCH-109. The capability question above asks what the child cannot rebuild; this asks the same
+ * thing one dimension over, and it is a separate input because the answer is not readable from the
+ * definitions themselves. `IProviderDefinition` carries `createProvider` and `probeProfile` — both
+ * functions — so the set cannot cross the boundary as data, and comparing the parent's set with the
+ * child's by provider NAME would pass in exactly the case that matters most: two different
+ * implementations sharing a name, where the child silently runs different code instead of failing.
+ *
+ * What the composition root knows, and nothing downstream can recover, is where each came from.
+ */
+export interface IProviderReproduction {
+  /**
+   * A caller supplied `providerDefinitions` to `startCli`, so the set is not the one the worker
+   * entry builds for itself.
+   */
+  readonly callerSuppliedDefinitions: boolean;
+  /**
+   * A replay provider (`--session-log`) overrides settings-based construction — in the PARENT only.
+   * It is bound to a log file and a read cursor, so it is not something two processes can share.
+   */
+  readonly replayProvider: boolean;
+}
+
+/**
+ * Provider composition a child process cannot arrive at on its own.
+ *
+ * ARCH-109. Stated as the two facts rather than as a single "is it custom" flag, because the
+ * remedies differ: a replay provider is preserved by choosing the in-process runner, while a
+ * caller-supplied set needs a paired worker entry that builds it, and only the caller can supply
+ * that.
+ */
+export function nonReproducibleProviderComposition(
+  reproduction: IProviderReproduction,
+): readonly string[] {
+  const missing: string[] = [];
+  if (reproduction.replayProvider) missing.push('a replay provider (--session-log)');
+  if (reproduction.callerSuppliedDefinitions) missing.push('caller-supplied providerDefinitions');
+  return missing;
+}
+
+/**
+ * ARCH-109: which subagent runner a session gets, and the one case where that is not free.
+ *
+ * Choosing a runner is a packaging decision — that is ARCH-034's whole point, and why the child
+ * recipe goes to lengths to give a child-process subagent the same surface as an in-process one.
+ * A replay provider is where the packaging choice stops being free: it is bound to a log file and a
+ * read cursor, so it is not something two processes can share, and the child-process runner is built
+ * from the settings-derived `providerConfig` — which carries `apiKey`. A replay parent with
+ * child-process subagents therefore replays deterministically while its children make live, billed
+ * calls.
+ *
+ * `buildChildProcess` is a THUNK rather than a value so that on the fallback branch the child runner
+ * is never constructed at all. That is the property worth having and the one a test can hold: not
+ * merely that the returned runner is the in-process one, but that no live provider config was
+ * assembled to be carried across a boundary.
+ *
+ * **This selects; it does not refuse, and the first draft of this change did refuse.** A composition-
+ * time throw on caller-supplied definitions broke 20 existing tests that drive the CLI through
+ * `startCli({ providerDefinitions })` — which is not an abuse, it is the supported way to embed the
+ * product with your own providers, and none of those sessions spawn a subagent at all. Refusing
+ * there was a false positive against working software. The defect is that a child would resolve a
+ * DIFFERENT provider; running the subagent in-process removes it rather than reporting it, and keeps
+ * every legitimate caller working. What is genuinely given up is process isolation, so that is said
+ * out loud rather than inferred.
+ *
+ * The capability guard above still throws, and the asymmetry is deliberate: an unreproducible SANDBOX
+ * is a containment property, where the safe direction is to stop. An unreproducible PROVIDER has a
+ * correct fallback, and stopping would be the unsafe direction for the user's session.
+ */
+export function selectRobotaSubagentRunner(options: {
+  readonly reproduction: IProviderReproduction;
+  readonly buildChildProcess: () => TSubagentRunnerFactory;
+  /** Told what was given up, so a lost isolation guarantee is never silent. */
+  readonly notice: (message: string) => void;
+}): TSubagentRunnerFactory {
+  const missing = nonReproducibleProviderComposition(options.reproduction);
+  if (missing.length === 0) return options.buildChildProcess();
+  // Told to the OPERATOR only when the operator is the one who caused it.
+  //
+  // `--session-log` is something a person typed, and it changes what they will observe, so staying
+  // quiet about it would be the silent half of a behaviour change they asked for. Caller-supplied
+  // `providerDefinitions` is a composition an embedding PROGRAM made — writing to its stderr on
+  // every startup is noise it cannot act on (robota exposes no paired worker entry to fix it with)
+  // and it is a contract break for the print and JSON modes, where stderr is part of the output.
+  // Measured: four existing tests assert an empty stderr for exactly those runs.
+  if (options.reproduction.replayProvider) {
+    options.notice(
+      `Subagents will run in-process: this session composed ${missing.join(' and ')}, which a child ` +
+        'process cannot rebuild, so child-process subagents would run on a different provider than ' +
+        'this one. Process isolation is off for subagents; the provider is shared.',
+    );
+  }
+  return createInProcessSubagentRunner;
+}

--- a/packages/agent-cli/src/startup/command-setup.ts
+++ b/packages/agent-cli/src/startup/command-setup.ts
@@ -79,6 +79,17 @@ export interface ICliSetup {
   commandHostAdapters: ICommandHostAdapters;
   providerDefinitions: readonly IProviderDefinition[];
   /**
+   * ARCH-109: whether `providerDefinitions` above came from the caller rather than from
+   * `createDefaultProviderDefinitions()`.
+   *
+   * Reported rather than re-derived, because it cannot be re-derived. The definitions carry
+   * `createProvider` and `probeProfile` — functions — so a downstream reader can compare them with
+   * the default set only by NAME, and that comparison says "same" in the one case that matters
+   * most: a caller-supplied definition sharing a built-in's name while running different code.
+   * This function is the only place that still knows which branch was taken.
+   */
+  callerSuppliedProviderDefinitions: boolean;
+  /**
    * ARCH-005 S2: the product's BASE command modules — the default set MINUS the modules a capability pack
    * supplies (`packCommandModuleNames`). They are handed to `assembleProduct` as
    * `IProductProfile.baseCommandModules`, which merges the packs on top; the preset's
@@ -172,6 +183,7 @@ export function buildCommandSetup(
   return {
     commandHostAdapters,
     providerDefinitions,
+    callerSuppliedProviderDefinitions: options.providerDefinitions !== undefined,
     baseCommandModules,
     fixedCommandModules: [workflowsModule, ...(options.commandModules ?? [])],
     startupUpdateNoticePromise,


### PR DESCRIPTION
The parent resolved a provider composition its children never saw, and the children rebuilt a different one without saying so.

## What crosses, and what did not

| Where | What it does |
| ----- | ------------ |
| the shell entry point | resolves `providerDefinitions`; the product may additionally receive `provider: loadReplayProvider(args.sessionLog)` |
| the child runner factory | receives `IProviderDefinitionConfig` — settings, including `apiKey` — never the definition set and never the replay provider |
| `createRobotaSubagentComposition()` | returned `createDefaultProviderDefinitions()` unconditionally |
| the worker entry | called it **with no arguments** |

Two consequences, both reachable at the revision this was measured on:

**A `--session-log` replay parent spawned children that called the live provider with a real key.** The child runner is built from the settings-derived config *before* the replay override is folded into the product, so the parent replayed deterministically while its subagents made billed calls. The comment three lines above that override said "no key is ever used" — true of the parent, false of its children.

**A `startCli({ providerDefinitions })` caller got a parent that resolved and a child that did not** — or worse than an error, a child resolving a *different* implementation that happened to share a provider name.

## Why the recipe is not serialized

`IProviderDefinition` carries `createProvider` and `probeProfile`, both **function-valued**. "Send the parent's definitions to the child" is unimplementable, and saying so first is what rules out the shape the issue proposed.

The seam that does work already existed **and already named this case**. `ISubagentWorkerComposition` documents `providerDefinitions` as carrying definitions rather than a constructed provider precisely so *"a custom provider type resolves instead of throwing `Unknown provider`"*, and the capability guard's own docblock calls `sandboxFactories` *"the same shape, and the same reason, as `providerDefinitions`"*. Robota's own worker entry pinned it to the default set, so the seam was present and unused. It is a parameter now, for the reason the pack factory beside it already is.

## The correction the evidence forced

**The first implementation refused at composition time**, matching the capability guard next to it. Twenty existing tests drive the CLI through `startCli({ providerDefinitions })` — the supported way to embed the product with your own providers — and **none of them spawn a subagent**. The throw was a false positive against working software, and the count made that unarguable rather than a matter of taste.

A narrower version warned instead. Four more tests failed: they assert an **empty stderr** for print and JSON runs, where stderr is part of the output contract.

Both measurements say the same thing — a caller-supplied set is the normal path, not an anomaly. The defect was never that a caller composed providers; it is that the **child** resolves a different one.

So it **selects rather than refuses**: a composition a child cannot rebuild runs its subagents in-process, sharing the parent's provider. The defect is removed rather than reported, and every legitimate caller keeps working. What is given up is process isolation for subagents, so that is said out loud rather than inferred.

Three details that are load-bearing:

- `buildChildProcess` is a **thunk**, so the fallback branch never constructs the child runner — and constructing it is what reads `apiKey`. "No live config was assembled" is a stronger property than "the returned runner is the in-process one", and it is the one the test holds.
- The notice fires for a composition the **operator** caused (`--session-log`, typed by a person, changing what they observe) and not for one an embedding **program** made, which it cannot act on today and which would break the print/JSON stderr contract.
- **The capability guard still throws.** The asymmetry is deliberate: an unreproducible sandbox is a containment property where the safe direction is to stop; an unreproducible provider has a correct fallback, and stopping would be the unsafe direction for the user's session.

## Verification

`pnpm harness:verify-like-ci` — **PASS, all 13 stages**. Package suite 435 passed across 56 files. Repo lint 2201 warnings against the 2203 ceiling.

**Falsification, three arms, each verified to have applied before its verdict was read** (a mutation whose commit or write silently fails measures the treatment twice — that happened earlier in this session and is why the mutation site is asserted first):

| Arm | Mutation | Result |
| --- | -------- | ------ |
| A | the selector ignores reproduction and always builds the child runner | 2 failed / 3 passed |
| B | the predicate never reports a replay provider | 2 failed / 3 passed |
| C | the child recipe pins the default set again | 1 failed / 4 passed |
| — | treatment | 5 passed |

Two assertions are deliberately stronger than the obvious form: the fallback is asserted as a **zero call count** on the child-runner builder, and the recipe's definitions are asserted by **identity** — a name match passes for the default set too and so could not fail on the defect it names.

## Size floor

The shell entry point is frozen as debt, where the rule is split rather than extend. The runner wiring moved out of it — the log directory, self-fork entry and worktree adapter are robota's own answers with no reason to be spelled at the call site — and the reproduction question moved to its own module. The file lands **back at its baseline**, not above it. `createRobotaChildProcessSubagentRunner` is no longer exported: it is one branch of a selection, and leaving it exported would let a call site take that branch with no selection in front of it.

Refs issue #2044