### PR TITLE
docs(agent-interface-execution): the README describes this package

### DIFF
--- a/packages/agent-interface-execution/docs/README.md
+++ b/packages/agent-interface-execution/docs/README.md
@@ -22,12 +22,12 @@ import type {
 
 The four families it owns:
 
-| family               | source                              | what it carries                                                         |
-| -------------------- | ----------------------------------- | ----------------------------------------------------------------------- |
-| background task      | `background-task-contracts.ts`      | the request per kind, status, timeout and error categories, usage, logs |
-| background job group | `background-job-group-contracts.ts` | grouping independent jobs and their result envelopes                    |
-| subagent             | `subagent-contracts.ts`             | the spawn request, job state, and job result                            |
-| execution workspace  | `execution-workspace-contracts.ts`  | an execution's origin, entries, snapshots, and detail pages             |
+| family               | source                          | what it carries                                                         |
+| -------------------- | ------------------------------- | ----------------------------------------------------------------------- |
+| background task      | `background-task-contracts.ts`  | the request per kind, status, timeout and error categories, usage, logs |
+| background job group | `background-group-contracts.ts` | grouping independent jobs and their result envelopes                    |
+| subagent             | `subagent-contracts.ts`         | the spawn request, job state, and job result                            |
+| execution workspace  | `workspace-contracts.ts`        | an execution's origin, entries, snapshots, and detail pages             |
 
 ## Documents
 

--- a/packages/agent-interface-execution/docs/README.md
+++ b/packages/agent-interface-execution/docs/README.md
@@ -1,20 +1,33 @@
-# @robota-sdk/agent-interface-execution
+# @robota-sdk/agent-interface-execution — documents
 
-TUI interaction contracts for the Robota SDK. Contains only type contracts and narrow type
-guards — no implementation, no React, no Ink. Defines the interaction protocol between
-command handlers and TUI renderers.
+Execution-bounded contract families for the Robota SDK: what a background task is and what states it
+moves through, how independent jobs are grouped, what a subagent is asked to do and returns, and the
+workspace record that shows an execution's origin and detail.
+
+Type contracts only — no implementation. Layer 0: it depends on `@robota-sdk/agent-core` and on no
+peer `agent-interface-*` package. Consumers compose it downward; `agent-interface-session` names
+these types, never the reverse.
 
 ## Usage
 
 ```typescript
 import type {
-  ITuiCommandInteraction,
-  ITuiPickerInteraction,
-  ITuiConfirmInteraction,
-  TAnyTuiCommandInteraction,
+  TBackgroundTaskRequest,
+  IBackgroundTaskState,
+  ISubagentSpawnRequest,
+  IExecutionWorkspaceSnapshot,
 } from '@robota-sdk/agent-interface-execution';
-// Type contracts only — narrow TAnyTuiCommandInteraction on the `onMissingArgs` discriminant.
+// Narrow TBackgroundTaskRequest on `kind` — 'agent' | 'process' | 'scheduled'.
 ```
+
+The four families it owns:
+
+| family               | source                              | what it carries                                                         |
+| -------------------- | ----------------------------------- | ----------------------------------------------------------------------- |
+| background task      | `background-task-contracts.ts`      | the request per kind, status, timeout and error categories, usage, logs |
+| background job group | `background-job-group-contracts.ts` | grouping independent jobs and their result envelopes                    |
+| subagent             | `subagent-contracts.ts`             | the spawn request, job state, and job result                            |
+| execution workspace  | `execution-workspace-contracts.ts`  | an execution's origin, entries, snapshots, and detail pages             |
 
 ## Documents
 


### PR DESCRIPTION
Closes #2211.

`packages/agent-interface-execution/docs/README.md` described the TUI interaction package — *"no React, no Ink … the interaction protocol between command handlers and TUI renderers"* — and told the reader to import four names this package has never exported.

## Measured against the entry source, not the built package

A name can resolve through `dist/` and describe the last build rather than the source, so both sides were checked against `src/index.ts`:

```
the four the old README instructed        the four it instructs now
  ITuiCommandInteraction     NOT FOUND      TBackgroundTaskRequest       EXPORTED
  ITuiPickerInteraction      NOT FOUND      IBackgroundTaskState         EXPORTED
  ITuiConfirmInteraction     NOT FOUND      ISubagentSpawnRequest        EXPORTED
  TAnyTuiCommandInteraction  NOT FOUND      IExecutionWorkspaceSnapshot  EXPORTED
```

The defect this issue names is *"following it produces a compile error"*, so **whether the names exist is the whole test** — not whether the prose reads better.

## What replaced it

The four contract families the package actually owns, with the source file for each so a reader can go from the README to the definition in one hop:

| family | source |
| --- | --- |
| background task | `background-task-contracts.ts` |
| background job group | `background-job-group-contracts.ts` |
| subagent | `subagent-contracts.ts` |
| execution workspace | `execution-workspace-contracts.ts` |

The layer-0 statement is **copied from the package's own `index.ts` header rather than written fresh**, so the two cannot drift into different claims about the same rule.

## The sweep, including its false positives

This issue records that the defect arrived by a copy-and-`sed` and that its sibling carried it too, so every `packages/*/docs/README.md` was checked with the obvious heuristic — the first `@robota-sdk/*` a README names should be itself.

**It flagged two more, and both are wrong:**

```
packages/agent-provider-openai/docs/README.md              names agent-provider-openai-compatible
packages/agent-provider-openai-compatible/docs/README.md   names agent-provider-openai
```

Each names **itself in its heading** and the other in a correct cross-reference — `agent-provider-openai` consumes the compatible package's `./shared` entry, and the compatible package lists it as a consumer. The heuristic cannot tell a cross-reference from a mis-copy.

Reporting that rather than the count: **the sweep's answer was "three", the true answer is one**, and the difference is the heuristic's, not the tree's.

## Verification

```
pnpm harness:scan   143 passed, 2 skipped, 0 failed
```

Documentation only — no source, no contract, no export changes.
