### PR TITLE
fix(harness): the exact fire-site count runs against a corpus the suite owns

### DIFF
--- a/scripts/harness/__tests__/scan-hook-enforcement-reachable.test.mjs
+++ b/scripts/harness/__tests__/scan-hook-enforcement-reachable.test.mjs
@@ -63,6 +63,29 @@ function runScan(policySource) {
   }
 }
 
+/**
+ * A fire-site corpus this suite OWNS (issue #2280).
+ *
+ * The exact count `measurement-provenance` requires used to be `toBe(13)` against the live
+ * workspace, so any package adding a `runHooks(` call turned this SEC-016 suite red in a file its
+ * author never touched. The count was right and the coupling was still wrong.
+ *
+ * The paths are production-SHAPED but do not exist on disk — `isProductionSource` positively
+ * requires `packages|apps/<name>/src/`, so a fixture tree under `scripts/` is never counted, and one
+ * under `packages/` is what this scan already declined to write because a parallel suite would see
+ * it. Injection gives the exactness without either.
+ *
+ * FIVE sites: two in the first file, one in the second, and the third file is gated OUT — which is
+ * what makes the number a measurement of the walk rather than of the array's length.
+ */
+const FIXTURE_CORPUS = [
+  { relative: 'packages/fixture-pkg/src/a.ts', source: 'runHooks(one);\nrunHooks(two);\n' },
+  { relative: 'packages/fixture-pkg/src/b.ts', source: 'runHooks(three);\n' },
+  { relative: 'packages/fixture-pkg/src/c.ts', source: 'runHooks(four);\nrunHooks(five);\n' },
+  { relative: 'scripts/harness/not-production.ts', source: 'runHooks(gated);\n' },
+];
+const FIXTURE_SITE_COUNT = 5;
+
 describe('scan-hook-enforcement-reachable', () => {
   it('passes on the shipped policy, and says what it examined', () => {
     const { code, output } = runScan(realPolicy);
@@ -85,9 +108,18 @@ describe('scan-hook-enforcement-reachable', () => {
     });
 
     it('examinedFireSiteCount is exactly what the walk read', () => {
+      // Two properties, deliberately split (issue #2280).
+      //
+      // Against the LIVE workspace the counter must follow the walk it was given — that is what a
+      // derived comparison pins, and it is not coupled to any package's edits.
       const sites = findFireSites(['packages', 'apps']);
       expect(examinedFireSiteCount()).toBe(sites.length);
-      expect(examinedFireSiteCount()).toBe(13);
+
+      // Against a corpus this suite OWNS the count is EXACT, which is what catches a walk that
+      // under-reads: a derived comparison re-runs the same walk and cannot see it read too little.
+      findFireSites(null, FIXTURE_CORPUS);
+      expect(examinedFireSiteCount()).toBe(FIXTURE_SITE_COUNT);
+      expect(examinedFireSiteCount()).toBe(5);
     });
 
     it('examinedRowCount resets on a SECOND run rather than accumulating', () => {
@@ -101,11 +133,11 @@ describe('scan-hook-enforcement-reachable', () => {
     });
 
     it('examinedFireSiteCount resets on a SECOND run rather than accumulating', () => {
-      findFireSites(['packages', 'apps']);
+      findFireSites(null, FIXTURE_CORPUS);
       const first = examinedFireSiteCount();
-      findFireSites(['packages', 'apps']);
+      findFireSites(null, FIXTURE_CORPUS);
       expect(examinedFireSiteCount()).toBe(first);
-      expect(examinedFireSiteCount()).toBe(13);
+      expect(examinedFireSiteCount()).toBe(5);
     });
 
     it('the counters move with the input rather than being constants', () => {

--- a/scripts/harness/scan-hook-enforcement-reachable.mjs
+++ b/scripts/harness/scan-hook-enforcement-reachable.mjs
@@ -425,16 +425,41 @@ export function collectFireSitesFromSource(relative, rawSource) {
   return found;
 }
 
-export function findFireSites(pathspecs) {
+/**
+ * The live corpus: every tracked production `.ts` under `pathspecs`, paired with its source.
+ *
+ * Split out so `findFireSites` has a seam. It is the only part that touches disk.
+ */
+function* liveCorpus(pathspecs) {
+  for (const relative of enumerateFiles(pathspecs)) {
+    if (!relative.endsWith('.ts')) continue;
+    const file = path.join(WORKSPACE_ROOT, relative);
+    if (!existsSync(file)) continue;
+    yield { relative, source: readFileSync(file, 'utf8') };
+  }
+}
+
+/**
+ * Every `runHooks(` fire site across a corpus.
+ *
+ * `corpus` is injectable — an iterable of `{ relative, source }` — and defaults to the live
+ * workspace. It exists so the EXACT count assertion `measurement-provenance` requires can run
+ * against a corpus the test owns.
+ *
+ * The alternative the coupling issue proposed, a fixture tree on disk, is refused by this scan's
+ * own gate: `isProductionSource` positively requires `packages|apps/<name>/src/`, so a fixture
+ * under `scripts/` is never counted — and putting one under `packages/` is what the note above
+ * `collectFireSitesFromSource` already declined, because a parallel suite would see it. An injected
+ * corpus takes production-SHAPED paths without those files existing, so the gate is unchanged and
+ * nothing is written where another suite can find it.
+ */
+export function findFireSites(pathspecs, corpus) {
   /** @type {TFireSite[]} */
   const sites = [];
 
-  for (const relative of enumerateFiles(pathspecs)) {
-    if (!relative.endsWith('.ts')) continue;
+  for (const { relative, source } of corpus ?? liveCorpus(pathspecs)) {
     if (!isProductionSource(relative)) continue;
-    const file = path.join(WORKSPACE_ROOT, relative);
-    if (!existsSync(file)) continue;
-    sites.push(...collectFireSitesFromSource(relative, readFileSync(file, 'utf8')));
+    sites.push(...collectFireSitesFromSource(relative, source));
   }
   examinedFireSites = sites.length;
   return sites;


### PR DESCRIPTION
Closes #2280.

Two cases asserted `toBe(13)` against the **live workspace**, so any package adding a production `runHooks(` call reddened this SEC-016 suite in a file its author never touched. The count was correct, the assertion was correct, and the coupling was still wrong.

## The resolution this issue proposed does not work, and the scan's own gate is what refuses it

> *the fix is to make the exact assertion run against a fixture corpus owned by the test — a small tree checked in beside it*

Measured before building anything:

```
isProductionSource('scripts/harness/__tests__/fixtures/pkg/src/a.ts')  REJECTED
isProductionSource('packages/__fixtures__/x/src/a.ts')                 REJECTED
isProductionSource('packages/agent-session/src/tool-hook-helpers.ts')  ACCEPTED
```

`isProductionSource` **positively requires** `packages|apps/<name>/src/` — deliberately, so a new sibling directory has to earn inclusion. A fixture tree beside the test is therefore never counted.

And putting one inside `packages/` is precisely what this scan already declined to do. Its own note above `collectFireSitesFromSource` says so:

> Extracting the per-source unit pins the behaviour **without writing a fixture file into `packages/`, where a parallel suite would see it.**

## What was built instead

`findFireSites(pathspecs, corpus)` gains a seam: an optional iterable of `{ relative, source }`, defaulting to the live walk — which is now the only part that touches disk.

**An injected corpus uses production-SHAPED paths without those files existing.** The gate is untouched, nothing is written where another suite can find it, and the exactness lands on a corpus the test owns.

The two properties this issue says both matter are now asserted separately, which is the actual resolution:

| corpus | assertion | what it pins |
|---|---|---|
| live workspace | `toBe(sites.length)` | the counter follows the walk it was given |
| owned fixture | `toBe(5)` | **exact** — which is what catches a walk that under-reads |

The fixture carries **four** files and only three count; the fourth is gated out. That is deliberate: it makes the number a measurement of the walk rather than of the array's length.

## Falsification, both directions

**The coupling is broken.** Appending a `runHooks(` call to `packages/agent-session/src/tool-hook-helpers.ts` moves the live count 13 → 14:

```
before this change:  the suite reddens on toBe(13)
after:               46 passed
```

**The floor still bites.** Replacing the exact assertion with `toBeGreaterThan(0)`:

```
[no-exact-count-assertion] … examinedFireSiteCount: … never asserts it against an exact numeric value
[no-reset-case]            … has no case asserting it after a SECOND run of the finder
```

Restored, `measurement-provenance` passes. **Both properties survive; only the coupling is gone** — which is what this issue asked for, by a route it did not anticipate.

## Verification

```
scan-hook-enforcement-reachable suite   46 passed
pnpm harness:test                       1149 passed (73 files)
pnpm harness:scan                       143 passed, 2 skipped, 0 failed
```
