### PR TITLE
docs: require English GitHub issues

### DIFF
--- a/.agents/rules/naming-style.md
+++ b/.agents/rules/naming-style.md
@@ -13,6 +13,9 @@ Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
 - **Everything else defaults to English**, unless the user explicitly requests otherwise: code and comments,
   ALL repository documents (including `.design/`), commit messages (conventional-commits format), and any other
   written artifact.
+- **GitHub issue titles and bodies default to English** for consistent triage, search, automation, and
+  cross-session handoff. Translate an issue written in another language when discovered; preserve quoted
+  user text only when needed as evidence and provide an English summary.
 
 ### Korean Writing Style (only when Korean output is explicitly requested)
 

--- a/.agents/skills/github-issue-triage/SKILL.md
+++ b/.agents/skills/github-issue-triage/SKILL.md
@@ -17,6 +17,10 @@ This skill owns procedure only. It does not redefine the queue or make Issues th
 
 ## Create an Issue (mandatory intake contract)
 
+Issue titles and bodies are repository artifacts and must be written in English by default. If an issue
+arrives in another language, translate it during intake while preserving the original meaning and any
+required evidence.
+
 Use one of the three repository Issue Forms for every new Issue:
 
 - **Bug report** → exactly `bug` + `status:needs-triage`


### PR DESCRIPTION
## Background
A newly filed issue used Korean prose, which makes cross-session triage, search, and automation inconsistent.

## Summary
- state that GitHub issue titles and bodies default to English
- add the same requirement to the issue-triage skill
- translate issue #2490 into English while preserving its intent

Closes #2490

## Verification
The issue was updated and the repository language rule and triage skill now agree.