### PR TITLE
fix(tui,playground): two exports get real consumers instead of prose ones

### DIFF
--- a/packages/agent-playground/src/components/playground/__tests__/plugin-container-block.test.tsx
+++ b/packages/agent-playground/src/components/playground/__tests__/plugin-container-block.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PluginContainerBlock } from '../plugin-container-block';
+import { PLUGIN_CATEGORIES, PLUGIN_PRIORITIES } from '../plugin-container-block-types';
+
+import type { IPluginBlock } from '../plugin-container-block-types';
+
+/**
+ * The component was exported with no consumer anywhere in the repository, and `orphan-exports` passed
+ * over it because a sibling file's header sentence — " * Types, constants, and utilities for
+ * PluginContainerBlock" — contains the name. **A sentence describing a file satisfied "someone uses
+ * it."** (issue #2362; the scan blind spot is issue #2258 / HARNESS-123.)
+ *
+ * The fix is not to unexport it: `content/v2.0.0/examples/playground-implementation.md:136-141`
+ * documents importing and rendering it, and this repository does not remove a surface for having few
+ * callers. The fix is to make "no consumer" untrue, and a test is the consumer that also proves the
+ * component works — which is what its sibling `agent-container-block` already has.
+ */
+function block(id: string, name: string, priority: number): IPluginBlock {
+  return {
+    id,
+    plugin: {
+      name,
+      version: '1.0.0',
+      initialize: async () => undefined,
+      dispose: async () => undefined,
+    },
+    isActive: true,
+    isEnabled: true,
+    category: PLUGIN_CATEGORIES.STORAGE,
+    priority,
+    options: {},
+    stats: { calls: 0, errors: 0 },
+    validationErrors: [],
+  };
+}
+
+describe('PluginContainerBlock', () => {
+  it('renders the plugins it is given', () => {
+    render(
+      <PluginContainerBlock
+        plugins={[block('a', 'HistoryPlugin', PLUGIN_PRIORITIES.DEFAULT)]}
+        onPluginsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('HistoryPlugin')).toBeTruthy();
+  });
+
+  it('says so when there are none, rather than rendering an empty frame', () => {
+    // The positive control for the case above: without it, the first assertion would also hold in a
+    // component that rendered every name it was ever given and never cleared, and "renders plugins"
+    // would be proved by a component that cannot represent the empty case at all.
+    render(<PluginContainerBlock plugins={[]} onPluginsChange={vi.fn()} />);
+    expect(screen.getByText('No plugins configured')).toBeTruthy();
+    expect(screen.queryByText('HistoryPlugin')).toBeNull();
+  });
+
+  it('orders plugins by descending priority', () => {
+    // The list is sorted before rendering, and a sort is the kind of thing a mount-only smoke test
+    // cannot see. Asserting the ORDER, not just presence.
+    render(
+      <PluginContainerBlock
+        plugins={[
+          block('low', 'LowPlugin', PLUGIN_PRIORITIES.LOW),
+          block('high', 'HighPlugin', PLUGIN_PRIORITIES.CRITICAL),
+        ]}
+        onPluginsChange={vi.fn()}
+      />,
+    );
+    const rendered = screen.getAllByText(/Plugin$/).map((node) => node.textContent);
+    expect(rendered.indexOf('HighPlugin')).toBeLessThan(rendered.indexOf('LowPlugin'));
+  });
+});

--- a/packages/agent-transport-tui/src/__tests__/cjk-defer-submit.test.tsx
+++ b/packages/agent-transport-tui/src/__tests__/cjk-defer-submit.test.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import CjkTextInput from '../CjkTextInput.js';
+import { IME_SUBMIT_DEFER_MS } from '../flows/defer-submit.js';
 
 /**
  * CLI-061 — integration proof that the CjkTextInput defer-submit includes a trailing IME character whose stdin
@@ -11,9 +12,16 @@ import CjkTextInput from '../CjkTextInput.js';
  *
  * Real timers + a real wait > IME_SUBMIT_DEFER_MS so the deferred submit actually fires (fake timers conflict
  * with Ink's own render scheduling).
+ *
+ * That wait is DERIVED from the constant rather than written next to a comment quoting it. Before, this file
+ * waited a hard-coded 90ms and said `// > 50ms defer` in prose — so raising IME_SUBMIT_DEFER_MS past 90 would
+ * have left the test waiting less than the defer it exists to outlast, and the comment asserting otherwise.
+ * The constant was also, by that arrangement, exported and named by nothing but a comment.
  */
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
-const waitDefer = (): Promise<void> => new Promise((r) => setTimeout(r, 90)); // > 50ms defer
+const DEFER_WAIT_MARGIN_MS = 40;
+const waitDefer = (): Promise<void> =>
+  new Promise((r) => setTimeout(r, IME_SUBMIT_DEFER_MS + DEFER_WAIT_MARGIN_MS));
 
 function Harness({ onSubmit }: { onSubmit: (value: string) => void }): React.ReactElement {
   const [value, setValue] = useState('');


### PR DESCRIPTION
## What

Two exports had no consumer, and `orphan-exports` passed over both because a **doc comment** contains the name. Closes #2362.

```
PluginContainerBlock    only other occurrence:  plugin-container-block-types.ts:2
                        " * Types, constants, and utilities for PluginContainerBlock"
IME_SUBMIT_DEFER_MS     only other occurrence:  __tests__/cjk-defer-submit.test.tsx:12
                        " * … a real wait > IME_SUBMIT_DEFER_MS so the deferred submit actually fires"
```

**The fix is not to unexport either.** This repository does not remove a surface for having few callers. It is to make *"no consumer"* untrue.

## `IME_SUBMIT_DEFER_MS` — the orphan was the smaller half

The CLI-061 integration test waited a **hard-coded 90ms** and said `// > 50ms defer` in a comment, while naming the constant only in prose.

**So raising `IME_SUBMIT_DEFER_MS` past 90 would have left the test waiting less than the defer it exists to outlast — and the comment asserting otherwise.** The wait is now derived: `IME_SUBMIT_DEFER_MS + DEFER_WAIT_MARGIN_MS`.

**Proven, not argued.** With the constant temporarily raised to 200:

```
old hard-coded 90ms   →  2 failed   ("includes a trailing syllable…", "a second Enter…")
derived wait          →  2 passed
```

## `PluginContainerBlock` — it gets the consumer its sibling already has

`content/v2.0.0/examples/playground-implementation.md:136-141` documents importing and rendering it, so it is an intended surface, not an accident. Its sibling `agent-container-block` has a test; this had none.

Three cases, and the third is the one that does work a mount-only smoke test cannot:

- the list renders what it is given;
- **the empty state says `No plugins configured`** — the positive control, without which "renders plugins" would be proved by a component that cannot represent the empty case;
- **the priority sort is asserted by ORDER**, not presence.

**Mutation-checked:** reversing `sort((a, b) => b.priority - a.priority)` kills the ordering case and leaves the other two — so it measures the sort rather than the mount.

## The verification that matters

`pnpm harness:scan` passing proves nothing here: **it passed before this change too — that was the defect.**

The decisive check is the experiment that found them. With every comment blanked across `packages/*/src` (offset-preserving), `orphan-exports` previously went red on both symbols. Now:

```
2482 files walked, 1686 rewritten
✓ orphan-exports
```

**The references are code, not prose.**

## Scope

The scan blind spot that let both stand is issue #2258, with the measurement and design decision recorded in `HARNESS-123`. **These two were defects independent of it** — an export with no consumer is one regardless of what can see it — which is why they were filed and fixed separately.

`agent-transport-tui` and `agent-playground` suites green; `pnpm harness:scan` 143 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4KcLfy15wxYjKpaUduAMH