### PR TITLE
docs(cli): record that the CLI-083 scenario discriminates, not merely that it passes

### DIFF
--- a/.agents/tasks/CLI-083-the-org-policy-loader-has-no-caller-so-four-enforcement-sites-are-unreachable-in.md
+++ b/.agents/tasks/CLI-083-the-org-policy-loader-has-no-caller-so-four-enforcement-sites-are-unreachable-in.md
@@ -155,6 +155,22 @@ the implementation PR rather than before implementation; the run therefore remai
 regression evidence and does not satisfy either done-gate stage. That planning-order violation is
 recorded here instead of being rewritten as if the gate had run on time.
 
+Control (2026-08-25; also NOT gate evidence): the run above establishes that the scenario passes,
+which on its own does not establish that it could fail. Removing the `loadOrgPolicy()` call from
+`command-setup.ts` and rebuilding the CLI turns the same scenario red —
+
+```
+× blocks a provider switch forbidden only by the policy loaded from disk
+  → PTY waitForSince timeout (15000ms) for
+    /Provider "openai" is not allowed by your organization policy/
+```
+
+— the refusal message never appears, so the scenario is not byte-identical with and without the
+behaviour it names. The call was restored and the green re-verified. This is recorded because a
+passing scenario and a discriminating one are different claims, and only the second says anything;
+it remains engineering regression evidence and satisfies neither done-gate stage, for the ordering
+reason stated above, which no amount of green can change.
+
 ### [DONE-GATE-STAGE-1] — 🔴 NON-COMPLIANCE | 2026-08-25
 
 **Status remains:** done


### PR DESCRIPTION
Refs #2287. Docs-only. **`status: blocked` is deliberately unchanged.**

## What this adds

The CLI-083 record held one line of engineering evidence: the PTY scenario passed 1/1. **That establishes the scenario passes and says nothing about whether it could fail.**

Removing the `loadOrgPolicy()` call from `command-setup.ts` and rebuilding the CLI turns the same scenario red:

```
× blocks a provider switch forbidden only by the policy loaded from disk
  → PTY waitForSince timeout (15000ms) for
    /Provider "openai" is not allowed by your organization policy/
```

The refusal message never arrives. So the scenario is not byte-identical with and without the behaviour it names — which is the property that makes the green mean something. The call was restored and the green re-verified.

A passing scenario and a discriminating one are different claims. A record carrying only the first is missing the only part that could have failed.

## What this deliberately does not do

**It does not touch the status, and it is not offered as gate evidence.**

`DONE-GATE-STAGE-1` returned `NON-COMPLIANCE` on this item for **ordering** — the scenario was authored after the implementation merged — and its required action says in terms:

> do not treat the retrospective scenario or **its engineering test output** as a Stage 1 PASS

My run is that engineering test output. **No amount of green changes when the scenario was written**, so the control strengthens the evidence and cannot discharge the gate. The item stays `blocked` and unrouted; the disposition for retrospectively-authored scenarios is with the owner, and it is a class question rather than this item's — 33 of 129 live records and 267 of 909 completed ones have no scenario section at all (issue #2308).

## Verification

144 scans pass on a clean tree. Docs-only: no source, no tests, no behaviour.
