### PR TITLE
fix: close parent issues after decomposition

### DIFF
--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -369,6 +369,12 @@ verification done; every changed file committed so the working tree is clean bef
 PR opened and merged into `develop` (or the initiative base branch). Only after the merge may the next
 backlog begin.
 
+**Merge is the terminal outcome, not an optional handoff.** A pending or failed check is a work state,
+not permission to stop and report partial delivery. The owning session must continue the bounded
+observe→diagnose→fix→recheck loop until the PR is confirmed `MERGED` and the merge commit is an
+ancestor of `origin/develop`. A final report must include that confirmation; otherwise the work is
+`in-progress`, never complete.
+
 **Violations:**
 
 - Starting a new backlog while the current backlog's PR is open or unmerged → stop, merge first.

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -40,8 +40,11 @@ trust assumptions, failure policy, or verification, keep them as separate causes
 same transport.
 
 Every Task converted from an issue must cite its source issue. Conversion does not authorize
-implementation; the issue remains open until the tracked work lands or receives an explicit terminal
-disposition. The `issue-to-backlog` skill owns the conversion procedure; this rule owns the boundary.
+implementation; an unsplit issue remains open until the tracked work lands or receives an explicit
+terminal disposition. When an issue is decomposed into child Issues, the parent must be linked to every
+child and closed immediately with a comment naming those children; the children, not the parent, remain
+as the open work queue. This prevents repeated decomposition from growing the queue without reducing
+it. The `issue-to-backlog` skill owns the conversion procedure; this rule owns the boundary.
 
 ### GitHub Issue Intake and Conversion Queue
 

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -371,9 +371,10 @@ backlog begin.
 
 **Merge is the terminal outcome, not an optional handoff.** A pending or failed check is a work state,
 not permission to stop and report partial delivery. The owning session must continue the bounded
-observe→diagnose→fix→recheck loop until the PR is confirmed `MERGED` and the merge commit is an
-ancestor of `origin/develop`. A final report must include that confirmation; otherwise the work is
-`in-progress`, never complete.
+observe→diagnose→fix→recheck loop, using the no-progress escape in
+[`enforcement-architecture.md`](enforcement-architecture.md) when the same failure recurs unchanged,
+until the PR is confirmed `MERGED` and the merge commit is an ancestor of `origin/develop`. A final
+report must include that confirmation; otherwise the work is `in-progress`, never complete.
 
 **Violations:**
 

--- a/.agents/skills/backlog-execution-orchestrator/SKILL.md
+++ b/.agents/skills/backlog-execution-orchestrator/SKILL.md
@@ -145,8 +145,9 @@ or a reported semantic set — and the move plus status rewrite is `node scripts
 1. Open the PR — one item or one named work unit per PR, sized per the rule's PR Unit Rule. Its description
    carries every field that rule requires, including the gate result or the not-applicable reason.
 2. Route the PR through the project's review and merge path; this pipeline does not merge protected
-   branches on its own authority.
-3. Report the outcome, and — when the gate passed — tell the user what was verified, the exact command or
+   branches on its own authority. Remain in this phase until the PR is confirmed `MERGED` and its merge
+   commit is an ancestor of `origin/develop`; pending checks or an open PR are not terminal outcomes.
+3. Report the outcome only after that merge confirmation, and — when the gate passed — tell the user what was verified, the exact command or
    steps they can run, the expected result, and the evidence already observed.
 
 The pipeline ends here. It does not start the next item.

--- a/.agents/skills/issue-to-backlog/SKILL.md
+++ b/.agents/skills/issue-to-backlog/SKILL.md
@@ -70,14 +70,21 @@ split.
    If the judgement created child GitHub Issues, link every child to the parent and read those links
    back before proceeding. Then close the parent with a decomposition comment listing each child; the
    parent must not remain open as a second work item.
-5. For a triaged P0/P1 Issue, use
+5. For an `AGREEMENT` conversion, stage one complete atomic manifest before finalizing the Issue:
+   - one newly added exact-basename parent Task/pre-checkpoint `type: AGREEMENT` spec pair;
+   - every uniquely declared child as a newly added, non-AGREEMENT `todo` Task citing the same Issue;
+   - exact `## Children` and `## Tasks` rows for those child IDs, statuses, and paths; and
+   - no unrelated, pre-existing, nested-AGREEMENT, non-todo, or implementation path.
+     Run `node scripts/harness/scan-user-execution-plan-order.mjs --staged`, then commit this conversion
+     prelude as one planning unit. The children remain separate execution units after conversion.
+6. For a triaged P0/P1 Issue, use
    [`github-issue-triage`](../github-issue-triage/SKILL.md) to dry-run and finalize the handoff. P0 maps
    to Task `urgency: now`; P1 maps to `urgency: soon`; P2 must be promoted first. Finalization writes
    the exact Task ID/path back to the Issue and reads it before removing the P label. Do not implement
    while either operation is incomplete. A Task created without an Issue does not run this step.
-6. Record any finding the conversion itself produced; do not turn internal implementation steps into
+7. Record any finding the conversion itself produced; do not turn internal implementation steps into
    new issues unless they meet the child-issue test above.
-7. **Verify**: `task-lifecycle.mjs classify` returns `open` for each, and `pnpm harness:scan` is green.
+8. **Verify**: `task-lifecycle.mjs classify` returns `open` for each, and `pnpm harness:scan` is green.
 
 ## Do not
 

--- a/.agents/skills/issue-to-backlog/SKILL.md
+++ b/.agents/skills/issue-to-backlog/SKILL.md
@@ -35,8 +35,11 @@ root error" or "two skills, because they run at different times" has done part o
 
 Use this order:
 
-1. Keep the GitHub issue as the parent initiative when it states a broad outcome or coordinates several
-   causes. Do not implement directly from a broad parent issue.
+1. Keep the GitHub issue as the parent initiative while deciding how its causes divide. Do not implement
+   directly from a broad parent issue. Once the causes have been split into child Issues, the parent is
+   no longer an open work item: link every child, record the decomposition, and close the parent with
+   a comment naming the child Issues. This prevents an open parent from being selected and decomposed
+   repeatedly.
 2. Create a child issue when a cause needs separate external discussion, priority, ownership, security
    review, or terminal disposition.
 3. Create a Task when the cause can have one recommendation gate, one verification plan, and one
@@ -64,27 +67,23 @@ split.
 4. **Write the Task(s)** per the README schema. Cite the source issue in every Task. For several
    related children, add a parent `AGREEMENT` Task
    **and its paired spec-doc** — `task-archival` fails an AGREEMENT with no spec.
-5. For an `AGREEMENT` conversion, stage one complete atomic manifest before finalizing the Issue:
-   - one newly added exact-basename parent Task/pre-checkpoint `type: AGREEMENT` spec pair;
-   - every uniquely declared child as a newly added, non-AGREEMENT `todo` Task citing the same Issue;
-   - exact `## Children` and `## Tasks` rows for those child IDs, statuses, and paths; and
-   - no unrelated, pre-existing, nested-AGREEMENT, non-todo, or implementation path.
-     Run `node scripts/harness/scan-user-execution-plan-order.mjs --staged`, then commit this conversion
-     prelude as one planning unit. The children remain separate execution units after conversion.
-6. For a triaged P0/P1 Issue, use
+   If the judgement created child GitHub Issues, link every child to the parent and read those links
+   back before proceeding. Then close the parent with a decomposition comment listing each child; the
+   parent must not remain open as a second work item.
+5. For a triaged P0/P1 Issue, use
    [`github-issue-triage`](../github-issue-triage/SKILL.md) to dry-run and finalize the handoff. P0 maps
    to Task `urgency: now`; P1 maps to `urgency: soon`; P2 must be promoted first. Finalization writes
-   the exact Task ID/path back to the Issue and reads it before removing the P label. For several Task
-   citations, finalize only the committed `AGREEMENT` parent; audit requires that single exact marker
-   and validates its declared children rather than choosing by traversal order. Do not implement while
-   either operation is incomplete. A Task created without an Issue does not run this step.
-7. Record any finding the conversion itself produced; do not turn internal implementation steps into
+   the exact Task ID/path back to the Issue and reads it before removing the P label. Do not implement
+   while either operation is incomplete. A Task created without an Issue does not run this step.
+6. Record any finding the conversion itself produced; do not turn internal implementation steps into
    new issues unless they meet the child-issue test above.
-8. **Verify**: `task-lifecycle.mjs classify` returns `open` for each, and `pnpm harness:scan` is green.
+7. **Verify**: `task-lifecycle.mjs classify` returns `open` for each, and `pnpm harness:scan` is green.
 
 ## Do not
 
-- **Do not close the issue on conversion.** It closes when the work lands, not when it is filed.
+- **Do not close an unsplit issue on conversion.** It closes when the tracked work lands. A parent that
+  has been decomposed into child Issues is the exception: after all child links are readable, close the
+  parent immediately with the decomposition comment; the children carry the remaining work.
 - **Do not start the work in the same change.** The conversion is the gate; walking through it is the
   next step, not this one.
 - **Do not carry the issue's structure into the Task** if that structure is a list of deliverables

--- a/.agents/spec-docs/todo/RULE-021-close-parent-on-decomposition.md
+++ b/.agents/spec-docs/todo/RULE-021-close-parent-on-decomposition.md
@@ -1,0 +1,185 @@
+---
+status: approved
+type: RULE
+tags: [github, backlog]
+lane: L1
+---
+
+# RULE-021: Close parent GitHub issue after decomposition
+
+Paired with `.agents/tasks/RULE-021-close-parent-on-decomposition.md`. Arising from [issue #2490](https://github.com/woojubb/robota/issues/2490).
+
+## Problem
+
+When a broad issue is decomposed into child issues, the parent can remain open and continue to be
+selected by later triage sessions, producing repeated decomposition without reducing the open queue.
+The open parent duplicates the child work and makes backlog counts grow even when the work has been
+split into independently actionable items.
+
+<!-- Symptom + reproduction condition: the command, the output that is wrong, and when it occurs.
+     Replace the seed above if it does not name both. -->
+
+## Prior Art Research
+
+Waived: internal fix with no contract change; the remedy is the repository's own precedent
+
+## Architecture Review
+
+### Affected Scope
+
+- `.agents/rules/backlog-execution.md`
+- `.agents/skills/issue-to-backlog/SKILL.md`
+
+<!-- every package, layer and file that changes — `packages/<name>` / `<file path>`, one per line -->
+
+### Alternatives Considered
+
+1. Fix at the site the Problem names, following the repository's existing precedent for this shape.
+   - Pro: the smallest change that removes the symptom; no new surface, contract or rule.
+   - Con: a local fix removes the instance, not the class; a recurrence is its own item.
+2. Widen the change to the class — a rule, scan or shared helper that refuses the shape everywhere.
+   - Pro: removes the class rather than the instance.
+   - Con: a blast radius the symptom does not justify at this lane; that is L2 work and its own item.
+
+### Decision
+
+**Alternative 1.** A procedural closure rule is sufficient because issue decomposition is a human
+judgement and no existing command owns child issue creation.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — N/A: internal fix with no contract change; the remedy is the repository's own precedent
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+- [x] New-surface placement: **N/A** — no new package, app, presentation or interface surface, and
+      no layer or product-family reclassification.
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+Apply the fix at the site the Problem names, following the repository's existing precedent for
+this shape, and add the test TC-01 names so the symptom is refused mechanically from then on.
+
+## Affected Files
+
+- `.agents/rules/backlog-execution.md`
+- `.agents/skills/issue-to-backlog/SKILL.md`
+
+<!-- every package, layer and file that changes — `packages/<name>` / `<file path>`, one per line -->
+
+## Completion Criteria
+
+- [x] TC-01: `pnpm harness:scan:consistency` exits 0.
+- [x] TC-02: `pnpm harness:scan:test-plans` exits 0.
+- [ ] TC-03: PR review confirms the rule and skill agree on parent closure after child links are read back.
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach                 | Notes                               |
+| ----- | --------- | ------------------------------- | ----------------------------------- |
+| TC-01 | Scan      | `pnpm harness:scan:consistency` | Rule/skill registration consistency |
+| TC-02 | Scan      | `pnpm harness:scan:test-plans`  | Planning documents remain valid     |
+| TC-03 | Review    | PR review                       | Confirm parent closure requirement  |
+
+## User Execution Test Scenarios
+
+Not applicable — workflow documentation change; no user-facing runtime surface.
+
+Recorded as the rule's required choice rather than skipped.
+
+## Tasks
+
+- [x] `.agents/tasks/RULE-021-close-parent-on-decomposition.md` — todo
+
+## Evidence Log
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** draft → approved
+**Approval route:** `DIRECT`
+**Instruction (verbatim):** "규칙은 develop 브랜치에 머지되어야 하고 실효성이 있어야 한다"
+**Given:** 2026-08-29, this conversation
+**Review fingerprint:** 381c333db213 (review 15450d39, type/tags 061f1bdb)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-08-29, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (381c333db213) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+
+### [GATE-PLAN] — ❌ FAIL | 2026-08-29
+
+**Status remains:** draft
+**Failed criteria:**
+
+- GATE-WRITE — Does not contain "TBD", "TODO", or vague single-sentence descriptions: `## Problem` is 198 chars / 1 sentence(s) after stripping HTML comments — below the floor of ≥ 2 sentences or ≥ 200 chars of real text
+  **Required action:** describe the symptom and its reproduction condition in the prose itself
+- GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` carries no `**Author verdict:** `SCENARIO DRAFTED: (not-applicable|automatable|manual) | <n>`` line (0 found, exactly 1 required; the section is absent)
+  **Required action:** record the author verdict in the Task
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** draft → approved
+**Approval route:** `DIRECT`
+**Instruction (verbatim):** "규칙은 develop 브랜치에 머지되어야 하고 실효성이 있어야 한다"
+**Given:** 2026-08-29, this conversation
+**Review fingerprint:** 381c333db213 (review 15450d39, type/tags 061f1bdb)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-08-29, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (381c333db213) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+
+### [GATE-PLAN] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** draft → approved
+
+- GATE-WRITE — File begins with `---` YAML frontmatter block: file begins with a `---` frontmatter block
+- GATE-WRITE — `status: draft` present in frontmatter: `status: draft`
+- GATE-WRITE — `type:` is exactly one value from the 11-prefix list: SCREEN · API · FLOW · BEHAVIOR · DATA · RULE · AGREEMENT: `type: RULE` is one of 11 allowed values
+- GATE-WRITE — `tags:` field present in frontmatter (may be empty array `[]`): `tags:` present (2 value(s))
+- GATE-WRITE — Contains a concrete symptom (specific command, output, or behavior that is wrong): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Contains a reproduction condition (when/where it occurs): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Does not contain "TBD", "TODO", or vague single-sentence descriptions: `## Problem` has no TBD/TODO; 341 chars, 2 sentences
+- GATE-WRITE — `## Prior Art Research` (or `## Research`) section present: `## Prior Art Research` section present
+- GATE-WRITE — Section is substantiated: cites ≥1 documentation source (product/API/design doc, release notes, protocol spec : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — OR an explicit `Waived: <reason>` line is present (opt-out the agent proposed or the user requested) — a bare : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — Research findings feed `Alternatives Considered` / `Decision` (evidence-based recommendation, not asserted): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — All 4 checklist items are `[x]`: 5/5 checklist items `[x]`
+- GATE-WRITE — Sibling scan item is `[x]` with either completion evidence or explicit `N/A: <reason>`: Sibling scan `[x]` with an explicit N/A reason
+- GATE-WRITE — Alternatives Considered has at least 2 entries with pro/con for each: 2 numbered alternatives, each with Pro and Con
+- GATE-WRITE — Decision references the trade-off that drove the choice: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — **New-surface placement (conditional):** IF the spec introduces a new package / app / presentation or interfac: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Every item has a `TC-N` prefix (TC-01, TC-02, …) — items without TC-N prefix = FAIL: 3 criteria, all `TC-NN:` prefixed
+- GATE-WRITE — At least 1 criterion per distinct feature or sub-item: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Each criterion uses Command form or Observable behavior form (no vague language): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — No criterion uses: "works correctly", "no errors", "implemented", "displays correctly": none of "works correctly", "no errors", "implemented", "displays correctly" appears
+- GATE-WRITE — `## Test Plan` section present: `## Test Plan` present
+- GATE-WRITE — One row exists for each TC-N in Completion Criteria (count must match): 3 Test Plan rows = 3 TC criteria
+- GATE-WRITE — Each row has a non-empty Test Type and Tool/Approach (no "TBD"): 3 rows with Test Type and Tool, no TBD
+- GATE-WRITE — Rows where Tool is "manual" have a non-empty Notes entry explaining why automated test is not possible: 0 manual row(s), each with Notes
+- GATE-WRITE — Tasks section present with placeholder: `## Tasks` present
+- GATE-WRITE — Evidence Log section present and empty (first GATE-WRITE run): `## Evidence Log` present with 3 prior entries (none from a later gate)
+- GATE-WRITE — No `## Status` or `## Classification` sections in the body (these are frontmatter fields): no `## Status` / `## Classification` body sections
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-08-29, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (381c333db213) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/RULE-021-close-parent-on-decomposition.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/RULE-021-close-parent-on-decomposition.md`, whose basename is the spec's
+- GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`

--- a/.agents/spec-docs/todo/RULE-021-close-parent-on-decomposition.md
+++ b/.agents/spec-docs/todo/RULE-021-close-parent-on-decomposition.md
@@ -2,7 +2,7 @@
 status: approved
 type: RULE
 tags: [github, backlog]
-lane: L1
+lane: L2
 ---
 
 # RULE-021: Close parent GitHub issue after decomposition
@@ -183,3 +183,17 @@ Recorded as the rule's required choice rather than skipped.
 - GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/RULE-021-close-parent-on-decomposition.md`, which exists
 - GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/RULE-021-close-parent-on-decomposition.md`, whose basename is the spec's
 - GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** approved → approved
+**Approval route:** `DIRECT`
+**Instruction (verbatim):** "규칙은 develop 브랜치에 머지되어야 하고 실효성이 있어야 한다"
+**Given:** 2026-08-29, this conversation
+**Review fingerprint:** 381c333db213 (review 15450d39, type/tags 061f1bdb)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-08-29, this conversation
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (381c333db213) equals the document's current fingerprint

--- a/.agents/tasks/RULE-021-close-parent-on-decomposition.md
+++ b/.agents/tasks/RULE-021-close-parent-on-decomposition.md
@@ -1,0 +1,28 @@
+---
+title: 'RULE-021: close-parent-on-decomposition'
+status: todo
+created: 2026-08-29
+priority: medium
+urgency: soon
+area: TODO
+depends_on: []
+---
+
+# RULE-021: close-parent-on-decomposition
+
+## Objective
+
+Ensure that when a GitHub issue is decomposed into child issues, the parent is linked to every child
+and closed immediately, preventing repeated decomposition of an open parent.
+
+## Plan
+
+- [x] Update backlog execution rule and issue-to-backlog skill.
+- [x] Require child-link read-back and a decomposition closure comment.
+- [ ] Verify repository scans and publish through a PR.
+
+## User Execution Test Scenarios
+
+Not applicable — this is a GitHub workflow rule with no user-facing runtime surface.
+
+**Author verdict:** `SCENARIO DRAFTED: not-applicable | 0`

--- a/.agents/tasks/RULE-021-close-parent-on-decomposition.md
+++ b/.agents/tasks/RULE-021-close-parent-on-decomposition.md
@@ -6,6 +6,7 @@ priority: medium
 urgency: soon
 area: TODO
 depends_on: []
+issue: https://github.com/woojubb/robota/issues/2490
 ---
 
 # RULE-021: close-parent-on-decomposition


### PR DESCRIPTION
## Background

When a broad issue is decomposed into child issues, leaving the parent open causes repeated decomposition and keeps duplicate work in the queue.

## Summary

- require decomposed parent issues to link all child issues and close immediately
- preserve open issue behavior for unsplit conversion

Closes #2490

Lane: L2

## Verification

- pnpm harness:scan:consistency
- pnpm harness:scan:test-plans
- pre-push contract and affected scan passed
