### PR TITLE
docs(tasks): CLI-078 holds both constructions outside the fold (CLI-078)

### DIFF
--- a/.agents/tasks/CLI-078-eval-command-outside-product-profile.md
+++ b/.agents/tasks/CLI-078-eval-command-outside-product-profile.md
@@ -1,30 +1,94 @@
 ---
-title: 'CLI-078: `robota eval` composes its own provider outside the product profile'
+title: 'CLI-078: `robota eval` composes its own provider outside the product profile — and so does the subagent runner factory, before the fold'
 status: todo
 created: 2026-07-25
-priority: low
-urgency: later
+priority: medium
+urgency: soon
 area: packages/agent-cli
 depends_on: [ARCH-005]
 ---
 
-# CLI-078: the eval surface bypasses the product profile
+# CLI-078: two collaborators are constructed outside the one assembly point
 
 ## Problem
 
 After the ARCH-005 S2 collapse, `robota`'s main surfaces assemble through `assembleProduct`, but
-`packages/agent-cli/src/eval/eval-command.ts:89` still composes its own provider outside the profile
+`packages/agent-cli/src/eval/eval-command.ts` still composes its own provider outside the profile
 (found by the S2 conformance review). So there are two provider-construction paths in one product.
+
+**There are three.** Measured at `a0b7891ea` while testing whether issue #2048's four claims were one
+problem:
+
+- **`eval` builds its own path.** `eval-command.ts:100-107` calls `createProviderFromSettings` →
+  `createAgentRuntime`, with `providerDefinitions: createDefaultProviderDefinitions()` at :104,
+  unconditionally. (The original citation above was `:89`; the construction is the same one, moved.)
+- **`createRobotaSubagentRunnerFactory` is called at `cli.ts:233` — nineteen lines BEFORE
+  `assembleProduct` at :252** — carrying its own `providerConfig: { ...providerSettings, model: modelId }`
+  and a `reproduction:` block. `backgroundTaskRunners` (:232) is constructed there too. Both are then
+  handed to serve-mode (:341-342) and print-mode (:421-422) **directly, around the assembly.**
+
+These two are one cause, which is why this record holds both: **a collaborator constructed outside the
+single assembly point cannot receive what assembly folds in.** Fixing one and leaving the other
+reproduces the pattern registered as issue #2314 — a fix landing on one of several paths carrying the
+same value, and reading as complete.
+
+## What ARCH-109 did and did not do
+
+ARCH-109 found a child-process subagent rebuilding the default provider set. Its fix,
+`subagent-provider-reproduction.ts`, made the recipe hold session-wide — and `cli.ts:250-251` records
+exactly that: _"that parenthesis was true of this process and false of its children until
+`subagent-provider-reproduction.ts` made it hold session-wide."_
+
+**ARCH-109 reproduced the recipe on the far side of the bypass and left the bypass standing.** The
+call at :233 is the same construction, relocated out of `cli.ts` under the file-size floor — out of the
+file is not into the right place. And the reproduction never reached `eval`:
+`git log --all -S createRobotaSubagentComposition -- packages/agent-cli/src/eval/` returns nothing,
+where the same query without the pathspec returns the ARCH-109 commits.
+
+## The seam comment is part of what has to change
+
+`cli.ts:274` calls the `buildRobotaRuntimeOptions` result "the kernel's RUNTIME SEAM — every surface
+below binds to THIS one result." That is true of `commandModules`, `agentDefinitions` and `toolOptions`,
+which do pass through it. It is false of the two collaborators handed around it.
+
+This cost a wrong measurement: reading the comment produced a verdict that the modes bind
+post-assembly, corrected only by checking construction order. **A document's self-description diverging
+from what the document contains** is the same object as issue #2048's summary line claiming a direction
+its own evidence line refutes (see CLI-080). In both, the true version was cheaper to reach than the
+false one — construction order, and the next paragraph. Whoever fixes this must correct the comment, or
+the next reader stops where that reading stopped.
 
 ## What
 
-Decide and record: either route `eval` through the product profile like the other surfaces, or
-document it as a deliberately separate shell path (with the reason — e.g. eval needs a provider
-configuration the interactive profile should not carry). Silence is the thing to avoid: an
-undocumented second path is how the composition root grew back last time.
+Decide and record: either route `eval` and the runner factory through the product profile like the
+other surfaces, or document them as deliberately separate shell paths (with the reason — e.g. eval
+needs a provider configuration the interactive profile should not carry). Silence is the thing to
+avoid: an undocumented second path is how the composition root grew back last time.
+
+**Scope the fix by asking what the fold would have to accept.** If `assembleProduct` cannot take a
+subagent runner factory without the caller building it first, that constraint is the real one and it
+decides the size of this item.
+
+## Priority
+
+Raised to `medium` / `soon` on the structural bypass, which is confirmed above. **Not raised further,
+deliberately:** ARCH-109's measured harm was two specific things — a replay parent whose children called
+live with a real key, and caller-supplied definitions failing to resolve in the child. **Neither is
+measured for the eval path**, and this is not ranked on the assumption that a structural sibling carries
+the same harm. If the eval path is found to carry the key exposure, it goes higher **on that
+measurement rather than on the resemblance.**
 
 ## Test Plan
 
 If routed: `eval` still passes its existing suite and the provider it receives is the one the profile
-resolves (assert equality). If documented-as-separate: a comment at the call site + a line in
-`agent-cli/docs/SPEC.md` stating the exemption and its reason.
+resolves (assert equality). For the runner factory, the equivalent assertion is that the factory the
+modes receive is the one assembly produced — a construction-order test, since the defect is invisible to
+a value comparison when both paths happen to resolve the same provider. If documented-as-separate: a
+comment at each call site + a line in `agent-cli/docs/SPEC.md` stating the exemption and its reason.
+
+## User Execution Test Scenarios
+
+Not authorable yet, and deliberately left empty rather than filled with a placeholder. This record's
+disposition is undecided — routing through the profile and documenting a separate path deliver
+different user-observable behavior, and one of them delivers none. The scenarios are authored when the
+disposition is chosen, before implementation.

--- a/.agents/tasks/CLI-078-eval-command-outside-product-profile.md
+++ b/.agents/tasks/CLI-078-eval-command-outside-product-profile.md
@@ -88,7 +88,13 @@ comment at each call site + a line in `agent-cli/docs/SPEC.md` stating the exemp
 
 ## User Execution Test Scenarios
 
-Not authorable yet, and deliberately left empty rather than filled with a placeholder. This record's
-disposition is undecided — routing through the profile and documenting a separate path deliver
-different user-observable behavior, and one of them delivers none. The scenarios are authored when the
-disposition is chosen, before implementation.
+Unwritten, with the reason recorded here as Stage 1 requires — not left blank. This record's
+disposition is undecided: routing through the profile and documenting a separate path deliver
+different user-observable behavior, and one of them delivers none. Writing a scenario now would
+invent one for work whose shape is not chosen.
+
+**This reason is temporal and does not survive the choice.** It makes writing impossible _now_, and
+expires the moment the disposition is decided — at which point this section must be filled, before
+implementation. A reason that has expired reads exactly like one that has not, so it is said here
+explicitly: if the disposition is on record and this section is still empty, the exception no longer
+applies and the omission is a defect, not an exception.


### PR DESCRIPTION
## What

Extends CLI-078 with the second construction outside `assembleProduct`, and raises it to `medium` / `soon`.

## Why

Issue #2048 proposes converging CLI-078, CLI-079, CLI-080 and one newly observed bypass into a single item. Measuring its four claims at `a0b7891ea` says the bundle does not hold — but **two of the four do share a cause**, and that pairing is what this PR records.

| claim | verdict |
|---|---|
| `eval` builds its own provider/runtime path | **true** — `eval-command.ts:100-107`, `createDefaultProviderDefinitions()` unconditional at `:104` |
| mode dispatch consumes pre-assembly collaborators | **true** — `cli.ts:232-233` construct before `assembleProduct` at `:252`, passed to both modes at `:341-342` / `:421-422` |
| default CLI composes `/mode` against the SPEC | true, and **already CLI-079** — unchanged here |
| the executor exemption is wider than the rule | true, and **already CLI-080** — unchanged here |

The first two are one cause: **a collaborator constructed outside the single assembly point cannot receive what assembly folds in.** Fixing one and leaving the other reproduces issue #2314.

**No new IDs were allocated.** All three claims that survive already have records; only the second claim was unrecorded, and it belongs in the record that already owns "constructed outside the product profile".

## What this says about ARCH-109

ARCH-109 reproduced the provider recipe on the far side of the bypass and left the bypass standing — `cli.ts:250-251` documents that in its own words. Its fix never reached `eval`: `git log --all -S createRobotaSubagentComposition -- packages/agent-cli/src/eval/` returns nothing, where the same query without the pathspec returns the ARCH-109 commits.

## Two corrections recorded rather than quietly fixed

- The runtime-seam comment at `cli.ts:274` claims "every surface below binds to THIS one result". True of the three collaborators that pass through the seam, false of the two handed around it. **It cost a wrong measurement in this very investigation** — the first reading of claim 2 was FALSE, corrected only by checking construction order.
- Issue #2048 line 8 says the exemption is *narrower* than the rule; its own line 17 says *wider*, as does CLI-080's title. The evidence line is right and the summary line is what a reader acts on.

Both are a document's self-description diverging from what the document contains. Recorded in CLI-078 rather than filed as a fourth meta-issue.

## Priority

`low`/`later` → `medium`/`soon`, on the confirmed structural bypass. **Deliberately not higher:** ARCH-109's measured harm (a replay parent whose children called live with a real key; caller-supplied definitions failing to resolve) is **not measured for the eval path**, and this is not ranked on the assumption that a structural sibling carries the same harm. The record states what would move it.

## Verification

`pnpm harness:scan` — 143 passed, 2 skipped, 0 failures. Advisories are pre-existing and unrelated.

Docs-only: one task record. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH