### PR TITLE
docs(tasks): close TRANS-009 (TRANS-009)

### DIFF
--- a/.agents/spec-docs/done/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
+++ b/.agents/spec-docs/done/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 type: BEHAVIOR
 tags: [transport, tui, correctness]
 ---

--- a/.agents/tasks/completed/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
+++ b/.agents/tasks/completed/TRANS-009-the-transport-toggle-reports-enabled-after-a-file-write-and-discards-the-write-f.md
@@ -1,8 +1,9 @@
 ---
 title: 'TRANS-009: the transport toggle reports enabled after a file write and discards the write failure'
 issue: https://github.com/woojubb/robota/issues/2050
-status: in-progress
+status: done
 created: 2026-08-25
+completed: 2026-08-25
 priority: high
 urgency: soon
 area: packages/agent-transport, packages/agent-transport-tui


### PR DESCRIPTION
## What

Terminal status and `completed:` date for TRANS-009, and both documents moved to their terminal folders — the spec document to `.agents/spec-docs/done/`, the task record to `.agents/tasks/completed/` — in one commit, so neither is left disagreeing with its status.

The work landed as `f6e84ac5e` and was verified against what the remote tree holds (`git show origin/develop:` on both changed files), not against the PR description.

## Why separate from the delivering PR

`backlog-execution.md` asks for the terminal status and the `git mv` in the same commit as the closing work. The delivering PR merged without them, which leaves the record `in-progress` while its work is done. This is that commit, made atomically rather than left for an audit to find.

## A trap worth naming, since I walked into it

`sed -i` on the frontmatter followed by `git mv` **commits the rename alone** — the content edit stays unstaged, and the commit then asserts a status change the tree does not contain. Caught here by reading the diff stat (`2 files changed, 0 insertions(+), 0 deletions(-)`) rather than by any check, and amended before pushing.

Worth noting what could not have caught it: `pnpm harness:scan` passed at 143 both before and after the amend, because it reads the **working tree** and the working tree was correct the whole time. **A staged/unstaged mismatch is invisible to every scan in the suite** — the file says the right thing, the commit does not.

## Scope

Issue #2050 stays open. It also carries TRANS-010 (`todo`, depends on TRANS-009) and TRANS-002 (`todo`), and this closes neither.

## Verification

`pnpm harness:scan` — 143 passed, 2 skipped, 0 failures. Two frontmatter lines and two renames; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH