### PR TITLE
docs(harness): state why HARNESS-118 has no user execution scenario

### DIFF
--- a/.agents/tasks/HARNESS-118-citations-of-a-task-record-path-are-not-re-derived-when-the-record-moves-is-rena.md
+++ b/.agents/tasks/HARNESS-118-citations-of-a-task-record-path-are-not-re-derived-when-the-record-moves-is-rena.md
@@ -101,3 +101,25 @@ every one of the four outcomes was discovered in the real tree and no fixture wo
 `conflict`. Gate commands: `node scripts/harness/run-all-scans.mjs`, `pnpm lint` (exit code),
 `pnpm typecheck`, and the three mutants above run individually with an applied-check confirming the
 mutation is in the tree before the result is read.
+
+## User Execution Test Scenarios
+
+**Not applicable — no runnable user-facing behaviour, and the reason is the change's whole subject.**
+
+This delivers a harness scan over `.agents/` documents plus repairs to sixteen citations inside them.
+Its entire surface is repository governance: it changes no product command, no TUI or browser flow,
+no SDK or example flow, and no workflow a user of Robota can run. A person using the CLI cannot
+observe it at any input, because nothing it touches is reachable from one — the "users" of a
+task-record path citation are the agents and readers working inside this repository.
+
+`backlog-execution.md` warns specifically against inventing a scenario for documentation-only,
+rule-only or governance-only work, and this is all three. A scenario here would have to be an
+engineering command (`node scripts/harness/scan-task-path-citations.mjs`), which the same rule
+excludes by name: the engineering test plan above already owns it, and restating it under this
+heading would dress a harness invocation as user execution.
+
+Recorded rather than omitted because the rule requires the REASON, not merely the absence of a
+scenario — and because this record shipped without the section at all, which is the defect
+[issue #2308](https://github.com/woojubb/robota/issues/2308) exists for: nothing emits the section
+and nothing checks for it, so an author who fills in the headings they were given produces a
+non-compliant record and learns of it, if ever, from a gate long afterwards.


### PR DESCRIPTION
Refs #2308. Docs-only. Status unchanged; the item is **not** reopened.

## What was missing

HARNESS-118 shipped without a `## User Execution Test Scenarios` section. `backlog-execution.md` requires one on every record whose work reached implementation — **either a scenario, or a reasoned not-applicable entry.** An absent section is non-compliant either way, and the remedy is a paragraph, not a re-delivery.

## Why not applicable, and why that is not the cheap answer

The rule's test is whether the change delivers **runnable user-facing behaviour, command behaviour, TUI/browser behaviour, or workflow behaviour.**

HARNESS-118 delivered a harness scan over `.agents/` documents plus repairs to sixteen citations inside them. No product command, no TUI or browser flow, no SDK or example flow. **A person using the Robota CLI cannot observe it at any input**, because nothing it touches is reachable from one — the readers of a task-record path citation are the agents working inside this repository.

The rule warns specifically against inventing a scenario for documentation-only, rule-only or governance-only work, and this is all three. The only executable is `node scripts/harness/scan-task-path-citations.mjs`, which the same rule excludes by name and which the record's engineering test plan already owns. Restating it here would dress a harness invocation as user execution.

## What is deliberately NOT in this PR

**TRANS-007 is excluded, and the exclusion is the judgement that mattered.**

That record changed behaviour a user can observe: a resume on a damaged session returned a fifteen-empty-member record with no indication anything was wrong, and a rename silently did nothing. Both changed. So its section needs a **real** scenario — which, authored now, would be retrospective, and that is exactly the disposition currently with the owner after CLI-083.

`Not applicable` is the answer that lets a sweep finish, and a wrongly-labelled one is worse than a blocked record: it closes the question instead of holding it open, and nothing re-opens it. TRANS-007 joins the class rather than being answered cheaply here.

## Verification

144 scans pass on a clean tree, including `spec-user-execution-section`. Docs-only: no source, no tests, no behaviour.
