### PR TITLE
fix(executor): agent-core's provider helpers have one exporter (ARCH-111)

### DIFF
--- a/.agents/spec-docs/draft/ARCH-111-the-executor-re-exports-core-owned-provider-helpers-so-two-consumers-disagree-ab.md
+++ b/.agents/spec-docs/draft/ARCH-111-the-executor-re-exports-core-owned-provider-helpers-so-two-consumers-disagree-ab.md
@@ -1,0 +1,118 @@
+---
+status: draft
+type: RULE
+tags: [architecture, ownership, providers]
+---
+
+# ARCH-111: one function, two exporting packages, two consumers that disagree
+
+## Problem
+
+`normalizeProviderConfig` and `createProviderFromConfig` are owned by `agent-core` and re-exported by
+`agent-executor`. Measured at `c1c3ac079`, one product imports the same function from both:
+
+```
+agent-framework/src/command-api/provider/provider-factory.ts:2   createProviderFromConfig  ← agent-executor
+agent-framework/src/command-api/provider/provider-merge.ts:1     normalizeProviderConfig   ← agent-executor
+agent-product/src/assemble-product.ts:2                          createProviderFromConfig  ← agent-core
+```
+
+Both compile. Issue #2051 describes consumers _preferring_ the facade; measurement shows the product
+doing both at once, which is a different and worse thing — **two consumers holding different answers
+to who owns the symbol, with nothing able to notice.**
+
+## Prior Art Research
+
+Waived: the question is which of this repository's own packages owns two of its own functions, and
+whether a re-export created by its own prior change (ARCH-PROVIDER-003) still has a reason to exist
+under its own release policy. No external product's documentation bears on it. The evidence that
+decides it is the re-export's stated purpose and this repository's ruling on backward compatibility,
+both read directly below.
+
+## Solution (draft direction)
+
+Remove the re-export; point the two `agent-framework` imports at `@robota-sdk/agent-core`.
+
+**Why the reason for the duplicate is gone.** `agent-executor/src/providers/provider-factory.ts:14`
+says it exists _"so existing `@robota-sdk/agent-executor` consumers are unaffected"_, and
+ARCH-PROVIDER-003 line 68 says _"re-exports from the new location (no consumer break)"_. That is a
+backward-compatibility guarantee. **This repository does not make one** — the owner's standing ruling
+is that legacy is not a consideration before release.
+
+**The ground is deliberately not "few consumers".** The owner has ruled that a public interface is not
+made private or removed for having one caller or none — only when it is genuinely unnecessary or does
+not fit the design. **The argument here is the second one:** the symbol has one owner, the duplicate
+name exists solely for a guarantee this repository does not make, and its presence is precisely what
+lets two consumers disagree about the owner. Import count is evidence of the effect, not the reason.
+
+**Why it is mechanical**, checked rather than assumed: `agent-framework` already depends on
+`@robota-sdk/agent-core` and already imports from it in **156 files**. Repointing two lines adds no
+dependency edge and changes no behaviour.
+
+## Completion Criteria (draft)
+
+- `agent-executor` no longer exports `normalizeProviderConfig` or `createProviderFromConfig`, asserted
+  at the type level rather than by `grep`, so a returning export fails at compile time.
+- `agent-framework`'s provider suites pass with the imports repointed — proving the two names were one
+  function and the facade added nothing.
+- **Positive control**: `agent-core` still exports both, so a suite proving the executor dropped them
+  cannot pass against a workspace that lost them entirely.
+- `agent-executor/docs/SPEC.md` stops listing exports the package no longer has.
+- `tsgo --noEmit` clean workspace-wide — a missed consumer is a build failure here, not a silent
+  fallback, so the compiler is the real coverage check.
+- `pnpm harness:scan` green.
+
+## Test Plan
+
+See Completion Criteria; the type-level export assertion and the positive control are the two that
+carry it. The compiler covers consumer reach, which is the part a test enumerating known call sites
+would get wrong if one were missed.
+
+## User Execution Test Scenarios
+
+Not authorable, and left unwritten with the reason recorded rather than filled with a placeholder.
+This item deletes a duplicate export and repoints two imports at the same function: `robota`'s
+behaviour, output and exit codes are identical before and after. That identity is the acceptance
+criterion, not a gap in it.
+
+**This reason does not expire** — it is a property of what the item delivers, not of an undecided
+disposition.
+
+## Evidence Log
+
+- 2026-08-25 — Measured at `c1c3ac079`. Three import sites, two packages, one function; all compile.
+- 2026-08-25 — `agent-framework/package.json` lists `@robota-sdk/agent-core`; `agent-framework/src`
+  imports from it in 156 files. The change adds no edge.
+- 2026-08-25 — Re-export's stated purpose read at `provider-factory.ts:14` and at
+  ARCH-PROVIDER-003:68. Both are consumer-compatibility, which the owner's ruling removes.
+- 2026-08-25 — Split from issue #2051's other half, filed as issue #2347: injecting an environment
+  resolver changes `resolveEnvReference`, a published `agent-core` export named in two SPECs, so it
+  carries its own decision under `backlog-execution.md` § Agent Decision Authority.
+- 2026-08-25 — **GATE-APPROVAL: owner sign-off obtained.** Asked whether to remove the re-export,
+  keep it while unifying the imports, or defer; the owner selected **"승인, 재수출 제거"** — approve,
+  remove the re-export. A peer session's instruction to take this half set the ORDER of work and was
+  explicitly not treated as this approval.
+- 2026-08-26 — Implemented: re-export removed from `provider-factory.ts`, `providers/index.ts` and
+  `src/index.ts`; `agent-framework`'s two imports repointed at `agent-core`; the executor SPEC's
+  export list and its "pure utilities" paragraph corrected.
+- 2026-08-26 — **The compiler found the consumer I had not counted.** `tsgo --noEmit` failed on
+  `agent-executor/src/providers/provider-factory.test.ts`, which imported both names from the module
+  under test. That is the coverage property the record claimed: a missed consumer is a build failure,
+  not a silent fallback.
+- 2026-08-26 — Two `OrgPolicyParseError` errors appeared in `agent-cli` and were **not** this branch:
+  they reproduce with the change stashed, and `pnpm build:deps` clears them. The stale-`dist`
+  advisory the scan suite prints is exactly this case, and following it was what kept a pre-existing
+  cross-package error from being read as a branch defect.
+- 2026-08-26 — **The surface assertion was vacuous on the first attempt and the mutation is what
+  showed it.** Written as `import type * as Executor from '@robota-sdk/agent-executor'`, it resolved
+  through `dist/` and described the last build: re-adding the re-export produced **no type error at
+  all**. Repointed at `../index.js` — the package's own entry source — and the same mutation now
+  fails with two `TS2322`s. A surface assertion that reads a built artifact is the vacuous-green shape
+  this repository exists to remove, and it was one line away from shipping.
+- 2026-08-26 — A second mutation placed at `providers/index.ts` also produced no error, correctly:
+  `src/index.ts` gates the surface with an explicit named list, so the sub-barrel cannot widen it. The
+  mutation had to be placed at the real surface to be a mutation of the property under test.
+- 2026-08-26 — `sdk-public-surface` reported the executor's surface **shrank** 2 → 1 and asked for a
+  re-freeze in the same change; done, with the reason recorded at the constant.
+- 2026-08-26 — `agent-executor` 105, `agent-framework` 1559, `agent-product` 18, `agent-core` 1198
+  tests pass. `pnpm run typecheck` exit 0 workspace-wide. `pnpm harness:scan` 143 passed, 0 failures.

--- a/.agents/tasks/ARCH-111-the-executor-re-exports-core-owned-provider-helpers-so-two-consumers-disagree-ab.md
+++ b/.agents/tasks/ARCH-111-the-executor-re-exports-core-owned-provider-helpers-so-two-consumers-disagree-ab.md
@@ -1,0 +1,94 @@
+---
+title: 'ARCH-111: the executor re-exports core-owned provider helpers so two consumers disagree about the owner'
+issue: https://github.com/woojubb/robota/issues/2051
+status: todo
+created: 2026-08-25
+priority: medium
+urgency: soon
+area: packages/agent-executor, packages/agent-framework
+depends_on: []
+---
+
+# ARCH-111: one function, two exporting packages, two consumers that disagree
+
+## Problem
+
+`normalizeProviderConfig` and `createProviderFromConfig` are owned by `agent-core`. `agent-executor`
+re-exports both. Measured at `c1c3ac079`, the product imports the same function from both packages at
+once:
+
+```
+agent-framework/src/command-api/provider/provider-factory.ts:2   createProviderFromConfig  ← agent-executor
+agent-framework/src/command-api/provider/provider-merge.ts:1     normalizeProviderConfig   ← agent-executor
+agent-product/src/assemble-product.ts:2                          createProviderFromConfig  ← agent-core
+```
+
+**Both compile, and nothing notices.** This is not a facade being preferred over an owner; it is two
+consumers inside one product holding different answers to who owns the symbol.
+
+## Why the duplicate exists, and why that reason is gone
+
+`agent-executor/src/providers/provider-factory.ts:14` states its purpose:
+
+> Re-exported here so existing `@robota-sdk/agent-executor` consumers are unaffected.
+
+And ARCH-PROVIDER-003, which created it, at line 68: _"re-exports from the new location (no consumer
+break)."_
+
+**That is a backward-compatibility guarantee, and this repository does not make one** — the owner's
+standing ruling is that legacy is not a consideration before release. So the duplicate's only stated
+justification no longer applies.
+
+**The ground for removing it is NOT that it has few consumers.** A public interface is not removed for
+having one caller or none; that is explicitly ruled out. The ground is that the symbol has one owner,
+the duplicate name exists solely for a guarantee this repository does not make, and **its presence is
+what allows two consumers in one product to disagree about the owner.** That is a design argument, and
+it is the only one this record makes.
+
+## Why this is mechanical
+
+Checked rather than assumed:
+
+- `agent-framework/package.json` already lists `@robota-sdk/agent-core` as a dependency;
+- `agent-framework/src` already imports from `@robota-sdk/agent-core` in **156 files**.
+
+So repointing two import lines adds no dependency edge and changes no behaviour. It deletes a
+duplicate name.
+
+## Direction
+
+Remove `export { normalizeProviderConfig, createProviderFromConfig }` from
+`agent-executor/src/providers/provider-factory.ts` and its onward re-exports in
+`agent-executor/src/providers/index.ts` and `agent-executor/src/index.ts`. Point
+`agent-framework`'s two imports at `@robota-sdk/agent-core`. Update
+`agent-executor/docs/SPEC.md`'s export list to stop listing what the package no longer exports.
+
+`resolveProfileApiKey` and `createProviderFromProfile` **stay** — they depend on the executor-owned
+`ISerializableProviderProfile` and are not re-exports of anything.
+
+## Test Plan
+
+- `agent-executor` no longer exports either name: a type-level assertion, not a `grep`, so the check
+  fails at compile time if the export returns.
+- `agent-framework`'s provider tests still pass with the import repointed, proving the two functions
+  are the same function and the facade added nothing.
+- **Positive control**: `agent-core` still exports both, so a suite proving the executor dropped them
+  cannot pass against a workspace that lost them entirely.
+- `pnpm harness:scan` green, `tsgo --noEmit` clean across the workspace — the compiler is the real
+  check here, since a missed consumer is a build failure rather than a silent fallback.
+
+## Not in scope
+
+Injecting an environment resolver, and `resolveProfileApiKey`'s second ambient read — issue #2347.
+That half changes a published `agent-core` export named in two SPECs, so it carries its own decision.
+
+## User Execution Test Scenarios
+
+Not authorable, and left unwritten with the reason recorded rather than filled with a placeholder.
+This item deletes a duplicate export and repoints two imports at the same function; `robota`'s
+behaviour, output and exit codes are identical before and after, which is the acceptance criterion
+rather than a gap in it.
+
+**This reason does not expire.** It is a property of what the item delivers, not of an undecided
+disposition. If a later revision changes user-visible behaviour, that revision needs scenarios and this
+paragraph does not cover it.

--- a/packages/agent-executor/docs/SPEC.md
+++ b/packages/agent-executor/docs/SPEC.md
@@ -50,7 +50,7 @@ agent-executor
   │   │   └── scheduled-task-runner.ts          -- croner-based scheduled runner
   │   └── types.ts                              -- task requests, state, result, runner ports
   ├── providers/
-  │   └── provider-factory.ts                   -- normalizeProviderConfig, createProviderFromConfig/Profile
+  │   └── provider-factory.ts                   -- resolveProfileApiKey, createProviderFromProfile
   └── subagents/
       ├── types.ts                              -- subagent job contracts and runner port
       ├── subagent-manager.ts                   -- compatibility facade over BackgroundTaskManager
@@ -205,12 +205,10 @@ The package entrypoint exports these symbols explicitly from `src/index.ts`. SDK
 
 Functions in `src/providers/` resolve serializable provider config or profiles into live `IAIProvider` instances. They depend only on `@robota-sdk/agent-core` provider definitions and are provider-package-agnostic.
 
-| Export                      | Kind     | Description                                                                                    |
-| --------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `normalizeProviderConfig`   | function | Merges explicit settings with definition defaults; resolves `$ENV:` references in `apiKey`     |
-| `resolveProfileApiKey`      | function | Resolves `apiKey` (direct or `$ENV:`) or `apiKeyEnv` from an `ISerializableProviderProfile`    |
-| `createProviderFromConfig`  | function | Creates an `IAIProvider` from a resolved `IProviderConfig` using injected provider definitions |
-| `createProviderFromProfile` | function | Convenience: normalizes a profile and delegates to `createProviderFromConfig`                  |
+| Export                      | Kind     | Description                                                                                  |
+| --------------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `resolveProfileApiKey`      | function | Resolves `apiKey` (direct or `$ENV:`) or `apiKeyEnv` from an `ISerializableProviderProfile`  |
+| `createProviderFromProfile` | function | Convenience: normalizes a profile and delegates to `agent-core`'s `createProviderFromConfig` |
 
 ## Extension Points
 
@@ -376,7 +374,10 @@ Unit tests cover:
   assert both spawn paths consume the pair and unknown shells record zero spawn attempts
 - subagent manager lifecycle facade behavior
 - worktree runner clean/dirty/failure/delegation/hook behavior with fake adapters
-- provider factory: `normalizeProviderConfig`, `resolveProfileApiKey`, `createProviderFromConfig`, `createProviderFromProfile`
+- provider factory: `resolveProfileApiKey`, `createProviderFromProfile`. **`normalizeProviderConfig` and
+  `createProviderFromConfig` are `agent-core`'s and are not re-exported here (ARCH-111)** — they were,
+  "so existing consumers are unaffected", and the duplicate name is what let `agent-framework` and
+  `agent-product` import the same function from two different packages.
 
 Adapter packages or shells must add integration tests for concrete side effects such as local Git or child processes.
 
@@ -402,7 +403,9 @@ Pure helper contracts:
 - `createBackgroundTaskLogPage()` owns cursor pagination for append-only task logs.
 - `createDefaultBackgroundTaskRunners()` returns `[createManagedShellProcessRunner(), createScheduledTaskRunner()]` as the default runner set for CLI/SDK assembly.
 
-Provider factory functions (`normalizeProviderConfig`, `resolveProfileApiKey`, `createProviderFromConfig`, `createProviderFromProfile`) are pure utilities that depend only on `@robota-sdk/agent-core` provider definition types and produce `IAIProvider` instances.
+This package's provider factory functions are `resolveProfileApiKey` and `createProviderFromProfile`; they depend on the executor-owned `ISerializableProviderProfile` and delegate normalization to `agent-core`.
+
+They are **not pure**: `resolveProfileApiKey` reads `process.env` for the `apiKeyEnv` branch, and the `agent-core` normalization it delegates to resolves `$ENV:` references ambiently. This paragraph previously called all four functions "pure utilities", which was a claim about a property the code does not have; issue #2347 is the item that would make it true.
 
 Cross-package port consumers:
 

--- a/packages/agent-executor/src/index.ts
+++ b/packages/agent-executor/src/index.ts
@@ -31,12 +31,7 @@ export type {
   ICreateLimitedOutputCaptureOptions,
   ILimitedOutputCapture,
 } from './background-tasks/index.js';
-export {
-  createProviderFromConfig,
-  createProviderFromProfile,
-  normalizeProviderConfig,
-  resolveProfileApiKey,
-} from './providers/index.js';
+export { createProviderFromProfile, resolveProfileApiKey } from './providers/index.js';
 export {
   SubagentManager,
   WorktreeSubagentRunner,

--- a/packages/agent-executor/src/providers/index.ts
+++ b/packages/agent-executor/src/providers/index.ts
@@ -1,6 +1,3 @@
-export {
-  createProviderFromConfig,
-  createProviderFromProfile,
-  normalizeProviderConfig,
-  resolveProfileApiKey,
-} from './provider-factory.js';
+// ARCH-111: the two `agent-core`-owned helpers are not surfaced here. `agent-core` is their owner and
+// their only exporter; the profile helpers below are this package's own.
+export { createProviderFromProfile, resolveProfileApiKey } from './provider-factory.js';

--- a/packages/agent-executor/src/providers/owner-surface.test.ts
+++ b/packages/agent-executor/src/providers/owner-surface.test.ts
@@ -1,0 +1,54 @@
+/**
+ * ARCH-111 — `agent-core`'s provider helpers have one exporter, and it is not this package.
+ *
+ * A `grep` would pass the moment someone re-added the export with different whitespace, and a runtime
+ * `expect(mod.normalizeProviderConfig).toBeUndefined()` would pass against a package that failed to
+ * build at all. These are TYPE-level assertions: if either name returns to this package's surface the
+ * assignment stops compiling, so `tsgo --noEmit` fails before any test runs.
+ *
+ * The duplicate they replace was created by ARCH-PROVIDER-003 "so existing consumers are unaffected"
+ * — a backward-compatibility guarantee this repository does not make. What it bought instead was
+ * `agent-framework` importing `createProviderFromConfig` from here while `agent-product` imported the
+ * same function from `agent-core`, both compiling, with nothing able to notice.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type * as Core from '@robota-sdk/agent-core';
+// The package's OWN entry source, not '@robota-sdk/agent-executor'. Importing by package name
+// resolves through `dist/`, so the assertion would describe the last build rather than this source —
+// measured: re-adding the re-export and typechecking produced no error at all until this line
+// changed. A surface assertion that reads a stale artifact is the vacuous-green shape this
+// repository spends its time removing.
+import type * as Executor from '../index.js';
+
+// Absent from the executor.
+const normalizeIsNotExecutors: 'normalizeProviderConfig' extends keyof typeof Executor
+  ? false
+  : true = true;
+const createFromConfigIsNotExecutors: 'createProviderFromConfig' extends keyof typeof Executor
+  ? false
+  : true = true;
+
+// THE POSITIVE CONTROL. Present on the owner — without these, the two assertions above would hold
+// just as well in a workspace where both functions had been deleted outright, which is a different
+// and worse outcome than the one being asserted.
+const normalizeIsCores: 'normalizeProviderConfig' extends keyof typeof Core ? true : false = true;
+const createFromConfigIsCores: 'createProviderFromConfig' extends keyof typeof Core ? true : false =
+  true;
+
+// This package's OWN provider helper stays: it depends on the executor-owned
+// `ISerializableProviderProfile` and is not a re-export of anything.
+const profileHelperStays: 'resolveProfileApiKey' extends keyof typeof Executor ? true : false =
+  true;
+
+describe('ARCH-111: one owner for the core provider helpers', () => {
+  it('holds the surface assertions at compile time', () => {
+    expect([
+      normalizeIsNotExecutors,
+      createFromConfigIsNotExecutors,
+      normalizeIsCores,
+      createFromConfigIsCores,
+      profileHelperStays,
+    ]).toEqual([true, true, true, true, true]);
+  });
+});

--- a/packages/agent-executor/src/providers/owner-surface.test.ts
+++ b/packages/agent-executor/src/providers/owner-surface.test.ts
@@ -13,6 +13,18 @@
  */
 import { describe, expect, it } from 'vitest';
 
+// The RUNTIME surface, read as values. The type assertions below are compile-time only, and vitest
+// does not typecheck — so on their own their `expect` body is a tautology over five literal `true`s
+// that passes against the very code this file exists to forbid. This import is what makes the test
+// go red without the change.
+// Every LEVEL of the re-export chain, not just the package surface. The change spans three files —
+// `provider-factory.ts`, `providers/index.ts`, `src/index.ts` — and reversing any ONE of them leaves
+// the other two still narrowing, so a test that reads only the outermost surface stays green against
+// each single-file reversal. It would guard the whole chain and nothing in it.
+import * as FactoryModule from './provider-factory.js';
+import * as ProvidersBarrel from './index.js';
+import * as ExecutorSurface from '../index.js';
+
 import type * as Core from '@robota-sdk/agent-core';
 // The package's OWN entry source, not '@robota-sdk/agent-executor'. Importing by package name
 // resolves through `dist/`, so the assertion would describe the last build rather than this source —
@@ -42,6 +54,37 @@ const profileHelperStays: 'resolveProfileApiKey' extends keyof typeof Executor ?
   true;
 
 describe('ARCH-111: one owner for the core provider helpers', () => {
+  // Written as three plain cases rather than one `it.each`. A parameterised title is `'%s …'` in the
+  // source and interpolated at run time, so `check-regression-red-proof.mjs` — which matches the
+  // titles a diff ADDED against the titles that ran — cannot recognise it as an added case. It
+  // reported `added-cases-pass`: a case did fail with the fix reversed, and the checker could not
+  // tell it was one of mine. A test invisible to the red-proof matcher guards nothing it can prove.
+  it('provider-factory.ts does not re-export agent-core provider helpers', () => {
+    const surface = Object.keys(FactoryModule);
+    expect(surface).not.toContain('normalizeProviderConfig');
+    expect(surface).not.toContain('createProviderFromConfig');
+  });
+
+  it('providers/index.ts does not re-export agent-core provider helpers', () => {
+    const surface = Object.keys(ProvidersBarrel);
+    expect(surface).not.toContain('normalizeProviderConfig');
+    expect(surface).not.toContain('createProviderFromConfig');
+  });
+
+  it('src/index.ts does not re-export agent-core provider helpers', () => {
+    const surface = Object.keys(ExecutorSurface);
+    expect(surface).not.toContain('normalizeProviderConfig');
+    expect(surface).not.toContain('createProviderFromConfig');
+  });
+
+  it("still exports this package's own profile helpers", () => {
+    // The positive control for the case above: without it, both assertions would hold against a
+    // package whose entry file failed to export anything at all.
+    const surface = Object.keys(ExecutorSurface);
+    expect(surface).toContain('resolveProfileApiKey');
+    expect(surface).toContain('createProviderFromProfile');
+  });
+
   it('holds the surface assertions at compile time', () => {
     expect([
       normalizeIsNotExecutors,

--- a/packages/agent-executor/src/providers/provider-factory.test.ts
+++ b/packages/agent-executor/src/providers/provider-factory.test.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import {
-  normalizeProviderConfig,
-  resolveProfileApiKey,
-  createProviderFromConfig,
-  createProviderFromProfile,
-} from './provider-factory.js';
+import { resolveProfileApiKey, createProviderFromProfile } from './provider-factory.js';
+// ARCH-111: these two are `agent-core`'s, and this file names their owner like every other consumer.
+// Importing them from the module under test was how the duplicate surface stayed reachable.
+import { normalizeProviderConfig, createProviderFromConfig } from '@robota-sdk/agent-core';
 import type { IProviderDefinition, IAIProvider } from '@robota-sdk/agent-core';
 import type { ISerializableProviderProfile } from '../background-tasks/types.js';
 

--- a/packages/agent-executor/src/providers/provider-factory.ts
+++ b/packages/agent-executor/src/providers/provider-factory.ts
@@ -7,13 +7,17 @@ import {
 import type { ISerializableProviderProfile } from '../background-tasks/types.js';
 import type { IAIProvider, IProviderDefinition } from '@robota-sdk/agent-core';
 
-/**
- * `normalizeProviderConfig` and `createProviderFromConfig` were relocated into `agent-core`
- * (ARCH-PROVIDER-003) — they import only `agent-core` symbols, so the one credential-resolution path can be
- * reused by the `dag-node-llm-text` leaf (which depends on `agent-core` alone). Re-exported here so existing
- * `@robota-sdk/agent-executor` consumers are unaffected.
+/*
+ * ARCH-111: `normalizeProviderConfig` and `createProviderFromConfig` are NOT re-exported.
+ *
+ * ARCH-PROVIDER-003 relocated them into `agent-core` and left a re-export here "so existing
+ * consumers are unaffected" — a backward-compatibility guarantee this repository does not make. What
+ * the duplicate name bought instead was two consumers inside one product disagreeing about the owner:
+ * `agent-framework` imported them from here while `agent-product` imported the same function from
+ * `agent-core`, and both compiled.
+ *
+ * They are imported above because this file's own helpers call them. That is a use, not a surface.
  */
-export { normalizeProviderConfig, createProviderFromConfig };
 
 /**
  * Profile-based helpers stay in `agent-executor`: they depend on the executor-owned

--- a/packages/agent-framework/src/command-api/provider/provider-factory.ts
+++ b/packages/agent-framework/src/command-api/provider/provider-factory.ts
@@ -1,5 +1,8 @@
-import { ENV_REFERENCE_PREFIX, isEnvReference } from '@robota-sdk/agent-core';
-import { createProviderFromConfig } from '@robota-sdk/agent-executor';
+import {
+  ENV_REFERENCE_PREFIX,
+  createProviderFromConfig,
+  isEnvReference,
+} from '@robota-sdk/agent-core';
 
 import { readMergedProviderSettingsFromSources, resolveActiveProvider } from './provider-merge.js';
 

--- a/packages/agent-framework/src/command-api/provider/provider-merge.ts
+++ b/packages/agent-framework/src/command-api/provider/provider-merge.ts
@@ -1,4 +1,4 @@
-import { normalizeProviderConfig } from '@robota-sdk/agent-executor';
+import { normalizeProviderConfig } from '@robota-sdk/agent-core';
 
 import { SettingsParseError } from '../../config/settings-parse-error.js';
 import { readSettingsSourceText } from '../../config/settings-source.js';

--- a/scripts/harness/check-sdk-public-surface.mjs
+++ b/scripts/harness/check-sdk-public-surface.mjs
@@ -386,7 +386,10 @@ export function examinedPackageCount() {
 const FROZEN_FINDING_COUNTS = {
   'agent-command': 27,
   'agent-core': 20,
-  'agent-executor': 2,
+  // ARCH-111: 2 → 1. The re-export of `agent-core`'s `normalizeProviderConfig` and
+  // `createProviderFromConfig` was removed, so the executor no longer widens the SDK surface with
+  // symbols it does not own. Re-frozen in the same change, per this ratchet's own instruction.
+  'agent-executor': 1,
   'agent-interface-transport': 1,
   'agent-plugin': 8,
   'agent-provider-anthropic': 4,


### PR DESCRIPTION
## What

`normalizeProviderConfig` and `createProviderFromConfig` are `agent-core`'s. `agent-executor` re-exported both, and the product imported the same function from **both packages at once**:

```
agent-framework/src/command-api/provider/provider-factory.ts:2   createProviderFromConfig  ← agent-executor
agent-framework/src/command-api/provider/provider-merge.ts:1     normalizeProviderConfig   ← agent-executor
agent-product/src/assemble-product.ts:2                          createProviderFromConfig  ← agent-core
```

Both compiled, and nothing could notice. Item 1 of issue #2051; the structural half is issue #2347.

## Why the duplicate had no reason left

`provider-factory.ts:14` said what it was for — *"Re-exported here so existing `@robota-sdk/agent-executor` consumers are unaffected"* — and ARCH-PROVIDER-003:68 agrees: *"re-exports from the new location (no consumer break)."* **That is a backward-compatibility guarantee this repository does not make.**

**The ground is deliberately not "few consumers".** A public interface is not removed for having one caller or none. The argument is that the symbol has one owner, the duplicate exists solely for a guarantee this repository does not make, and **the duplicate is precisely what let two consumers disagree about the owner.** Import count is evidence of the effect, not the reason.

## Mechanical, checked rather than assumed

`agent-framework` already depends on `@robota-sdk/agent-core` and already imports from it in **156 files**. Repointing two lines adds no dependency edge and changes no behaviour.

## Three things the verification caught that reading would not have

**1. The compiler found the consumer I had not counted.** `tsgo --noEmit` failed on the executor's own `provider-factory.test.ts`, which imported both names from the module under test. That is the coverage property the record claimed for this change: a missed consumer is a build failure, not a silent fallback.

**2. The surface assertion was vacuous on the first attempt.** Written as `import type * as Executor from '@robota-sdk/agent-executor'` it resolved through `dist/` and described the **last build** — re-adding the re-export produced **no type error at all**. Repointed at `../index.js`, the package's own entry source, the same mutation now fails with two `TS2322`s. A surface assertion that reads a built artifact is the vacuous-green shape this repository exists to remove, and it was one line from shipping.

A second mutation at `providers/index.ts` also produced no error — correctly: `src/index.ts` gates the surface with an explicit named list, so a sub-barrel cannot widen it. The mutation had to be placed at the real surface to be a mutation of the property under test.

**3. Two `OrgPolicyParseError` errors in `agent-cli` were not this branch.** They reproduce with the change stashed and clear after `pnpm build:deps` — the stale-`dist` case the scan suite prints an advisory for. Following that advisory is what kept a pre-existing cross-package error from being read as a branch defect.

## Ratchet

`sdk-public-surface` reported the executor's surface **shrank** from 2 findings to 1 and asked for a re-freeze in the same change so the gain is kept. Done, with the reason recorded at the constant.

## SPEC

The export list is corrected, and this paragraph is replaced:

> Provider factory functions (`normalizeProviderConfig`, `resolveProfileApiKey`, `createProviderFromConfig`, `createProviderFromProfile`) are **pure utilities**…

**Two of those four read `process.env`.** That was a document asserting a property the code does not have. It now says what is true, and names issue #2347 as the item that would make the original claim correct.

## Verification

`agent-executor` 105 · `agent-framework` 1559 · `agent-product` 18 · `agent-core` 1198 tests pass. `pnpm run typecheck` exit 0 workspace-wide. `pnpm harness:scan` 143 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH