### PR TITLE
docs(tasks): HARNESS-052 records the unobservable-dispatch instance (HARNESS-052)

### DIFF
--- a/.agents/tasks/HARNESS-052-vacuous-green-sweep.md
+++ b/.agents/tasks/HARNESS-052-vacuous-green-sweep.md
@@ -359,6 +359,27 @@ Stated rather than implied, because an audit claiming completeness it cannot hav
   around it" is a property of behaviour over time; nothing here measures it. Fixing G7 also _created_
   a B-shaped risk (three false positives) that had to be corrected before it shipped, which is the
   general hazard of tightening an A-shaped rule.
+- **Whether a dispatched agent published what it found is outside any mechanism we can write.**
+  `pr-finding-resolution-loop` step 5 dispatches `pr-review-writer` to post and then `pr-review-fixer`
+  to fix; measured at `24f803bff`, nothing enforces the first half — the two files under
+  `scripts/harness/` that name the writer are a doc comment and an _exemption_ entry. **The
+  consequence is not an unmerged pull request**: the merge gate wants a published verdict from the CI
+  reviewer and never wanted this one. The consequence is that findings vanish. What bounds any fix is
+  observability — a hook sees a `gh` invocation, so it can tell that something _was_ posted; it cannot
+  see a subagent that returned findings into a context and stopped, so it cannot tell that something
+  was _not_. **The enforceable property is therefore about the artifact, never about the dispatch.**
+  Recorded here rather than as its own item: it is an instance of this sweep's class, not a new one.
+  `scan-review-findings.mjs` is **not** an example of the failure — its header scopes itself to
+  contract presence explicitly, and `orchestration-map.md` footnote § records it as a partial floor
+  rather than counting it as satisfied. A check that declares what it does not cover, and a map that
+  refuses to count it as coverage, is the shape this sweep is trying to produce.
+  - The case that prompted this — a loop reported as running many reviewer dispatches and no writer
+    dispatch, losing two real findings — **is not recorded anywhere in this repository**; it reached
+    this record through a session message and its counts are not reproducible from any artifact here.
+    They are therefore omitted rather than restated. That is not a footnote to the instance: **the
+    evidence that findings vanish when they stay in a session survives only in a session**, which is
+    the same defect one level up, and it is why the structural claim above is stated from what the
+    tree shows instead.
 - **The single most useful result of this sweep was a defect in the sweep's own guard** (G3), found
   by an independent reader after the guard was written, tested, reviewed and green. That is the
   honest summary of the ceiling: the method that works is adversarial falsification by someone other


### PR DESCRIPTION
## What

Adds one bullet to HARNESS-052's `## The mechanical ceiling`: the PR-review pipeline states a publish-then-fix ordering that nothing enforces, and the reason no mechanism can enforce it as stated.

## Why here and not as a new item

HARNESS-052 is `in-progress`, `high` / `soon`, and its title is the class verbatim — *"sweep for checks that report success over work they did not do."* It already fences nine instances by name; this one is not among them. Filing it separately would allocate beside the record that owns the cause.

## What was measured, at `24f803bff`

`pr-finding-resolution-loop` step 5 dispatches `pr-review-writer` to post, then `pr-review-fixer` to fix. The two files under `scripts/harness/` that name the writer are a **doc comment** (`declared-boundaries-hold.test.mjs`, describing finding #1546) and an **exemption entry** (`depth-verdict-reachable.test.mjs:176`). Neither enforces the ordering.

**The consequence is not an unmerged pull request.** The merge gate requires a published verdict from the CI reviewer — it never wanted this one. What is lost is findings.

**And that bounds any fix.** A hook sees a `gh` invocation, so it can tell that something *was* posted; it cannot see a subagent that returned findings into a context and stopped, so it cannot tell that something was *not*. The enforceable property is about the artifact, never about the dispatch — which means the item as originally framed (*"a reviewer dispatch requires a writer dispatch"*) is not mechanizable, while *"a merge requires a published review"* already exists.

## The counter-example is named too

`scan-review-findings.mjs` is **not** an instance of this failure, and the bullet says so. Its header scopes itself to contract presence explicitly (*"Scoped honestly"*), and `orchestration-map.md` footnote § records it as a **partial floor rather than counting it as satisfied**. A check that declares what it does not cover, and a map that refuses to count it as coverage, is what this sweep is trying to produce — recording it beside the gap keeps the sweep from reading as though every partial floor were a failure.

## One thing deliberately left out

The case that prompted this — a loop reported as running many reviewer dispatches and no writer dispatch, losing two real findings — reached me through a session message. `git grep` finds its counts **nowhere in this repository**, and they are not reproducible from any artifact here, so they are omitted rather than restated.

That omission is in the record with its reason, because it is not incidental: **the evidence that findings vanish when they stay in a session survives only in a session.** The structural claim above is stated from what the tree shows instead.

## Verification

`pnpm harness:scan` at the current base — 143 passed, 2 skipped, **0 failures**.

Docs-only: one task record, `status: in-progress` unchanged. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH