### PR TITLE
fix(harness): let typecheck see agent-executor and agent-server tests

### DIFF
--- a/apps/agent-server/tsconfig.json
+++ b/apps/agent-server/tsconfig.json
@@ -6,5 +6,5 @@
     "moduleResolution": "Bundler"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/agent-executor/src/background-tasks/__tests__/background-task-manager.test.ts
+++ b/packages/agent-executor/src/background-tasks/__tests__/background-task-manager.test.ts
@@ -230,7 +230,6 @@ describe('BackgroundTaskManager', () => {
       depth: 1,
       cwd: '/workspace',
       cronExpression: '0 0 * * *',
-      permissionPolicy: 'inherit-allowlist' as const,
     });
     await flushMicrotasks();
     await flushMicrotasks();

--- a/packages/agent-executor/src/subagents/__tests__/subagent-manager.test.ts
+++ b/packages/agent-executor/src/subagents/__tests__/subagent-manager.test.ts
@@ -5,6 +5,7 @@ import type {
   ISubagentJobResult,
   ISubagentJobStart,
   ISubagentRunner,
+  ISubagentSpawnRequest,
 } from '../types.js';
 import type { ITokenUsage } from '@robota-sdk/agent-core';
 
@@ -83,7 +84,7 @@ function createUsageReportingRunner(output: string, usage: ITokenUsage): ISubage
   };
 }
 
-function createSpawnRequest(prompt: string) {
+function createSpawnRequest(prompt: string): ISubagentSpawnRequest {
   return {
     agentType: 'general-purpose',
     label: 'General purpose',
@@ -92,6 +93,7 @@ function createSpawnRequest(prompt: string) {
     depth: 1,
     cwd: '/workspace',
     prompt,
+    permissionPolicy: 'inherit-allowlist',
   };
 }
 

--- a/packages/agent-executor/src/subagents/__tests__/worktree-subagent-runner.test.ts
+++ b/packages/agent-executor/src/subagents/__tests__/worktree-subagent-runner.test.ts
@@ -43,6 +43,7 @@ function createJob(isolation?: TBackgroundTaskIsolation): ISubagentJobStart {
       depth: 1,
       cwd: '/repo',
       prompt: 'do work',
+      permissionPolicy: 'inherit-allowlist',
       ...(isolation ? { isolation } : {}),
     },
   };

--- a/packages/agent-executor/tsconfig.json
+++ b/packages/agent-executor/tsconfig.json
@@ -12,5 +12,5 @@
     "noEmit": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
**Part 1 of issue #2192.** `packages/agent-session` follows in a second pull request — **this does not close the issue**, and the issue's title stays true until both land.

## The sweep the issue asked for

> *Worth checking whether other packages carry the same exclusion — this was found in one package by accident, not by a sweep.*

62 packages carry a `tsconfig.json`. **Three exclude their tests**, and the repository norm (`agent-core`: `include: ["src/**/*"]`, no test exclusion) is not one of them.

## What the exclusion was hiding

Control first, treatment second, with the mutation verified applied before the treatment ran:

```
exclusion in place    executor  0    session  0    server 0
exclusion removed     executor 11    session 55    server 0
```

**66 errors across 17 files**, reported as zero by `pnpm typecheck` today. The issue recorded two.

## All eleven are one cluster, and it is the issue's own thesis

CORE-025 made `permissionPolicy` **required** on `ISubagentSpawnRequest` — which is `Omit<IAgentBackgroundTaskRequest, 'kind'>` — and swept the consumers with the compiler. **These fixtures were not in the compiler's view, so the sweep did not reach them.** Same defect, same cause, five times the size.

Ten came from **one factory**:

```diff
-function createSpawnRequest(prompt: string) {
+function createSpawnRequest(prompt: string): ISubagentSpawnRequest {
```

The annotation is the point, not the field. A fixture with a declared contract fails **at the factory, once**, when that contract changes — instead of at ten call sites, or at none.

## The eleventh goes the other way, and it raises a real question

A test passed `permissionPolicy: 'inherit-allowlist'` to a `kind: 'scheduled'` request. **`IScheduledBackgroundTaskRequest` has never had that field** — only `IAgentBackgroundTaskRequest` does. So the value was dropped by the type and present at runtime.

Removed here to match the contract. But a scheduled task can carry `agentInstruction` and **wake the agent loop** (FLOW-001/FLOW-002), and what permission policy governs that loop is not answered by any contract I can find. The test's author evidently believed one applied. **That is a question for its own issue, not something a test fixture should settle**, and I am filing it rather than deciding it here.

## `apps/agent-server` has zero errors

Its exclusion costs nothing today. That makes it the clearest statement of the actual problem: **a blind spot is not a defect, and it is invisible precisely while it happens to be empty.** It is included because the next required field added to a type its tests use would land in the same silence.

## Falsification

The claim is *the gate can now see what it could not*, so it was tested rather than asserted. A deliberate `depth: 'NOT_A_NUMBER'` was injected into a test file and typechecked under both configurations:

```
with the exclusion      0 errors reported                      ← gate blind
without the exclusion   subagent-manager.test.ts(93,5) TS2322  ← gate reports it
```

**The first attempt at that control was invalid and is reported rather than quietly redone**: the edit that restored the exclusion hit `"outDir": "dist"` and produced tsconfig parse errors, so the "control" was measuring a broken config, not the old behaviour. It was rebuilt and re-run; the numbers above are from the corrected run.

## Verification

```
agent-executor tests    104 passed (14 files)
pnpm typecheck          0 errors, workspace-wide
pnpm harness:scan       143 passed, 2 skipped, 0 failed
```
