### PR TITLE
test(cli): record CLI-083 completion non-compliance

### DIFF
--- a/.agents/loop-runs/pr-finding-resolution-loop.jsonl
+++ b/.agents/loop-runs/pr-finding-resolution-loop.jsonl
@@ -5,3 +5,4 @@
 {"runId":"r20260822143042","opened":"2026-08-22T14:30:42.608Z","closed":"2026-08-22T16:19:13.813Z","roundFindings":[7,4,4,4,0],"terminal":"converged","ref":null}
 {"runId":"r20260822165532","opened":"2026-08-22T16:55:32.554Z","closed":"2026-08-22T16:58:01.257Z","roundFindings":[1,0],"extensions":{},"terminal":"converged","ref":null}
 {"runId":"r20260824160623","opened":"2026-08-24T16:06:23.805Z","closed":"2026-08-24T16:30:21.079Z","roundFindings":[1],"extensions":{},"terminal":"abandoned","ref":null}
+{"runId":"r20260824171233","opened":"2026-08-24T17:12:33.472Z","closed":"2026-08-24T17:27:31.884Z","roundFindings":[3,1,0],"extensions":{},"terminal":"converged","ref":null}

--- a/.agents/loop-runs/user-execution-scenario.jsonl
+++ b/.agents/loop-runs/user-execution-scenario.jsonl
@@ -1,3 +1,4 @@
 {"runId":"r20260822102755","opened":"2026-08-22T10:27:55.565Z","closed":"2026-08-22T10:30:14.506Z","roundFindings":[0],"terminal":"converged","ref":null}
 {"runId":"r20260822101704","opened":"2026-08-22T10:17:04.191Z","closed":"2026-08-22T10:20:32.258Z","roundFindings":[0],"terminal":"converged","ref":null}
 {"runId":"r20260822123624","opened":"2026-08-22T12:36:24.269Z","closed":"2026-08-22T12:38:08.382Z","roundFindings":[0],"terminal":"converged","ref":null}
+{"runId":"r20260824172131","opened":"2026-08-24T17:21:31.574Z","closed":"2026-08-24T17:22:33.594Z","roundFindings":[1],"extensions":{},"terminal":"halted-for-user","ref":null}

--- a/.agents/loop-runs/user-request-gate.jsonl
+++ b/.agents/loop-runs/user-request-gate.jsonl
@@ -8,3 +8,4 @@
 {"runId":"r20260822095743","opened":"2026-08-22T09:57:43.571Z","closed":"2026-08-22T09:58:39.749Z","roundFindings":[0],"terminal":"converged","ref":null}
 {"runId":"r20260822101318","opened":"2026-08-22T10:13:18.520Z","closed":"2026-08-22T10:17:49.915Z","roundFindings":[1],"terminal":"halted-for-user","ref":null}
 {"runId":"r20260822102601","opened":"2026-08-22T10:26:01.076Z","closed":"2026-08-22T10:27:19.576Z","roundFindings":[0],"terminal":"converged","ref":null}
+{"runId":"r20260824170834","opened":"2026-08-24T17:08:34.035Z","closed":"2026-08-24T17:10:09.100Z","roundFindings":[0],"extensions":{},"terminal":"converged","ref":null}

--- a/.agents/tasks/CLI-083-the-org-policy-loader-has-no-caller-so-four-enforcement-sites-are-unreachable-in.md
+++ b/.agents/tasks/CLI-083-the-org-policy-loader-has-no-caller-so-four-enforcement-sites-are-unreachable-in.md
@@ -1,9 +1,8 @@
 ---
 title: 'CLI-083: the org policy loader has no caller, so four enforcement sites are unreachable in the shipped product'
 issue: https://github.com/woojubb/robota/issues/2287
-status: done
+status: blocked
 created: 2026-08-24
-completed: 2026-08-25
 priority: medium
 urgency: soon
 area: packages/agent-cli, packages/agent-command, packages/agent-product
@@ -91,7 +90,7 @@ refactor lands on the same code. That is filed separately; it is not this item.
       end-to-end case must go RED. The chain being present is not the chain being fed.
 - [x] TC-08 — `run-all-scans` green on a clean tree; `pnpm lint` by EXIT CODE.
 
-## Completion disposition
+## Implementation and completion disposition
 
 PR #2293 delivered the loader call, provider-module wiring, serve-session projection, and the shell
 forwarding up to the default TUI channel. Merge commit
@@ -100,12 +99,19 @@ forwarding up to the default TUI channel. Merge commit
 
 Review exposed a broader, recurring cause: optional session capabilities are manually projected by
 the TUI and headless surfaces. The default TUI channel→session hop and print/goal path still omit
-`orgPolicy`. Those are not silently counted as delivered here: both sites carry `Contained —
-ARCH-110.` and the root work remains open in
-[`ARCH-110`](../ARCH-110-session-capability-projections-can-silently-drop-optional-fields.md) /
+`orgPolicy`. Those are not silently counted as delivered here: the actual omission sites in
+`buildTuiSessionOptions` and `HeadlessInteractionChannel` carry `Contained — ARCH-110.`, and the root
+work remains open in
+[`ARCH-110`](ARCH-110-session-capability-projections-can-silently-drop-optional-fields.md) /
 [issue #2295](https://github.com/woojubb/robota/issues/2295). CLI-083 completes the regression repair
 that made the four enforcement sites reachable in the shipped composition; ARCH-110 owns making
 every presentation path complete and mechanically preventing the next optional-field drop.
+
+The implementation disposition is not a valid completion disposition. The user-execution scenario
+was authored after implementation and after merge, so `DONE-GATE-STAGE-1` returned
+`NON-COMPLIANCE` on 2026-08-25 and the `user-execution-scenario` pipeline halted without entering
+Stage 2. This item therefore remains nonterminal and blocked even though issue #2287 correctly stays
+closed for the shipped product fix; no retrospective gate evidence is being fabricated.
 
 ## Not in scope
 
@@ -127,21 +133,38 @@ Gate commands: `pnpm build`, `pnpm typecheck`, the affected package suites,
 
 ### Scenario: a policy loaded from disk blocks a provider switch in the built TUI
 
+Executability decision: `agent-executable` through the repository's real-PTY driver.
+
 Prerequisites: build the Robota CLI; create an isolated HOME with Anthropic and OpenAI provider
 profiles and `.robota/org-policy.json` containing
 `{"allowedProviders":["anthropic"],"adminContact":"ops@example.com"}`.
 
-Steps: launch the built `robota` binary in a real terminal with that HOME, wait for the TUI prompt,
-enter `/provider switch openai`, and submit it.
+Steps: launch the built `robota --disable-update-check` binary in a real terminal with that HOME,
+wait for the TUI prompt, enter `/provider switch openai`, and submit it.
 
 Expected: the TUI reports `Provider "openai" is not allowed by your organization policy` and names
 `anthropic` as the allowed provider. No model call or network request occurs.
 
 Cleanup: terminate the TUI and remove the isolated project/HOME directory.
 
-Evidence (2026-08-25):
+Engineering regression evidence (2026-08-25; not Done Gate Stage 2 evidence):
 `pnpm --filter @robota-sdk/agent-transport-tui exec vitest run --config vitest.pty.config.ts src/__tests__/pty/org-policy.ptytest.ts`
 ran the built binary in a pseudo-terminal and passed 1/1 in 2.07s. The permanent scenario is
 `packages/agent-transport-tui/src/__tests__/pty/org-policy.ptytest.ts`. This scenario was added after
-the implementation PR rather than before implementation; that planning-order violation is recorded
-here instead of being rewritten as if the gate had run on time.
+the implementation PR rather than before implementation; the run therefore remains engineering
+regression evidence and does not satisfy either done-gate stage. That planning-order violation is
+recorded here instead of being rewritten as if the gate had run on time.
+
+### [DONE-GATE-STAGE-1] — 🔴 NON-COMPLIANCE | 2026-08-25
+
+**Status remains:** done
+**Violation:** `DONE-GATE-STAGE-1` has no prior gate, but its PLAN-stage ordering was bypassed: merge
+commit `d39c9e12979d46e9efe40e8ba823f0503c296c78` delivered the implementation before this scenario
+existed, while commit `3a44a5903bfae6cdb5eb60896736be2f31cc62ff` added the scenario afterward and already set the item
+to `status: done` under `.agents/tasks/completed/`. The scenario itself also explicitly records that it
+was added after the implementation PR. Per the Done Gate absolute rule, completion cannot precede both
+done-gate stages, and a retrospective scenario cannot establish the required pre-implementation PLAN
+ordering.
+**Required action:** Route this process violation through `user-execution-scenario`; do not treat the
+retrospective scenario or its engineering test output as a Stage 1 PASS, and do not run Stage 2 as though
+PLAN had returned `PLANNED`.

--- a/.agents/tasks/completed/CLI-083-the-org-policy-loader-has-no-caller-so-four-enforcement-sites-are-unreachable-in.md
+++ b/.agents/tasks/completed/CLI-083-the-org-policy-loader-has-no-caller-so-four-enforcement-sites-are-unreachable-in.md
@@ -1,8 +1,9 @@
 ---
 title: 'CLI-083: the org policy loader has no caller, so four enforcement sites are unreachable in the shipped product'
 issue: https://github.com/woojubb/robota/issues/2287
-status: todo
+status: done
 created: 2026-08-24
+completed: 2026-08-25
 priority: medium
 urgency: soon
 area: packages/agent-cli, packages/agent-command, packages/agent-product
@@ -72,19 +73,39 @@ refactor lands on the same code. That is filed separately; it is not this item.
 
 ## Plan
 
-- [ ] TC-01 — `createDefaultCommandModules` accepts `orgPolicy` again and forwards it to the provider
+- [x] TC-01 — `createDefaultCommandModules` accepts `orgPolicy` again and forwards it to the provider
       command module, so `allowedProviders` and `requireApiKeyFromEnv` are reachable.
-- [ ] TC-02 — `buildServeSessionOptions` carries `orgPolicy` into `TInteractiveSessionOptions`.
-- [ ] TC-03 — `buildRuntimeOptions` (the composition kernel) carries it too.
-- [ ] TC-04 — `command-setup.ts` calls `loadOrgPolicy()` and passes the result.
-- [ ] TC-05 — a session built through a real projection with a real `org-policy.json` on disk blocks
-      a `blockedCommands` entry. Not a policy object handed to the session.
-- [ ] TC-06 — MUTANT: wire ONE projection only; the other projection's test must go RED. A test that
+- [x] TC-02 — `buildServeSessionOptions` carries `orgPolicy` into `TInteractiveSessionOptions`.
+- [x] TC-03 — disposition recorded: the product/TUI/headless projection mechanism was not patched
+      field-by-field here; it is contained under ARCH-110 / issue #2295, with the known gaps marked
+      at their projection sites.
+- [x] TC-04 — `command-setup.ts` calls `loadOrgPolicy()` and passes the result.
+- [x] TC-05 — the built CLI, running in a real PTY with a real `org-policy.json` on disk, rejects a
+      provider switch forbidden by `allowedProviders`. The originally planned TUI `blockedCommands`
+      assertion crosses the contained channel→session gap and therefore belongs to ARCH-110 rather
+      than being falsely claimed here.
+- [x] TC-06 — MUTANT: wire ONE projection only; the other projection's test must go RED. A test that
       covers both leaves a half-wiring green, which reads as "the policy is loaded now" — the same
       shape as the hand-fed test that hid this.
-- [ ] TC-07 — MUTANT: remove the `loadOrgPolicy()` call while leaving the parameter chain intact; the
+- [x] TC-07 — MUTANT: remove the `loadOrgPolicy()` call while leaving the parameter chain intact; the
       end-to-end case must go RED. The chain being present is not the chain being fed.
-- [ ] TC-08 — `run-all-scans` green on a clean tree; `pnpm lint` by EXIT CODE.
+- [x] TC-08 — `run-all-scans` green on a clean tree; `pnpm lint` by EXIT CODE.
+
+## Completion disposition
+
+PR #2293 delivered the loader call, provider-module wiring, serve-session projection, and the shell
+forwarding up to the default TUI channel. Merge commit
+`d39c9e12979d46e9efe40e8ba823f0503c296c78` was independently verified on `origin/develop`;
+[issue #2287](https://github.com/woojubb/robota/issues/2287) was closed with that commit.
+
+Review exposed a broader, recurring cause: optional session capabilities are manually projected by
+the TUI and headless surfaces. The default TUI channel→session hop and print/goal path still omit
+`orgPolicy`. Those are not silently counted as delivered here: both sites carry `Contained —
+ARCH-110.` and the root work remains open in
+[`ARCH-110`](../ARCH-110-session-capability-projections-can-silently-drop-optional-fields.md) /
+[issue #2295](https://github.com/woojubb/robota/issues/2295). CLI-083 completes the regression repair
+that made the four enforcement sites reachable in the shipped composition; ARCH-110 owns making
+every presentation path complete and mechanically preventing the next optional-field drop.
 
 ## Not in scope
 
@@ -101,3 +122,26 @@ state. The end-to-end case writes a real `org-policy.json` and drives a real ent
 
 Gate commands: `pnpm build`, `pnpm typecheck`, the affected package suites,
 `node scripts/harness/run-all-scans.mjs`, and `pnpm lint` read by exit code.
+
+## User Execution Test Scenarios
+
+### Scenario: a policy loaded from disk blocks a provider switch in the built TUI
+
+Prerequisites: build the Robota CLI; create an isolated HOME with Anthropic and OpenAI provider
+profiles and `.robota/org-policy.json` containing
+`{"allowedProviders":["anthropic"],"adminContact":"ops@example.com"}`.
+
+Steps: launch the built `robota` binary in a real terminal with that HOME, wait for the TUI prompt,
+enter `/provider switch openai`, and submit it.
+
+Expected: the TUI reports `Provider "openai" is not allowed by your organization policy` and names
+`anthropic` as the allowed provider. No model call or network request occurs.
+
+Cleanup: terminate the TUI and remove the isolated project/HOME directory.
+
+Evidence (2026-08-25):
+`pnpm --filter @robota-sdk/agent-transport-tui exec vitest run --config vitest.pty.config.ts src/__tests__/pty/org-policy.ptytest.ts`
+ran the built binary in a pseudo-terminal and passed 1/1 in 2.07s. The permanent scenario is
+`packages/agent-transport-tui/src/__tests__/pty/org-policy.ptytest.ts`. This scenario was added after
+the implementation PR rather than before implementation; that planning-order violation is recorded
+here instead of being rewritten as if the gate had run on time.

--- a/packages/agent-transport-tui/src/__tests__/pty/org-policy.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/org-policy.ptytest.ts
@@ -1,8 +1,9 @@
 /**
- * Real-PTY organization-policy scenario (CLI-083 done-gate evidence).
+ * Real-PTY organization-policy engineering regression scenario (CLI-083).
  *
  * Drives the built Robota CLI with an isolated HOME. Nothing injects a policy object into the
- * command module: the refusal can only come from the shipped `loadOrgPolicy()` startup path.
+ * command module: the refusal can only come from the shipped `loadOrgPolicy()` startup path. The
+ * update check is disabled so this isolated scenario performs no startup network request.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
@@ -54,7 +55,7 @@ describe('organization policy through the built CLI (CLI-083)', () => {
   });
 
   it('blocks a provider switch forbidden only by the policy loaded from disk', async () => {
-    session = spawnTui({ projectDir, homeDir });
+    session = spawnTui({ projectDir, homeDir, args: ['--disable-update-check'] });
     await session.waitFor(/Type a message or \/help/);
 
     const since = session.outputOffset();

--- a/packages/agent-transport-tui/src/__tests__/pty/org-policy.ptytest.ts
+++ b/packages/agent-transport-tui/src/__tests__/pty/org-policy.ptytest.ts
@@ -1,0 +1,70 @@
+/**
+ * Real-PTY organization-policy scenario (CLI-083 done-gate evidence).
+ *
+ * Drives the built Robota CLI with an isolated HOME. Nothing injects a policy object into the
+ * command module: the refusal can only come from the shipped `loadOrgPolicy()` startup path.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { spawnTui } from './pty-driver.js';
+
+import type { IPtySession } from './pty-driver.js';
+
+function writeOrgPolicyFixture(homeDir: string): void {
+  const settingsDir = join(homeDir, '.robota');
+  mkdirSync(settingsDir, { recursive: true });
+  writeFileSync(
+    join(settingsDir, 'settings.json'),
+    JSON.stringify({
+      currentProvider: 'anthropic',
+      providers: {
+        anthropic: { type: 'anthropic', model: 'claude-test-model', apiKey: 'pty-dummy-key' },
+        openai: { type: 'openai', model: 'gpt-test-model', apiKey: 'pty-dummy-key' },
+      },
+    }),
+    'utf8',
+  );
+  writeFileSync(
+    join(settingsDir, 'org-policy.json'),
+    JSON.stringify({ allowedProviders: ['anthropic'], adminContact: 'ops@example.com' }),
+    'utf8',
+  );
+}
+
+describe('organization policy through the built CLI (CLI-083)', () => {
+  let projectDir: string;
+  let homeDir: string;
+  let session: IPtySession | undefined;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'robota-pty-org-policy-'));
+    homeDir = join(projectDir, 'home');
+    writeOrgPolicyFixture(homeDir);
+  });
+
+  afterEach(async () => {
+    await session?.disposeAsync();
+    session = undefined;
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('blocks a provider switch forbidden only by the policy loaded from disk', async () => {
+    session = spawnTui({ projectDir, homeDir });
+    await session.waitFor(/Type a message or \/help/);
+
+    const since = session.outputOffset();
+    await session.sendKeys('/provider switch openai');
+    await session.pressEnter();
+
+    await session.waitForSince(
+      since,
+      /Provider "openai" is not allowed by your organization policy/,
+    );
+    expect(session.snapshotSince(since)).toContain('Allowed: anthropic');
+  }, 60_000);
+});

--- a/packages/agent-transport-tui/src/tui-session-options.ts
+++ b/packages/agent-transport-tui/src/tui-session-options.ts
@@ -14,6 +14,8 @@ import type { TInteractiveSessionOptions } from '@robota-sdk/agent-framework';
 export function buildTuiSessionOptions(
   opts: ITuiInteractionChannelOptions,
 ): TInteractiveSessionOptions {
+  // Contained — ARCH-110. This manual channel→session projection still omits `orgPolicy`; the
+  // cross-surface projection fix and its mechanical guard belong to that root work item.
   return {
     cwd: opts.cwd,
     provider: opts.provider,


### PR DESCRIPTION
## Recommendation

Record the CLI-083 product regression evidence without converting retrospective verification into a passed done gate. Keep the shipped fix and closed product issue intact, restore the Task to a nonterminal state, label the actual ARCH-110 omission site, and retain a network-isolated PTY regression scenario.

## Review verdict

ENDORSE for this corrective follow-up: the approach follows the user-execution and task lifecycle rules without fabricating retroactive PASS evidence. Final local review on head 58db2517d reported ACTIONABLE FINDINGS: 0 after the finding sequence 3, 1, 0.

## Changes

- restore CLI-083 from completed to blocked after DONE-GATE-STAGE-1 NON-COMPLIANCE
- record the halted user-execution pipeline and distinguish engineering regression evidence from done-gate evidence
- add a real-PTY regression scenario for disk-loaded organization policy
- disable startup update checks in the isolated PTY scenario
- place the ARCH-110 containment label on buildTuiSessionOptions, the actual channel-to-session omission

## Verification

- root build passed
- agent-transport-tui: 77 test files, 694 tests passed
- harness contract tier: 177 files, 3802 tests passed
- agent-transport-tui typecheck passed
- package scenario verification passed
- harness scans: 141 passed, 2 explicit skips in pre-push
- CLI smoke: robota 3.0.0-beta.79
- targeted PTY scenario: 1 passed

## User execution gate

NON-COMPLIANCE / HALT. The scenario was authored after implementation and merge, so Stage 1 cannot be passed retrospectively and Stage 2 was not entered. CLI-083 remains blocked in the Task root. The PTY run is recorded only as engineering regression evidence.

## Residual risk

The default TUI session projection and headless print/goal projection still omit orgPolicy. ARCH-110 / issue #2295 owns the cross-surface projection fix and mechanical prevention.