### PR TITLE
docs(tasks): CLI-080 records the direction and what the guard checks (CLI-080)

### DIFF
--- a/.agents/tasks/CLI-080-composition-root-executor-exemption-wider-than-documented-rule.md
+++ b/.agents/tasks/CLI-080-composition-root-executor-exemption-wider-than-documented-rule.md
@@ -20,13 +20,33 @@ about what "composition root" covers.
 
 ## Evidence
 
-- `.agents/project-structure.md:357-370` — "the **single permitted exception** is the **composition
+- `.agents/project-structure.md:375-385` (cited as `:357-370` when filed; the text moved, not the rule) — "the **single permitted exception** is the **composition
   root** … composition-root wiring is the only valid exemption category."
 - `packages/agent-cli/src/subagents/git-worktree-isolation-adapter.ts:6-11` — value-imports
   `BackgroundTaskError` (plus port types) from `@robota-sdk/agent-executor`.
-- `scripts/harness/check-background-workspace-conformance.mjs:74-78` — a third exemption entry:
+- `scripts/harness/check-background-workspace-conformance.mjs:73-79` — a third exemption entry:
   "`…/git-worktree-isolation-adapter.ts`: 'composition root — concrete worktree adapter wiring'". The
   adapter is a concrete I/O class, not the assembly point.
+
+## The direction, and what the guard actually enforces
+
+**Issue #2048 states this backwards, and acting on its summary would enlarge the hole.** Its line 8
+says the guard exempts the adapter _"under a category **narrower** than the written rule permits"_;
+its own line 17 says _"a guard exemption **wider** than the documented category"_, which is what this
+record's title has said since it was filed. The evidence line is right and the summary line is what a
+reader acts on — someone implementing line 8 as written would widen an already-over-wide exemption
+while believing they were aligning it. Issue #2048 is closed with that noted.
+
+**The mechanism is the reason this recurs.** The guard's own comment states the requirement it
+enforces: _"every entry requires a reason string"_ (`check-background-workspace-conformance.mjs:73`).
+That is exactly what is checked — **a reason, not a true one.** The first two exemptions are the
+rule's own worked examples; the third asserts membership in the category by writing the category's
+name into a free-text string. The rule says composition-root wiring is the only valid category, and
+**nothing checks that a file claiming the category is one.**
+
+So the doc-side and code-side directions above are both still open, but neither closes this on its
+own: whichever is chosen, a category that a file can join by describing itself will drift again. That
+belongs in whatever fix lands here, not in a separate item.
 
 ## Direction
 


### PR DESCRIPTION
## What

Adds to CLI-080 the two things measured while testing issue #2048's bundling claim, which were reported on that issue's close but never reached this record.

## Why

**Issue #2048's summary line states this exemption's direction backwards.** Line 8 says the guard exempts the adapter *"under a category **narrower** than the written rule permits"*; line 17 of the same issue says *"a guard exemption **wider** than the documented category"*, which is what CLI-080's title has said since it was filed on 2026-08-13. The evidence line is right and the summary is what a reader acts on — **someone implementing line 8 as written would enlarge an already-over-wide exemption while believing they were aligning it.**

**And the mechanism is why this recurs.** The guard's own comment states the requirement it enforces:

```js
// HARNESS-011: composition-root exemptions … every entry requires a reason string
```

That is exactly what is checked — **a reason, not a true one.** The first two exemptions are the rule's own worked examples; the third asserts membership in the category by writing the category's name into a free-text string. `project-structure.md:385` says composition-root wiring is the only valid category, and nothing checks that a file claiming it is one.

So the note is written to survive the fix: whichever of CLI-080's two existing directions is taken, **a category a file can join by describing itself will drift again.** That belongs in the fix that lands here, not in a separate item — no new ID is allocated.

## Also

Two cited line ranges had moved since the record was filed (`project-structure.md:357-370` → `:375-385`; the guard block by one line). Noted **as moved** rather than silently replaced — a record whose subject is a citation going stale is the worst place to quietly correct one. All four cited lines were re-confirmed against `origin/develop` at `72c69f371` before this PR was opened.

## Verification

- `pnpm harness:scan` at the current base — 144 passed, 1 skipped, **0 failures**.
- Rebased onto `72c69f371` (#2330 landed while this branch was held during the write freeze) and re-verified there rather than at the base it was cut from.

Docs-only: one task record, `status: todo` unchanged. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH