### PR TITLE
fix(transport): payload frames share the text protocol's budget (ARCH-030)

### DIFF
--- a/packages/agent-transport-protocol/docs/SPEC.md
+++ b/packages/agent-transport-protocol/docs/SPEC.md
@@ -176,6 +176,8 @@ once and the carriers stay dumb.
 | `createWsHandler`                       | function  |
 | `IWsHandlerOptions`                     | interface |
 | `createOutboundDelivery`                | function  | ARCH-030: the ONLY producer of a connection's outbound delivery boundary                   |
+| `isOverPendingBudget`                   | function  | ARCH-030: is a carrier holding more than the budget allows — `undefined` is never over     |
+| `DEFAULT_MAX_PENDING_BYTES`             | constant  | ARCH-030: the outbound backpressure budget, in carrier-pending bytes                       |
 | `TOutboundDeliver`                      | type      | ARCH-030: the branded boundary a carrier passes down as `IWsHandlerOptions.deliver`        |
 | `TDeliveryErrorHandler`                 | type      | ARCH-030: a carrier's failure policy — required, invoked at most once per boundary         |
 | `PROTOCOL_SESSION_EVENT_CLASSIFICATION` | constant  | Exhaustive protocol surface policy for every shared session-event key                      |

--- a/packages/agent-transport-protocol/src/index.ts
+++ b/packages/agent-transport-protocol/src/index.ts
@@ -1,7 +1,11 @@
 export { createWsHandler } from './ws-handler.js';
 export type { IWsHandlerOptions } from './ws-handler.js';
 // ARCH-030: the connection-scoped outbound delivery boundary every carrier builds and passes down.
-export { createOutboundDelivery } from './outbound-delivery.js';
+export {
+  createOutboundDelivery,
+  isOverPendingBudget,
+  DEFAULT_MAX_PENDING_BYTES,
+} from './outbound-delivery.js';
 export type { TDeliveryErrorHandler, TOutboundDeliver } from './outbound-delivery.js';
 export { PROTOCOL_SESSION_EVENT_CLASSIFICATION } from './ws-session-events.js';
 // `ISubscribeSessionEventsOptions` is NOT here (ARCH-030): it is the options bag of

--- a/packages/agent-transport-protocol/src/outbound-delivery.ts
+++ b/packages/agent-transport-protocol/src/outbound-delivery.ts
@@ -98,6 +98,24 @@ export type TDeliveryErrorHandler = (error: Error, event: TServerMessage['type']
 const BYTES_PER_MIB = Number('1024') * Number('1024');
 export const DEFAULT_MAX_PENDING_BYTES = Number('8') * BYTES_PER_MIB;
 
+/**
+ * Is this carrier holding more than the budget allows?
+ *
+ * Exported because a WebSocket carries TWO kinds of outbound frame over one socket — the text
+ * protocol and TRANS-001's payload channels — and only one of them goes through
+ * {@link createOutboundDelivery}. A budget the binary path re-implemented would be a second opinion
+ * about one socket's backpressure; a budget it skipped would leave the same non-reading peer
+ * unbounded on the other half of the connection.
+ *
+ * `undefined` is unknown, not zero: a carrier that cannot report backpressure is never over budget.
+ */
+export function isOverPendingBudget(
+  pending: number | undefined,
+  limit: number = DEFAULT_MAX_PENDING_BYTES,
+): boolean {
+  return pending !== undefined && pending > limit;
+}
+
 export function createOutboundDelivery(
   send: (message: TServerMessage) => void,
   onDeliveryError: TDeliveryErrorHandler,
@@ -111,7 +129,7 @@ export function createOutboundDelivery(
     // by what the carrier is still holding, and adding one more frame first would make the boundary
     // the last contributor to the overflow it is reporting.
     const pending = pendingBytes?.();
-    if (pending !== undefined && pending > maxPendingBytes) {
+    if (isOverPendingBudget(pending, maxPendingBytes)) {
       closed = true;
       reportFailure(
         new Error(

--- a/packages/agent-transport-ws/src/__tests__/outbound-delivery-carrier.test.ts
+++ b/packages/agent-transport-ws/src/__tests__/outbound-delivery-carrier.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { WebSocket } from 'ws';
 
 import { WsSessionDelivery } from '../ws-session-delivery.js';
+import { DEFAULT_MAX_PENDING_BYTES } from '@robota-sdk/agent-transport-protocol';
 
 import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
 
@@ -35,12 +36,19 @@ async function withUnhandledRejectionCapture(run: () => void | Promise<void>): P
   return captured;
 }
 
-/** A socket whose `readyState` the test controls, so "disconnected" is deterministic. */
-function createControllableSocket(): { socket: WebSocket; close: () => void } {
-  const state = { readyState: WebSocket.OPEN as number };
+/** A socket whose `readyState` and `bufferedAmount` the test controls, so both are deterministic. */
+function createControllableSocket(): {
+  socket: WebSocket;
+  close: () => void;
+  setBuffered: (bytes: number) => void;
+} {
+  const state = { readyState: WebSocket.OPEN as number, bufferedAmount: 0 };
   const socket = {
     get readyState(): number {
       return state.readyState;
+    },
+    get bufferedAmount(): number {
+      return state.bufferedAmount;
     },
     send: vi.fn(),
     close: vi.fn(() => {
@@ -51,6 +59,9 @@ function createControllableSocket(): { socket: WebSocket; close: () => void } {
     socket,
     close: () => {
       state.readyState = WebSocket.CLOSED;
+    },
+    setBuffered: (bytes: number) => {
+      state.bufferedAmount = bytes;
     },
   };
 }
@@ -112,5 +123,50 @@ describe('WsSessionDelivery + the outbound boundary (ARCH-030)', () => {
     delivery.deliver({ type: 'protocol_error', message: 'third' });
 
     expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ARCH-030: payload frames share the text protocol's budget", () => {
+  it('refuses a binary frame when the socket is over budget, and closes once', () => {
+    // Until this path existed, TRANS-001 payload frames went straight to `socket.send` — outside the
+    // boundary, with no budget. `bufferedAmount` does not distinguish text from binary, so a peer
+    // that stopped reading accumulated payload frames invisibly to a budget guarding only the JSON
+    // half of the same socket.
+    const { socket, setBuffered } = createControllableSocket();
+    const delivery = new WsSessionDelivery(socket);
+
+    delivery.deliverBinary(new Uint8Array([1, 2, 3]));
+    expect(socket.send).toHaveBeenCalledTimes(1);
+
+    setBuffered(DEFAULT_MAX_PENDING_BYTES + 1);
+    delivery.deliverBinary(new Uint8Array([4, 5, 6]));
+
+    expect(socket.send).toHaveBeenCalledTimes(1); // not sent
+    expect(socket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('the SAME budget governs both halves of one socket', () => {
+    // The property that makes this shared rather than duplicated: bytes pending because of binary
+    // frames close the connection when a JSON reply is attempted, and the reverse. One socket, one
+    // reading, one limit.
+    const { socket, setBuffered } = createControllableSocket();
+    const delivery = new WsSessionDelivery(socket);
+
+    setBuffered(DEFAULT_MAX_PENDING_BYTES + 1);
+    delivery.deliver({ type: 'protocol_error', message: 'over budget from binary backlog' });
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send on a socket that is not open, and does not close it a second time', () => {
+    const { socket, close } = createControllableSocket();
+    const delivery = new WsSessionDelivery(socket);
+    close();
+
+    delivery.deliverBinary(new Uint8Array([1]));
+
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(socket.close).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-transport-ws/src/ws-session-delivery.ts
+++ b/packages/agent-transport-ws/src/ws-session-delivery.ts
@@ -1,4 +1,4 @@
-import { createOutboundDelivery } from '@robota-sdk/agent-transport-protocol';
+import { createOutboundDelivery, isOverPendingBudget } from '@robota-sdk/agent-transport-protocol';
 import { WebSocket } from 'ws';
 
 import type { TOutboundDeliver, TServerMessage } from '@robota-sdk/agent-transport-protocol';
@@ -32,6 +32,32 @@ export class WsSessionDelivery {
       () => this.socket.bufferedAmount,
     );
   }
+
+  /**
+   * Put a TRANS-001 payload frame on this socket, under the SAME budget and the same close policy as
+   * the text protocol (ARCH-030 / issue #1734).
+   *
+   * A WebSocket carries two kinds of outbound frame over one socket, and until this existed the
+   * binary half went straight to `socket.send` — outside the boundary, with no budget, and with a
+   * failure that could only surface as a throw inside a listener. `bufferedAmount` does not
+   * distinguish the two, so a non-reading peer accumulating payload frames was invisible to a budget
+   * that only guarded the other half.
+   *
+   * It is not `deliver`: that boundary is typed for `TServerMessage` and its brand is what makes a
+   * raw send unusable where a protocol frame is required. Widening it to accept bytes would remove
+   * the property the brand exists for.
+   */
+  readonly deliverBinary = (frame: Uint8Array): void => {
+    if (this.closed) return;
+    if (this.socket.readyState !== WebSocket.OPEN) return;
+    if (isOverPendingBudget(this.socket.bufferedAmount)) {
+      this.close();
+      return;
+    }
+    this.socket.send(frame, { binary: true }, (error) => {
+      if (error) this.close();
+    });
+  };
 
   private rawSend(message: TServerMessage): void {
     if (this.socket.readyState !== WebSocket.OPEN) throw new Error('WebSocket is not open');

--- a/packages/agent-transport-ws/src/ws-transport-configurable.ts
+++ b/packages/agent-transport-ws/src/ws-transport-configurable.ts
@@ -6,7 +6,7 @@
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 
 import { createWsHandler } from '@robota-sdk/agent-transport-protocol';
-import { WebSocketServer, WebSocket } from 'ws';
+import { WebSocketServer } from 'ws';
 
 import { PayloadChannelRegistry } from './payload-channels.js';
 import {
@@ -32,7 +32,7 @@ import type {
   TChannelEventMap,
 } from '@robota-sdk/agent-interface-transport';
 import type { IProtocolSession } from '@robota-sdk/agent-transport-protocol';
-import type { RawData } from 'ws';
+import type { RawData, WebSocket } from 'ws';
 
 /**
  * RUNTIME-13: forced-terminate deadline for `stop()`. `WebSocketServer.close()` fires its callback only after
@@ -245,9 +245,11 @@ export class WsTransport
           delivery.bindProtocolCleanup(handler.cleanup);
 
           delivery.bindSinkDetach(
-            channels.addSink((frame: Uint8Array) => {
-              if (ws.readyState === WebSocket.OPEN) ws.send(frame, { binary: true });
-            }),
+            // ARCH-030: through the connection's own delivery, so payload frames share the text
+            // protocol's backpressure budget and its close policy. The bare `readyState` check plus
+            // `ws.send` that stood here was the last outbound path on this socket outside the
+            // boundary.
+            channels.addSink((frame: Uint8Array) => delivery.deliverBinary(frame)),
           );
 
           // Route by frame opcode: TEXT → the text-agent protocol profile, BINARY → the


### PR DESCRIPTION
Part of #1734 (ARCH-030), continuing from #2294. **Not `Closes`** — the acceptance comparison is
below and items remain.

## The last outbound path on this socket that was outside the boundary

A WebSocket carries two kinds of outbound frame, and only one went through the connection's boundary.
TRANS-001 payload frames went straight to `socket.send` behind a bare `readyState` check:

```ts
channels.addSink((frame: Uint8Array) => {
  if (ws.readyState === WebSocket.OPEN) ws.send(frame, { binary: true });
}),
```

No budget, no delivery-error path, and a failure that could surface only as a throw inside a listener.

**`bufferedAmount` does not distinguish the two.** So a peer that stopped reading accumulated payload
frames **invisibly to a budget guarding the JSON half of the same socket** — the contract case #1734
names, on the half nobody was watching.

## One socket, one reading, one limit

`WsSessionDelivery` gains `deliverBinary`, sharing the socket's reading, the same limit and the same
close policy. The budget predicate is extracted so both halves ask one question:

- a budget the binary path **re-implemented** would be a second opinion about one socket's
  backpressure;
- a budget it **skipped** would leave the same peer unbounded on the other half.

It is deliberately **not** `deliver`. That boundary is typed for `TServerMessage`, and its brand is
what makes a raw send unusable where a protocol frame is required. Widening it to accept bytes would
remove the property the brand exists for.

## One line here is not covered by a test, and this is the statement of it

The **wiring** — `channels.addSink(...)` routing through `delivery.deliverBinary` — is unasserted. A
mutant reverting it to the raw send **kills no test**.

Distinguishing them needs a socket over an 8 MiB budget, and the payload-channel suite runs a real
server. Covering it would mean making the limit injectable — an API widened for a test rather than
for a caller, which is not a trade this change makes.

What *is* covered: a mutant that drops the budget check from `deliverBinary` dies. **It is the
routing, not the behaviour, that is unasserted**, and the distinction is the whole content of this
section.

Recorded here and in the commit rather than left for a reader to find.

## Acceptance comparison against issue #1734's reopened scope

| Item | Before #2294 | Now |
| --- | --- | --- |
| queue / **byte** / time budgets | none | **byte** |
| `accepted \| queued \| refused` result | none | **not delivered** — 50 of 51 call sites cannot act on it |
| overflow / drain / **terminal** policy | none | **terminal**, reusing the existing carrier path |
| shared enforcement: WS **text**, WS **binary**, WebRTC, **resume replay** | none | **text + binary + replay**; WebRTC still open |
| non-reading peer contract case | none | delivered |
| replay-burst contract case | none | delivered |

Still open: the queue and time budgets, the result vocabulary, and WebRTC. The issue stays open.

## Verification

`pnpm harness:verify-like-ci` exit 0, all 12 stages, on base `8a906d9ab`; 143 scans; 231 tests across
the two packages. `spec-public-surface` required the two new runtime exports to be documented; they
are, in the package SPEC's Public API table.
