### PR TITLE
fix(subagent): the wire payload carries what the child reads, not the parent's config (ARCH-044)

### DIFF
--- a/packages/agent-framework/src/assembly/create-subagent-session.ts
+++ b/packages/agent-framework/src/assembly/create-subagent-session.ts
@@ -43,8 +43,20 @@ const LEGACY_AGENT_TOOL_NAME = 'Agent';
 export interface ISubagentOptions {
   /** Agent definition (built-in or custom). */
   agentDefinition: IAgentDefinition;
-  /** Parent's resolved config (for provider, permissions, etc.). */
-  parentConfig: IResolvedConfig;
+  /**
+   * ARCH-044 (issue #2047): the config members this assembly READS, not the parent's whole config.
+   *
+   * Declared structurally so both callers satisfy it — the in-process runner passes its full
+   * `IResolvedConfig`, and the child-process runner passes a projection carrying only these. Before
+   * this it demanded `IResolvedConfig`, which is why the child's wire payload had to carry the
+   * parent's resolved credential and `env` map to typecheck, neither of which anything here reads.
+   */
+  parentConfig: {
+    readonly provider: { readonly model: string };
+    readonly permissions: IResolvedConfig['permissions'];
+    readonly defaultTrustLevel: IResolvedConfig['defaultTrustLevel'];
+    readonly hooks?: IResolvedConfig['hooks'];
+  };
   /** Parent's loaded context (CLAUDE.md, AGENTS.md). */
   parentContext: ILoadedContext;
   /** Parent session's available tools (to inherit/filter). */

--- a/packages/agent-subagent-runner/src/__tests__/parent-config-projection.test.ts
+++ b/packages/agent-subagent-runner/src/__tests__/parent-config-projection.test.ts
@@ -1,0 +1,79 @@
+/**
+ * ARCH-044 (issue #2047) — the wire payload carries what the child reads, not the parent's whole config.
+ *
+ * `ISubagentWorkerStartPayload.parentConfig` was `IInProcessSubagentRunnerDeps['config']` — the whole
+ * `IResolvedConfig` — built two lines above `providerProfile: createProviderProfile(...)`, which
+ * SEC-009 hardened to carry `apiKeyEnv` and leave the resolved secret behind. So the secret crossed
+ * anyway, on the member nobody scoped.
+ *
+ * Measured at `7ee0ca6e4`, the child reads exactly four members:
+ *   provider.model, permissions, defaultTrustLevel   (create-subagent-session.ts:190,214,226)
+ *   hooks                                            (child-process-subagent-worker.ts:141)
+ *
+ * `provider.apiKey` is not among them and neither is `env`. A search for a spread, an
+ * `Object.keys`, or a whole-object pass finds none, so those four are the value's readers rather
+ * than merely its named ones. **The credential is structurally cloned into a second process and read
+ * by nothing** — there is no benefit to weigh the exposure against.
+ *
+ * These test the PROJECTION's behaviour, not its type. Structural typing would accept
+ * `return config` where the narrow type is expected — an object with excess properties is assignable
+ * — so the type alone cannot keep the secret off the wire, and a test that only typechecked would
+ * pass while the secret shipped.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { projectParentConfig } from '../child-process-subagent-runner.js';
+
+import type { IInProcessSubagentRunnerDeps } from '@robota-sdk/agent-framework';
+
+function parentConfig(): IInProcessSubagentRunnerDeps['config'] {
+  return {
+    defaultTrustLevel: 'moderate',
+    language: 'ko',
+    currentProvider: 'openai',
+    provider: {
+      name: 'openai',
+      model: 'test-model',
+      apiKey: 'sk-the-resolved-secret',
+      apiKeyEnv: 'OPENAI_API_KEY',
+      baseURL: 'http://localhost:1234/v1',
+    },
+    permissions: { allow: ['Read'], deny: ['Bash(rm -rf /)'] },
+    env: { SOME_TOKEN: 'another-secret' },
+  } as unknown as IInProcessSubagentRunnerDeps['config'];
+}
+
+describe('ARCH-044: the projected parent config', () => {
+  it('does not carry the resolved credential', () => {
+    const projected = projectParentConfig(parentConfig()) as { provider?: { apiKey?: unknown } };
+
+    expect(projected.provider?.apiKey).toBeUndefined();
+  });
+
+  it('does not carry the env map — a second unread carrier of secrets', () => {
+    // One projection removes two classes rather than one field, which is the argument for
+    // projecting rather than deleting `provider.apiKey` in place.
+    expect((projectParentConfig(parentConfig()) as { env?: unknown }).env).toBeUndefined();
+  });
+
+  it('carries the four members the child actually reads', () => {
+    // The control. A projection that returned `{}` would satisfy both cases above and break every
+    // child; these are the fields measured as read.
+    const projected = projectParentConfig(parentConfig());
+
+    expect(projected.provider.model).toBe('test-model');
+    expect(projected.permissions).toEqual({ allow: ['Read'], deny: ['Bash(rm -rf /)'] });
+    expect(projected.defaultTrustLevel).toBe('moderate');
+  });
+
+  it('drops the members nothing reads, rather than passing the object through', () => {
+    // The assertion that a `return config` implementation fails. Without it the two cases above are
+    // satisfied by deleting two fields and leaving the rest of the parent's config on the wire.
+    expect(Object.keys(projectParentConfig(parentConfig())).sort()).toEqual([
+      'defaultTrustLevel',
+      'permissions',
+      'provider',
+    ]);
+  });
+});

--- a/packages/agent-subagent-runner/src/__tests__/parent-config-projection.test.ts
+++ b/packages/agent-subagent-runner/src/__tests__/parent-config-projection.test.ts
@@ -23,7 +23,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { projectParentConfig } from '../child-process-subagent-runner.js';
+import { projectParentConfig } from '../parent-config-projection.js';
 
 import type { IInProcessSubagentRunnerDeps } from '@robota-sdk/agent-framework';
 

--- a/packages/agent-subagent-runner/src/child-process-subagent-ipc.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-ipc.ts
@@ -1,5 +1,9 @@
 import type { ISessionUsageTotals, TPermissionMode, TToolArgs } from '@robota-sdk/agent-core';
-import type { IAgentDefinition, IInProcessSubagentRunnerDeps } from '@robota-sdk/agent-framework';
+import type {
+  IAgentDefinition,
+  IInProcessSubagentRunnerDeps,
+  IResolvedConfig,
+} from '@robota-sdk/agent-framework';
 import type {
   ISerializableProviderProfile,
   ISubagentSpawnRequest,
@@ -10,6 +14,14 @@ export type TSubagentWorkerWireValue = string | number | boolean | null | undefi
 type TSubagentWorkerWireRecord = Record<string, TSubagentWorkerWireValue>;
 
 import type { ISandboxProjection } from './worker-composition.js';
+
+/** ARCH-044: the four config members the child reads. See `projectParentConfig`. */
+export interface ISubagentWorkerParentConfig {
+  readonly provider: { readonly model: string };
+  readonly permissions: IResolvedConfig['permissions'];
+  readonly defaultTrustLevel: IResolvedConfig['defaultTrustLevel'];
+  readonly hooks?: IResolvedConfig['hooks'];
+}
 
 export interface ISubagentWorkerStartPayload {
   taskId: string;
@@ -25,7 +37,17 @@ export interface ISubagentWorkerStartPayload {
    */
   worktree?: { readonly path: string; readonly branch?: string };
   agentDefinition: IAgentDefinition;
-  parentConfig: IInProcessSubagentRunnerDeps['config'];
+  /**
+   * ARCH-044 (issue #2047): the config members the child reads, declared here rather than indexed
+   * out of the runtime type.
+   *
+   * It was `IInProcessSubagentRunnerDeps['config']`, so the wire shape was the in-process shape and
+   * grew with it — which put the parent's resolved `provider.apiKey` and its `env` map into a second
+   * process where nothing read either. Declaring the members means a new field on `IResolvedConfig`
+   * does not reach the child by default; `projectParentConfig` is what enforces it at runtime,
+   * because structural typing would accept the whole config here.
+   */
+  parentConfig: ISubagentWorkerParentConfig;
   parentContext: IInProcessSubagentRunnerDeps['context'];
   providerProfile: ISerializableProviderProfile;
   /**

--- a/packages/agent-subagent-runner/src/child-process-subagent-runner.ts
+++ b/packages/agent-subagent-runner/src/child-process-subagent-runner.ts
@@ -25,6 +25,7 @@ import {
   sendWorkerMessage,
   type IChildProcessRuntime,
 } from './child-process-subagent-transport.js';
+import { projectParentConfig } from './parent-config-projection.js';
 import { SUBAGENT_WORKER_MODE_FLAG, type ISubagentWorkerEntry } from './worker-entry.js';
 
 import type { ISubagentWorkerStartPayload } from './child-process-subagent-ipc.js';
@@ -193,7 +194,7 @@ export class ChildProcessSubagentRunner implements ISubagentRunner {
       request: job.request,
       ...(job.worktree ? { worktree: job.worktree } : {}),
       agentDefinition: applyRequestOverrides(definition, job),
-      parentConfig: this.deps.config,
+      parentConfig: projectParentConfig(this.deps.config),
       parentContext: this.deps.context,
       providerProfile: createProviderProfile(this.providerConfig, this.deps, job),
       permissionMode: this.deps.permissionMode,

--- a/packages/agent-subagent-runner/src/parent-config-projection.ts
+++ b/packages/agent-subagent-runner/src/parent-config-projection.ts
@@ -1,0 +1,35 @@
+/**
+ * ARCH-044 (issue #2047) — what the parent's config contributes to the child's wire payload.
+ *
+ * Its own module because "which config members cross a process boundary" is a different question
+ * from "how a child process is run", and the runner answered both until this file existed.
+ */
+
+import type { ISubagentWorkerParentConfig } from './child-process-subagent-ipc.js';
+import type { IInProcessSubagentRunnerDeps } from '@robota-sdk/agent-framework';
+
+/**
+ * ARCH-044 (issue #2047): the config members the CHILD reads, and no others.
+ *
+ * `parentConfig` was the parent's whole `IResolvedConfig`, so the payload's shape was derived from a
+ * runtime type and grew whenever that type grew. It carried the resolved `provider.apiKey` — two
+ * lines above `createProviderProfile`, which SEC-009 hardened precisely to keep that secret off the
+ * wire — and an `env` map, and **nothing in the child read either**. Measured: the child touches
+ * `provider.model`, `permissions`, `defaultTrustLevel` and `hooks`, and no spread, `Object.keys` or
+ * whole-object pass reaches the rest.
+ *
+ * Declared as an explicit shape rather than an `Omit` of the runtime type, so a new field on
+ * `IResolvedConfig` does NOT reach the child by default — which is the whole of ARCH-044. It is
+ * built key by key for the same reason: structural typing would accept the whole config where this
+ * type is expected, so the type documents the intent and this function is what enforces it.
+ */
+export function projectParentConfig(
+  config: IInProcessSubagentRunnerDeps['config'],
+): ISubagentWorkerParentConfig {
+  return {
+    provider: { model: config.provider.model },
+    permissions: config.permissions,
+    defaultTrustLevel: config.defaultTrustLevel,
+    ...(config.hooks === undefined ? {} : { hooks: config.hooks }),
+  };
+}


### PR DESCRIPTION
Refs #2047 (ARCH-044). **`Refs`, not `Closes` — see "What this does not do".**

## The finding, and why it is not a trade-off

`ISubagentWorkerStartPayload.parentConfig` was `IInProcessSubagentRunnerDeps['config']` — the parent's whole `IResolvedConfig`. It was built **two lines above** `providerProfile: createProviderProfile(...)`, the call SEC-009 hardened to carry `apiKeyEnv` and leave the resolved secret behind:

```ts
parentConfig: this.deps.config,                  // ← the whole config, incl. provider.apiKey
providerProfile: createProviderProfile(...),     // ← hardened by SEC-009
```

**So the credential crossed anyway, on the member nobody scoped.** SEC-009 removed the second copy of the secret and left the first.

Measured at `7ee0ca6e4`, the child reads **four** members:

| member | read at |
| --- | --- |
| `provider.model` | `create-subagent-session.ts:190,191` |
| `permissions` | `create-subagent-session.ts:214` |
| `defaultTrustLevel` | `create-subagent-session.ts:226` |
| `hooks` | `child-process-subagent-worker.ts:141` |

`provider.apiKey` is not among them. Neither is `env`. A search for a spread, an `Object.keys`, or a whole-object pass finds none, so those four are the **value's** readers rather than merely its named ones.

**The credential is structurally cloned into a second process and read by nothing.** There is no benefit to weigh the exposure against — which is what makes the removal unarguable rather than a scoping decision.

`env` is a `Record<string, string>` and equally unread, so **one projection removes two classes of secret**, not one field.

## The fix, and why it needs both halves

The payload declares the four members; `projectParentConfig` builds them key by key.

**I tried the type alone first, and it did not hold.** My first version narrowed only `ISubagentWorkerStartPayload.parentConfig` and expected the compiler to enforce it. It does not.

**Why both halves are here, and this is the part worth reviewing.** TypeScript's excess-property check does not apply to a non-literal, so `return config` typechecks against the narrow type and ships the secret. The type states the intent; the function enforces it; **the test's exact key-set assertion is what catches a pass-through.**

`createSubagentSession`'s `parentConfig` parameter is narrowed to the same shape. It demanded `IResolvedConfig`, which is precisely why the child's payload had to carry the credential to typecheck at all. Both callers satisfy the narrower type structurally — the in-process runner still passes its full config unchanged.

The projection lives in its own module: *which config members cross a process boundary* is a different question from *how a child process is run*, and the runner answered both. That also returns `child-process-subagent-runner.ts` to 291 lines, under the ceiling my first version crossed at 318.

## Verification

Red proof is its own commit — four cases, failing because the projection did not exist.

| mutant | result |
| --- | --- |
| return the whole config (what structural typing allows) | red — 3 cases, including the key-set assertion |
| keep `apiKey` on the projected provider | red |

Controls: the four measured members must still arrive (a projection returning `{}` would satisfy both removals and break every child), and the key set is asserted exactly.

143 scans pass, 2 skipped — `document-authority` and `new-rule-declares-enforcement`, both self-skipping for want of a subject on this branch. `agent-subagent-runner` 45, `agent-framework` 1553, `agent-cli` 441. `pnpm typecheck` 0, `pnpm lint` **exit 0** — my first version added 2 warnings over the 2203 ceiling and the module extraction removed them.

## What this does not do

**#2047 stays open.** It asks for a JSON-safe totally decoded DTO. Measured, **JSON-safety is not the defect**: I traced every payload member and found no `Date`, no function, no `undefined` semantics. The issue names those as a class without saying which occur, and none does. This fixes the defect that is real — the payload's shape being derived from a runtime type, and what that carried.

**`parentContext` is deliberately not narrowed here.** Same shape, and measured: **two** readers (`agentsMd`, `projectNotesMd`) out of seven members, so its unread remainder includes `agentsFileEntries` and `projectNotesFileEntries` — which carry whole file contents. One narrowing per change; that one is specified and follows.

**A harness defect found on the way, not fixed here:** `tsconfig.eslint.json` includes only `.ts`/`.tsx`, while `lint-staged` runs `eslint` over `*.{js,mjs,cjs}`. The two tracked `.mjs` fixtures under `packages/agent-subagent-runner/src/__tests__/fixtures/` therefore **cannot be edited and committed** — the pre-commit hook fails with a parser error. I routed around it by testing the projection directly rather than extending a fixture.

