### PR TITLE
docs(tasks): ARCH-109 is delivered and its record is archived

### DIFF
--- a/.agents/tasks/completed/ARCH-109-a-child-process-subagent-rebuilds-the-default-provider-set-so-a-replay-or-caller.md
+++ b/.agents/tasks/completed/ARCH-109-a-child-process-subagent-rebuilds-the-default-provider-set-so-a-replay-or-caller.md
@@ -156,21 +156,82 @@ This Task is `done` for what it set out to change. The issue is the thing that i
 
 ## User Execution Test Scenarios
 
-**Scenario 1 — a replay run makes no live call from a subagent.**
+Both were executed against the BUILT binary (`packages/agent-cli/bin/robota.cjs`) on 2026-08-25, in a
+throwaway `$HOME` with a minimal environment so no real key or token could reach the run.
 
-- Prerequisite: a session log recorded from a run whose transcript invokes the subagent tool, and a
-  configured provider profile whose key is invalid (so any live call fails loudly rather than
-  silently succeeding and billing).
-- Steps: `robota --session-log <path> -p "<the recorded prompt>"`
-- Expected: the run completes from the log; stderr carries the line beginning
-  `Subagents will run in-process:`; no authentication error appears, because no live call is made.
-- Before this change the same run produced a provider authentication error from the child, or — with
-  a valid key — a real billed call.
-- Evidence: to be captured on the implemented build.
+### Scenario 1 — a replay session does not reach the live provider
 
-**Scenario 2 — an embedded product with its own providers keeps working, quietly.**
+`robota --session-log <log> -p '<prompt>'`, with a profile whose key is deliberately invalid.
 
-- Steps: run any existing `startCli({ providerDefinitions })` embedding in print mode.
-- Expected: stdout unchanged and **stderr empty**. This is the scenario that rejected the first
-  design, so it is recorded as a scenario rather than only as a test.
-- Evidence: to be captured on the implemented build.
+```
+=== exit code ===
+0
+=== stdout ===
+two
+=== stderr ===
+Subagents will run in-process: this session composed a replay provider (--session-log), which a child
+process cannot rebuild, so child-process subagents would run on a different provider than this one.
+Process isolation is off for subagents; the provider is shared.
+=== observations ===
+in-process notice present: true
+authentication error present: false
+```
+
+**Control, and it is what makes this evidence rather than decoration.** The same setup with
+`--session-log` removed:
+
+```
+=== stderr ===
+[ERROR] [ExecutionService] [ROUND] Provider call failed
+401 {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}
+=== observations ===
+in-process notice present: false
+authentication error present: true
+```
+
+So the key really is invalid and a live call really does happen on that path — which is what makes the
+replay run's _absence_ of an authentication error mean "no live call" instead of "nothing tried".
+The notice appears only for a replay session.
+
+### Scenario 1's second half could NOT be executed, and the reason is measured
+
+The scenario as written wanted the _subagent_ observed making no live call. **The subagent cannot be
+reached from this surface.** A recorded tool call has no observable effect under `--session-log -p`:
+
+| Round-0 tool call                                        | stdout |
+| -------------------------------------------------------- | ------ |
+| `Agent` (the subagent tool)                              | `two`  |
+| `NoSuchToolARCH109` (a name that does not exist)         | `two`  |
+| `Read` against a file containing `ARCH109-PROBE-CONTENT` | `two`  |
+
+`two` is round 1's recorded content. A tool name that cannot resolve produces output identical to one
+that can, and the probe file's content never appears; `--permission-mode bypassPermissions` changed
+nothing. Filed as issue #2302.
+
+**Recorded as a blocked half rather than a passed gate.** Had the first table been written without the
+`NoSuchToolARCH109` and `Read` rows, this scenario would have read as passing while proving nothing
+about the subagent — the exact shape the fix itself is about, one level up.
+
+### Scenario 2 — an embedded product with its own providers keeps working, and says nothing
+
+Public SDK usage: `startCli({ providerDefinitions: [...] })` in print mode.
+
+```
+=== exit code ===
+0
+=== stdout ===
+embedded provider answered
+=== stderr ===
+
+=== observations ===
+stderr empty: true
+startup refusal present: false
+```
+
+**This is a regression guard, not a demonstration.** It would also have passed before this change —
+that is the point, since the first design broke it. It proves the fallback did not cost the embedding
+path, and it is recorded as a scenario because it is what rejected the first design.
+
+One thing learned by running it rather than reasoning about it: a provider's response `timestamp` must
+be a `Date` instance, not an ISO string — `execution-event-emitter-high-level.ts` checks
+`instanceof Date`, and an ISO string fails with `[EXECUTION] assistant response timestamp is required`.

--- a/.agents/tasks/completed/ARCH-109-a-child-process-subagent-rebuilds-the-default-provider-set-so-a-replay-or-caller.md
+++ b/.agents/tasks/completed/ARCH-109-a-child-process-subagent-rebuilds-the-default-provider-set-so-a-replay-or-caller.md
@@ -1,8 +1,9 @@
 ---
 title: 'ARCH-109: a child-process subagent rebuilds the default provider set, so a replay or caller-supplied provider does not cross the boundary'
 issue: https://github.com/woojubb/robota/issues/2044
-status: in-progress
+status: done
 created: 2026-08-25
+completed: 2026-08-25
 priority: critical
 urgency: now
 area: packages/agent-cli, packages/agent-subagent-runner
@@ -66,6 +67,25 @@ of the entry point — it is the supported way to embed the product with your ow
 of those sessions spawn a subagent at all. A composition-time throw was a **false positive against
 working software**, and the count made that unarguable rather than a matter of taste.
 
+Delivered as `360695df1` (PR #2297). The two failing sets, as the runs reported them:
+
+```
+Test Files  4 failed | 51 passed (55)
+      Tests  20 failed | 417 passed (437)
+AssertionError: expected [Function] to throw error including 'process.exit:0'
+  but got 'robota cannot start: this session composed caller-supplied providerDefinitions…'
+  ❯ packages/agent-cli/src/__tests__/cli-exit-codes.test.ts:103
+
+Test Files  1 failed | 54 passed (55)
+      Tests  4 failed | 431 passed (435)
+AssertionError: expected 'Subagents will run in-process: this s…' to be ''
+  ❯ packages/agent-cli/src/__tests__/cli-update-check.test.ts:126
+```
+
+The second block is the narrower version — a warning rather than a throw — and
+`packages/agent-cli/src/__tests__/cli-update-check.test.ts:126` is `expect(stderr.mock.calls.join('')).toBe('')`,
+which is the print/JSON output contract rather than a test being fussy.
+
 Then four more tests failed on a narrower version: they assert an empty stderr for print and JSON
 runs, where stderr is part of the output contract. So even a _warning_ on every embedded startup was
 wrong.
@@ -116,6 +136,23 @@ correct fallback, and stopping would be the unsafe direction for the user's sess
   | —   | treatment                                                            | 21 passed            |
 
 - Package suite: 435 passed / 55 files.
+
+## What this Task did NOT deliver
+
+Recorded here as well as on the issue, because a `done` record beside an open issue invites the
+reading that the issue is stale. It is not: issue #2044 stays open with three of its four acceptance
+criteria unmet, and the comparison is in a comment there naming `360695df1`.
+
+- **A self-fork test using a custom provider across parent and child.** The seam is a parameter now,
+  but robota's worker entry still calls the recipe with no arguments and exposes no paired worker
+  entry, so there is no supported way to arrange the crossing yet.
+- **An end-to-end replay assertion.** The mechanism is asserted at the selector — zero calls to the
+  child-runner builder, which is what would read the key — but no test drives a replay run through
+  the subagent tool and observes no network call.
+- **Startup refusal.** Deliberately rejected on evidence; see the correction above. That rejection is
+  a proposal back to the issue's author, and the issue is where it is argued.
+
+This Task is `done` for what it set out to change. The issue is the thing that is not finished.
 
 ## User Execution Test Scenarios
 


### PR DESCRIPTION
The change landed on `develop` as `360695df1` (PR #2297). `status: done` with its completion date and the `git mv` to `completed/` are in one commit, which is the atomic pair the lifecycle requires.

**The record gains a section naming what it did not deliver**, because a `done` record sitting beside an open issue invites the reading that the issue is stale. It is not — issue #2044 keeps three of its four acceptance criteria, and the item-by-item comparison is a comment there naming the delivering commit:

- no self-fork test crossing the boundary with a custom provider (the seam is a parameter, but robota's worker entry still calls the recipe with no arguments and exposes no paired worker entry);
- no end-to-end replay assertion (the mechanism is asserted at the selector — zero calls to the child-runner builder, which is what would read the key — but no test drives a replay run through the subagent tool);
- no startup refusal, **deliberately rejected on evidence** rather than skipped, which makes it a proposal back to the issue's author rather than a silent omission.

**No user-execution gate is claimed as passed.** The two scenarios in the record are written and unexecuted, and the record says so rather than reporting a gate it did not run.

## One finding against my own record, caught by the pre-push gate

`unearned-done-claims` (rule U2) refused the first version: the evidence section *"Direction, and the correction the evidence forced"* cited nothing — no path, PR ref, sha, filename or pasted output. It was right. The section argued from two test-failure counts and named neither the runs nor the files, so a reader had to take the numbers on trust in a record whose whole purpose is to be checkable later.

Fixed by pasting the two failing runs and naming `packages/agent-cli/src/__tests__/cli-exit-codes.test.ts:103` and `packages/agent-cli/src/__tests__/cli-update-check.test.ts:126` — the second being `expect(stderr.mock.calls.join('')).toBe('')`, which is the print/JSON output contract rather than a test being fussy. Worth recording that the gate caught a prose defect in a document about not overclaiming.

Verification: `unearned-done-claims`, `backlog-placement` and `task-archival` all pass — the three that own this transition.

Refs issue #2044