### PR TITLE
fix: preserve deterministic agreement finalization

### DIFF
--- a/.agents/skills/issue-to-backlog/SKILL.md
+++ b/.agents/skills/issue-to-backlog/SKILL.md
@@ -81,7 +81,9 @@ split.
    [`github-issue-triage`](../github-issue-triage/SKILL.md) to dry-run and finalize the handoff. P0 maps
    to Task `urgency: now`; P1 maps to `urgency: soon`; P2 must be promoted first. Finalization writes
    the exact Task ID/path back to the Issue and reads it before removing the P label. Do not implement
-   while either operation is incomplete. A Task created without an Issue does not run this step.
+   while either operation is incomplete. For several Task citations, finalize only the committed
+   AGREEMENT parent; audit requires that single exact marker and validates its declared children rather
+   than choosing by traversal order. A Task created without an Issue does not run this step.
 7. Record any finding the conversion itself produced; do not turn internal implementation steps into
    new issues unless they meet the child-issue test above.
 8. **Verify**: `task-lifecycle.mjs classify` returns `open` for each, and `pnpm harness:scan` is green.


### PR DESCRIPTION
Restore the deterministic AGREEMENT-parent finalization rule that was lost during conflict resolution of #2493. This follow-up keeps the conversion and issue-triage workflow deterministic. Local pre-push verification was attempted; the contract tier stalled alongside concurrent repository verification, so remote required CI is the authority.