### PR TITLE
fix(hooks): the frozen-diff refusal was unreachable to anyone obeying the rule beside it

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -522,6 +522,31 @@ Case: [PROC-013](https://github.com/woojubb/robota/issues/2283).
 **Zero findings obliges exactly one thing: STOP EDITING.** It is not a signal to merge, not a
 deadline, and not a reason to hurry.
 
+**A push into an open pull request requires a NAMED GROUND, and there are exactly three.** This is not
+a caution and not a preference. Work with no ground does not get done more carefully — **it does not
+get started.**
+
+1. **A finding published on that pull request.** Published means posted where the next reader sees it:
+   a reviewer verdict, or a review you posted yourself through the writer. A finding held in one
+   session is not a ground — see below.
+2. **A required check that is red.** The check names what is wrong; fixing it is the resolution.
+3. **The base moved and the branch must be rebased.** That is not an edit and does not restart the
+   loop.
+
+**Nothing else is a ground.** Not an improvement you noticed. Not your own prose re-read and found
+imprecise. Not advice a reviewer attached to a passing verdict. Not a thing that is _true_ and _better_
+and _would have been caught eventually_. Every one of those is real work and every one belongs in the
+next pull request.
+
+**Before pushing, name which of the three it is.** If you cannot name it in one sentence pointing at
+something another person can open — a comment, a check, a commit range — **there is no ground and the
+push does not happen.** "It was wrong and I fixed it" is not a ground; it is a description of the work,
+and every unjustified round in the measured case could have said it.
+
+**The burden runs the other way from intuition.** A defect you can see is not permission to touch a
+frozen diff; it is a reason to write it down somewhere it will survive. The pull request under review
+is the one place it must not go.
+
 **Advice arriving alongside a zero count is not a finding.** A reviewer may add SHOULD or CONSIDER
 notes on a diff it has just passed. Those are input for a FUTURE pull request. Acting on them
 re-opens the diff, producing a new head, a new round, and new advice on the new code — a loop with no
@@ -540,11 +565,70 @@ terminal condition, because each fix creates the surface the next round reads.
 hook cannot see. Reaching for it repeatedly is the signal that the reason has stopped being examined,
 and nothing counts repeated use.
 
+**A verdict nobody published is not a verdict — and driving your own work with one is a private gate.**
+
+The measured case ran five rounds. Every round the repository's reviewer posted `ACTIONABLE FINDINGS: 0`
+and said in words that it found nothing. The session never saw any of it:
+
+```
+pr-review-reviewer dispatched      32×  (5× on this pull request)
+pr-review-writer dispatched         0×  ← no finding ever reached a pull request
+gh pr view <the PR>                 0×  ← the gate's input was never read
+```
+
+It dispatched its own reviewer each round, consumed the findings privately, pushed a fix, and
+dispatched again. **The merge gate's input was zero from round one; the pull request could have merged
+four hours earlier.** After the first commit, non-comment `.ts` lines changed: **zero**. Four hours of
+SPEC prose, comments and changeset text, on a change the repository had already passed.
+
+**So the rule is not "the reviewer keeps suggesting things" and not "stop when the gate says zero".**
+
+- **If you dispatch a reviewer, publish its verdict.** `pr-review-writer` exists for this. An
+  unpublished verdict is the input to no gate, visible to nobody, and answerable by nobody — and a
+  session that fixes against it has built a gate only it can see, then reports being held by it.
+- **Publishing converts a finding from fuel into a record.** Published, it can be answered, deferred,
+  filed as its own issue, or refuted by someone else. Unpublished, the only thing that can be done
+  with it is the next commit.
+- **Read the gate's input before concluding you are blocked by it.** `gh pr view <n>` is the value the
+  merge gate reads. A session that has never run it does not know whether it is blocked.
+
+**And publishing is what supplies the exit.** The session's own account of why recognising the pattern
+did not stop it: _"there was no place to say this finding is real and not for this pull request."_
+There is such a place, and it is the pull request — but only for a finding that was posted to it. A
+finding that exists only in one session has nowhere to be deferred to, so the only move available is
+to fix it now.
+
+**The reverse failure is real too and the rule must not create it.** Of the local findings here, the
+first round's two MUSTs were genuine — one was a SPEC asserting _"executor injection has no public
+entry point at all"_ where at least seven public paths existed, a false universal in a
+security-adjacent document. **A rule reading only "the gate says zero, so stop" ships those.** That is
+the argument for publishing rather than for discarding: the repository's light-pass reviewer and a
+dispatched deep reviewer answer different questions, and the gap between them belongs on the pull
+request where both are visible, not inside whichever session happened to look.
+
+**The ordering is already written down and nothing checks it.** `pr-finding-resolution-loop` step 5
+reads _"Dispatch `pr-review-writer` (posts the review to the PR), **then** `pr-review-fixer`"_ — publish
+first, fix second. Measured: no file under `scripts/harness/` or `.claude/hooks/` references
+`pr-review-writer` at all, so a session can run reviewer → fixer → push, thirty-two times, and no
+mechanism notices the middle step was skipped. **The rule was not missing; its enforcement was.** What
+catches the loop today is the frozen-diff refusal below, which refuses the second push once the pull
+request's own verdict reads zero — verified against this case's branch.
+
+**The test for an edit remains: did anyone ask for it?** A finding you published and someone can read
+counts as asked. A finding only you have seen does not — and neither does your own prose, re-read.
+
 **If no more issues can be found, there is nothing left to fix.**
 
 Enforced by: `pre-push-check` for the half a machine can decide — it refuses a push into an open pull
 request whose latest reviewer verdict reports `ACTIONABLE FINDINGS: 0`, because there is then nothing
-for that push to resolve. The rest is not mechanizable here: whether to merge, and when, is a
+for that push to resolve. **That refusal was unreachable when this rule was first written**, and the
+way it was unreachable is worth keeping: the check sat inside the branch that runs only when no local
+review is recorded, so a session that recorded one — which this file REQUIRES before a first push —
+skipped the branch entirely and never reached the check. A guard bypassed by obeying the rule beside
+it is not a guard. It is now evaluated on every push, before the override short-circuit, and it has
+its own hatch: `PRE_PUSH_ALLOW_FROZEN_DIFF=1` inline. `PRE_PUSH_ALLOW_UNREVIEWED=1` does **not**
+excuse it — that one asserts the diff is unreviewed, which is a different claim about a different
+rule, and one switch disarming two unrelated gates is how both stop being asked. The rest is not mechanizable here: whether to merge, and when, is a
 judgement about a state the repository can observe but not evaluate, and a check that merged on green
 would be the automation this section exists to refuse.
 
@@ -638,6 +722,7 @@ opposite lifetime from inline and the reason this form is worth naming rather th
 | ------------------------------------------------------------------------------------------------- | ----------------------------- | ----------- |
 | `MERGE_GATE_ACK`                                                                                  | `merge-gate.sh`               | inline      |
 | `PRE_PUSH_ALLOW_UNREVIEWED`                                                                       | `pre-push-check.sh`           | inline      |
+| `PRE_PUSH_ALLOW_FROZEN_DIFF`                                                                      | `pre-push-check.sh`           | inline      |
 | `WORKTREE_CWD_GUARD_ALLOW_MAIN`                                                                   | `worktree-cwd-guard.sh`       | inline      |
 | `BRANCH_GUARD_ALLOW_DELETE`, `_BASE`, `_BRANCH_COPY`, `_OPEN_BRANCHES`, `_BADNAME`, `_MAIN_MERGE` | `branch-guard.sh`             | either      |
 | `BULK_EDIT_ACK`                                                                                   | `bulk-edit-guard.sh`          | either      |

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -783,10 +783,60 @@ esac
 # on `git push-x`: `\b` treats the `-` as a word boundary and matched, the explicit class does not.
 # ACK_RE carries the `PRE_PUSH_ALLOW_UNREVIEWED=1` prefix so it cannot simply be RE_PUSH_STMT, but
 # its push token uses the SAME boundary class now, not `\b`. (#1667 review)
+# PROC-013 / #2323: the frozen-diff refusal, hoisted out of the "no local review recorded" branch.
+#
+# It used to live inside `if ! REVIEW_STATE=$(recorder --show)`, which runs ONLY when the recorder
+# FAILS. So a session that recorded a local review before each push — which git-branch.md REQUIRES —
+# made the recorder succeed, skipped that whole branch, and reached `exit 0` without this check ever
+# running. Measured on PR #2323: five pushes, five reviews, every one `ACTIONABLE FINDINGS: 0`. The
+# loop guard was bypassed by doing the thing the rules mandate, which is the worst possible place to
+# put a guard. PR #2235 ran 22 rounds the same way.
+#
+# It is also evaluated BEFORE the `PRE_PUSH_ALLOW_UNREVIEWED=1` short-circuit below, because that
+# override says one thing — "this diff is unreviewed" — and the frozen-diff rule says another: "this
+# pull request is clean, stop editing it". One switch must not disarm two unrelated rules, and the
+# override's own message never claimed to excuse this one.
+frozen_diff_refusal() {
+  local branch="$1" open_pr latest_count
+  [[ -n "$branch" ]] || return 1
+  # `gh pr list --head`, not `pr view`: `pr view` takes a number, a URL or a branch and decides by
+  # shape, so a branch named `42` would be answered with pull request #42's state.
+  open_pr=$(cd "$PROJECT_DIR" &&
+    bounded_gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty' || echo "")
+  [[ "$open_pr" =~ ^[1-9][0-9]*$ ]] || return 1
+  # The reviewer filter and the unanchored marker are merge-gate.sh's, deliberately: a gate whose
+  # input its own subject can write is not a gate, and jq's regex does not anchor at line
+  # boundaries. Unknown is NOT zero — a refusal on a failed measurement blocks correct work on no
+  # evidence, so an unreadable count returns 1 and the push proceeds to the checks below.
+  latest_count=$( (cd "$PROJECT_DIR" &&
+    bounded_gh pr view "$open_pr" --json comments,reviews \
+      --jq "([.comments[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"^github-actions(\\\\[bot\\\\])?$\"))) | map(select(.body | test(\"ACTIONABLE FINDINGS:[[:space:]]*[0-9]+\"; \"i\"))) | sort_by(.at) | last // {} | .body // \"\"" 2>/dev/null) |
+    sed -nE 's/^ACTIONABLE FINDINGS: ([0-9]+)$/\1/p' | tail -1 || echo "")
+  [[ "$latest_count" == "0" ]] || return 1
+  echo "[pre-push-check] Blocked: PR #$open_pr's latest review reports ACTIONABLE FINDINGS: 0," >&2
+  echo "[pre-push-check] so there is nothing for this push to resolve — it is new work on a PR" >&2
+  echo "[pre-push-check] that is already merge-ready, and a reviewer who passed it never saw it." >&2
+  echo "[pre-push-check] git-branch.md: an open PR's diff is frozen except to resolve a finding." >&2
+  echo "[pre-push-check] Recording a local review does NOT excuse this, and neither does" >&2
+  echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED — that one says the diff is unreviewed, which is" >&2
+  echo "[pre-push-check] a different claim. Let #$open_pr land, then open a second PR for this work." >&2
+  echo "[pre-push-check] Deliberate exception: PRE_PUSH_ALLOW_FROZEN_DIFF=1 inline." >&2
+  return 0
+}
+
 PUSH_RE="$RE_PUSH_STMT"
 ACK_RE='(^|[[:space:];&|(])PRE_PUSH_ALLOW_UNREVIEWED=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push([^-[:alnum:]_]|$)'
 PUSH_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$PUSH_RE" | grep -c . || true)
 ACK_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$ACK_RE" | grep -c . || true)
+
+# The frozen-diff rule is asked FIRST, and its own override is the only one that excuses it.
+# `PRE_PUSH_ALLOW_FROZEN_DIFF=1` is matched with the same statement-scoped shape as the other
+# override: it excuses the push it prefixes, not the shell it was typed in.
+FROZEN_ACK_RE='(^|[[:space:];&|(])PRE_PUSH_ALLOW_FROZEN_DIFF=1([[:space:]]+[[:alnum:]_]+=[^[:space:]]+)*[[:space:]]+git[[:space:]]+((-C|-c)[[:space:]]+[^[:space:]]+[[:space:]]+)*push([^-[:alnum:]_]|$)'
+FROZEN_ACK_COUNT=$(printf '%s' "$COMMAND_VERBS" | grep -oE "$FROZEN_ACK_RE" | grep -c . || true)
+if [[ "$FROZEN_ACK_COUNT" -lt "$PUSH_COUNT" ]] && frozen_diff_refusal "$CUR_BRANCH"; then
+  exit 2
+fi
 
 if [[ "$ACK_COUNT" -gt 0 && "$ACK_COUNT" -ge "$PUSH_COUNT" ]]; then
   echo "[pre-push-check] Override: PRE_PUSH_ALLOW_UNREVIEWED=1 — this push carries an unreviewed diff." >&2
@@ -880,22 +930,11 @@ if ! REVIEW_STATE=$(cd "$PROJECT_DIR" && node "$RECORDER" --show 2>&1); then
     # or `ACTIONABLE FINDINGS: 0` to block someone else's legitimate push. A gate whose input its own
     # subject can write is not a gate. Kept as its own literal because merge-gate.sh does not export
     # it — the two must be changed together, said here rather than left to be noticed.
-    REVIEWER_RE='^github-actions(\\[bot\\])?$'
-    LATEST_COUNT=$( (cd "$PROJECT_DIR" &&
-      bounded_gh pr view "$OPEN_PR" --json comments,reviews \
-        --jq "([.comments[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"$REVIEWER_RE\"))) | map(select(.body | test(\"ACTIONABLE FINDINGS:[[:space:]]*[0-9]+\"; \"i\"))) | sort_by(.at) | last // {} | .body // \"\"" 2>/dev/null) |
-      sed -nE 's/^ACTIONABLE FINDINGS: ([0-9]+)$/\1/p' | tail -1 || echo "")
-
-    if [[ "$LATEST_COUNT" == "0" ]]; then
-      echo "[pre-push-check] Blocked: PR #$OPEN_PR's latest review reports ACTIONABLE FINDINGS: 0," >&2
-      echo "[pre-push-check] so there is nothing for this push to resolve — it is new work on a PR" >&2
-      echo "[pre-push-check] that is already merge-ready, and a reviewer who passed it never saw it." >&2
-      echo "[pre-push-check] git-branch.md: an open PR's diff is frozen except to resolve a finding." >&2
-      echo "[pre-push-check] Let #$OPEN_PR land, then open a second PR for this work." >&2
-      echo "[pre-push-check] Deliberate exception: PRE_PUSH_ALLOW_UNREVIEWED=1 inline." >&2
-      exit 2
-    fi
-
+    # PROC-013 / #2323: the frozen-diff refusal used to live HERE, and that was the defect.
+    # This branch runs only when the recorder FAILS, so a session that recorded a local review —
+    # which the rules require — never reached it. It is now `frozen_diff_refusal`, called before the
+    # override short-circuit near the top of this file, so it is asked on every push regardless of
+    # local-review state. Not duplicated here: two implementations agree until one of them changes.
     echo "[pre-push-check] Open pull request on '$CUR_BRANCH': its review automation owns the review" >&2
     echo "[pre-push-check] of this push. Resolve what that review reports; do not review it again." >&2
     exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ The most-hit refusals, in imperative form. Reasoning lives in [git-branch.md](.a
 - **Record a local review before the first push**: `pnpm harness:review:record --findings <n>`.
 - **A merge needs**: CI green, a reviewer verdict quoting the _exact_ current base and head, `ACTIONABLE FINDINGS: 0`, and every review thread **answered and resolved** — fixing a finding is not answering it.
 - **Cut branches from a freshly-fetched `origin/develop`**, one at a time.
-- **An open PR's diff is frozen** except to resolve a reported finding. `ACTIONABLE FINDINGS: 0` means STOP EDITING, not "merge now" — advice arriving with a zero count is input for a FUTURE PR, and one issue/PR is owned by exactly one session ([git-branch.md](.agents/rules/git-branch.md)).
+- **A push into an open PR needs a NAMED GROUND — a published finding, a red check, or a rebase.** Nothing else, including your own re-reading and advice attached to a passing verdict. If you cannot name which one, the push does not happen. A verdict you never published is the input to no gate ([git-branch.md](.agents/rules/git-branch.md)).
 - **Never enumerate files in a way that follows symlinks** (`find -L`, `grep -R`, `rg --follow`): in a pnpm workspace it reaches the dependency store, where a write is invisible to `git status` and to every scan.
 - **Never wait in the foreground** — a `sleep` budget over 60s, or a loop polling a remote status. Run it in the background, or use `Monitor`.
 

--- a/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
+++ b/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
@@ -106,13 +106,13 @@ function stubGh({ prNumber, findings, author = 'github-actions[bot]' }) {
   return dir;
 }
 
-function push({ findings, prNumber = 4242, author }) {
+function push({ findings, prNumber = 4242, author, prefix = '' }) {
   const dir = scratchRepo();
   const result = spawnSync('bash', [HOOK], {
     input: JSON.stringify({
       tool_name: 'Bash',
       cwd: dir,
-      tool_input: { command: `git push -u origin ${BRANCH}` },
+      tool_input: { command: `${prefix}git push -u origin ${BRANCH}` },
     }),
     encoding: 'utf8',
     timeout: 120_000,
@@ -136,7 +136,29 @@ describe('pre-push open-PR freeze — RED direction', () => {
   it('names the recovery, not only the refusal', () => {
     const res = push({ findings: 0 });
     expect(res.output).toMatch(/open a second PR/i);
-    expect(res.output).toMatch(/PRE_PUSH_ALLOW_UNREVIEWED=1/);
+    // The hatch is this rule's own. It used to be PRE_PUSH_ALLOW_UNREVIEWED, and that was the
+    // defect: one switch disarmed two unrelated rules while its message claimed only the first.
+    expect(res.output).toMatch(/PRE_PUSH_ALLOW_FROZEN_DIFF=1/);
+  });
+
+  it('the unreviewed-diff override does NOT excuse a frozen diff', () => {
+    // The measured failure (#2323) needed no override at all, but the two hatches sharing one name
+    // is how a session reaching for the documented one silently disarms this one too.
+    const res = push({ findings: 0, prefix: 'PRE_PUSH_ALLOW_UNREVIEWED=1 ' });
+    expect(res.status).toBe(2);
+    expect(res.output).toMatch(/nothing for this push to resolve/);
+  });
+
+  it('its own override does excuse it', () => {
+    const res = push({ findings: 0, prefix: 'PRE_PUSH_ALLOW_FROZEN_DIFF=1 ' });
+    expect(res.status).not.toBe(2);
+  });
+
+  it('says that recording a local review does not excuse it either', () => {
+    // The refusal lived inside the branch that runs only when NO local review is recorded, so a
+    // session obeying the record-before-push rule skipped it. The message now says so.
+    const res = push({ findings: 0 });
+    expect(res.output).toMatch(/Recording a local review does NOT excuse this/);
   });
 });
 

--- a/scripts/harness/progress-report-acknowledgments.json
+++ b/scripts/harness/progress-report-acknowledgments.json
@@ -264,6 +264,18 @@
       "timestamp": "2026-08-23T09:10:11.430Z",
       "ratio": "14/16",
       "reason": "The same session's SECOND violation, and it is the first one's echo: while explaining that I had reported a bare ratio, I quoted the bare ratio again. Acknowledging a violation by restating it unquantified reproduces it — the rule governs the narration, not only the original claim. Both entries stand because both findings are real and a transcript cannot be edited. Recorded with the percentage this time: 14 of 16 is 87.5%."
+    },
+    {
+      "transcript": "1dab1a14-5866-4ce5-acb6-d843c00d09b7.jsonl",
+      "timestamp": "2026-08-24T18:55:24.178Z",
+      "ratio": "33/129",
+      "reason": "A real violation, committed by me while orchestrating: I relayed a peer's measurement of missing scenario sections as 33/129 and 267/909 with no percentage. Recorded rather than fixed, because the transcript is append-only. The relevant numbers are 26% and 29%."
+    },
+    {
+      "transcript": "1dab1a14-5866-4ce5-acb6-d843c00d09b7.jsonl",
+      "timestamp": "2026-08-24T18:58:53.140Z",
+      "ratio": "33/129",
+      "reason": "The same ratio again three minutes later, in a summary table of the same session. The repeat is the argument for the scan: I had just written the number and still did not convert it, which is why this rule is mechanized rather than remembered."
     }
   ]
 }


### PR DESCRIPTION
A pull request ran five rounds. Its reviewer posted `ACTIONABLE FINDINGS: 0` every time and said in words that it found nothing. After the first commit, non-comment TypeScript lines changed: **zero**. Four hours of SPEC prose, comments and changeset text on a change the repository had already passed.

## What actually happened

The owning session supplied the decisive numbers itself:

```
pr-review-reviewer dispatched   32×   (5× on this pull request)
pr-review-writer dispatched      0×   ← no finding ever reached a pull request
gh pr view <the PR>              0×   ← the gate's input was never read
```

It closed a loop against **a reviewer whose output reached no pull request and no gate**, then described being held by a gate it had never consulted. **The merge gate's input was zero from round one** — this could have merged four hours earlier.

Its own first account said the verdicts were 7 / 1 / 1 / 2 / 3. Measured on the pull request: five `github-actions` comments, all zero, **0 reviews and 0 review threads** — no source for those counts exists there. The session then measured its own dispatch counts and withdrew the account. Both halves were true of different things, and the gap between them is the finding.

## Why the hook did not stop it

`pre-push-check` already carried the refusal for exactly this case. **It could not fire.**

```
823  if ! REVIEW_STATE=$(recorder --show); then     ← runs ONLY when the recorder FAILS
889      if LATEST_COUNT == 0 → exit 2              ← the guard, inside that branch
919  exit 0                                          ← recorder succeeded → push allowed
```

A session that records a local review — which `git-branch.md` **requires** before a first push — makes the recorder succeed, skips the branch, and reaches `exit 0` without the check running. **A guard bypassed by obeying the rule beside it is not a guard.** The unreviewed-diff override reached `exit 0` earlier still, so one switch disarmed two unrelated rules while its own message claimed only the first.

## The change

- The refusal is a function evaluated **on every push, before both bypasses**, with its own hatch `PRE_PUSH_ALLOW_FROZEN_DIFF=1`. `PRE_PUSH_ALLOW_UNREVIEWED` no longer excuses it — that one asserts the diff is unreviewed, a different claim about a different rule.
- The old copy is **deleted**, not left beside it: two implementations agree until one of them changes.
- **The rule now requires a NAMED GROUND for any push into an open pull request, and there are exactly three** — a published finding, a red required check, or a rebase. Nothing else: not an improvement you noticed, not your own prose re-read, not advice attached to a passing verdict. **If you cannot name which one in a sentence pointing at something another person can open, the push does not happen.**
- `AGENTS.md`'s always-loaded card carries the same sentence, because it is re-injected after every compaction and this is the line that has to reach a session mid-work. Still 112 lines.
- The rule also records that `pr-finding-resolution-loop` step 5 already says *post, then fix* — and that **no file under `scripts/harness/` or `.claude/hooks/` references `pr-review-writer` at all.** The rule was not missing; its enforcement was.

## Verification

**Against the branch that produced the case:** refused. A branch with no open pull request, and an empty branch: allowed.

**Control:** the same function does not exist on `develop`, and there the check sits at line 889 inside the branch opening at 823 — unreachable whenever a local review is recorded.

**Every allow-path preceding the new call site** is a non-Bash tool, a non-push command, or an integration branch. None is reachable by a feature branch pushing into an open pull request.

**Tests: 9 passed**, including three new ones pinning the change — the unreviewed override does *not* excuse a frozen diff, its own override does, and the message says recording a local review does not excuse it either. `pnpm harness:scan`: 144 passed, 1 skipped.

Two ratios I reported without percentages are recorded in the acknowledgments file rather than edited out of history. They were 26% and 29%.

Refs issue #2323