### PR TITLE
fix(harness): the frozen-diff guard reads a red required check

### DIFF
--- a/.agents/rules/git-branch.md
+++ b/.agents/rules/git-branch.md
@@ -663,7 +663,15 @@ skipped the branch entirely and never reached the check. A guard bypassed by obe
 it is not a guard. It is now evaluated on every push, before the override short-circuit, and it has
 its own hatch: `PRE_PUSH_ALLOW_FROZEN_DIFF=1` inline. `PRE_PUSH_ALLOW_UNREVIEWED=1` does **not**
 excuse it — that one asserts the diff is unreviewed, which is a different claim about a different
-rule, and one switch disarming two unrelated gates is how both stop being asked. The rest is not mechanizable here: whether to merge, and when, is a
+rule, and one switch disarming two unrelated gates is how both stop being asked.
+
+**It reads two of the three grounds and says which.** A published finding is the verdict count; a red
+required check it now reads too, because for a while it did not — and a push resolving a failing check
+was refused as work on a pull request the same hook called merge-ready while `merge-gate.sh` would
+have blocked the merge on `mergeStateStatus`. **A rebase it cannot see**, so that is the ground the
+hatch is for, and the refusal says so rather than offering a remedy the author is already following.
+An unreadable answer to either question leaves the refusal standing: unknown is not zero, in both
+directions. The rest is not mechanizable here: whether to merge, and when, is a
 judgement about a state the repository can observe but not evaluate, and a check that merged on green
 would be the automation this section exists to refuse.
 

--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -813,14 +813,37 @@ frozen_diff_refusal() {
       --jq "([.comments[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[]? | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"^github-actions(\\\\[bot\\\\])?$\"))) | map(select(.body | test(\"ACTIONABLE FINDINGS:[[:space:]]*[0-9]+\"; \"i\"))) | sort_by(.at) | last // {} | .body // \"\"" 2>/dev/null) |
     sed -nE 's/^ACTIONABLE FINDINGS: ([0-9]+)$/\1/p' | tail -1 || echo "")
   [[ "$latest_count" == "0" ]] || return 1
-  echo "[pre-push-check] Blocked: PR #$open_pr's latest review reports ACTIONABLE FINDINGS: 0," >&2
-  echo "[pre-push-check] so there is nothing for this push to resolve — it is new work on a PR" >&2
-  echo "[pre-push-check] that is already merge-ready, and a reviewer who passed it never saw it." >&2
-  echo "[pre-push-check] git-branch.md: an open PR's diff is frozen except to resolve a finding." >&2
+  # A RED REQUIRED CHECK IS THE SECOND OF THE RULE'S THREE GROUNDS, and this guard used to be blind
+  # to it — measured three times in one day across two sessions (issue #2338). A push that resolves a
+  # failing check is not new work on a merge-ready pull request; the pull request is not merge-ready,
+  # and `merge-gate.sh` would refuse it one step later on `mergeStateStatus`. Two hooks disagreeing
+  # about the same pull request at the same instant is what made the refusal unfollowable: its remedy
+  # ("let it land first") named something the blocked push was the precondition for.
+  #
+  # `--json bucket` and not `conclusion`: `gh pr checks` reports a bucket per check and `fail` is the
+  # one that matters here. Unknown is NOT zero, for the same reason as the count above — an
+  # unreadable answer must not manufacture a refusal, so a failed read leaves `failing` empty and the
+  # guard proceeds to block as before rather than silently allowing.
+  local failing
+  failing=$( (cd "$PROJECT_DIR" &&
+    bounded_gh pr checks "$open_pr" --json bucket --jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null) || echo "")
+  if [[ "$failing" =~ ^[1-9][0-9]*$ ]]; then
+    return 1
+  fi
+  # What this guard OBSERVED, not what it inferred. The previous wording asserted a diagnosis — "this
+  # is new work on a merge-ready PR" — that the guard never established, and it was wrong in every
+  # measured instance including the one where the refusal itself was correct.
+  echo "[pre-push-check] Blocked: PR #$open_pr's latest review reports ACTIONABLE FINDINGS: 0 and no" >&2
+  echo "[pre-push-check] required check is failing, so this push has no published finding and no red" >&2
+  echo "[pre-push-check] check to resolve." >&2
+  echo "[pre-push-check] git-branch.md: a push into an open PR needs a NAMED GROUND — a published" >&2
+  echo "[pre-push-check] finding, a red required check, or a rebase. The first two are read above." >&2
+  echo "[pre-push-check] If your ground is a REBASE, or a finding this hook cannot see, say which:" >&2
+  echo "[pre-push-check] PRE_PUSH_ALLOW_FROZEN_DIFF=1 inline." >&2
+  echo "[pre-push-check] If it is none of the three, the push does not happen — let #$open_pr land." >&2
   echo "[pre-push-check] Recording a local review does NOT excuse this, and neither does" >&2
   echo "[pre-push-check] PRE_PUSH_ALLOW_UNREVIEWED — that one says the diff is unreviewed, which is" >&2
-  echo "[pre-push-check] a different claim. Let #$open_pr land, then open a second PR for this work." >&2
-  echo "[pre-push-check] Deliberate exception: PRE_PUSH_ALLOW_FROZEN_DIFF=1 inline." >&2
+  echo "[pre-push-check] a different claim." >&2
   return 0
 }
 

--- a/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
+++ b/scripts/harness/__tests__/pre-push-open-pr-freeze.test.mjs
@@ -49,7 +49,7 @@ function scratchRepo() {
  * comment carrying the verdict marker. A stub answering its own preferred shape would keep passing
  * while the hook stopped working.
  */
-function stubGh({ prNumber, findings, author = 'github-actions[bot]' }) {
+function stubGh({ prNumber, findings, author = 'github-actions[bot]', failingChecks = 0 }) {
   const dir = makeTemp('openpr-gh-');
   scratch.push(dir);
 
@@ -87,6 +87,12 @@ function stubGh({ prNumber, findings, author = 'github-actions[bot]' }) {
     [
       '#!/bin/bash',
       "# Run the caller's own --jq over the fixture payload, the way gh does.",
+      '# The THIRD question the guard asks (issue #2338): is a required check failing? Answered',
+      '# from the fixture like the others, so the guard reads a real number and not a stub decision.',
+      'if [[ "$*" == *"pr checks"* ]]; then',
+      `  printf '%s\\n' '${failingChecks}'`,
+      '  exit 0',
+      'fi',
       'if [[ "$*" == *"comments,reviews"* ]]; then',
       '  jqexpr=""',
       '  while [ $# -gt 0 ]; do',
@@ -106,7 +112,7 @@ function stubGh({ prNumber, findings, author = 'github-actions[bot]' }) {
   return dir;
 }
 
-function push({ findings, prNumber = 4242, author, prefix = '' }) {
+function push({ findings, prNumber = 4242, author, prefix = '', failingChecks = 0 }) {
   const dir = scratchRepo();
   const result = spawnSync('bash', [HOOK], {
     input: JSON.stringify({
@@ -119,7 +125,7 @@ function push({ findings, prNumber = 4242, author, prefix = '' }) {
     env: {
       ...process.env,
       CLAUDE_PROJECT_DIR: dir,
-      PATH: `${stubGh({ prNumber, findings, author })}${path.delimiter}${process.env.PATH}`,
+      PATH: `${stubGh({ prNumber, findings, author, failingChecks })}${path.delimiter}${process.env.PATH}`,
     },
   });
   return { status: result.status ?? 1, output: `${result.stdout ?? ''}${result.stderr ?? ''}` };
@@ -130,12 +136,18 @@ describe('pre-push open-PR freeze — RED direction', () => {
     const res = push({ findings: 0 });
     expect(res.status).toBe(2);
     expect(res.output).toMatch(/ACTIONABLE FINDINGS: 0/);
-    expect(res.output).toMatch(/nothing for this push to resolve/);
+    // What the guard OBSERVED, not a diagnosis it never established (issue #2338): the wording used
+    // to assert "new work on a merge-ready PR", which was false in every measured instance.
+    expect(res.output).toMatch(/no published finding and no red\s+.*check to resolve/s);
+    expect(res.output).not.toMatch(/already merge-ready/);
   });
 
   it('names the recovery, not only the refusal', () => {
     const res = push({ findings: 0 });
-    expect(res.output).toMatch(/open a second PR/i);
+    // It must name ALL THREE grounds, and say which two it read — a refusal that lists only the
+    // remedy it can see trains the author to override for the one it cannot (issue #2338).
+    expect(res.output).toMatch(/published\s+.*finding, a red required check, or a rebase/s);
+    expect(res.output).toMatch(/let #4242 land/i);
     // The hatch is this rule's own. It used to be PRE_PUSH_ALLOW_UNREVIEWED, and that was the
     // defect: one switch disarmed two unrelated rules while its message claimed only the first.
     expect(res.output).toMatch(/PRE_PUSH_ALLOW_FROZEN_DIFF=1/);
@@ -146,7 +158,7 @@ describe('pre-push open-PR freeze — RED direction', () => {
     // is how a session reaching for the documented one silently disarms this one too.
     const res = push({ findings: 0, prefix: 'PRE_PUSH_ALLOW_UNREVIEWED=1 ' });
     expect(res.status).toBe(2);
-    expect(res.output).toMatch(/nothing for this push to resolve/);
+    expect(res.output).toMatch(/no published finding and no red/);
   });
 
   it('its own override does excuse it', () => {
@@ -159,6 +171,31 @@ describe('pre-push open-PR freeze — RED direction', () => {
     // session obeying the record-before-push rule skipped it. The message now says so.
     const res = push({ findings: 0 });
     expect(res.output).toMatch(/Recording a local review does NOT excuse this/);
+  });
+});
+
+describe('pre-push open-PR freeze — a RED REQUIRED CHECK is ground #2 (issue #2338)', () => {
+  // Measured three times in one day across two sessions: the guard blocked a push that was fixing a
+  // failing required check, on the claim the pull request was "already merge-ready" — while
+  // merge-gate.sh would have refused that same pull request at the same instant on mergeStateStatus.
+  // The remedy it offered ("let it land, then open a second PR") named something the blocked push
+  // was the precondition for.
+  it('allows the push when a required check is failing, even at zero findings', () => {
+    const res = push({ findings: 0, failingChecks: 1 });
+    expect(res.status).toBe(0);
+  });
+
+  it('still refuses at zero findings when NO check is failing', () => {
+    // The control for the case above. Without it, a guard that never blocks would pass it.
+    const res = push({ findings: 0, failingChecks: 0 });
+    expect(res.status).toBe(2);
+  });
+
+  it('does not treat an unreadable check answer as zero failures', () => {
+    // Unknown is not zero, the same way the findings count is not. A failed read must leave the
+    // refusal standing rather than manufacture a permission out of a broken query.
+    const res = push({ findings: 0, failingChecks: 'not-a-number' });
+    expect(res.status).toBe(2);
   });
 });
 


### PR DESCRIPTION
Closes #2338.

A red required check is the **second of the rule's three grounds**, and this guard could not see it. Three instances in one day, two sessions, unrelated changes:

| | ground | the guard said | followable |
|---|---|---|---|
| PR #2349 | rebase | "new work on a merge-ready PR" | no |
| PR #2356 | red CodeQL, **high severity** | "already merge-ready" | no |
| PR #2357 | red `regression-red-proof` | "already merge-ready" | no |

**In the last two the claim was false at the moment it was printed.** `merge-gate.sh` asks `mergeStateStatus == CLEAN` first and would have refused those same pull requests at the same instant. Two hooks disagreeing about one pull request is what made the refusal impossible to obey — *"let it land, then open a second PR"* named something the blocked push was the **precondition for**.

## The condition

```bash
failing=$(bounded_gh pr checks "$open_pr" --json bucket --jq '[.[] | select(.bucket == "fail")] | length')
if [[ "$failing" =~ ^[1-9][0-9]*$ ]]; then
  return 1
fi
```

The guard already shells out to `gh` for the verdict count. This is **one field, not a new mechanism** — which is what made it the narrow fix rather than a redesign.

**Unknown is not zero, in both directions.** A non-numeric answer leaves the refusal standing rather than manufacturing a permission out of a broken query — the mirror of the rule already applied to an unreadable findings count.

## The message is the wider half

It asserted a diagnosis the guard never established: *"this is new work on a PR that is already merge-ready."* What it actually knows is narrower — the latest verdict says zero and a push is happening.

**That sentence was wrong in all three instances above, and in a fourth where the refusal itself was correct.** Another session batched a merge and a branch deletion; the hook evaluated before the merge, saw an open pull request at zero findings, and refused the deletion with the same words. Refusing was right — deleting the branch of an open pull request closes it — and the explanation was still wrong.

That fourth case is what proves the two defects are independent: **fixing the condition leaves the message wrong on every correct block it still makes.** So the message now reports what was read, names all three grounds, and says which one the hatch is for — because a rebase is the ground it cannot see, and a refusal that offers a remedy the author is already following is what trains the override.

## Falsification

```
new branch replaced with `if false`   →  1 failed | 11 passed
                                          the one failure is "allows the push when a
                                          required check is failing" — and only that one
restored                              →  12 passed
```

The three new cases carry their own controls, because a guard that never blocks would pass the first one alone:

- **a refusal at zero failing checks** — the control for the permission;
- **a non-numeric check answer that must not read as zero** — the control for the unknown.

Three existing cases asserted the **old wording**. They are restated as properties — that the message reports what was observed, and that it names all three grounds — rather than re-pinned to new prose, so the next wording change does not have to touch them.

The `gh` stub answers the new question **from the fixture**, like the other two, so the guard reads a real number rather than a stub's decision.

## Verification

```
pre-push-open-pr-freeze suite   12 passed
pnpm harness:test               1149 passed (73 files)
pnpm harness:scan               143 passed, 2 skipped, 0 failed
```

`.agents/rules/git-branch.md` records which grounds the hook reads and which it cannot, so the rule and the mechanism no longer disagree about the hook's reach.
