### PR TITLE
docs(memory): the agent-run memory names a shipped instance, not an open fix

### DIFF
--- a/.agents/memory/agent-run-capability-verification.md
+++ b/.agents/memory/agent-run-capability-verification.md
@@ -14,6 +14,8 @@ surface enables was silently dodging the user-execution gate as "N/A (no runnabl
 **How to apply.** Enforced in [backlog-execution.md](../rules/backlog-execution.md) → "Capability Reachability — no
 library-seam N/A dodge": an intermediate library-only slice records engineering evidence and NAMES the pending
 agent-run verification; it must not claim the capability done, and the epic is not COMPLETE until the agent-run
-verification passes. Concrete open fix: `.agents/tasks/SELFHOST-008-P6-surface-wiring-and-agent-run-verification.md`
-(wire memory into agent-cli + agent-run capture→recall e2e). Extends [[gui-verification-agent-owned]] and
+verification passes. Concrete instance, SHIPPED and agent-run verified: SELFHOST-008-P6 wired memory into agent-cli and proved
+capture→recall end to end with a real provider — [the run](../evals/scenarios/selfhost-008-memory-agent-run.md),
+[the spec](../spec-docs/done/SELFHOST-008-P6-surface-wiring.md). It is this rule's worked example, not
+outstanding work. Extends [[gui-verification-agent-owned]] and
 [[user-execution-scenario-evidence]]. Mechanization deferred (reachability is semantic) → tracked HARNESS backlog item.

--- a/scripts/harness/scan-task-path-citations.mjs
+++ b/scripts/harness/scan-task-path-citations.mjs
@@ -112,12 +112,6 @@ const SENTENCE_CONTRADICTS_REPAIR = [
     outcome: 'conflict',
     why: 'same conflict as the gate script, and the surrounding prose says DIST-002 too — renumbering one without the other would be worse',
   },
-  {
-    file: '.agents/memory/agent-run-capability-verification.md',
-    cited: `${TASKS_DIR}SELFHOST-008-P6-surface-wiring-and-agent-run-verification.md`,
-    outcome: 'conflict',
-    why: 'the document calls a completed item an open fix; that is a status claim, filed as issue #2262',
-  },
 ];
 
 /**


### PR DESCRIPTION
Closes #2262.

This issue asks a question before it asks for a change: **did SELFHOST-008-P6 ship?** If yes, correct the sentence; if no, the spec-doc is in `done/` wrongly and that is the more serious finding.

**It shipped.** Checked against the tree, not against its own checkboxes — all seven completion criteria are `[x]`, and a ticked box is not evidence. Issue #2068 closed today on a tracker whose seven boxes were *never* ticked while every leaf was closed; the two facts move independently.

## What made it checkable

P6's own problem statement recorded that a grep across `packages/agent-cli/src` for the memory seam found **zero** references. That is a measurement anyone can repeat:

```
automaticMemory   2 files
recallMemory      2 files
memoryStore       7 files
```

plus `packages/agent-cli/src/startup/memory-enablement.ts`, and `packages/agent-cli/src/cli.ts` passing `workspaceComposition.memoryStore` through. The seam P6 called dark is wired.

## The agent-run half — the part that could have been claimed without happening

TC-04 and TC-05 are AGENT-RUN criteria, which is exactly what the surrounding memory document exists to say cannot be dodged. `.agents/evals/scenarios/selfhost-008-memory-agent-run.md` carries real transcripts, not a description of what would happen:

```
$ robota -p --memory --memory-autosave "remember that this project is released with 'pnpm ship'"
Using anthropic (claude-sonnet-4-6) via ANTHROPIC_API_KEY …
Got it! I've saved the project convention …

Result
  ✅ Capture: a real run wrote the fact to <cwd>/.robota/memory/
  ✅ Recall:  a fresh session, paraphrased question, recalled it — <recalled-memory> reached the model
  ✅ Default-off preserved: without --memory nothing is written
```

**So the memory document asserted outstanding work in the very document that records the rule against claiming a capability without an agent run — about the work that satisfied that rule.**

## Why the path was not simply repaired

This issue's own reasoning, and it is right: pointing the citation at the completed record while the sentence still reads *"Concrete open fix"* produces **a resolvable link carrying a false statement**, which is worse than a broken one. A reader would then have a working link telling them work is outstanding when it is not.

The sentence now names P6 as this rule's worked example and links both records that show it. Every relative link in the file was verified to resolve — with the check asserting it found links at all, so an empty match cannot pass as a green.

## The scan told me the remaining step

`task-path-citations` pins this exact citation with an exemption whose `why` **cites this issue by number**. Fixing the citation turned it red:

```
[stale exemption] 1 exemption(s) no longer match a finding. Either the citation was fixed —
drop the row in the SAME change — or the scan stopped seeing it.
```

Control arm run before treating it as mine: clean `develop` passes, the change fails. The row is dropped here, in the same change, as the scan requires — an unlocked gain is a licence to grow back.

## Verification

```
pnpm harness:scan   143 passed, 2 skipped, 0 failed
```

Documentation and one harness exemption row. No source, no contract.
