### PR TITLE
fix(agent-framework): write the update-check cache owner-only

### DIFF
--- a/.changeset/2229-update-check-owner-only.md
+++ b/.changeset/2229-update-check-owner-only.md
@@ -1,0 +1,11 @@
+---
+'@robota-sdk/agent-framework': patch
+---
+
+The CLI update-check cache is now written owner-only (`0600`) into an owner-only directory (`0700`), instead of inheriting the process umask.
+
+SEC-020 made every writer into the CLI's own store owner-only and scoped this one file out as "not a session record", which left it the only file the product created there at `0644` under a permissive umask. The store directory is the confidentiality boundary and the file modes are the layer beneath it — an exception in that layer is only invisible while the layer above it holds.
+
+The write now goes through `writeOwnerOnlyFile`, which creates the parent owner-only and sets the mode at creation rather than tightening afterwards, so the file never exists readable. A cache an older version left at `0644` is repaired at its next write.
+
+`getUserUpdateCheckCachePath`, `readUpdateCheckCache`, `writeUpdateCheckCache` and `IUpdateCheckCache` moved to an internal `update-check-cache` module. **They are exported from the package root under the same names, so no import changes.**

--- a/packages/agent-framework/src/index.ts
+++ b/packages/agent-framework/src/index.ts
@@ -704,23 +704,25 @@ export {
   formatCliUpdateCheckMessage,
   formatCliUpdateNotice,
   getStartupCliUpdateNotice,
-  getUserUpdateCheckCachePath,
-  readUpdateCheckCache,
   shouldRunStartupCliUpdateCheck,
-  writeUpdateCheckCache,
   CLI_UPDATE_CACHE_TTL_MS,
   CLI_UPDATE_PACKAGE_NAME,
   CLI_UPDATE_REGISTRY_URL,
   CLI_UPDATE_TIMEOUT_MS,
 } from './update-check/update-check.js';
+export {
+  getUserUpdateCheckCachePath,
+  readUpdateCheckCache,
+  writeUpdateCheckCache,
+} from './update-check/update-check-cache.js';
 export { resolveCliUpdateNotice } from './update-check/resolve-cli-update-notice.js';
 export type {
   ICheckForCliUpdateOptions,
   ICliUpdateNotice,
   IStartupCliUpdatePolicyInput,
-  IUpdateCheckCache,
   TCliUpdateCheckResult,
 } from './update-check/update-check.js';
+export type { IUpdateCheckCache } from './update-check/update-check-cache.js';
 
 // ── Agent runtime ─────────────────────────────────────────────
 export { createAgentRuntime, createStatelessRuntime } from './runtime/index.js';

--- a/packages/agent-framework/src/update-check/__tests__/update-check.test.ts
+++ b/packages/agent-framework/src/update-check/__tests__/update-check.test.ts
@@ -6,6 +6,9 @@ import {
   mkdtempSync,
   statSync,
   writeFileSync,
+  openSync,
+  closeSync,
+  fstatSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -262,8 +265,16 @@ describe('writeUpdateCheckCache owner-only mode (issue #2229)', () => {
       writeUpdateCheckCache(cachePath, { ...CACHE });
     });
 
-    expect(statSync(cachePath).mode & 0o777).toBe(0o600);
-    expect(JSON.parse(readFileSync(cachePath, 'utf8')).latestVersion).toBe('3.0.0-beta.57');
+    // One descriptor for both facts. `statSync(path)` followed by `readFileSync(path)` resolves the
+    // path twice, which is the check-then-act shape CodeQL rejects — the same one it caught in
+    // `owner-only-store.ts` on PR #2224, where the repository chose to fix rather than suppress.
+    const fd = openSync(cachePath, 'r');
+    try {
+      expect(fstatSync(fd).mode & 0o777).toBe(0o600);
+      expect(JSON.parse(readFileSync(fd, 'utf8')).latestVersion).toBe('3.0.0-beta.57');
+    } finally {
+      closeSync(fd);
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/agent-framework/src/update-check/__tests__/update-check.test.ts
+++ b/packages/agent-framework/src/update-check/__tests__/update-check.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  mkdtempSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,11 +18,16 @@ import {
   compareSemverVersions,
   formatCliUpdateCheckMessage,
   formatCliUpdateNotice,
-  getUserUpdateCheckCachePath,
   isNewerSemverVersion,
-  readUpdateCheckCache,
   shouldRunStartupCliUpdateCheck,
 } from '../update-check.js';
+import {
+  getUserUpdateCheckCachePath,
+  readUpdateCheckCache,
+  writeUpdateCheckCache,
+} from '../update-check-cache.js';
+
+import type { IUpdateCheckCache } from '../update-check-cache.js';
 
 const TEST_DIR = mkdtempSync(join(tmpdir(), 'robota-update-check-test-'));
 
@@ -198,5 +211,59 @@ describe('shouldRunStartupCliUpdateCheck', () => {
         disableUpdateCheck: true,
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * SEC-020 (issue #2021) made every writer into `~/.robota` owner-only and scoped `update-check.json`
+ * out. Issue #2229 is that exception: it left one file the CLI creates in its own store at 0644.
+ *
+ * The umask is set EXPLICITLY in each case and restored afterwards. A case that inherits a
+ * restrictive umask passes whether or not the mode was ever requested — it would be an assertion
+ * about the environment that ran it, not about this code.
+ */
+describe('writeUpdateCheckCache owner-only mode (issue #2229)', () => {
+  const CACHE: IUpdateCheckCache = {
+    packageName: '@robota-sdk/agent-cli',
+    checkedAt: '2026-05-01T00:00:00.000Z',
+    currentVersion: '3.0.0-beta.56',
+    latestVersion: '3.0.0-beta.57',
+  };
+
+  function withPermissiveUmask<T>(run: () => T): T {
+    const previous = process.umask(0o022);
+    try {
+      return run();
+    } finally {
+      process.umask(previous);
+    }
+  }
+
+  it('writes 0600 into a 0700 directory under a permissive umask', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'robota-update-check-mode-'));
+    const cachePath = join(dir, '.robota', 'update-check.json');
+
+    withPermissiveUmask(() => writeUpdateCheckCache(cachePath, { ...CACHE }));
+
+    expect(statSync(cachePath).mode & 0o777).toBe(0o600);
+    expect(statSync(join(dir, '.robota')).mode & 0o777).toBe(0o700);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('repairs a 0644 cache an older version left behind', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'robota-update-check-repair-'));
+    const cachePath = join(dir, '.robota', 'update-check.json');
+
+    withPermissiveUmask(() => {
+      mkdirSync(join(dir, '.robota'), { recursive: true });
+      writeFileSync(cachePath, '{}\n', { encoding: 'utf8', mode: 0o644 });
+      // The pre-condition is the point of the case: without it a green says nothing about repair.
+      expect(statSync(cachePath).mode & 0o777).toBe(0o644);
+      writeUpdateCheckCache(cachePath, { ...CACHE });
+    });
+
+    expect(statSync(cachePath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(cachePath, 'utf8')).latestVersion).toBe('3.0.0-beta.57');
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/agent-framework/src/update-check/update-check-cache.ts
+++ b/packages/agent-framework/src/update-check/update-check-cache.ts
@@ -1,0 +1,76 @@
+/**
+ * Persistence for the CLI update-check cache: where it lives, how it is read, how it is written.
+ *
+ * Split out of `update-check.ts` under the anti-monolith ratchet — that file sits on its frozen
+ * 305-line baseline, and routing the write through the owner-only writer (issue #2229) needed one
+ * line more than it had. The cluster carved out here is the cohesive one: a path, a codec, and the
+ * two IO calls, with the policy and formatting left behind.
+ *
+ * The write goes through `writeOwnerOnlyFile` because SEC-020 (issue #2021) made every writer into
+ * the CLI's own store owner-only and scoped this one out, leaving it the single file created there
+ * at 0644 under a permissive umask. The store directory is the confidentiality boundary; the file
+ * mode is the layer beneath it, so it carries no exception. `writeOwnerOnlyFile` also creates the
+ * parent owner-only and sets the mode at CREATION rather than chmod-ing after, so the file never
+ * exists readable.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { writeOwnerOnlyFile } from '@robota-sdk/agent-core/node';
+
+/** The JSON value shape this codec walks. Owned here because the cache is its only consumer pair. */
+export type TJsonValue =
+  string | number | boolean | null | readonly TJsonValue[] | { readonly [key: string]: TJsonValue };
+
+export interface IUpdateCheckCache {
+  packageName: string;
+  checkedAt: string;
+  currentVersion: string;
+  latestVersion?: string;
+  errorMessage?: string;
+}
+export function getUserUpdateCheckCachePath(
+  home = process.env.HOME ?? process.env.USERPROFILE ?? '/',
+): string {
+  return join(home, '.robota', 'update-check.json');
+}
+export function readUpdateCheckCache(path: string): IUpdateCheckCache | undefined {
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as TJsonValue;
+    return parseUpdateCheckCache(parsed);
+  } catch {
+    // allow-fallback: corrupt cache must not block startup; silently discard and re-fetch
+    return undefined;
+  }
+}
+export function writeUpdateCheckCache(path: string, cache: IUpdateCheckCache): void {
+  writeOwnerOnlyFile(path, JSON.stringify(cache, null, 2) + '\n');
+}
+function parseUpdateCheckCache(value: TJsonValue): IUpdateCheckCache | undefined {
+  if (!isJsonObject(value)) {
+    return undefined;
+  }
+  const candidate = value;
+  if (
+    typeof candidate.packageName === 'string' &&
+    typeof candidate.checkedAt === 'string' &&
+    typeof candidate.currentVersion === 'string' &&
+    (candidate.latestVersion === undefined || typeof candidate.latestVersion === 'string') &&
+    (candidate.errorMessage === undefined || typeof candidate.errorMessage === 'string')
+  ) {
+    return {
+      packageName: candidate.packageName,
+      checkedAt: candidate.checkedAt,
+      currentVersion: candidate.currentVersion,
+      ...(candidate.latestVersion !== undefined && { latestVersion: candidate.latestVersion }),
+      ...(candidate.errorMessage !== undefined && { errorMessage: candidate.errorMessage }),
+    };
+  }
+  return undefined;
+}
+function isJsonObject(value: TJsonValue): value is { readonly [key: string]: TJsonValue } {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/agent-framework/src/update-check/update-check.ts
+++ b/packages/agent-framework/src/update-check/update-check.ts
@@ -1,8 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-
+import {
+  getUserUpdateCheckCachePath,
+  readUpdateCheckCache,
+  writeUpdateCheckCache,
+} from './update-check-cache.js';
 import { compareSemverVersions, isNewerSemverVersion } from '../utils/semver-compare.js';
 import { trimTrailingChars } from '../utils/trim-char.js';
+
+import type { IUpdateCheckCache, TJsonValue } from './update-check-cache.js';
 
 export const CLI_UPDATE_PACKAGE_NAME = '@robota-sdk/agent-cli';
 export const CLI_UPDATE_REGISTRY_URL = 'https://registry.npmjs.org';
@@ -20,14 +24,6 @@ export interface ICliUpdateNotice {
   currentVersion: string;
   latestVersion: string;
   installCommand: string;
-}
-
-export interface IUpdateCheckCache {
-  packageName: string;
-  checkedAt: string;
-  currentVersion: string;
-  latestVersion?: string;
-  errorMessage?: string;
 }
 
 export type TCliUpdateCheckResult =
@@ -60,33 +56,6 @@ interface INpmPackageMetadata {
   };
 }
 export { compareSemverVersions, isNewerSemverVersion };
-
-type TJsonValue =
-  string | number | boolean | null | readonly TJsonValue[] | { readonly [key: string]: TJsonValue };
-
-export function getUserUpdateCheckCachePath(
-  home = process.env.HOME ?? process.env.USERPROFILE ?? '/',
-): string {
-  return join(home, '.robota', 'update-check.json');
-}
-
-export function readUpdateCheckCache(path: string): IUpdateCheckCache | undefined {
-  if (!existsSync(path)) {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as TJsonValue;
-    return parseUpdateCheckCache(parsed);
-  } catch {
-    // allow-fallback: corrupt cache must not block startup; silently discard and re-fetch
-    return undefined;
-  }
-}
-
-export function writeUpdateCheckCache(path: string, cache: IUpdateCheckCache): void {
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(cache, null, 2) + '\n', 'utf8');
-}
 
 export async function checkForCliUpdate(
   options: ICheckForCliUpdateOptions,
@@ -274,31 +243,4 @@ async function fetchLatestVersion(options: {
 function buildPackageMetadataUrl(registryUrl: string, packageName: string): string {
   // `trimTrailingChars` rather than `/\/+$/`: an unanchored trailing-run regex is quadratic (SEC-003).
   return `${trimTrailingChars(registryUrl, '/')}/${encodeURIComponent(packageName)}`;
-}
-
-function parseUpdateCheckCache(value: TJsonValue): IUpdateCheckCache | undefined {
-  if (!isJsonObject(value)) {
-    return undefined;
-  }
-  const candidate = value;
-  if (
-    typeof candidate.packageName === 'string' &&
-    typeof candidate.checkedAt === 'string' &&
-    typeof candidate.currentVersion === 'string' &&
-    (candidate.latestVersion === undefined || typeof candidate.latestVersion === 'string') &&
-    (candidate.errorMessage === undefined || typeof candidate.errorMessage === 'string')
-  ) {
-    return {
-      packageName: candidate.packageName,
-      checkedAt: candidate.checkedAt,
-      currentVersion: candidate.currentVersion,
-      ...(candidate.latestVersion !== undefined && { latestVersion: candidate.latestVersion }),
-      ...(candidate.errorMessage !== undefined && { errorMessage: candidate.errorMessage }),
-    };
-  }
-  return undefined;
-}
-
-function isJsonObject(value: TJsonValue): value is { readonly [key: string]: TJsonValue } {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/scripts/harness/file-size-baseline.json
+++ b/scripts/harness/file-size-baseline.json
@@ -25,7 +25,6 @@
   "packages/agent-framework/src/interactive/interactive-session-skill-router.ts": 341,
   "packages/agent-framework/src/interactive/interactive-session.ts": 998,
   "packages/agent-framework/src/testing/scripted-session-harness.ts": 454,
-  "packages/agent-framework/src/update-check/update-check.ts": 305,
   "packages/agent-framework/src/user-local/memory.ts": 310,
   "packages/agent-interface-session/src/session-contracts.ts": 355,
   "packages/agent-playground/src/components/playground/assembly-canvas/assembly-canvas.tsx": 305,


### PR DESCRIPTION
Closes #2229.

## Reproduced before fixing

The umask is set **explicitly**, per this issue's own third acceptance criterion — a case that inherits a restrictive umask passes whether or not the mode was ever requested:

```
umask 022, current implementation
  dir  mode: 755
  file mode: 644
```

The write now goes through `writeOwnerOnlyFile`, which SEC-020 added and the other four store writers already use: it creates the parent owner-only and carries the mode from **creation** via `wx` rather than chmod-ing afterwards, so the file never exists readable.

## The file had to be split, not extended

This is the part worth reading, because it is not what the issue anticipated.

`packages/agent-framework/src/update-check/update-check.ts` sat exactly on its frozen **305-line** `file-size` baseline. The minimal correct change came to **306** — and the extra line was the blank line `import/order` requires between import groups. Removing it turns the lint warning count to 2204 against a ceiling of 2203 with **zero headroom** (issue #2251), so that route is closed too.

So: a security fix, blocked by an anti-monolith ratchet, over one line of import formatting.

**The ratchet's own prescription is "split instead of extending", and that is what was done** rather than arguing for an exemption. The cache-persistence cluster — the path, the JSON codec, and the two IO calls — moved to `update-check-cache.ts`. The original is now **256 lines and drops out of the baseline entirely**; the scan then asked for the tightening to be re-frozen in the same change, which it was:

```
before:  file-grew-past-baseline … 306 lines (baseline froze it at 305)
after:   ratchet-tighten … shrank below its baseline. Run --write-baseline in the SAME change
final:   file-size scan passed (78 baselined entries — one fewer than before)
```

**The public surface is unchanged.** `getUserUpdateCheckCachePath`, `readUpdateCheckCache`, `writeUpdateCheckCache` and `IUpdateCheckCache` are re-exported from the package root under the same names, so no consumer import changes.

## Two things caught along the way, recorded rather than smoothed over

**A twelve-line explanatory comment failed two scans.** The first attempt explained the change in the source file; it failed `file-size` *and* `product-identity` — a library naming its consumer's product, 51 → 52. The explanation belongs in the commit, the changeset and this pull request. It is now in all three and in none of the source.

**The first test fixture drifted from its contract** — missing `packageName`, `checkedAt` and `currentVersion` from `IUpdateCheckCache`. That is precisely the fixture-drift class fixed in issue #2192 hours ago, and it was caught in seconds **because this package's tests are typechecked**. A small demonstration that the sweep was worth running.

## Red proof, run twice

Once before the split and once after — a refactor can change what a case is asking, so a red proof taken only before it proves less than it looks:

```
fix reverted, both new cases   FAIL   expected 384 (0600), got 420 (0644)
fix present, all 15 cases      PASS
other 13 cases                 PASS in both arms   ← the red is the fix, not the harness
```

And end-to-end against the **built** package rather than the source, because that is what ships:

```
exists:    true
dir  mode: 700   (expect 700)
file mode: 600   (expect 600)
```

## Acceptance

| criterion | status |
|---|---|
| freshly written cache is 0600, directory 0700, permissive umask | **met** |
| a 0644 cache from an older version is 0600 after the next write | **met** — with the 0644 pre-condition asserted, so a green means repair |
| the test sets the umask explicitly | **met** — set and restored per case |

## Verification

```
agent-framework tests   1561 passed (195 files)
pnpm typecheck          0 errors, workspace-wide
pnpm harness:scan       143 passed, 2 skipped, 0 failed
```
