### PR TITLE
fix(protocol): refuse a submit prompt that is not a string (TRANS-008)

### DIFF
--- a/.agents/tasks/TRANS-008-a-truthy-non-string-submit-prompt-is-re-broadcast-to-every-attached-client-as-a-.md
+++ b/.agents/tasks/TRANS-008-a-truthy-non-string-submit-prompt-is-re-broadcast-to-every-attached-client-as-a-.md
@@ -1,0 +1,103 @@
+---
+title: 'TRANS-008: a truthy non-string submit prompt is re-broadcast to every attached client as a typed frame'
+issue: https://github.com/woojubb/robota/issues/2045
+status: todo
+created: 2026-08-24
+priority: medium
+urgency: soon
+area: packages/agent-transport-protocol
+depends_on: []
+---
+
+# TRANS-008: a truthy non-string submit prompt is re-broadcast to every attached client as a typed frame
+
+## Objective
+
+A `submit` frame whose `prompt` is a truthy non-string reaches the session, is re-emitted as a
+`user_message`, and is delivered to every attached client inside a frame whose `content` is declared
+`string`. One unguarded field lets a client put a shape-invalid value into a typed frame delivered to
+its peers.
+
+## Measured at `b9081fe7c`, before designing
+
+Issue #2045 proposes a total runtime decoder for `agent-transport-protocol`. Its premise holds — the
+package owns the unions and decodes nothing, and there are **three** cast sites, one more than the
+issue lists:
+
+```
+ws-handler.ts:92                     JSON.parse(data) as TClientMessage
+agent-transport-gui/…:66             JSON.parse(data) as TServerMessage
+agent-transport-webrtc-web/…:118     parsed as TServerMessage        (not named in the issue)
+```
+
+`TClientMessage` has 24 variants, 14 carrying payload fields, and exactly **2** ad-hoc guards —
+`!msg.prompt` and `!msg.name`, both falsy checks. So an unvalidated payload reaches every handler.
+
+**What the consumers do with it is a separate question, and asking it changed the scope.**
+
+- **`permission-response` — no harm.** `msg.result` reaches `resolvePermission` unvalidated, but
+  `interpretApproval` (`agent-session/src/abortable-approval.ts:61`) compares by strict equality
+  against `'allow-session'` / `'allow-project'` and otherwise returns `allowed: result === true`.
+  Every malformed value denies. A decoder here would prevent nothing.
+- **`ack` / `resume` — self-inflicted and bounded.** A non-numeric seq coerces to `false` and drops
+  nothing; a huge one drops everything and the sender's next resume overruns into a full refresh.
+  The buffer is separately bounded by frame count and bytes.
+- **`submit.prompt` — the one that crosses.** `{}`, `[]`, `42`, `true` are truthy, pass
+  `!msg.prompt`, and reach `session.submit(input: string)`. The execution controller then does
+  `emit('user_message', displayInput ?? input)`, `ws-session-events.ts` marks `user_message` as
+  `'forwarded'`, and it is delivered to **every** attached client — which accept it with
+  `as TServerMessage` at both client cast sites.
+
+So the harm is one field, and it is not the "one field" of a lost setting: it crosses from one client
+to its peers through a frame the type system says is a string.
+
+## Plan
+
+- [x] TC-01 — a non-string `prompt` (object, array, number, boolean) is refused at the ingress and
+      never reaches `session.submit`.
+- [x] TC-02 — an EMPTY prompt is still refused. Control: a type check that replaced the falsy guard
+      would otherwise admit `''`.
+- [x] TC-03 — a real string prompt still submits. Control: a handler that refused everything would
+      satisfy TC-01 without it.
+- [x] TC-04 — MUTANT: the falsy guard restored goes red.
+- [x] TC-05 — MUTANT: the type half alone (dropping emptiness) goes red on TC-02.
+- [x] TC-06 — MUTANT: refusing everything goes red on TC-03.
+
+## Not in scope, and deliberately
+
+**The total decoder issue #2045 proposes is NOT resolved by this item and stays open.** This closes
+the one measured crossing; it does not decide whether the package should decode. That disposition is
+a data-correctness judgement and belongs to the owner.
+
+**`rtc-responder-gate.ts` is untouched and still casts.** A decoder scoped to the file list in the
+issue would leave it defective while reading as complete — recorded here because it survives whatever
+is decided about the decoder.
+
+**Thirteen of the fourteen payload-carrying fields were not traced to their use sites.** The ones the
+issue names were. If another crosses the way `prompt` does, that is a finding for issue #2045, not a
+widening of this diff.
+
+## Test Plan
+
+`packages/agent-transport-protocol/src/__tests__/submit-prompt-shape.test.ts` drives the real
+`createWsHandler` ingress rather than the guard in isolation: the defect is what reaches the session,
+not what a predicate returns. Gate commands: `pnpm build`, `pnpm typecheck`, the package suite,
+`node scripts/harness/run-all-scans.mjs`, and `pnpm lint` read by exit code.
+
+## User Execution Test Scenarios
+
+**Not applicable — and the reason is the point, not a formality.**
+
+This change is reachable only over the WebSocket protocol surface, and only by a client that sends a
+frame the product's own clients cannot construct: every first-party client builds `submit` from a
+string-typed input box or argument, so no supported user action produces a non-string `prompt`. The
+scenario would require hand-crafting a malformed frame against a running host, which is a protocol
+probe rather than a user execution.
+
+The user-visible behaviour is unchanged by design: a real prompt still submits (TC-03) and an empty
+one is still refused (TC-02). A scenario that exercised those would be verifying what this change
+deliberately does not alter.
+
+Recorded rather than omitted because `backlog-execution.md` requires the reason to be written — and
+because three earlier records of mine omitted this section entirely, which is what made the omission
+invisible.

--- a/packages/agent-transport-protocol/src/__tests__/submit-prompt-shape.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/submit-prompt-shape.test.ts
@@ -20,16 +20,18 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { createTestInteractiveSession } from '@robota-sdk/agent-interface-session/testing';
 
 import { createOutboundDelivery } from '../outbound-delivery.js';
 import { createWsHandler } from '../ws-handler.js';
 
 import type { TServerMessage } from '../ws-protocol.js';
-import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
 
 function setup() {
   const submit = vi.fn().mockResolvedValue({ turnId: 't1', completed: Promise.resolve() });
-  const session = { submit, on: vi.fn(), off: vi.fn() } as unknown as IInteractiveSession;
+  // The published conformant double, not a cast: a hand-rolled object asserted to be an
+  // `IInteractiveSession` is a partial re-implementation nothing checks against the real contract.
+  const session = Object.assign(createTestInteractiveSession(), { submit });
   const sent: TServerMessage[] = [];
   const { onMessage } = createWsHandler({
     session,

--- a/packages/agent-transport-protocol/src/__tests__/submit-prompt-shape.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/submit-prompt-shape.test.ts
@@ -1,0 +1,76 @@
+/**
+ * TRANS-008 (issue #2045) — a `submit` prompt that is not a string must not reach the session.
+ *
+ * `parseClientMessage` does `JSON.parse(data) as TClientMessage`, and the only guard in the submit
+ * handler is `if (!msg.prompt)`. That is a FALSY check, not a type check: `{}`, `[]` and `42` are
+ * truthy, so they pass it and reach `session.submit(input: string)`.
+ *
+ * Why this one field and not the other thirteen with payloads: the value does not stop at the
+ * session. `interactive-session-execution-controller.ts:249` does
+ * `emit('user_message', displayInput ?? input)`, `ws-session-events.ts` classifies `user_message` as
+ * `'forwarded'` and delivers `{ type: 'user_message', content, … }` — declared `content: string` —
+ * to EVERY attached client, not only the sender. Both client cast sites (`ws-session-client.ts:66`,
+ * `rtc-responder-gate.ts:118`) accept it with `as TServerMessage`, so nothing on the receiving side
+ * rejects it either.
+ *
+ * So one unguarded field lets a client put a shape-invalid value into a typed frame delivered to its
+ * peers. The permission and resume paths were measured too and do NOT cross that way: `interpretApproval`
+ * compares by strict equality against a closed set and defaults to deny, and a malformed `ack`/`resume`
+ * seq degrades only the sender's own attachment.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createOutboundDelivery } from '../outbound-delivery.js';
+import { createWsHandler } from '../ws-handler.js';
+
+import type { TServerMessage } from '../ws-protocol.js';
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
+
+function setup() {
+  const submit = vi.fn().mockResolvedValue({ turnId: 't1', completed: Promise.resolve() });
+  const session = { submit, on: vi.fn(), off: vi.fn() } as unknown as IInteractiveSession;
+  const sent: TServerMessage[] = [];
+  const { onMessage } = createWsHandler({
+    session,
+    deliver: createOutboundDelivery((msg) => sent.push(msg), vi.fn()),
+  });
+  return { submit, sent, onMessage };
+}
+
+describe('TRANS-008: a non-string submit prompt is refused at the ingress', () => {
+  it.each([
+    ['an object', {}],
+    ['an array', []],
+    ['a number', 42],
+    ['a boolean', true],
+  ])('refuses %s — it is truthy, so the falsy guard passes it', (_label, prompt) => {
+    const { submit, sent, onMessage } = setup();
+
+    onMessage(JSON.stringify({ type: 'submit', prompt }));
+
+    // The session must never see it: once it does, the value is re-emitted as `user_message` to
+    // every attached client inside a frame whose `content` is declared `string`.
+    expect(submit).not.toHaveBeenCalled();
+    expect(sent.some((msg) => msg.type === 'protocol_error')).toBe(true);
+  });
+
+  it('still refuses an EMPTY prompt, which the falsy guard already caught', () => {
+    // The control for the guard that exists. A type check that replaced it would otherwise let
+    // `''` through — a regression hidden by the new assertions above.
+    const { submit, sent, onMessage } = setup();
+
+    onMessage(JSON.stringify({ type: 'submit', prompt: '' }));
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(sent.some((msg) => msg.type === 'protocol_error')).toBe(true);
+  });
+
+  it('still accepts a real string prompt, so the refusal is about shape and not about submitting', () => {
+    const { submit, onMessage } = setup();
+
+    onMessage(JSON.stringify({ type: 'submit', prompt: 'hello' }));
+
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
+++ b/packages/agent-transport-protocol/src/__tests__/ws-handler.test.ts
@@ -419,7 +419,12 @@ describe('WebSocket Transport Handler', () => {
   it('submit without prompt sends protocol_error', () => {
     const { onMessage, sent } = setup();
     onMessage(JSON.stringify({ type: 'submit' }));
-    expect(sent[0]).toEqual({ type: 'protocol_error', message: 'prompt is required' });
+    // TRANS-008: the wording changed with the guard. "required" was false for a prompt that WAS
+    // provided and had the wrong type; the refusal is about shape and the message now says so.
+    expect(sent[0]).toEqual({
+      type: 'protocol_error',
+      message: 'prompt must be a non-empty string',
+    });
   });
 
   it('submit rejection surfaces a protocol_error (WS-001)', async () => {

--- a/packages/agent-transport-protocol/src/ws-handler.ts
+++ b/packages/agent-transport-protocol/src/ws-handler.ts
@@ -221,8 +221,12 @@ function handleSessionControlMessage(
   driverId?: TDriverId,
 ): void {
   if (msg.type === 'submit') {
-    if (!msg.prompt) {
-      deliver({ type: 'protocol_error', message: 'prompt is required' });
+    // TRANS-008 (issue #2045). A TYPE check, not a falsy one: `{}`, `[]`, `42` and `true` are truthy
+    // and passed the previous `!msg.prompt` guard. It matters more here than at the other payload
+    // fields because the value does not stop at this session — it is re-emitted as `user_message` to
+    // EVERY attached client inside a frame whose `content` is declared `string`.
+    if (typeof msg.prompt !== 'string' || msg.prompt.length === 0) {
+      deliver({ type: 'protocol_error', message: 'prompt must be a non-empty string' });
       return;
     }
     // REMOTE-014 E5: attribute this remote turn to the SERVER-ASSIGNED driver id (never a client-sent one).


### PR DESCRIPTION
Refs #2045. **Deliberately `Refs`, not `Closes` — see "What this does not decide" below.**

## The one measured crossing

The submit handler's guard was `if (!msg.prompt)` — falsy, not typed — and `parseClientMessage` does `JSON.parse(data) as TClientMessage` without decoding. So `{}`, `[]`, `42` and `true` all passed it and reached `session.submit(input: string)`.

**Why this field and not the other thirteen carrying payloads: the value does not stop at the session.**

```
execution-controller:249   emit('user_message', displayInput ?? input)
ws-session-events.ts:47    user_message: 'forwarded'
ws-session-events.ts:104   deliver({ type: 'user_message', content, … })
ws-protocol.ts:70          { type: 'user_message'; content: string; … }
```

It is delivered to **every attached client, not only the sender**, inside a frame whose `content` is declared `string` — and both client cast sites (`ws-session-client.ts:66`, `rtc-responder-gate.ts:118`) accept it with `as TServerMessage`. One unguarded field let a client put a shape-invalid value into a typed frame delivered to its peers.

## Measured at `b9081fe7c` before designing

`TClientMessage` has **24 variants, 14 with payload fields, and exactly 2 ad-hoc guards** — both falsy checks. So an unvalidated payload reaches every handler. **What the consumers do with it is a separate question, and asking it is what narrowed this:**

| path | outcome |
| --- | --- |
| `permission-response` | **No harm.** `interpretApproval` compares by strict equality against `'allow-session'`/`'allow-project'` and otherwise returns `allowed: result === true`. Every malformed value denies — **a decoder here would prevent nothing.** |
| `ack` / `resume` | **Self-inflicted, bounded.** A non-numeric seq drops nothing; a huge one forces the sender's own full refresh. The buffer is separately bounded by frames and bytes. |
| `submit.prompt` | **Crosses to peers.** Fixed here. |

## Verification

Red proof is its own commit: 4 cases fail, 2 pass as controls.

| mutant | result |
| --- | --- |
| the falsy guard restored | red |
| the type half alone, emptiness dropped | red — caught by the empty-prompt control |
| refuse everything | red — caught by the accepts-a-string control |

The controls are load-bearing in both directions: without the empty-prompt case a type check would silently admit `''`; without the accepts-a-string case a handler that refused everything would satisfy all four positive cases.

**One correction from inside this work.** My first mutant run reported all three surviving. That was my harness, not the code — a command substitution inside the `echo` string clobbered `$?` before it was read, so the exit code belonged to a different command. Re-run reading the status directly, all three die. Recorded because it is the same defect this repository has been finding all day: **a number read from the wrong place looks like a measurement.**

The error message changed from `prompt is required` to `prompt must be a non-empty string`, and one existing assertion was updated. The old wording was false for a prompt that *was* provided and had the wrong type.

144 scans pass, `agent-transport-protocol` 187 / `agent-transport-gui` 21 / `agent-cli` 441, typecheck 0, `pnpm lint` exit 0.

## What this does not decide

**Issue #2045 stays open.** It proposes a total runtime decoder for the package; this closes the one crossing I could measure. Whether the package should decode totally is a data-correctness disposition and belongs to the owner, not to this merge. **A merge that closed the issue would read as that decision having been made.**

Three things stated so a later reader is not misled by the green:

- **`rtc-responder-gate.ts` is untouched and still casts.** It is a second client transport with the same hole, in a package #2045 never names — a decoder scoped to the issue's file list would leave it defective while reading as complete.
- **Thirteen of the fourteen payload-carrying fields were not traced to their use sites.** The ones the issue names were. If another crosses the way `prompt` does, that is a finding for #2045, not a widening of this diff.
- The record carries the same three statements, not only this description.
