### PR TITLE
fix(transport): the toggle reports what it did, and says when it applies (TRANS-009)

### DIFF
--- a/.agents/spec-docs/active/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
+++ b/.agents/spec-docs/active/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
@@ -1,0 +1,161 @@
+---
+status: in-progress
+type: BEHAVIOR
+tags: [transport, tui, correctness]
+---
+
+# TRANS-009: the transport toggle reports enabled after a file write and discards the write failure
+
+## Problem
+
+Toggling a transport in the settings TUI tells the user it is enabled. Nothing has been started. If
+the write that produced that claim failed, the user is told nothing at all.
+
+Measured at `1874a187e`:
+
+```ts
+// transport-registry.ts:124-127
+async setEnabled(name: string, enabled: boolean): Promise<void> {
+  this.requireConfigurable(name);
+  this.settings.setEnabled(name, enabled);   // → readSettings / writeSettings. That is all.
+}
+```
+
+`grep -nE 'start|stop'` over `transport-settings-view.ts` returns one hit, inside a doc comment about
+the _other_ half of the registry. Nothing on this path starts or stops a runtime transport. The method
+is `async` and returns `Promise<void>` while doing nothing asynchronous, which is what makes the
+caller's `await` look like it is waiting for an operation.
+
+```tsx
+// TransportTUI.tsx:71-79
+registry
+  .setEnabled(entry.transport.name, !entry.config.enabled)
+  .then(() => {
+    refresh();
+    setSaving(false);
+  })
+  .catch(() => setSaving(false)); // the failure, taken and discarded
+```
+
+`TransportTUI.tsx:26-28` renders the badge from `entry.config.enabled` — the persisted value. So the
+row reads `[enabled]` because a file changed, not because a transport is running.
+
+**One path reports a success it did not achieve; the other reports nothing about a failure it did
+have. Both come from the same two lines.**
+
+## Prior Art Research
+
+Waived: the subject is the internal contract between this repository's transport registry, its
+settings persistence and its own TUI. The decidable question — whether this product's toggle is
+immediate or deferred — is a fact about this codebase's lifecycle model (`startAll` reads
+`getEnabled()` at start; there is no per-transport start), read directly below. No external product's
+documentation determines what `TransportRegistry` already does.
+
+## Solution (draft direction)
+
+**Recommendation: make the surface tell the truth about the deferred behaviour, rather than making the
+behaviour immediate.**
+
+Deferred is what the code already does and it is coherent: `startAll` reads `getEnabled()` when a
+session starts, so a toggle takes effect at the next start. Making it immediate would require a
+per-transport start/stop that the lifecycle does not have — `ITransportLifecycleRegistryView` offers
+`startAll` and `stopAll` over the whole set, and the registry carries a single `state` machine. That
+is new lifecycle surface, and lifecycle semantics are ARCH-011's territory rather than this fix's.
+
+So:
+
+1. **The TUI renders what actually happened** — the change is saved and applies from the next start,
+   not "enabled" as a running state. Issue #2050 names this option explicitly: _"If they apply next
+   session, name and render that explicitly."_
+2. **The failure surfaces.** The `catch` receives a typed error and the component renders it.
+   `transport-registry-errors.ts` already builds errors with a stable `name` and `code`, so the shape
+   exists; nothing new is needed on the contract to stop discarding it.
+3. **The SPEC states which it is.** `agent-transport/docs/SPEC.md:187` lists `setEnabled` among the
+   registry's methods and says nothing about when it takes effect — which is why two readings were
+   available.
+
+**Deliberately NOT in scope:** changing `setEnabled` from `Promise<void>`, or making it synchronous.
+It is misleading, and it is a contract change across `ITransportSettingsRegistryView`,
+`ITransportRegistryView` and both SPECs for no correctness gain once the surface is honest. Worth its
+own item if anyone wants it.
+
+## Completion Criteria (draft)
+
+- A toggle against a real registry leaves the adapter **not started**, and the surface says the change
+  applies from the next start. The assertion is on the adapter's state, not on the settings file — the
+  file is what the current code already gets right.
+- A failing write surfaces in the TUI. Driven with a settings path that cannot be written, asserting
+  on what the component renders rather than on whether `writeSettings` threw.
+- **Positive control**: the success path still renders success, so a test proving a failure is
+  reported cannot pass against a component that reports failure unconditionally.
+- **Coverage control**: at least one case exercises the state the change actually alters — the render
+  path — rather than only the persistence path that was already correct. (HARNESS-122's lesson: a
+  mutation test proves a case measures the guard, not that the cases cover its reach.)
+- `agent-transport/docs/SPEC.md` states when a toggle takes effect.
+- `pnpm harness:scan` green.
+
+## Test Plan
+
+- A toggle leaves the adapter **not started** and the surface says the change applies at the next
+  start. The assertion is on what the component RENDERS, not on whether `setEnabled` was called — a
+  test asserting the call passes against the old code and the new one, because the call was never the
+  defect.
+- A failing write renders its reason. Driven with a rejecting registry, asserting on the frame.
+- A non-`Error` rejection still produces a sentence rather than `undefined`.
+- **Positive control**: the success path renders no failure, so the two failure cases cannot pass
+  against a component that reports failure unconditionally.
+- **Both badge branches are asserted.** The enabled branch alone left the disabled one uncovered by a
+  change that rewrote both — measured: reverting the badge killed one case before the second was
+  added and two after.
+- `agent-transport/docs/SPEC.md` states when a settings change takes effect.
+- `pnpm harness:scan` green; both affected package suites green.
+
+## User Execution Test Scenarios
+
+### Scenario 1 — a toggle no longer claims a transport is running
+
+1. Run `robota` and open the transport settings surface.
+2. Select a disabled transport and press space.
+3. Read the row and the footer.
+
+**Expected:** the row shows the saved setting (`[on]`), and the footer states that the change applies
+the next time Robota starts. **Before this change:** the row read `[enabled]`, which a user reasonably
+took to mean the transport was up — nothing had been started, and nothing said so.
+
+### Scenario 2 — a failed save is reported
+
+1. Make the settings file unwritable (`chmod 400` on the resolved settings path).
+2. Run `robota`, open transport settings, and press space on any transport.
+
+**Expected:** the surface reports `Not saved — …` with the reason. **Before this change:** the
+spinner stopped and nothing else changed; re-opening the surface showed the old value with no
+explanation.
+
+## Evidence Log
+
+- 2026-08-25 — Measured at `1874a187e`. `setEnabled` → `TransportSettingsView.setEnabled` → `mutate` →
+  `readSettings`/`writeSettings`; no start/stop on the path. TUI badge renders `entry.config.enabled`.
+- 2026-08-25 — Lifecycle surface checked before recommending deferred: `ITransportLifecycleRegistryView`
+  exposes `startAll`/`stopAll` only, and `TransportRegistry` carries one `state`. There is no
+  per-transport start to call, so "immediate" is a new capability rather than a wiring fix.
+- 2026-08-25 — `agent-transport/docs/SPEC.md:187` names `setEnabled` without saying when it takes
+  effect. Both readings were available from the document, which is part of the defect.
+- 2026-08-25 — **GATE-APPROVAL: owner sign-off obtained**, including the design decision. Asked
+  immediate-versus-deferred; the owner selected **"지연임을 사실대로 표시"** — render the deferred
+  behaviour truthfully rather than making the toggle immediate. A peer session's instruction to start
+  this item set the ORDER of work and was explicitly not treated as this approval.
+- 2026-08-25 — Implemented. `TransportTUI` badge names the saved setting (`[on]`/`[off]`) instead of
+  `[enabled]`/`[disabled]`; a footer states the change applies at the next start; the `catch` renders
+  the reason instead of discarding it. `agent-transport/docs/SPEC.md` now states that `setEnabled`
+  and `setOptions` persist only, and why that had to be written down.
+- 2026-08-25 — Six cases added, and verified by mutation against each of the three changes: reverting
+  the badge kills 2, restoring the discarding `catch` kills 2, removing the footer kills 1. The
+  success case is the positive control — without it the failure cases would pass against a component
+  that reports failure unconditionally.
+- 2026-08-25 — **Coverage checked, not just mutation-killed.** The first badge case asserted only the
+  enabled branch, so reverting the badge killed one test while the change had rewritten both branches.
+  A disabled-branch case was added and the same mutant then kills two. This is HARNESS-122's lesson
+  applied rather than restated: a mutation proves a case measures the change, not that the cases reach
+  across it.
+- 2026-08-25 — `agent-transport-tui` 700 tests pass, `agent-transport` 82 pass, `tsgo --noEmit` clean,
+  `pnpm harness:scan` 143 passed / 0 failures.

--- a/.agents/tasks/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
+++ b/.agents/tasks/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
@@ -1,7 +1,7 @@
 ---
 title: 'TRANS-009: the transport toggle reports enabled after a file write and discards the write failure'
 issue: https://github.com/woojubb/robota/issues/2050
-status: todo
+status: in-progress
 created: 2026-08-25
 priority: high
 urgency: soon

--- a/packages/agent-transport-tui/src/TransportTUI.tsx
+++ b/packages/agent-transport-tui/src/TransportTUI.tsx
@@ -2,6 +2,16 @@
  * TransportTUI — interactive overlay for transport enable/disable settings.
  *
  * Arrow keys navigate the list, space toggles enabled/disabled, enter/esc closes.
+ *
+ * TRANS-009: a toggle SAVES a setting. It does not start or stop anything — `registry.setEnabled`
+ * writes the settings file and returns, and `startAll` reads `getEnabled()` when a session starts, so
+ * the change takes effect at the next start. This component used to render `[enabled]` on the way
+ * back from that write, which told the user a transport was running when nothing had been started.
+ *
+ * The badge therefore names the SAVED setting and the footer says when it applies. And a failed write
+ * is rendered rather than swallowed: the previous `.catch(() => setSaving(false))` took the error and
+ * discarded it, so a settings file that could not be written looked exactly like a successful save
+ * with the row unchanged.
  */
 
 import { Box, Text, useInput } from 'ink';
@@ -25,7 +35,8 @@ interface IEntryRowProps {
 function TransportEntryRow({ entry, selected }: IEntryRowProps): React.ReactElement {
   const enabled = entry.config.enabled;
   const dot = enabled ? '●' : '○';
-  const badge = enabled ? '[enabled] ' : '[disabled]';
+  // The saved setting, not a running state — see the file header.
+  const badge = enabled ? '[on] ' : '[off]';
   const portOpt = entry.config.options?.port;
   const portHint = typeof portOpt === 'number' ? `port: ${portOpt}` : '';
   return (
@@ -46,6 +57,7 @@ function useTransportInput(
   registry: ITransportSettingsRegistryView<IInteractiveSession>,
   setCursor: (fn: (c: number) => number) => void,
   setSaving: (v: boolean) => void,
+  setError: (v: string | undefined) => void,
   onClose: () => void,
   refresh: () => void,
 ): void {
@@ -69,16 +81,22 @@ function useTransportInput(
           const entry = entries[cursor];
           if (!entry) return;
           setSaving(true);
+          setError(undefined);
           registry
             .setEnabled(entry.transport.name, !entry.config.enabled)
             .then(() => {
               refresh();
               setSaving(false);
             })
-            .catch(() => setSaving(false));
+            .catch((cause: unknown) => {
+              // The reason, not just the fact. A settings file that cannot be written and a
+              // transport that refuses configuration are different problems for the user.
+              setError(cause instanceof Error ? cause.message : 'could not save the setting');
+              setSaving(false);
+            });
         }
       },
-      [saving, entries, cursor, registry, onClose, refresh, setCursor, setSaving],
+      [saving, entries, cursor, registry, onClose, refresh, setCursor, setSaving, setError],
     ),
   );
 }
@@ -92,11 +110,22 @@ export default function TransportTUI({ registry, onClose }: IProps): React.React
   const [entries, setEntries] = useState(() => registry.getAll());
   const [cursor, setCursor] = useState(0);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
   const refresh = useCallback((): void => {
     setEntries(registry.getAll());
   }, [registry]);
 
-  useTransportInput(entries, cursor, saving, registry, setCursor, setSaving, onClose, refresh);
+  useTransportInput(
+    entries,
+    cursor,
+    saving,
+    registry,
+    setCursor,
+    setSaving,
+    setError,
+    onClose,
+    refresh,
+  );
 
   return (
     <Box flexDirection="column" paddingX={2} paddingY={1}>
@@ -106,12 +135,18 @@ export default function TransportTUI({ registry, onClose }: IProps): React.React
           <TransportEntryRow key={entry.transport.name} entry={entry} selected={i === cursor} />
         ))}
       </Box>
-      <Box marginTop={1}>
+      <Box marginTop={1} flexDirection="column">
         <Text dimColor>↑↓ select space toggle enter/esc close</Text>
+        <Text dimColor>A toggle is saved now and applies the next time Robota starts.</Text>
       </Box>
       {saving && (
         <Box marginTop={1}>
           <Text color={PALETTE.text.warning}>Saving…</Text>
+        </Box>
+      )}
+      {error !== undefined && (
+        <Box marginTop={1}>
+          <Text color={PALETTE.text.error}>{`Not saved — ${error}`}</Text>
         </Box>
       )}
     </Box>

--- a/packages/agent-transport-tui/src/__tests__/TransportTUI.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/TransportTUI.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * TRANS-009 — the toggle surface tells the truth about what it did.
+ *
+ * Two defects, one place. `registry.setEnabled` writes a settings file and returns; nothing on that
+ * path starts a transport, and `startAll` reads `getEnabled()` at session start. So the row used to
+ * report a transport as running because a file had changed. And the failure branch was
+ * `.catch(() => setSaving(false))` — the error taken and discarded, so an unwritable settings file
+ * looked exactly like a successful save.
+ *
+ * The assertions are on what the COMPONENT RENDERS, not on whether the registry was called. A test
+ * that asserts `setEnabled` was invoked passes against both the old code and the new one, because
+ * the call was never the defect.
+ */
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TransportTUI from '../TransportTUI.js';
+
+import type { IInteractiveSession } from '@robota-sdk/agent-interface-session';
+import type {
+  ITransportEntry,
+  ITransportSettingsRegistryView,
+} from '@robota-sdk/agent-interface-transport';
+
+function entry(name: string, enabled: boolean): ITransportEntry<IInteractiveSession> {
+  return {
+    transport: { name },
+    config: { enabled, options: {} },
+  } as unknown as ITransportEntry<IInteractiveSession>;
+}
+
+function registryWith(
+  setEnabled: ITransportSettingsRegistryView<IInteractiveSession>['setEnabled'],
+  entries = [entry('ws', false)],
+): ITransportSettingsRegistryView<IInteractiveSession> {
+  return {
+    getAll: () => entries,
+    setEnabled,
+    setOptions: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ITransportSettingsRegistryView<IInteractiveSession>;
+}
+
+const flush = async (): Promise<void> => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+};
+
+describe('TRANS-009: the surface says when a toggle applies', () => {
+  it('states that a toggle applies at the next start', () => {
+    const { lastFrame } = render(
+      <TransportTUI
+        registry={registryWith(vi.fn().mockResolvedValue(undefined))}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(lastFrame()).toContain('applies the next time Robota starts');
+  });
+
+  it('does not describe a saved setting as a running transport', () => {
+    // `[enabled]` read as "this is up". The badge names the saved setting instead.
+    const { lastFrame } = render(
+      <TransportTUI
+        registry={registryWith(vi.fn().mockResolvedValue(undefined), [entry('ws', true)])}
+        onClose={vi.fn()}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('[enabled]');
+    expect(frame).toContain('[on]');
+  });
+
+  it('names the saved setting for a disabled transport too', () => {
+    // The other half of the badge's ternary. Asserting only the enabled branch leaves the disabled
+    // one uncovered by the change that rewrote both — the coverage gap HARNESS-122 was made of: a
+    // mutation proves a case measures the guard, not that the cases reach across it.
+    const { lastFrame } = render(
+      <TransportTUI
+        registry={registryWith(vi.fn().mockResolvedValue(undefined), [entry('ws', false)])}
+        onClose={vi.fn()}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('[disabled]');
+    expect(frame).toContain('[off]');
+  });
+});
+
+describe('TRANS-009: a failed save is reported, not swallowed', () => {
+  it('renders the reason when the write fails', async () => {
+    const registry = registryWith(vi.fn().mockRejectedValue(new Error('EACCES: settings.json')));
+    const { stdin, lastFrame } = render(<TransportTUI registry={registry} onClose={vi.fn()} />);
+
+    stdin.write(' ');
+    await flush();
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Not saved');
+    expect(frame).toContain('EACCES: settings.json');
+  });
+
+  it('reports a non-Error rejection rather than rendering nothing', async () => {
+    // The branch that would otherwise print `undefined` — a rejection that is not an Error still has
+    // to produce a sentence, because the user's question is whether their change took effect.
+    const registry = registryWith(vi.fn().mockRejectedValue('nope'));
+    const { stdin, lastFrame } = render(<TransportTUI registry={registry} onClose={vi.fn()} />);
+
+    stdin.write(' ');
+    await flush();
+
+    expect(lastFrame() ?? '').toContain('could not save the setting');
+  });
+
+  // THE POSITIVE CONTROL. Without it the two cases above pass against a component that renders
+  // "Not saved" unconditionally — which would be a worse defect than the one being fixed.
+  it('shows no failure when the save succeeds', async () => {
+    const registry = registryWith(vi.fn().mockResolvedValue(undefined));
+    const { stdin, lastFrame } = render(<TransportTUI registry={registry} onClose={vi.fn()} />);
+
+    stdin.write(' ');
+    await flush();
+
+    expect(lastFrame() ?? '').not.toContain('Not saved');
+  });
+});

--- a/packages/agent-transport/docs/SPEC.md
+++ b/packages/agent-transport/docs/SPEC.md
@@ -190,6 +190,16 @@ delegated to the runner. Does not own interactive UI.
 `transports` block of a settings file at the path supplied to the constructor. Holds no
 concrete-transport import.
 
+**When a settings change takes effect (TRANS-009).** `setEnabled` and `setOptions` **persist only**.
+Neither starts, stops, or reconfigures a running transport: the enabled set is read by `startAll` via
+`getEnabled()` when a session starts, so a change applies from the **next** start. The registry
+exposes no per-transport start or stop — `startAll` and `stopAll` act over the whole set — so
+"immediate" is not a capability that exists to be invoked.
+
+This is stated because it was not: a surface that called `setEnabled` and then reported the transport
+as enabled was reading a persisted value as a running state, and both readings were available from a
+method list that said nothing about timing.
+
 **Runner ownership (ARCH-011).** `startAll` awaits each adapter's readiness-returning `start()`, then
 immediately owns every runner's separate completion promise. A startup generation is sealed only
 after every enabled subject is registered, so a synchronously successful first runner cannot make a


### PR DESCRIPTION
## What

Toggling a transport in the settings TUI reported it **enabled**. Nothing had been started.

```ts
// transport-registry.ts:124-127
async setEnabled(name, enabled): Promise<void> {
  this.requireConfigurable(name);
  this.settings.setEnabled(name, enabled);   // → readSettings / writeSettings. That is all.
}
```

`startAll` reads `getEnabled()` when a session starts, so a change applies at the **next** start. The badge rendered the persisted value as a running state.

**And the same two lines discarded the failure:**

```tsx
.catch(() => setSaving(false));   // the error, taken and thrown away
```

A settings file that could not be written looked exactly like a successful save with the row unchanged. **One path reported a success it did not achieve; the other reported nothing about a failure it did have.**

## Why deferred rather than immediate

Deferred is what the code already does, and it is coherent. Making the toggle immediate needs a **per-transport start** that the lifecycle does not have — `ITransportLifecycleRegistryView` offers `startAll` / `stopAll` over the whole set, and the registry carries one `state` machine. That is new capability rather than a wiring fix, and lifecycle semantics belong with ARCH-011's work.

Issue #2050 names this option itself: *"If they apply next session, name and render that explicitly."* Owner approved the choice at GATE-APPROVAL; quoted in the Evidence Log.

## The change

- the badge names the **saved setting** (`[on]` / `[off]`), not a running state;
- the footer states that a toggle applies the next time Robota starts;
- the `catch` renders the reason — `transport-registry-errors.ts` already builds typed errors, so nothing new was needed on the contract to stop discarding them;
- `agent-transport/docs/SPEC.md` states that `setEnabled` and `setOptions` **persist only**, and why that had to be written down: a method list saying nothing about timing left both readings available.

## Verification — and the coverage check, not just the mutation

Six cases, mutation-checked against each of the three changes:

```
revert the badge            → 2 cases fail
restore the discarding catch → 2 cases fail
remove the footer line      → 1 case fails
baseline                     6 passed
```

The success case is the **positive control**: without it the two failure cases would pass against a component that reports failure unconditionally.

**And the coverage gap was found and closed rather than assumed away.** The first badge case asserted only the *enabled* branch — so reverting the badge killed **one** test while the change had rewritten **both** branches. A disabled-branch case was added, and the same mutant then kills two. That is HARNESS-122's lesson applied rather than restated: *a mutation proves a case measures the change; it says nothing about whether the cases reach across it.*

`agent-transport-tui` 700 tests pass · `agent-transport` 82 pass · `tsgo --noEmit` clean · `pnpm harness:scan` 143 passed, 0 failures.

## Scope

TRANS-010 (the settings I/O behind a port) and TRANS-002 (options never reaching adapters) are separate records and untouched here. `setEnabled` keeps its `Promise<void>` signature — misleading, but changing it is a contract change across two interfaces and two SPECs for no correctness gain once the surface is honest, and it is called out in the spec document as deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH