### PR TITLE
docs(tasks): split issue #2050 into TRANS-009 and TRANS-010 (TRANS-009)

### DIFF
--- a/.agents/tasks/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
+++ b/.agents/tasks/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
@@ -1,0 +1,111 @@
+---
+title: 'TRANS-009: the transport toggle reports enabled after a file write and discards the write failure'
+issue: https://github.com/woojubb/robota/issues/2050
+status: todo
+created: 2026-08-25
+priority: high
+urgency: soon
+area: packages/agent-transport, packages/agent-transport-tui
+depends_on: []
+---
+
+# TRANS-009: the transport toggle reports enabled after a file write and discards the write failure
+
+## Problem
+
+Toggling a transport in the settings TUI tells the user the transport is enabled. Nothing has been
+started. If the write that produced that claim failed, the user is told nothing at all.
+
+Two halves of one user-visible lie, produced by the same two lines of TUI code.
+
+## Evidence
+
+Measured at `e5551e9b6`.
+
+**The success half.** `packages/agent-transport/src/transport-registry.ts:124-127`:
+
+```ts
+async setEnabled(name: string, enabled: boolean): Promise<void> {
+  this.requireConfigurable(name);
+  this.settings.setEnabled(name, enabled);
+}
+```
+
+`this.settings.setEnabled` is `TransportSettingsView.setEnabled`, which calls `mutate` →
+`readSettings` / `writeSettings`. **It writes a file and returns.** `grep -nE 'start|stop'` over
+`transport-settings-view.ts` returns one hit, in a doc comment describing the _other_ half of the
+registry. Nothing on this path starts or stops a runtime transport.
+
+The method is `async` and returns `Promise<void>` while doing nothing asynchronous, which is what
+makes the caller's `await` look like it is waiting for an operation.
+
+**The silence half.** `packages/agent-transport-tui/src/TransportTUI.tsx:71-79`:
+
+```tsx
+registry
+  .setEnabled(entry.transport.name, !entry.config.enabled)
+  .then(() => {
+    refresh();
+    setSaving(false);
+  })
+  .catch(() => setSaving(false));
+```
+
+The `catch` takes the error and discards it whole. A `requireConfigurable` rejection and a
+`writeSettings` failure both land here and both produce the same visible result as success minus the
+refresh: the spinner stops.
+
+## Why the two are one item
+
+They are the same two lines, they are verified by the same fixture, and fixing either alone leaves a
+user misinformed — one about what is running, the other about whether their action took effect. A
+reconciled toggle that still swallows its failure reports a lie less often; a surfaced failure on a
+toggle that never starts anything reports the same lie with better error handling.
+
+## Direction
+
+Two decisions, and the record should not pre-empt either — both are named in issue #2050:
+
+1. **If toggles are immediate**, persistence and start/stop become one typed operation whose result
+   the caller can render. `setEnabled` stops being an `async` method that awaits nothing.
+2. **If they apply next session**, the surface says so explicitly, and the TUI renders "enabled on
+   next start" rather than "enabled".
+
+Either way the failure path must be renderable: the `catch` receives a typed error and the TUI shows
+it. `transport-registry-errors.ts` already exists and already builds typed errors with a stable
+`name` and `code`, so the shape is available.
+
+## Test Plan
+
+- A toggle against a real registry proves the documented runtime behaviour — if immediate, the
+  adapter is started; if deferred, it is not, and the surface says so. **The assertion is on the
+  adapter's state, not on the settings file**, because the settings file is what the current code
+  already gets right.
+- A failing write surfaces in the TUI. Drive it with a settings path that cannot be written and
+  assert on what the component renders, not on whether `writeSettings` threw.
+- Positive control for both: the success path still renders success, so a test that proves a failure
+  is reported cannot pass against a component that reports failure unconditionally.
+- `pnpm harness:scan` green.
+
+## User Execution Test Scenarios
+
+### Scenario 1 — a toggle claims a transport is running that is not
+
+1. Run `robota` and open the transport settings surface.
+2. Select a transport that is currently disabled and press space to enable it.
+3. Observe the row now reports the transport as enabled.
+4. Without restarting, check whether that transport is actually accepting connections on its port.
+
+**Expected after the fix:** either the transport is genuinely started and accepting connections, or
+the row states that the change applies from the next start. **Today:** the row reports enabled and
+nothing is listening.
+
+### Scenario 2 — a failed write reports nothing
+
+1. Make the settings file unwritable (`chmod 400` on the resolved settings path).
+2. Run `robota`, open transport settings, and toggle any transport.
+3. Observe what the surface reports.
+
+**Expected after the fix:** the surface reports that the change could not be saved, naming the
+reason. **Today:** the spinner stops and nothing else changes; re-opening the surface shows the old
+value with no explanation.

--- a/.agents/tasks/TRANS-010-the-transport-settings-view-carries-the-framework-settings-i-o-the-registry-shed.md
+++ b/.agents/tasks/TRANS-010-the-transport-settings-view-carries-the-framework-settings-i-o-the-registry-shed.md
@@ -1,0 +1,94 @@
+---
+title: 'TRANS-010: the transport settings view carries the framework settings I/O the registry shed'
+issue: https://github.com/woojubb/robota/issues/2050
+status: todo
+created: 2026-08-25
+priority: medium
+urgency: later
+area: packages/agent-transport, packages/agent-framework
+depends_on: [TRANS-009]
+---
+
+# TRANS-010: the registry's filesystem dependency moved one file over
+
+## Problem
+
+Issue #2050 says `TransportRegistry` combines lifecycle, persistence and projection, and that its core
+cannot be tested without a filesystem import. The split has since happened. **The dependency did not
+go away — it travelled with the seam.**
+
+## Evidence
+
+Measured at `e5551e9b6`. `packages/agent-transport` has moved 394 lines since issue #2050's pinned
+revision `15800bf0`; `transport-registry.ts` went 299 → 270 lines and two files appeared.
+
+`transport-registry.ts` no longer imports concrete settings I/O at all — its imports are local
+(`./transport-registry-errors.js`, `./transport-run-generation.js`, `./transport-settings-view.js`)
+plus type-only imports. That half of the issue's claim is answered.
+
+`transport-settings-view.ts:13`:
+
+```ts
+import { readSettings, writeSettings, type TSettingsData } from '@robota-sdk/agent-framework';
+```
+
+**That is the import the issue objects to, one file over.** Issue #2050's first acceptance criterion —
+_registry core tests run with an in-memory settings repository and no filesystem import_ — is still
+unmet, but for a different reason than the issue gives: the registry's shape is no longer the
+problem, the dependency's location is.
+
+## Why the seam was cut where it was
+
+`transport-settings-view.ts`'s own header says so:
+
+> They were one 299-line file, one line under the anti-monolith limit, so the next addition had to
+> split something. This is the seam that was already there rather than a cut made to fit.
+
+The seam was real and the split was the right one. **What it did not do was change what is on either
+side of it.** A cut made to satisfy a line count relocates whatever was on the wrong side; deciding
+that a dependency should be injected is a separate decision, and it was not the one being made.
+
+## Direction
+
+Inject an `ITransportSettingsRepository` — issue #2050's own proposal — implemented by the
+shell/framework adapter, so `agent-transport` names a port and `agent-framework` supplies the file
+implementation. The registry core and the settings view then both test against an in-memory
+implementation.
+
+Sequenced after TRANS-009 deliberately: TRANS-009 may change what the persistence call has to
+return (a typed result the caller can render), and that shape belongs in the port. Doing the
+injection first would let a testability constraint fix the signature before the correctness fix knows
+what it needs.
+
+## Test Plan
+
+- Registry core tests and settings-view tests construct with an in-memory repository and the package's
+  production source imports no filesystem API. The assertion is on the **import graph**, not on
+  whether a test happened to avoid touching disk — a test that writes to a temp directory passes the
+  weaker version while the dependency is still there.
+- Positive control: the framework-backed implementation still reads and writes real settings, so a
+  suite proving the port is honoured cannot pass against a package that has no persistence at all.
+- `pnpm harness:scan` green.
+
+## Related
+
+`TRANS-002`'s evidence cites `transport-registry.ts:84-94` for `startAll`; at `e5551e9b6` those lines
+are `replace()` and `startAll` is at `:134`. **The split described above is what moved them.** The
+change was correct, the record was correct when written, and the citation died between them with no
+event either side would notice — a third route to a stale citation, after a record declared and never
+created (issue #2049) and a file drifting under a citation over time (CLI-080).
+
+Refresh TRANS-002's line references as part of whichever item next edits this file, rather than as its
+own change.
+
+## User Execution Test Scenarios
+
+Not authorable, and left unwritten with the reason recorded rather than filled with a placeholder.
+This item delivers no user-facing behaviour: it relocates a dependency behind a port so the same
+behaviour becomes testable without a filesystem. A user running the CLI before and after sees
+identical output, which is the acceptance criterion rather than a gap in it.
+
+**This reason does not expire.** Unlike a disposition that is merely undecided, it is a property of
+what the item delivers, and it stays true however the port is shaped. If a later revision of this
+item changes user-visible behaviour, that revision needs scenarios and this paragraph no longer
+applies to it.


### PR DESCRIPTION
## What

Two records for issue #2050's four claims, after measuring them at the current base. **No third ID:** the remaining claim already has one.

| claim | verdict | disposition |
|---|---|---|
| `setEnabled` reports enabled after a file write | **true** | **TRANS-009** |
| the TUI discards the write failure | **true** | **TRANS-009** — same two lines |
| the registry cannot be tested without a filesystem import | **partly landed**, remainder relocated | **TRANS-010** |
| persisted options never reach adapters | **true** | **TRANS-002**, already exists |

Issue #2050 says it *"Includes the adjacent active TRANS-002 option-delivery problem"* — it is a bundling proposal, and the bundle does not hold.

## TRANS-009 — one user-visible lie with two halves

```ts
// transport-registry.ts:124-127
async setEnabled(name, enabled): Promise<void> {
  this.requireConfigurable(name);
  this.settings.setEnabled(name, enabled);   // writes a file. that is all.
}
```

`grep -nE 'start|stop'` over `transport-settings-view.ts` returns one hit, in a doc comment about the *other* half of the registry. Nothing on this path starts a transport. The method is `async` and does nothing asynchronous, which is what makes the caller's `await` look like it is waiting for an operation.

```tsx
// TransportTUI.tsx:71-79
.then(() => { refresh(); setSaving(false); })
.catch(() => setSaving(false));          // the failure, discarded whole
```

**One path reports a success it did not achieve; the other reports nothing about a failure it did have — from the same two lines.** Paired because fixing either alone still leaves a user misinformed.

## TRANS-010 — the dependency moved one file over

`agent-transport` has moved 394 lines since issue #2050's pinned revision. `transport-registry.ts` (299 → 270) no longer imports concrete settings I/O at all — that half of the claim is answered. But `transport-settings-view.ts:13` does:

```ts
import { readSettings, writeSettings, type TSettingsData } from '@robota-sdk/agent-framework';
```

Its own header says the split happened because the file was *"one line under the anti-monolith limit, so the next addition had to split something."* **A seam cut to satisfy a line count relocates whatever was on the wrong side of it.** Sequenced after TRANS-009 because the persistence call's return shape is TRANS-009's decision and belongs in the port.

## A stale citation with a third cause

`TRANS-002` cites `transport-registry.ts:84-94` for `startAll`; at the current base those lines are `replace()` and `startAll` is at `:134`. **The split described in TRANS-010 is what moved them.** The change was correct, the record was correct when written, and the citation died between them with no event either side would notice — after a record declared and never created (issue #2049) and a file drifting under a citation over time (CLI-080). Recorded in TRANS-010, to be refreshed by whichever item next edits that file rather than as its own change.

## Scenarios

TRANS-009's are written — it has user-visible behaviour, and both scenarios name what a user sees today versus after. TRANS-010's are unwritten with the reason recorded, and **that reason does not expire**: the item delivers no user-facing behaviour by construction, not by an undecided disposition.

## Verification

`pnpm harness:scan` at the current base — 144 passed, 1 skipped, 0 failures. Docs-only: two task records. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH