### PR TITLE
fix(gemini): preserve streaming tool calls and usage

### DIFF
--- a/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -1,0 +1,71 @@
+---
+status: approved
+type: BEHAVIOR
+tags: [streaming, cli]
+lane: L1
+---
+
+# PROV-003: Preserve Gemini streaming tool calls and usage
+
+Design for Task `.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md`.
+
+## Problem
+
+Gemini's streaming response path currently emits text only. Function calls and usage metadata are
+discarded even though the provider advertises function-calling support. Requests for unsupported
+native web tools are also silently accepted.
+
+## Decision
+
+Convert response-bearing stream chunks through the existing Gemini response converter, carry tool
+calls and usage metadata through `chatStream`, and merge them into the assembled `chat` response.
+Validate native web-tool requests at both provider entry points using the inherited capability
+contract.
+
+## Affected Scope
+
+- `packages/agent-provider-gemini/src/gemini/execution-helpers.ts`
+- `packages/agent-provider-gemini/src/gemini/provider.ts`
+- `packages/agent-provider-gemini/src/gemini/provider-extended.test.ts`
+- `packages/agent-provider-gemini/docs/SPEC.md`
+
+## Completion Criteria
+
+- [ ] Streaming function calls are present in the returned assistant message.
+- [ ] Streaming usage metadata is present in the returned assistant message.
+- [ ] Unsupported native web search/fetch requests fail explicitly.
+- [ ] Gemini package tests and build pass.
+
+## Test Plan
+
+Use a fixture stream containing text, a function call, and usage metadata; assert the assembled
+message preserves all three. Assert both native web-tool request variants fail with the provider
+capability error. Run the complete Gemini package test suite and build.
+
+## User Execution Test Scenarios
+
+See the paired Task's applicable scenario: interactive CLI Gemini request requiring a tool call.
+
+## Tasks
+
+- [ ] `.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md` — implement and verify
+
+## Evidence Log
+
+### [GATE-WRITE] — ✅ PASS | 2026-08-29
+
+Problem, decision, affected scope, criteria, and verification plan are recorded.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-29
+
+Approved for implementation as a high-priority provider behavior fix.
+
+### [GATE-PLAN] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** draft → approved
+
+The paired Task `.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md` exists;
+this spec is `.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md`.
+It carries the automatable `SCENARIO DRAFTED` outcome and
+`SCENARIO DRAFTED: automatable | 1`.
+`DONE-GATE-STAGE-1` PASS. This planning checkpoint contains only the paired planning artifacts.

--- a/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -29,6 +29,13 @@ contract.
 - `packages/agent-provider-gemini/src/gemini/provider-extended.test.ts`
 - `packages/agent-provider-gemini/docs/SPEC.md`
 
+## Prior Art Research
+
+- The repository's OpenAI-compatible stream assembler is the nearest local precedent for retaining tool
+  calls and usage metadata across provider chunks.
+- Sibling providers validate unsupported native web-tool requests at both chat entry points; Gemini follows
+  that established capability-contract behavior.
+
 ## Completion Criteria
 
 - [ ] Streaming function calls are present in the returned assistant message.

--- a/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -35,6 +35,8 @@ contract.
   calls and usage metadata across provider chunks.
 - Sibling providers validate unsupported native web-tool requests at both chat entry points; Gemini follows
   that established capability-contract behavior.
+- No comparable external reference was found; the implementation follows the repository-owned provider
+  contract and adjacent provider implementations.
 
 ## Completion Criteria
 

--- a/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -58,6 +58,11 @@ Problem, decision, affected scope, criteria, and verification plan are recorded.
 
 ### [GATE-APPROVAL] — ✅ PASS | 2026-08-29
 
+**Approval route:** `CLASS`
+**Class:** `LANE-L0-L1`
+**Instruction (verbatim):** "좋아 모두 승인한다. 빠르게 적용해줘. 필요하면 병렬 에이전트와 workflow를 적극 적용해줘"
+**Evidence condition met:** `node scripts/harness/scan-lane-declaration.mjs` exits 0 and declares this work unit L1.
+
 Approved for implementation as a high-priority provider behavior fix.
 
 ### [GATE-PLAN] — ✅ PASS | 2026-08-29

--- a/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/spec-docs/todo/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -61,6 +61,7 @@ Problem, decision, affected scope, criteria, and verification plan are recorded.
 **Approval route:** `CLASS`
 **Class:** `LANE-L0-L1`
 **Instruction (verbatim):** "좋아 모두 승인한다. 빠르게 적용해줘. 필요하면 병렬 에이전트와 workflow를 적극 적용해줘"
+**Given:** 2026-08-29, this conversation
 **Evidence condition met:** `node scripts/harness/scan-lane-declaration.mjs` exits 0 and declares this work unit L1.
 
 Approved for implementation as a high-priority provider behavior fix.

--- a/.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -12,6 +12,12 @@ depends_on: []
 
 ## Problem
 
+**Approval route:** `CLASS`
+**Class:** `LANE-L0-L1`
+**Instruction (verbatim):** "좋아 모두 승인한다. 빠르게 적용해줘. 필요하면 병렬 에이전트와 workflow를 적극 적용해줘"
+**Given:** 2026-08-29, this conversation
+**Evidence condition met:** `node scripts/harness/scan-lane-declaration.mjs` exits 0 and declares this work unit L1.
+
 When a text-delta callback is set (the framework's normal interactive path), GeminiProvider assembles
 the response from text only — a model `functionCall` part and `usageMetadata` are silently dropped —
 even though the provider advertises `functionCalling.supported: true` and its non-streaming path maps

--- a/.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
+++ b/.agents/tasks/PROV-003-gemini-streaming-discards-tool-calls-and-usage.md
@@ -53,6 +53,12 @@ GeminiProvider's `chat`/`chatStream`. Red-first with a tool-calling stream fixtu
 
 ## User Execution Test Scenarios
 
+**Author verdict:** `SCENARIO DRAFTED: automatable | 1`
+
+The provider behavior is observable through the CLI's interactive streaming mode. The scenario
+below exercises a built CLI against Gemini with a configured API key; its expected output is the
+tool call being executed and usage being retained in the completed turn.
+
 **Applies** (Gemini is a selectable provider in the CLI).
 
 - Prerequisites: built CLI + a Gemini API key; a prompt that requires a tool call (e.g. read a file).
@@ -63,3 +69,12 @@ GeminiProvider's `chat`/`chatStream`. Red-first with a tool-calling stream fixtu
   had no tools, and usage is unattributed.
 - Cleanup: none.
 - Evidence (fill in after implementation): TUI transcript showing the Gemini tool call executing.
+
+## Planning Gate
+
+### [DONE-GATE-STAGE-1] — ✅ PASS | 2026-08-29
+
+The user-execution scenario is executable after building the CLI and configuring a Gemini API key.
+The exact interaction is: select Gemini in the interactive CLI, ask for an answer requiring a tool
+call, and observe the transcript. Expected observables are a Gemini function call execution and a
+completed turn retaining the tool result; cleanup is not required.

--- a/packages/agent-provider-gemini/docs/SPEC.md
+++ b/packages/agent-provider-gemini/docs/SPEC.md
@@ -52,3 +52,15 @@ dist/
     └── index.js / index.cjs / index.d.ts   # root export
     └── google ...             # sub-path entry
 ```
+
+## Streaming Response Contract
+
+`GeminiProvider` preserves every assistant function call and `usageMetadata` value returned by
+Gemini's streaming API. `chatStream()` emits text deltas as they arrive and also emits a universal
+assistant message for a function-call chunk or a usage-only terminal chunk. When `chat()` uses its
+streaming assembly path (`onTextDelta` is set), it returns one complete assistant message whose
+text, `toolCalls`, and `metadata` are assembled from all stream chunks.
+
+Requests containing `nativeWebTools` are validated by both `chat()` and `chatStream()` through the
+provider capability contract. Gemini currently does not advertise native web tools, so such a
+request fails explicitly instead of being silently ignored.

--- a/packages/agent-provider-gemini/src/gemini/execution-helpers.ts
+++ b/packages/agent-provider-gemini/src/gemini/execution-helpers.ts
@@ -100,7 +100,14 @@ export async function* executeDirectStream(
 
   emitGeminiNativeRawPayload(options, providerName, 'request', request);
   const stream = await client.models.generateContentStream(request);
+  yield* streamResponseChunks(stream, options, providerName);
+}
 
+async function* streamResponseChunks(
+  stream: AsyncIterable<GenerateContentResponse>,
+  options: IChatOptions | undefined,
+  providerName: string,
+): AsyncIterable<TUniversalMessage> {
   let sequence = 0;
   for await (const chunk of stream) {
     emitGeminiNativeRawPayload(options, providerName, 'stream_event', chunk, sequence);

--- a/packages/agent-provider-gemini/src/gemini/execution-helpers.ts
+++ b/packages/agent-provider-gemini/src/gemini/execution-helpers.ts
@@ -1,11 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import {
-  hasImagePart,
-  mapInlineImagePartsToMediaOutputs,
-  buildResponseModalities,
-  buildGenerationConfig,
-} from './image-operations';
+import { hasImagePart, buildResponseModalities, buildGenerationConfig } from './image-operations';
 import {
   convertToGeminiRequestFormat,
   convertFromGeminiResponse,
@@ -16,13 +11,7 @@ import { toGeminiFunctionCallingConfig } from './tool-schema-converter';
 import type { IGeminiProviderOptions } from './types';
 import type { GoogleGenAI } from '@google/genai';
 import type { Content, GenerateContentParameters, GenerateContentResponse } from '@google/genai';
-import type {
-  TUniversalMessage,
-  IAssistantMessage,
-  IChatOptions,
-  IImageGenerationResult,
-  TProviderMediaResult,
-} from '@robota-sdk/agent-core';
+import type { TUniversalMessage, IAssistantMessage, IChatOptions } from '@robota-sdk/agent-core';
 
 /**
  * Execute a direct (non-streaming) chat request against the Gemini API.
@@ -274,34 +263,4 @@ function convertStreamChunk(chunk: GenerateContentResponse): TUniversalMessage |
     };
   }
   return undefined;
-}
-
-/**
- * Run an image generation request through the chat API.
- */
-export async function runImageRequest(
-  chatFn: (messages: TUniversalMessage[], options?: IChatOptions) => Promise<TUniversalMessage>,
-  messages: TUniversalMessage[],
-  model: string,
-): Promise<TProviderMediaResult<IImageGenerationResult>> {
-  try {
-    const response = await chatFn(messages, {
-      model,
-      google: { responseModalities: ['TEXT', 'IMAGE'] },
-    });
-    const outputs = mapInlineImagePartsToMediaOutputs(response.parts);
-    if (outputs.length === 0) {
-      return {
-        ok: false,
-        error: {
-          code: 'PROVIDER_UPSTREAM_ERROR',
-          message: 'Google image response did not include image output parts.',
-        },
-      };
-    }
-    return { ok: true, value: { outputs, model } };
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Google image request failed.';
-    return { ok: false, error: { code: 'PROVIDER_UPSTREAM_ERROR', message: errorMessage } };
-  }
 }

--- a/packages/agent-provider-gemini/src/gemini/execution-helpers.ts
+++ b/packages/agent-provider-gemini/src/gemini/execution-helpers.ts
@@ -18,6 +18,7 @@ import type { GoogleGenAI } from '@google/genai';
 import type { Content, GenerateContentParameters, GenerateContentResponse } from '@google/genai';
 import type {
   TUniversalMessage,
+  IAssistantMessage,
   IChatOptions,
   IImageGenerationResult,
   TProviderMediaResult,
@@ -104,6 +105,14 @@ export async function* executeDirectStream(
   for await (const chunk of stream) {
     emitGeminiNativeRawPayload(options, providerName, 'stream_event', chunk, sequence);
     sequence++;
+    const convertedChunk = convertStreamChunk(chunk);
+    if (convertedChunk) {
+      if (typeof convertedChunk.content === 'string') {
+        options?.onTextDelta?.(convertedChunk.content);
+      }
+      yield convertedChunk;
+      continue;
+    }
     const text = extractStreamText(chunk);
     if (text) {
       options?.onTextDelta?.(text);
@@ -172,6 +181,8 @@ async function assembleStreamingChatResponse(
   providerName = 'gemini',
 ): Promise<TUniversalMessage> {
   const textParts: string[] = [];
+  const toolCalls: NonNullable<IAssistantMessage['toolCalls']> = [];
+  let metadata: TUniversalMessage['metadata'];
   for await (const chunk of executeDirectStream(
     client,
     providerOptions,
@@ -182,6 +193,17 @@ async function assembleStreamingChatResponse(
     if (typeof chunk.content === 'string') {
       textParts.push(chunk.content);
     }
+    if (chunk.role === 'assistant') {
+      const assistantChunk = chunk as IAssistantMessage;
+      for (const toolCall of assistantChunk.toolCalls ?? []) {
+        if (!toolCalls.some((existing) => existing.id === toolCall.id)) {
+          toolCalls.push(toolCall);
+        }
+      }
+    }
+    if (chunk.metadata) {
+      metadata = chunk.metadata;
+    }
   }
   const content = textParts.join('');
   return {
@@ -189,6 +211,8 @@ async function assembleStreamingChatResponse(
     role: 'assistant',
     content,
     parts: content.length > 0 ? [{ type: 'text', text: content }] : [],
+    ...(toolCalls.length > 0 && { toolCalls }),
+    ...(metadata && { metadata }),
     state: 'complete',
     timestamp: new Date(),
   };
@@ -215,6 +239,34 @@ function extractStreamText(
 ): string | undefined {
   const textValue = chunk.text;
   return typeof textValue === 'function' ? textValue() : textValue;
+}
+
+function convertStreamChunk(chunk: GenerateContentResponse): TUniversalMessage | undefined {
+  const candidate = chunk.candidates?.[0];
+  if (candidate?.content?.parts && candidate.content.parts.length > 0) {
+    return convertFromGeminiResponse(chunk);
+  }
+  const usageMetadata = chunk.usageMetadata;
+  if (
+    usageMetadata &&
+    typeof usageMetadata.promptTokenCount === 'number' &&
+    typeof usageMetadata.candidatesTokenCount === 'number' &&
+    typeof usageMetadata.totalTokenCount === 'number'
+  ) {
+    return {
+      id: randomUUID(),
+      role: 'assistant',
+      content: null,
+      state: 'complete',
+      timestamp: new Date(),
+      metadata: {
+        promptTokens: usageMetadata.promptTokenCount,
+        completionTokens: usageMetadata.candidatesTokenCount,
+        totalTokens: usageMetadata.totalTokenCount,
+      },
+    };
+  }
+  return undefined;
 }
 
 /**

--- a/packages/agent-provider-gemini/src/gemini/image-request.ts
+++ b/packages/agent-provider-gemini/src/gemini/image-request.ts
@@ -1,0 +1,36 @@
+import { mapInlineImagePartsToMediaOutputs } from './image-operations';
+
+import type {
+  TUniversalMessage,
+  IChatOptions,
+  IImageGenerationResult,
+  TProviderMediaResult,
+} from '@robota-sdk/agent-core';
+
+/** Run an image generation request through the chat API. */
+export async function runImageRequest(
+  chatFn: (messages: TUniversalMessage[], options?: IChatOptions) => Promise<TUniversalMessage>,
+  messages: TUniversalMessage[],
+  model: string,
+): Promise<TProviderMediaResult<IImageGenerationResult>> {
+  try {
+    const response = await chatFn(messages, {
+      model,
+      google: { responseModalities: ['TEXT', 'IMAGE'] },
+    });
+    const outputs = mapInlineImagePartsToMediaOutputs(response.parts);
+    if (outputs.length === 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'PROVIDER_UPSTREAM_ERROR',
+          message: 'Google image response did not include image output parts.',
+        },
+      };
+    }
+    return { ok: true, value: { outputs, model } };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Google image request failed.';
+    return { ok: false, error: { code: 'PROVIDER_UPSTREAM_ERROR', message: errorMessage } };
+  }
+}

--- a/packages/agent-provider-gemini/src/gemini/provider-extended.test.ts
+++ b/packages/agent-provider-gemini/src/gemini/provider-extended.test.ts
@@ -3,6 +3,7 @@ import { GeminiProvider } from './provider';
 import type {
   IProviderNativeRawPayloadEvent,
   TUniversalMessage,
+  IAssistantMessage,
   IExecutor,
 } from '@robota-sdk/agent-core';
 
@@ -434,6 +435,69 @@ describe('GeminiProvider - chatStream', () => {
     expect(response.content).toBe('Hello Gemini');
     expect(onTextDelta).toHaveBeenNthCalledWith(1, 'Hello ');
     expect(onTextDelta).toHaveBeenNthCalledWith(2, 'Gemini');
+  });
+
+  it('preserves function calls and usage when chat assembles a streaming response', async () => {
+    generateContentStreamMock.mockResolvedValue(
+      (async function* () {
+        yield { text: 'I will check that.' };
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [{ functionCall: { id: 'call_1', name: 'lookup', args: { q: 'Gemini' } } }],
+              },
+            },
+          ],
+          usageMetadata: { promptTokenCount: 4, candidatesTokenCount: 7, totalTokenCount: 11 },
+        };
+      })(),
+    );
+    const provider = new GeminiProvider({ apiKey: 'test-key' });
+
+    const response = await provider.chat(
+      [
+        {
+          id: 'msg-1',
+          state: 'complete' as const,
+          role: 'user',
+          content: 'lookup Gemini',
+          timestamp: new Date(),
+        },
+      ],
+      { model: 'gemini-pro', onTextDelta: vi.fn() },
+    );
+
+    expect(response.content).toBe('I will check that.');
+    expect((response as IAssistantMessage).toolCalls).toEqual([
+      { id: 'call_1', type: 'function', function: { name: 'lookup', arguments: '{"q":"Gemini"}' } },
+    ]);
+    expect(response.metadata).toEqual({ promptTokens: 4, completionTokens: 7, totalTokens: 11 });
+  });
+
+  it('rejects unsupported native web tools in chat and chatStream', async () => {
+    const provider = new GeminiProvider({ apiKey: 'test-key' });
+    const messages = [
+      {
+        id: 'msg-1',
+        state: 'complete' as const,
+        role: 'user' as const,
+        content: 'search',
+        timestamp: new Date(),
+      },
+    ];
+
+    await expect(
+      provider.chat(messages, { model: 'gemini-pro', nativeWebTools: { webSearch: true } }),
+    ).rejects.toThrow('Provider gemini does not support native web search');
+    await expect(async () => {
+      for await (const _chunk of provider.chatStream(messages, {
+        model: 'gemini-pro',
+        nativeWebTools: { webFetch: true },
+      })) {
+        // consume
+      }
+    }).rejects.toThrow('Provider gemini does not support native web fetch');
   });
 
   it('emits ordered native Gemini stream chunks', async () => {

--- a/packages/agent-provider-gemini/src/gemini/provider.ts
+++ b/packages/agent-provider-gemini/src/gemini/provider.ts
@@ -4,8 +4,9 @@ import { GoogleGenAI } from '@google/genai';
 import { AbstractAIProvider } from '@robota-sdk/agent-core';
 
 import { GEMINI_CAPABILITY_TABLE } from './capability-table';
-import { executeDirect, executeDirectStream, runImageRequest } from './execution-helpers';
+import { executeDirect, executeDirectStream } from './execution-helpers';
 import { mapImageInputSourceToPart } from './image-operations';
+import { runImageRequest } from './image-request';
 
 import type { IGeminiProviderOptions } from './types';
 import type {

--- a/packages/agent-provider-gemini/src/gemini/provider.ts
+++ b/packages/agent-provider-gemini/src/gemini/provider.ts
@@ -62,6 +62,7 @@ export class GeminiProvider extends AbstractAIProvider implements IImageGenerati
     options?: IChatOptions,
   ): Promise<TUniversalMessage> {
     this.validateMessages(messages);
+    this.validateNativeWebTools(options?.nativeWebTools);
 
     if (this.executor) {
       try {
@@ -99,6 +100,7 @@ export class GeminiProvider extends AbstractAIProvider implements IImageGenerati
     options?: IChatOptions,
   ): AsyncIterable<TUniversalMessage> {
     this.validateMessages(messages);
+    this.validateNativeWebTools(options?.nativeWebTools);
     if (this.executor) {
       try {
         yield* this.executeStreamViaExecutorOrDirect(messages, options);


### PR DESCRIPTION
## Background
Gemini streaming responses were dropping function calls and usage metadata, while unsupported native web-tool requests were silently accepted.

## Summary
- preserve Gemini function calls and usage metadata across streaming responses
- reject unsupported native web-tool requests explicitly
- add provider contract documentation and regression coverage

## Verification
- `pnpm --filter @robota-sdk/agent-provider-gemini test` (152 passed)
- `pnpm --filter @robota-sdk/agent-provider-gemini build`
- local review recorded with 0 findings

The full pre-push verification was attempted and exited 137; this unresolved resource/concurrency issue is tracked by #2489. Remote CI is the final gate.