### PR TITLE
fix(harness): let typecheck see agent-session tests

### DIFF
--- a/packages/agent-session/src/__tests__/apply-model-options-cold-session.test.ts
+++ b/packages/agent-session/src/__tests__/apply-model-options-cold-session.test.ts
@@ -26,7 +26,13 @@ class ColdTestProvider extends AbstractAIProvider {
   readonly version = '1.0.0';
 
   override async chat(): Promise<TUniversalMessage> {
-    return { role: 'assistant', content: 'ok', state: 'complete', timestamp: new Date() };
+    return {
+      id: 'msg-cold-1',
+      role: 'assistant',
+      content: 'ok',
+      state: 'complete',
+      timestamp: new Date(),
+    };
   }
 }
 

--- a/packages/agent-session/src/__tests__/approval-wait-honours-abort.test.ts
+++ b/packages/agent-session/src/__tests__/approval-wait-honours-abort.test.ts
@@ -5,7 +5,11 @@ import { createScriptedProvider } from '@robota-sdk/agent-core/testing';
 import { PermissionEnforcer } from '../permission-enforcer.js';
 import { Session } from '../session.js';
 
-import type { IPermissionEnforcerOptions, TPermissionResult } from '../permission-types.js';
+import type {
+  IPermissionEnforcerOptions,
+  TPermissionHandler,
+  TPermissionResult,
+} from '../permission-types.js';
 import type { IToolWithEventService, ITerminalOutput, TToolArgs } from '@robota-sdk/agent-core';
 
 /**
@@ -100,7 +104,7 @@ describe('an approval prompt observes the turn abort (RUNTIME-005)', () => {
   it('an ALREADY aborted signal does not prompt at all', async () => {
     const controller = new AbortController();
     controller.abort();
-    const handler = vi.fn<[string, TToolArgs], Promise<TPermissionResult>>();
+    const handler = vi.fn<TPermissionHandler>();
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     await expect(enforcer.checkPermission('Bash', ARGS, controller.signal)).resolves.toBe(false);
@@ -112,9 +116,7 @@ describe('an approval prompt observes the turn abort (RUNTIME-005)', () => {
     // this fix's clothes.
     const controller = new AbortController();
     const enforcer = makeEnforcer({
-      permissionHandler: vi
-        .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-        .mockResolvedValue(true),
+      permissionHandler: vi.fn<TPermissionHandler>().mockResolvedValue(true),
     });
 
     await expect(enforcer.checkPermission('Bash', ARGS, controller.signal)).resolves.toBe(true);
@@ -122,9 +124,7 @@ describe('an approval prompt observes the turn abort (RUNTIME-005)', () => {
 
   it('works with no signal at all — the parameter is optional', async () => {
     const enforcer = makeEnforcer({
-      permissionHandler: vi
-        .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-        .mockResolvedValue(true),
+      permissionHandler: vi.fn<TPermissionHandler>().mockResolvedValue(true),
     });
     await expect(enforcer.checkPermission('Bash', ARGS)).resolves.toBe(true);
   });
@@ -182,9 +182,7 @@ describe('the turn signal reaches the prompt through the tool wrapper (RUNTIME-0
 
   it('an approved tool still runs — the signal did not turn every call into a denial', async () => {
     const enforcer = makeEnforcer({
-      permissionHandler: vi
-        .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-        .mockResolvedValue(true),
+      permissionHandler: vi.fn<TPermissionHandler>().mockResolvedValue(true),
     });
     const tool = makeTool();
     const [wrapped] = enforcer.wrapTools([tool]);

--- a/packages/agent-session/src/__tests__/compaction-failure-preservation.test.ts
+++ b/packages/agent-session/src/__tests__/compaction-failure-preservation.test.ts
@@ -25,7 +25,7 @@ function createProviderReturning(content: unknown): IAIProvider {
       state: 'complete' as const,
       timestamp: new Date(),
     }),
-  } as IAIProvider;
+  } as unknown as IAIProvider;
 }
 
 function createHistory(): TUniversalMessage[] {

--- a/packages/agent-session/src/__tests__/compaction-nothing-to-summarise.test.ts
+++ b/packages/agent-session/src/__tests__/compaction-nothing-to-summarise.test.ts
@@ -179,7 +179,7 @@ describe('CORE-031 — nothing to summarise is a no-op, not a summary', () => {
         state: 'complete' as const,
         timestamp: new Date(),
       }),
-    } as IAIProvider;
+    } as unknown as IAIProvider;
 
     // The value that made the overwrite possible was `''` — a string the caller happily wrote over
     // the conversation with. It must not come back at all.

--- a/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
+++ b/packages/agent-session/src/__tests__/core-027-tool-result-expresses-failure.test.ts
@@ -51,7 +51,7 @@ function makeEnforcer(overrides: Partial<IPermissionEnforcerOptions> = {}): Perm
     // The tool must actually RUN for a crash case to be about the crash. With the default config it
     // was denied instead, and the listener case then passed on the denial's own end event — green
     // for a reason that has nothing to do with what it asserts.
-    permissionHandler: async () => 'allow',
+    permissionHandler: async () => true,
     ...overrides,
   });
 }
@@ -170,7 +170,7 @@ describe('CORE-027: a denial, a crash and a success are three different things',
   it('tells a denial apart from a crash without reading prose', async () => {
     const denying = makeEnforcer({
       getPermissionMode: () => 'default',
-      permissionHandler: async () => 'deny',
+      permissionHandler: async () => false,
     });
     const [deniedTool] = denying.wrapTools([makeTool('Blocked', async () => ({ success: true }))]);
 

--- a/packages/agent-session/src/__tests__/permission-enforcer-session-allow.test.ts
+++ b/packages/agent-session/src/__tests__/permission-enforcer-session-allow.test.ts
@@ -14,7 +14,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { PermissionEnforcer } from '../permission-enforcer.js';
 import { buildPermissionEnforcer } from '../session-components.js';
 
-import type { IPermissionEnforcerOptions, TPermissionResult } from '../permission-types.js';
+import type {
+  IPermissionEnforcerOptions,
+  TPermissionHandler,
+  TPermissionResult,
+} from '../permission-types.js';
 import type { ITerminalOutput, TToolArgs } from '@robota-sdk/agent-core';
 
 // ---------------------------------------------------------------------------
@@ -52,9 +56,7 @@ const BASH_ARGS: TToolArgs = { command: 'pnpm test' };
 
 describe('PermissionEnforcer — permissionHandler session-allow', () => {
   it('Given allow-session response When called once Then adds tool to session list', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue('allow-session');
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     const result = await enforcer.checkPermission('Bash', BASH_ARGS);
@@ -64,9 +66,7 @@ describe('PermissionEnforcer — permissionHandler session-allow', () => {
   });
 
   it('Given allow-session granted earlier When called again Then handler is not called again', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue('allow-session');
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     await enforcer.checkPermission('Bash', BASH_ARGS);
@@ -79,9 +79,7 @@ describe('PermissionEnforcer — permissionHandler session-allow', () => {
   });
 
   it('Given session allow cleared When called again Then prompts user again', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue('allow-session');
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     await enforcer.checkPermission('Bash', BASH_ARGS);
@@ -95,10 +93,8 @@ describe('PermissionEnforcer — permissionHandler session-allow', () => {
   });
 
   it('Given allow-project response When called Then calls onProjectAllowTool and adds to session', async () => {
-    const onProjectAllowTool = vi.fn<[string], void>();
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue('allow-project');
+    const onProjectAllowTool = vi.fn<(toolName: string) => void>();
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue('allow-project');
     const enforcer = makeEnforcer({ permissionHandler: handler, onProjectAllowTool });
 
     const result = await enforcer.checkPermission('Bash', BASH_ARGS);
@@ -109,9 +105,7 @@ describe('PermissionEnforcer — permissionHandler session-allow', () => {
   });
 
   it('Given deny response When called Then returns false', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue(false);
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue(false);
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     const result = await enforcer.checkPermission('Bash', BASH_ARGS);
@@ -121,9 +115,7 @@ describe('PermissionEnforcer — permissionHandler session-allow', () => {
   });
 
   it('Given allow-once response When called Then returns true without adding to session list', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue(true);
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue(true);
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     const result = await enforcer.checkPermission('Bash', BASH_ARGS);
@@ -140,7 +132,7 @@ describe('PermissionEnforcer — permissionHandler session-allow', () => {
 describe('PermissionEnforcer — promptForApprovalFn session-allow', () => {
   it('Given allow-session from promptForApprovalFn When called once Then adds tool to session list', async () => {
     const promptFn = vi
-      .fn<[ITerminalOutput, string, TToolArgs], Promise<TPermissionResult>>()
+      .fn<NonNullable<IPermissionEnforcerOptions['promptForApprovalFn']>>()
       .mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ promptForApprovalFn: promptFn });
 
@@ -152,7 +144,7 @@ describe('PermissionEnforcer — promptForApprovalFn session-allow', () => {
 
   it('Given allow-session granted via promptFn When called again Then fn is not called again', async () => {
     const promptFn = vi
-      .fn<[ITerminalOutput, string, TToolArgs], Promise<TPermissionResult>>()
+      .fn<NonNullable<IPermissionEnforcerOptions['promptForApprovalFn']>>()
       .mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ promptForApprovalFn: promptFn });
 
@@ -166,9 +158,9 @@ describe('PermissionEnforcer — promptForApprovalFn session-allow', () => {
   });
 
   it('Given allow-project from promptForApprovalFn When called Then calls onProjectAllowTool', async () => {
-    const onProjectAllowTool = vi.fn<[string], void>();
+    const onProjectAllowTool = vi.fn<(toolName: string) => void>();
     const promptFn = vi
-      .fn<[ITerminalOutput, string, TToolArgs], Promise<TPermissionResult>>()
+      .fn<NonNullable<IPermissionEnforcerOptions['promptForApprovalFn']>>()
       .mockResolvedValue('allow-project');
     const enforcer = makeEnforcer({ promptForApprovalFn: promptFn, onProjectAllowTool });
 
@@ -190,9 +182,7 @@ describe('PermissionEnforcer — getSessionAllowedTools', () => {
   });
 
   it('After allow-session on multiple tools Returns all approved tools', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue('allow-session');
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     await enforcer.checkPermission('Bash', { command: 'ls' });
@@ -204,9 +194,7 @@ describe('PermissionEnforcer — getSessionAllowedTools', () => {
   });
 
   it('After clearSessionAllowedTools Returns empty list again', async () => {
-    const handler = vi
-      .fn<[string, TToolArgs], Promise<TPermissionResult>>()
-      .mockResolvedValue('allow-session');
+    const handler = vi.fn<TPermissionHandler>().mockResolvedValue('allow-session');
     const enforcer = makeEnforcer({ permissionHandler: handler });
 
     await enforcer.checkPermission('Bash', BASH_ARGS);

--- a/packages/agent-session/src/__tests__/permission-enforcer-span-events.test.ts
+++ b/packages/agent-session/src/__tests__/permission-enforcer-span-events.test.ts
@@ -63,7 +63,7 @@ describe('SELFHOST-004 P6 — permission wrapper forwards setEventService', () =
     const [wrapped] = enforcer.wrapTools([makeTool() as IToolWithEventService]);
     // Inject on the WRAPPER — must reach the original tool that originalExecute runs.
     wrapped!.setEventService(bus);
-    await wrapped!.execute({}, { executionId: 'e1' });
+    await wrapped!.execute({}, { toolName: 'spantool', parameters: {}, executionId: 'e1' });
 
     const spans = seen.filter((e) => e.type === SPAN_EVENTS.COMPLETED);
     expect(spans).toHaveLength(1);
@@ -74,7 +74,9 @@ describe('SELFHOST-004 P6 — permission wrapper forwards setEventService', () =
     const enforcer = makeEnforcer();
     const [wrapped] = enforcer.wrapTools([makeTool() as IToolWithEventService]);
     // no setEventService → original tool's bus stays unset; execute must still succeed
-    await expect(wrapped!.execute({}, { executionId: 'e1' })).resolves.toMatchObject({
+    await expect(
+      wrapped!.execute({}, { toolName: 'spantool', parameters: {}, executionId: 'e1' }),
+    ).resolves.toMatchObject({
       success: true,
     });
   });

--- a/packages/agent-session/src/__tests__/selfhost-009-existing-events-regression.test.ts
+++ b/packages/agent-session/src/__tests__/selfhost-009-existing-events-regression.test.ts
@@ -167,7 +167,7 @@ describe('SELFHOST-009 TC-04 — existing events still fire (agent-session sites
     const enforcer = new PermissionEnforcer(options);
     const [wrapped] = enforcer.wrapTools([makeTool('Read')]);
 
-    await wrapped!.execute({ path: '/x' });
+    await wrapped!.execute({ path: '/x' }, { toolName: 'Read', parameters: { path: '/x' } });
     await flush();
 
     expect(events).toContain('PreToolUse');

--- a/packages/agent-session/src/__tests__/selfhost-009-pretooluse-gate.test.ts
+++ b/packages/agent-session/src/__tests__/selfhost-009-pretooluse-gate.test.ts
@@ -88,7 +88,10 @@ describe('SELFHOST-009 TC-02 — PreToolUse security gate (functional)', () => {
     const enforcer = makeEnforcer(makeDenyExecutor('outcome-deny'));
     const [wrapped] = enforcer.wrapTools([makeTool('Bash', underlying)]);
 
-    const result = await wrapped!.execute({ command: 'rm -rf /' });
+    const result = await wrapped!.execute(
+      { command: 'rm -rf /' },
+      { toolName: 'Bash', parameters: { command: 'rm -rf /' } },
+    );
 
     expect(underlying).not.toHaveBeenCalled();
     const data = JSON.parse(result.data as string) as Record<string, unknown>;
@@ -105,7 +108,10 @@ describe('SELFHOST-009 TC-02 — PreToolUse security gate (functional)', () => {
     const enforcer = makeEnforcer(makeDenyExecutor('json-deny'));
     const [wrapped] = enforcer.wrapTools([makeTool('Write', underlying)]);
 
-    const result = await wrapped!.execute({ path: '/etc/passwd', content: 'x' });
+    const result = await wrapped!.execute(
+      { path: '/etc/passwd', content: 'x' },
+      { toolName: 'Write', parameters: { path: '/etc/passwd', content: 'x' } },
+    );
 
     expect(underlying).not.toHaveBeenCalled();
     const data = JSON.parse(result.data as string) as Record<string, unknown>;
@@ -129,7 +135,10 @@ describe('SELFHOST-009 TC-02 — PreToolUse security gate (functional)', () => {
     const enforcer = makeEnforcer(passExecutor);
     const [wrapped] = enforcer.wrapTools([makeTool('Read', underlying)]);
 
-    const result = await wrapped!.execute({ path: '/x' });
+    const result = await wrapped!.execute(
+      { path: '/x' },
+      { toolName: 'Read', parameters: { path: '/x' } },
+    );
 
     expect(underlying).toHaveBeenCalledOnce();
     expect(result.data).toBe('ran');

--- a/packages/agent-session/src/__tests__/session-lifecycle.test.ts
+++ b/packages/agent-session/src/__tests__/session-lifecycle.test.ts
@@ -9,6 +9,8 @@ import type {
 } from '@robota-sdk/agent-core';
 import { configureProvider } from '../session-lifecycle';
 
+import type { ISessionOptions } from '../session-types.js';
+
 const enabledCapabilities: IProviderCapabilities = {
   functionCalling: { supported: true },
   nativeWebTools: {
@@ -49,7 +51,9 @@ describe('configureProvider', () => {
   it('uses provider-neutral native web configuration hooks', () => {
     const provider = new HookedProvider();
 
-    configureProvider(provider, {}, vi.fn());
+    // `configureProvider` does not read its options argument (`_options`), so this case supplies
+    // the empty object it has always passed rather than an unrelated full session configuration.
+    configureProvider(provider, {} as ISessionOptions, vi.fn());
 
     expect(provider.configureNativeWebTools).toHaveBeenCalledWith({ webSearch: true });
   });

--- a/packages/agent-session/src/__tests__/session-provider-callback-isolation.test.ts
+++ b/packages/agent-session/src/__tests__/session-provider-callback-isolation.test.ts
@@ -9,16 +9,21 @@ function createSharedProvider(): IAIProvider & {
     name: 'mock-provider',
     version: '1.0.0',
     onTextDelta: undefined,
-    chat: vi.fn(async (_messages: TUniversalMessage[], options?: IChatOptions) => {
-      options?.onTextDelta?.('streamed text');
-      return {
-        id: 'assistant_1',
-        role: 'assistant',
-        content: 'final text',
-        timestamp: new Date(),
-        state: 'complete',
-      };
-    }),
+    chat: vi.fn(
+      async (
+        _messages: TUniversalMessage[],
+        options?: IChatOptions,
+      ): Promise<TUniversalMessage> => {
+        options?.onTextDelta?.('streamed text');
+        return {
+          id: 'assistant_1',
+          role: 'assistant',
+          content: 'final text',
+          timestamp: new Date(),
+          state: 'complete',
+        };
+      },
+    ),
     generateResponse: vi.fn(),
     supportsTools: () => true,
     validateConfig: () => true,
@@ -69,7 +74,7 @@ describe('Session provider callback isolation', () => {
   it('emits context updates before provider response and after usage reconciliation', async () => {
     const snapshots: Array<{ usedTokens: number; usedPercentage: number }> = [];
     const provider = createSharedProvider();
-    provider.chat = vi.fn(async () => {
+    provider.chat = vi.fn(async (): Promise<TUniversalMessage> => {
       expect(snapshots.length).toBeGreaterThan(0);
       return {
         id: 'assistant_1',

--- a/packages/agent-session/src/__tests__/session-record-field-preservation.test.ts
+++ b/packages/agent-session/src/__tests__/session-record-field-preservation.test.ts
@@ -33,8 +33,10 @@ class PreservationProvider extends AbstractAIProvider {
   ): Promise<TUniversalMessage> {
     const content = messages.at(-1)?.content;
     return {
+      id: 'msg-arch-015',
       role: 'assistant',
       content: `arch-015:${typeof content === 'string' ? content : ''}`,
+      state: 'complete',
       timestamp: new Date(),
     };
   }
@@ -51,6 +53,13 @@ const silentTerminal: ITerminalOutput = {
   write(): void {},
   writeLine(): void {},
   writeMarkdown(): void {},
+  writeError(): void {},
+  async prompt(): Promise<string> {
+    return '';
+  },
+  async select(): Promise<number> {
+    return 0;
+  },
   spinner(): ISpinner {
     return { stop(): void {}, update(): void {} };
   },

--- a/packages/agent-session/src/__tests__/session-run-realtime-context.test.ts
+++ b/packages/agent-session/src/__tests__/session-run-realtime-context.test.ts
@@ -54,11 +54,11 @@ function createFakeRobota(rounds: number): {
       return 'final response';
     },
   );
-  const robota = {
+  const agent = {
     getHistory: (): TUniversalMessage[] => [...messages],
     run,
   } as unknown as Robota;
-  return { robota, run };
+  return { agent, run };
 }
 
 function createProvider(): IAIProvider {
@@ -99,8 +99,8 @@ function createContext(
 describe('executeRun real-time context updates (BEHAVIOR-002)', () => {
   it('TC-01: emits a context update per round, not only at start and end', async () => {
     const updates: IContextWindowState[] = [];
-    const { robota } = createFakeRobota(2);
-    const ctx = createContext(robota, (state) => updates.push(state));
+    const { agent } = createFakeRobota(2);
+    const ctx = createContext(agent, (state) => updates.push(state));
 
     await executeRun('hello', undefined, ctx, new AbortController().signal);
 
@@ -110,8 +110,8 @@ describe('executeRun real-time context updates (BEHAVIOR-002)', () => {
 
   it('TC-02: emitted usedTokens are non-decreasing across the turn', async () => {
     const updates: IContextWindowState[] = [];
-    const { robota } = createFakeRobota(3);
-    const ctx = createContext(robota, (state) => updates.push(state));
+    const { agent } = createFakeRobota(3);
+    const ctx = createContext(agent, (state) => updates.push(state));
 
     await executeRun('hello', undefined, ctx, new AbortController().signal);
 
@@ -122,8 +122,8 @@ describe('executeRun real-time context updates (BEHAVIOR-002)', () => {
 
   it('TC-03: only assistant_message_committed triggers a per-round update, not other events', async () => {
     const updates: IContextWindowState[] = [];
-    const { robota } = createFakeRobota(2);
-    const ctx = createContext(robota, (state) => updates.push(state));
+    const { agent } = createFakeRobota(2);
+    const ctx = createContext(agent, (state) => updates.push(state));
 
     await executeRun('hello', undefined, ctx, new AbortController().signal);
 

--- a/packages/agent-session/src/__tests__/session-store-atomic.test.ts
+++ b/packages/agent-session/src/__tests__/session-store-atomic.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { NodeSessionStore } from '../session-store.js';
 
 import type { IInteractiveSessionRecord } from '@robota-sdk/agent-interface-session';
+import type { TUniversalMessage } from '@robota-sdk/agent-core';
 import { loadedOrMissing } from './store-load-helpers.js';
 
 let baseDir: string;
@@ -91,7 +92,9 @@ describe('SessionStore atomic persistence (CORE-019)', () => {
     // reach the destination file — the previous record must survive.
     const circular: Record<string, unknown> = {};
     circular.self = circular;
-    expect(() => store.save(createRecord({ messages: [circular] }))).toThrow();
+    expect(() =>
+      store.save(createRecord({ messages: [circular as unknown as TUniversalMessage] })),
+    ).toThrow();
 
     const loaded = loadedOrMissing(store, 'core-019-atomic');
     expect(loaded?.messages[0]?.content).toBe('original');

--- a/packages/agent-session/tsconfig.json
+++ b/packages/agent-session/tsconfig.json
@@ -12,5 +12,5 @@
     "noEmit": false
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
Closes #2192.

**Part 2, and the last one.** `packages/agent-session` was the third and final tsconfig excluding its tests. With this, all three the sweep found are closed and `pnpm typecheck` sees every test file in the workspace.

```
                          before part 1   after part 1   after this
packages/agent-executor         11              0             0
apps/agent-server                0              0             0
packages/agent-session          55             55             0
```

## Two of the 55 were not type nits

**A factory whose signature and body disagree.** `session-run-realtime-context.test.ts` declares `{ agent: Robota; run }` and returns `{ robota, run }`. Someone renamed the annotation and not the body, inside one function, and it sat in the tree — because nothing typechecked the file.

**Two invalid permission verdicts.** `core-027-tool-result-expresses-failure.test.ts` passed `async () => 'allow'` and `async () => 'deny'` as permission handlers. `TPermissionResult` is `boolean | 'allow-session' | 'allow-project'` — **neither string is a member**, and `abortable-approval.ts` reads:

```ts
return { allowed: result === true, … };
```

So both values **deny**.

I traced it before claiming a live bug, and there isn't one:

- the `'allow'` case runs under `bypassPermissions`, where `evaluatePermission` returns `'auto'` and `checkPermission` returns `true` **before the handler is reached** — the value is never consulted;
- the `'deny'` case does reach the handler, and gets the verdict it wanted **only because everything that is not `true` is a denial.**

No production defect. But the shape is worth naming: **an invalid permission verdict denies, silently, and a test asserting denial cannot distinguish that from a correct denial.** The file's own comment already worries about being "green for a reason that has nothing to do with what it asserts" — this is that, one layer down. Both handlers now use valid values.

## The rest are the issue's thesis, repeated

Fixtures out of step with contracts the compiler could not reach them to sweep:

- **17 sites** on vitest's old `vi.fn<[Args], Ret>()` tuple form. They now name the contract they stand in for — `vi.fn<TPermissionHandler>()`, `vi.fn<NonNullable<IPermissionEnforcerOptions['promptForApprovalFn']>>()` — so a mock **fails when the contract moves** instead of drifting from it. That is the same choice as part 1's `createSpawnRequest(): ISubagentSpawnRequest`: bind the double to the contract, not to a shape that happened to match once.
- **4 calls** to `execute(parameters)` where `IToolContract.execute(parameters, context)` requires the context.
- Message fixtures missing the `id` / `state` that `IBaseMessage` requires; `ITerminalOutput` doubles missing `writeError` / `prompt` / `select`; partial provider doubles cast straight to `IAIProvider`.

## Falsification

The claim is *the gate can now see what it could not*, so it was tested:

```
const provider: number = new HookedProvider();   // injected into a test file

with the exclusion      0 errors reported                      ← gate blind
without the exclusion   session-lifecycle.test.ts(52,11) TS2322 ← gate reports it
```

## Verification

```
agent-session tests     369 passed (49 files)
pnpm typecheck          0 errors, workspace-wide
pnpm harness:scan       143 passed, 2 skipped, 0 failed
```

**No production source was changed** — every edit is a test file or a tsconfig.

The one question this work raised that a test fixture should not settle is filed as issue #2354: a cron schedule injects a full tool-capable turn, and no permission contract on that path mentions it.
