### PR TITLE
fix(transport): the replay budget reaches production (ARCH-030)

### DIFF
--- a/packages/agent-transport-webrtc/src/__tests__/session-attachment-budget.test.ts
+++ b/packages/agent-transport-webrtc/src/__tests__/session-attachment-budget.test.ts
@@ -1,0 +1,95 @@
+/**
+ * ARCH-030 / issue #1734 — the replay path's backpressure budget REACHES production.
+ *
+ * `IAttachOptions.pendingBytes` existed with zero production callers: the bridge could take a
+ * carrier's backpressure reading and nothing gave it one, so the replay burst — the case the
+ * reopened scope names — ran unbudgeted while every other outbound path on the same connection was
+ * guarded.
+ *
+ * This case asserts the BEHAVIOUR, not the wiring. A test that checked the option reaches
+ * `bridge.attach` would have passed on the day the defect existed, because the option was reaching
+ * nothing on the way in. What can fail is a peer over budget going unclosed.
+ */
+import {
+  DEFAULT_MAX_PENDING_BYTES,
+  SessionResumeBridge,
+} from '@robota-sdk/agent-transport-protocol';
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-session/testing';
+import { describe, expect, it } from 'vitest';
+
+import { attachSession } from '../session-attachment.js';
+
+import type { IPairingChannel } from '../pairing-gate-options.js';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
+
+function fakeSession(): {
+  session: IInteractiveSession;
+  fire: (event: string, arg: unknown) => void;
+} {
+  const handlers = new Map<string, (arg: unknown) => void>();
+  const session = createTestInteractiveSession({
+    on: ((event: string, handler: (arg: unknown) => void) =>
+      handlers.set(event, handler)) as IInteractiveSession['on'],
+    off: ((event: string) => {
+      handlers.delete(event);
+    }) as IInteractiveSession['off'],
+  });
+  return { session, fire: (event, arg) => handlers.get(event)?.(arg) };
+}
+
+/** A channel whose backpressure the case controls, matching the optional structural slice. */
+function channelHolding(bytes: () => number): IPairingChannel & { sent: string[] } {
+  const sent: string[] = [];
+  return {
+    sent,
+    send: (data: string) => void sent.push(data),
+    close: () => undefined,
+    get bufferedAmount(): number {
+      return bytes();
+    },
+  };
+}
+
+describe('attachSession + the replay budget (ARCH-030)', () => {
+  it('closes a peer that is over budget when the replay burst is attempted', () => {
+    const { session, fire } = fakeSession();
+    const bridge = new SessionResumeBridge({ session });
+    for (const delta of ['a', 'b', 'c']) fire('text_delta', delta);
+
+    let pending = 0;
+    const channel = channelHolding(() => pending);
+    const failures: string[] = [];
+    const attached = attachSession({ channel, session, resumeBridge: bridge }, true, (error) =>
+      failures.push(error.message),
+    );
+
+    // The peer has accepted a backlog it is not reading.
+    pending = DEFAULT_MAX_PENDING_BYTES + 1;
+    attached.onSessionMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+
+    expect(channel.sent).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain('pending');
+    attached.cleanup();
+    bridge.dispose();
+  });
+
+  it('replays normally while the peer is reading', () => {
+    // The companion the case above needs: without it, a budget that refused everything would pass.
+    const { session, fire } = fakeSession();
+    const bridge = new SessionResumeBridge({ session });
+    for (const delta of ['a', 'b', 'c']) fire('text_delta', delta);
+
+    const channel = channelHolding(() => 0);
+    const failures: string[] = [];
+    const attached = attachSession({ channel, session, resumeBridge: bridge }, true, (error) =>
+      failures.push(error.message),
+    );
+    attached.onSessionMessage(JSON.stringify({ type: 'resume', lastSeq: 0 }));
+
+    expect(channel.sent).toHaveLength(3);
+    expect(failures).toHaveLength(0);
+    attached.cleanup();
+    bridge.dispose();
+  });
+});

--- a/packages/agent-transport-webrtc/src/pairing-gate-options.ts
+++ b/packages/agent-transport-webrtc/src/pairing-gate-options.ts
@@ -27,6 +27,15 @@ import type { ILocalPeerProof } from './local-peer-proof.js';
 export interface IPairingChannel {
   send(data: string): void;
   close(): void;
+  /**
+   * ARCH-030 / issue #1734: this channel's own count of what it has accepted and not yet written.
+   *
+   * Optional for the same reason `IDataChannelSink.bufferedAmount` is — the slice is structural and a
+   * test double may omit it — while a real `RTCDataChannel` always has it. It is here so the resume
+   * bridge's outbound boundary gets a reading: without one the replay path has no backpressure
+   * budget, which is a capability that exists and is never reached.
+   */
+  readonly bufferedAmount?: number;
 }
 
 /** E3 host reconnect/enrollment config. When present, the gate runs reactive (first-frame) mode detection. */

--- a/packages/agent-transport-webrtc/src/session-attachment.ts
+++ b/packages/agent-transport-webrtc/src/session-attachment.ts
@@ -51,6 +51,10 @@ export function attachSession(
     bridge.attach((data) => options.channel.send(data), {
       awaitResume: viaReconnect,
       onDeliveryError,
+      // ARCH-030: without this the bridge's boundary has no backpressure reading, so the replay
+      // path — the burst this budget exists for — runs unbudgeted while every other outbound path
+      // on the same connection is guarded. Read at call time; `bufferedAmount` is live.
+      pendingBytes: () => options.channel.bufferedAmount,
     });
     return {
       onSessionMessage: (data) => bridge.onClientMessage(data),


### PR DESCRIPTION
Part of #1734 (ARCH-030). **Not `Closes`** — the comparison is on the issue and items remain.

## The defect is mine, from PR #2294

`IAttachOptions.pendingBytes` was added so a bridge attachment could carry its carrier's backpressure
reading. Measured after it landed:

```
production callers passing `pendingBytes` to a bridge attachment ....... 0
```

Only a test passed one. So the **replay path — the burst this budget exists for** — ran unbudgeted
while every other outbound path on the same connection was guarded.

**An option added and not wired is a capability that exists and is never reached**, and counting its
existence as delivery is what erases the difference. My own PR body counted it as delivered
enforcement.

It surfaced from comparing #1734's acceptance items against `git show origin/develop:<file>` rather
than against that PR body — which is the reason the post-merge step reads the tree.

## The fix, and the check for the shape it could have repeated

`session-attachment.ts` now passes the reading. `IPairingChannel` carries `bufferedAmount` as an
optional structural member, for the reason `IDataChannelSink` already documents: the slice is
structural and a double may omit it, while a real data channel always has one.

Checked before calling it done — `session-attachment.ts:51` is the **only** bridge attach in
production, so this is not one site fixed with others left behind.

## The test asserts behaviour, not wiring, and that distinction is the point

**A case checking that the option reaches `bridge.attach` would have passed on the day this defect
existed**, because the option was reaching nothing on the way in. Asserting the argument arrives
proves the argument arrives.

What can fail is a peer over budget going unclosed. The mutant that removes the wiring produces
exactly that:

```
AssertionError: expected [ …(3) ] to have a length of +0 but got 3
```

Three frames replayed to a peer over its limit, where none should have been. Re-run after the rebase
rather than reused.

A companion case asserts a reading peer still receives its whole tail — without it, a budget that
refused **everything** would also pass.

## Verification

`pnpm harness:verify-like-ci` exit 0, all 12 stages, on base `d39c9e129`; 143 scans; 322 tests across
the two packages.

## What remains on #1734 — judged, and posted on the issue

- **Queue budget: declined.** The boundary holds no queue — measured, zero array operations in
  `outbound-delivery.ts`. The *carrier* queues, and `bufferedAmount` is that queue's reading. A queue
  budget would mean adding a second place that holds frames in front of the one that already does.
  Reverses if a reason to hold frames is ever proposed (retry, reorder, coalesce); none is.
- **Time budget: real, and filed separately as #2306.** A peer reading arbitrarily slowly stays under
  a byte budget forever. `bufferedAmount` is a quantity, not a history, so no threshold over it can
  tell 1 MiB held for 20ms from 1 MiB held for 20 minutes. Different mechanism, so it is not folded
  into this issue's scope.
- **Drain policy: dependent on the queue, therefore also declined.** With no queue there is nothing to
  drain; the carrier drains itself and overflow is terminal by design.

The issue is **not closed on my judgement** — a decline is a proposal back to the scope's author, not
a disposition to apply to someone else's issue.
