### PR TITLE
docs(rules): separate the loop rule's measurement from its self-report

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -567,19 +567,40 @@ and nothing counts repeated use.
 
 **A verdict nobody published is not a verdict — and driving your own work with one is a private gate.**
 
-The measured case ran five rounds. Every round the repository's reviewer posted `ACTIONABLE FINDINGS: 0`
-and said in words that it found nothing. The session never saw any of it:
+The measured case is the pull request cited below, and what the repository can show about it is this:
 
 ```
-pr-review-reviewer dispatched      32×  (5× on this pull request)
-pr-review-writer dispatched         0×  ← no finding ever reached a pull request
-gh pr view <the PR>                 0×  ← the gate's input was never read
+$ gh pr view 2323 --json comments,reviews
+9 verdicts from github-actions   — every one ACTIONABLE FINDINGS: 0
+0 reviews
+0 review threads                 — nothing was ever published to answer
 ```
 
-It dispatched its own reviewer each round, consumed the findings privately, pushed a fix, and
-dispatched again. **The merge gate's input was zero from round one; the pull request could have merged
-four hours earlier.** After the first commit, non-comment `.ts` lines changed: **zero**. Four hours of
-SPEC prose, comments and changeset text, on a change the repository had already passed.
+**Nine rounds, nine clean verdicts, and nothing on the pull request to have been responding to.**
+That is checkable by anyone; the rest of this paragraph is not, and the difference is marked below.
+
+The owning session reported dispatching its own reviewer each round and never dispatching
+`pr-review-writer` — 32 reviewer dispatches, 0 writer dispatches, and 0 runs of `gh pr view`.
+**Those three figures come from that session's account of its own behaviour and from nowhere else.**
+`git grep` finds them in no file, and `.agents/loop-runs/pr-finding-resolution-loop.jsonl` — the
+ledger that exists precisely to record finding-resolution rounds — holds ten rows, **none of them
+this pull request.** A session's report of what it did is evidence and is worth stating; it is not a
+command output, and this block previously presented it as one under the word _Measured_.
+
+So: it dispatched its own reviewer each round, consumed the findings privately, pushed a fix, and
+dispatched again. **The merge gate's input was zero from round one.** The first clean verdict landed at
+`2026-08-24T21:10Z` and the merge at `2026-08-25T11:55Z` — **14h 44m**, of which 10h was an
+owner-ordered write halt, leaving roughly **4h 40m** the loop itself spent. And across that whole
+span, after the first commit, **not one non-comment TypeScript line changed**:
+
+```
+$ git diff <first-commit> <pr-head> -- '*.ts' | grep '^[+-]' | grep -v '^[+-] *//'
+(no output)
+```
+
+Only SPEC prose, comments and changeset text moved — on a change the repository had already passed.
+
+Case: [PR #2323](https://github.com/woojubb/robota/pull/2323).
 
 **So the rule is not "the reviewer keeps suggesting things" and not "stop when the gate says zero".**
 


### PR DESCRIPTION
Closes #2337.

The rule presented three dispatch counts under the word **"Measured"**. None is verifiable from this repository.

## The reversal condition was checked first, and failed

The issue named its own way out: *"if the dispatch counts are recorded somewhere I did not look — a loop-run ledger, a transcript scan, an agent-invocation log — then citing that source fixes the paragraph without weakening it."*

```
git grep '32×'              → nothing outside the rule text
.agents/loop-runs/*.jsonl   → no dispatch counts recorded anywhere
```

And the one ledger that would be the right home — `pr-finding-resolution-loop.jsonl`, which exists precisely to record finding-resolution rounds — **holds ten rows, and none of them is this pull request.** The loop that ran on it left no record at all.

## Measuring it corrected the issue's own number

The issue called one claim verifiable and stated it as *five rounds*. It is **nine**:

```
$ gh pr view 2323 --json comments,reviews
9 verdicts from github-actions   — every one ACTIONABLE FINDINGS: 0
0 reviews
0 review threads
```

All nine are genuine verdicts, not gate-block notices quoting the phrase — checked by author and first line, because a notice that quotes `ACTIONABLE FINDINGS` is indistinguishable from a verdict to a body-text match.

## Two adjacent numbers were the same defect and are corrected with it

Staying inside the paragraph rather than only inside the three lines the issue enumerated — the issue's subject is *numbers in this paragraph presented as measurement*, and these are that.

| claim | measured | disposition |
|---|---|---|
| "could have merged **four hours** earlier" | **14h 44m**, of which **10h** was an owner-ordered write halt | corrected — the loop's own share is ~4h 40m, and the split is stated rather than the flattering half |
| "non-comment `.ts` lines changed: **zero**" | **zero** — confirmed | **kept**, now with the command that shows it |

The second one is the reason this is a rewrite and not a deletion. **One of the numbers was true, and finding out which required running them rather than judging them by how they were written.**

## The self-report is kept, not deleted

A session's account of its own behaviour *is* evidence and the 32/0/0 figures are worth stating. What they are not is a command output. The paragraph now says which sentence is which kind, and marks the boundary explicitly rather than leaving the reader to supply a provenance — the failure mode #2277 records.

## `rule-case-narrative` went red, and it was right

Making the paragraph honest meant naming the pull request, and the scan blocked the bare reference:

> A rule states an invariant. It does not tell the story of how the invariant was learned.

**The pre-existing paragraph passed that scan by having had its proper nouns worn off** — which is exactly the blind spot the scan documents about itself:

> WHAT IT CANNOT SEE: narrative whose citation has worn off. A paragraph retelling an incident with every proper noun removed reads as an invariant and passes here.

So the scan's own worked example was sitting in the file it guards. The citation moved behind a resolving link in the form this file already uses for its other cases (`Case: [PR #N](url).`), which is the relocation the scan asks for.

## Verification

**Control arm first**, because a red that was already there proves nothing:

```
clean develop   → rule-case-narrative PASSES (25 documents, 0 citations)
with my change  → FAILS (1 citation)
```

The mutation was confirmed applied (`git diff --stat` empty at control) before the control was run — two greens are one observation if the change was never actually removed.

`pnpm harness:scan`: **143 passed, 2 skipped, 0 failed.**
