### PR TITLE
docs(rules): the loop rule overclaimed in its own evidence line

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -608,9 +608,23 @@ request where both are visible, not inside whichever session happened to look.
 
 **The ordering is already written down and nothing checks it.** `pr-finding-resolution-loop` step 5
 reads _"Dispatch `pr-review-writer` (posts the review to the PR), **then** `pr-review-fixer`"_ — publish
-first, fix second. Measured: no file under `scripts/harness/` or `.claude/hooks/` references
-`pr-review-writer` at all, so a session can run reviewer → fixer → push, thirty-two times, and no
-mechanism notices the middle step was skipped. **The rule was not missing; its enforcement was.** What
+first, fix second. Measured: **nothing enforces that ordering.** `scripts/harness/__tests__/`
+mentions the writer — in a doc comment and in an exemption set — and neither reference checks that a
+dispatch happened, so a session can run reviewer → fixer → push, thirty-two times, and no mechanism
+notices the middle step was skipped.
+
+**This paragraph first said "no file references it at all", which was false**, and the correction is
+worth keeping rather than quietly applying: _referenced by nothing_ and _enforced by nothing_ are
+different claims, and the first was the stronger one to make and the cheaper one to falsify — eleven
+words of `grep`. A rule about not overclaiming, overclaiming in its own evidence line.
+
+**And the surrounding mechanism does better than this paragraph did.** `scan-review-findings.mjs`
+scopes itself in its own header — it checks contract PRESENCE, not that any mechanism ran — and
+`orchestration-map.md` records it as a **partial** floor rather than counting it as a satisfied one.
+A check that declares what it does not cover, and a map that refuses to count it as coverage, is the
+opposite of the failure this section describes.
+
+**The rule was not missing; its enforcement was.** What
 catches the loop today is the frozen-diff refusal below, which refuses the second push once the pull
 request's own verdict reads zero — verified against this case's branch.
 


### PR DESCRIPTION
The paragraph merged last night as `e8a4ee8c2` said *"no file under `scripts/harness/` or `.claude/hooks/` references `pr-review-writer` at all"*. **Two files do.**

```
scripts/harness/__tests__/declared-boundaries-hold.test.mjs    a doc comment, and a table fixture
scripts/harness/__tests__/depth-verdict-reachable.test.mjs     an exemption set
```

Neither checks that a dispatch happened, so **the substance holds — nothing enforces the ordering.** The stronger claim did not.

## Why this is a correction rather than an edit

**Referenced by nothing** and **enforced by nothing** are different claims. I made the first, in a section about not overclaiming, in the line offered as its measurement — and it took **eleven words of ** to falsify. Found by the session the follow-up item had been booked to, while measuring whether that item should exist at all.

The correction is written **into** the paragraph rather than applied silently. A reader who sees only the corrected sentence learns less than one who sees which claim was too strong, and this particular paragraph is read by people deciding what counts as evidence.

## What the paragraph also got wrong by omission

It read as though nothing in the area declared its own limits. Both do:

- `scan-review-findings.mjs` scopes itself in its own header — it checks **contract presence**, not that any mechanism ran, and says so.
- `orchestration-map.md` records that scan as a **partial** floor rather than counting it as satisfied.

**A check that declares what it does not cover, and a map that refuses to count it as coverage, is the opposite of the failure the section describes.** The paragraph is now accurate about that too.

## Disposition of the follow-up

**No new item.** The measurement that produced this correction also retired the item it came from: the review-dispatch case is one instance of **HARNESS-052** (`status: in-progress`, `priority: high`), whose title — *"sweep for checks that report success over work they did not do"* — is the class verbatim. Filing beside it would have been a fourth meta-issue wearing a different title. The instance goes into that record.

## Verification

`pnpm harness:scan` — 143 passed, 2 skipped, 0 failures, re-run at the current base after rebasing onto `24f803bff` rather than trusting the run from the base I cut from.

Refs issue #2323