### PR TITLE
fix(cli): an invalid settings file reaches the user as its message (issue #2342)

### DIFF
--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -11,8 +11,6 @@ import {
   checkForCliUpdate,
   formatCliUpdateCheckMessage,
   resolveCliUpdateNotice,
-  readSettings,
-  getUserSettingsPath,
 } from '@robota-sdk/agent-framework';
 import { assembleProduct } from '@robota-sdk/agent-product';
 import { parseCliArgs, parseToolList, printHelp } from './utils/cli-args.js';
@@ -20,6 +18,7 @@ import type { IParsedCliArgs } from './utils/cli-args.js';
 import { resolveShellPreset } from './startup/preset-selection.js';
 import type { IShellPresetResolution } from './startup/preset-selection.js';
 import { DEFAULT_AGENT_NAME, loadExternalPresets } from '@robota-sdk/agent-preset';
+import { readUserSettingsOrExit } from './startup/user-settings.js';
 import { runShellCommand } from './startup/shell-exec.js';
 import { buildPresetSurfaceOptions, toSessionOptions } from './startup/preset-surface-options.js';
 import type { IPreset } from '@robota-sdk/agent-preset';
@@ -155,7 +154,7 @@ export async function startCli(options: IStartCliOptions = {}): Promise<void> {
 
   // The shell's ONE preset resolution — see `resolveShellPreset` for why it is one. Resolved before
   // command setup so the preset's module-selection delta can reach `createDefaultCommandModules`.
-  const userSettings = readSettings(getUserSettingsPath());
+  const userSettings = readUserSettingsOrExit();
   const settingsPreset = typeof userSettings.preset === 'string' ? userSettings.preset : undefined;
   const externalPresetLoad = loadExternalPresets();
   for (const { file, error } of externalPresetLoad.errors) {

--- a/packages/agent-cli/src/startup/__tests__/user-settings.test.ts
+++ b/packages/agent-cli/src/startup/__tests__/user-settings.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #2342 — an invalid settings file reaches the user as its message, not as a stack trace.
+ *
+ * `readSettings` has thrown `SettingsParseError` since CLI-069, and the throw escaped to the
+ * top-level handler, which re-throws. So the message the typed error was written to carry — the file
+ * path and the remedy — arrived wrapped in a trace, if it arrived legibly at all.
+ *
+ * The cases assert the BEHAVIOUR. One asserting that `readUserSettingsOrExit` is called instead of
+ * `readSettings` would pass on the day this defect existed, because the call was already being made.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { readUserSettingsOrExit } from '../user-settings.js';
+
+const homes: string[] = [];
+
+/** A HOME whose `~/.robota/settings.json` this case controls, written verbatim. */
+function homeWithSettings(raw?: string): string {
+  const home = mkdtempSync(join(tmpdir(), 'issue-2342-home-'));
+  homes.push(home);
+  mkdirSync(join(home, '.robota'), { recursive: true });
+  if (raw !== undefined) writeFileSync(join(home, '.robota', 'settings.json'), raw, 'utf8');
+  return home;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+describe('readUserSettingsOrExit (issue #2342)', () => {
+  it('writes the message naming the file and the remedy, then exits 1', () => {
+    vi.stubEnv('HOME', homeWithSettings('{ "preset": "x"'));
+    const written: string[] = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      written.push(String(chunk));
+      return true;
+    });
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exited');
+    }) as never);
+
+    expect(() => readUserSettingsOrExit()).toThrow('exited');
+
+    expect(exit).toHaveBeenCalledWith(1);
+    // The two halves of the message that make it actionable: which file, and what to do.
+    expect(written.join('')).toContain('settings.json');
+    expect(written.join('')).toContain('Fix or delete the file');
+  });
+
+  it('returns the settings when the file parses', () => {
+    // The companion the refusal needs: without it, a function that always exited would also pass.
+    vi.stubEnv('HOME', homeWithSettings(JSON.stringify({ preset: 'default' })));
+
+    expect(readUserSettingsOrExit()).toEqual({ preset: 'default' });
+  });
+
+  it('returns empty settings when there is no file, rather than treating absence as an error', () => {
+    // CLI-069's distinction, asserted here because this guard sits on top of it: a MISSING file is
+    // not an error condition, and only an existing one that cannot be parsed is.
+    vi.stubEnv('HOME', homeWithSettings());
+
+    expect(readUserSettingsOrExit()).toEqual({});
+  });
+
+  it('lets an unrelated failure through instead of presenting it as a settings problem', () => {
+    // Without this, a broad catch passes the first case too. `readSettings` throws a plain Error for
+    // an unreadable path — a directory where the file should be — which is not a parse failure.
+    const home = homeWithSettings();
+    mkdirSync(join(home, '.robota', 'settings.json'), { recursive: true });
+    vi.stubEnv('HOME', home);
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exited');
+    }) as never);
+
+    expect(() => readUserSettingsOrExit()).not.toThrow('exited');
+    expect(exit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-cli/src/startup/user-settings.ts
+++ b/packages/agent-cli/src/startup/user-settings.ts
@@ -1,0 +1,41 @@
+import { getUserSettingsPath, readSettings, SettingsParseError } from '@robota-sdk/agent-framework';
+
+import type { TSettingsData } from '@robota-sdk/agent-framework';
+
+/**
+ * Read the user settings, presenting an unreadable file rather than throwing it at the user.
+ *
+ * Issue #2342. `readSettings` throws `SettingsParseError` for a file that EXISTS and does not parse —
+ * deliberately, under CLI-069, because an existing settings file that fails to parse is an error
+ * condition and never silently equated with a missing one. That decision is right and this does not
+ * change it.
+ *
+ * What was missing is the presentation. The throw escaped to the top-level handler, which re-throws
+ * anything that is not an IME hint, so a stray trailing comma in the settings file reached the user
+ * as a **stack trace** — and almost none of the message `SettingsParseError` was written to carry
+ * survives that:
+ *
+ * > `Settings file <path> contains invalid JSON: <reason>. Fix or delete the file, or run robota
+ * > diagnose.`
+ *
+ * It names the file and the remedy, which is the whole point of having a typed error.
+ *
+ * **Narrowed to `SettingsParseError` on purpose.** A broad catch would turn every unrelated startup
+ * defect into a clean exit wearing the settings message — a worse failure than the one being fixed,
+ * and one that still passes a test asserting only the happy refusal.
+ *
+ * It lives here rather than at the call site because `cli.ts` is at its `file-size` floor: the same
+ * guard inlined cost 17 lines when issue #2023 did this for the org policy and broke the freeze. The
+ * second reason survives the first being removed — the presentation of a read failure belongs beside
+ * the read rather than in the shell that happens to call it.
+ */
+export function readUserSettingsOrExit(): TSettingsData {
+  try {
+    return readSettings(getUserSettingsPath());
+  } catch (error) {
+    if (!(error instanceof SettingsParseError)) throw error;
+    // allow-fallback: an unreadable settings file is terminal — surface the file and the remedy, exit
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "apps/agent-server/src/websocket-server.ts": 363,
   "apps/remote-signaling/src/relay.ts": 311,
-  "packages/agent-cli/src/cli.ts": 441,
+  "packages/agent-cli/src/cli.ts": 440,
   "packages/agent-cli/src/remote-control/remote-control-controller.ts": 460,
   "packages/agent-cli/src/utils/cli-args.ts": 316,
   "packages/agent-command/src/context/context-command.ts": 306,


### PR DESCRIPTION
Closes #2342.

## The decision being fixed is the presentation, not the throw

`readSettings` has thrown `SettingsParseError` since CLI-069, deliberately: *"an EXISTING settings
file that fails to parse is an error condition, never silently equated with a missing file"*. That is
right and this does not change it.

**What was missing is that the message never reached the user.** The throw escaped to the top-level
handler in `bin.ts`, which re-throws anything that is not an IME hint — so a stray trailing comma in
`~/.robota/settings.json` arrived as a **stack trace**, and almost nothing of what the typed error
carries survived it:

> `Settings file <path> contains invalid JSON: <reason>. Fix or delete the file, or run robota
> diagnose.`

It names the file and the remedy. That is the entire reason for having a typed error rather than a
bare throw, and it was being discarded at the last step.

## The shape already existed, twice, in the same file

```ts
try { args = parseCliArgs(); }        catch { …is terminal — exit is the correct response }
try { preset = resolveShellPreset(…) } catch { …is terminal — surface available list, exit }
```

And a third time eight lines below this read, added by #2023 for the org policy. **`readSettings` was
the one call of this class in this file without it** — which is how the deferred finding came to be
filed in the first place.

## Narrow on purpose

`readUserSettingsOrExit` catches **only** `SettingsParseError`. A broad catch turns every unrelated
startup defect into a clean exit wearing the settings message — a worse failure than the one being
fixed, and one that **still passes a case asserting only the happy refusal.**

## Placement, and the size floor that forced the question

Beside the read rather than at the call site, for two reasons where the second survives the first
being removed:

- `packages/agent-cli/src/cli.ts` is at its `file-size` floor, and the same guard inlined cost **17
  lines** when #2023 did this for the org policy;
- the presentation of a read failure belongs beside the read rather than in the shell that happens to
  call it.

`file-size` fired **twice** and was right both times: at 442 for the added import, then again for
shrinking **below** the baseline once the two now-unused imports were dropped — *"an unlocked gain is
a licence to grow back to the old number."* Re-frozen in this change; one line of the baseline moved.

## Four cases, and the last two are what make the first two mean anything

| Case | Kills |
| --- | --- |
| message named, exit 1 | the mutant that re-throws instead of presenting |
| valid file returns settings | a guard that always exits |
| missing file returns `{}` | treating absence as an error — CLI-069's distinction |
| unrelated failure propagates | the mutant that catches broadly |

**The unrelated failure in the fourth was measured, not assumed.** A directory where the settings file
belongs makes `readSettings` throw a non-parse error. In #2324 the first version of the same companion
used a nonexistent cwd — **which does not fail at all**, so it asserted nothing and the broad-catch
mutant survived the case written to kill it. That is why this one was probed first.

## Verification

`pnpm harness:verify-like-ci` exit 0, all stages, on base `3a3f4d80c`; 143 scans; 81 tests.
