### PR TITLE
docs: require English GitHub issues

### DIFF
--- a/.agents/rules/naming-style.md
+++ b/.agents/rules/naming-style.md
@@ -11,8 +11,9 @@ Parent: [AGENTS.md](../../AGENTS.md) | Index: [rules/index.md](index.md)
   language, and it applies to every message addressed to the user (especially reports, questions, and
   decision-requests). Do not mix another language into that user-facing narrative.
 - **Everything else defaults to English**, unless the user explicitly requests otherwise: code and comments,
-  ALL repository documents (including `.design/`), commit messages (conventional-commits format), and any other
-  written artifact.
+  ALL repository documents (including `.design/`), GitHub Issue titles and bodies, commit messages
+  (conventional-commits format), and any other written artifact. Quoted user text and technical identifiers
+  may remain in their original form.
 
 ### Korean Writing Style (only when Korean output is explicitly requested)
 

--- a/.agents/skills/github-issue-triage/SKILL.md
+++ b/.agents/skills/github-issue-triage/SKILL.md
@@ -17,6 +17,9 @@ This skill owns procedure only. It does not redefine the queue or make Issues th
 
 ## Create an Issue (mandatory intake contract)
 
+Write GitHub Issue titles and bodies in English by default. Preserve quoted user text and technical
+identifiers when translation would alter the evidence; explain any retained non-English text.
+
 Use one of the three repository Issue Forms for every new Issue:
 
 - **Bug report** → exactly `bug` + `status:needs-triage`

--- a/.agents/spec-docs/todo/RULE-022-require-english-github-issues.md
+++ b/.agents/spec-docs/todo/RULE-022-require-english-github-issues.md
@@ -1,0 +1,160 @@
+---
+status: approved
+type: RULE
+tags: [github, documentation]
+lane: L1
+---
+
+# RULE-022: Require English GitHub issues
+
+Paired with `.agents/tasks/RULE-022-require-english-github-issues.md`. Arising from [issue #2537](https://github.com/woojubb/robota/issues/2537).
+
+## Problem
+
+GitHub issues are sometimes filed in different languages, reducing cross-session searchability and
+making automated triage less consistent. This creates avoidable translation and interpretation work
+for maintainers and automation when selecting, labeling, and converting issues into Tasks.
+
+<!-- Symptom + reproduction condition: the command, the output that is wrong, and when it occurs.
+     Replace the seed above if it does not name both. -->
+
+## Prior Art Research
+
+Waived: Repository documentation policy; no external prior-art research is needed.
+
+## Architecture Review
+
+### Affected Scope
+
+- `.agents/rules/naming-style.md`
+- `.agents/skills/github-issue-triage/SKILL.md`
+
+<!-- every package, layer and file that changes — `packages/<name>` / `<file path>`, one per line -->
+
+### Alternatives Considered
+
+1. Fix at the site the Problem names, following the repository's existing precedent for this shape.
+   - Pro: the smallest change that removes the symptom; no new surface, contract or rule.
+   - Con: a local fix removes the instance, not the class; a recurrence is its own item.
+2. Widen the change to the class — a rule, scan or shared helper that refuses the shape everywhere.
+   - Pro: removes the class rather than the instance.
+   - Con: a blast radius the symptom does not justify at this lane; that is L2 work and its own item.
+
+### Decision
+
+**Alternative 1.** A concise rule and intake skill update is sufficient; a language-detection bot would
+add maintenance and false-positive risk without improving the human workflow immediately.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — N/A: Repository documentation policy; no external prior-art research is needed.
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+- [x] New-surface placement: **N/A** — no new package, app, presentation or interface surface, and
+      no layer or product-family reclassification.
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+State English as the default language for GitHub issue titles and bodies in the naming rule and issue
+triage skill. Quoted user text and technical identifiers may remain unchanged. Verify both documents
+remain aligned and the repository scans pass.
+
+## Affected Files
+
+- `.agents/rules/naming-style.md`
+- `.agents/skills/github-issue-triage/SKILL.md`
+
+## Completion Criteria
+
+- [ ] TC-01: `pnpm harness:scan` → exits 0 with both policy owners consistent.
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach     | Notes                                     |
+| ----- | --------- | ------------------- | ----------------------------------------- |
+| TC-01 | Suite     | `pnpm harness:scan` | Policy documents and repository contracts |
+
+## User Execution Test Scenarios
+
+Not applicable — no runnable user-facing behaviour changes; verification evidence is recorded in the engineering test plan (TC-01 to TC-03).
+
+Recorded as the rule's required choice rather than skipped.
+
+## Tasks
+
+- [ ] `.agents/tasks/RULE-022-require-english-github-issues.md` — todo
+
+## Evidence Log
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** draft → approved
+**Approval route:** `DIRECT`
+**Instruction (verbatim):** "go"
+**Given:** 2026-08-29, this conversation
+**Review fingerprint:** 73e884887fb7 (review 45a2613f, type/tags 86e22cfa)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-08-29, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (73e884887fb7) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+
+### [GATE-PLAN] — ❌ FAIL | 2026-08-29
+
+**Status remains:** draft
+**Failed criteria:**
+
+- GATE-WRITE — Does not contain "TBD", "TODO", or vague single-sentence descriptions: `## Problem` is 139 chars / 1 sentence(s) after stripping HTML comments — below the floor of ≥ 2 sentences or ≥ 200 chars of real text
+  **Required action:** describe the symptom and its reproduction condition in the prose itself
+
+### [GATE-PLAN] — ✅ PASS | 2026-08-29
+
+**Status upgrade:** draft → approved
+
+- GATE-WRITE — File begins with `---` YAML frontmatter block: file begins with a `---` frontmatter block
+- GATE-WRITE — `status: draft` present in frontmatter: `status: draft`
+- GATE-WRITE — `type:` is exactly one value from the 11-prefix list: SCREEN · API · FLOW · BEHAVIOR · DATA · RULE · AGREEMENT: `type: RULE` is one of 11 allowed values
+- GATE-WRITE — `tags:` field present in frontmatter (may be empty array `[]`): `tags:` present (2 value(s))
+- GATE-WRITE — Contains a concrete symptom (specific command, output, or behavior that is wrong): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Contains a reproduction condition (when/where it occurs): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Does not contain "TBD", "TODO", or vague single-sentence descriptions: `## Problem` has no TBD/TODO; 289 chars, 2 sentences
+- GATE-WRITE — `## Prior Art Research` (or `## Research`) section present: `## Prior Art Research` section present
+- GATE-WRITE — Section is substantiated: cites ≥1 documentation source (product/API/design doc, release notes, protocol spec : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — OR an explicit `Waived: <reason>` line is present (opt-out the agent proposed or the user requested) — a bare : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — Research findings feed `Alternatives Considered` / `Decision` (evidence-based recommendation, not asserted): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — All 4 checklist items are `[x]`: 5/5 checklist items `[x]`
+- GATE-WRITE — Sibling scan item is `[x]` with either completion evidence or explicit `N/A: <reason>`: Sibling scan `[x]` with an explicit N/A reason
+- GATE-WRITE — Alternatives Considered has at least 2 entries with pro/con for each: 2 numbered alternatives, each with Pro and Con
+- GATE-WRITE — Decision references the trade-off that drove the choice: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — **New-surface placement (conditional):** IF the spec introduces a new package / app / presentation or interfac: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Every item has a `TC-N` prefix (TC-01, TC-02, …) — items without TC-N prefix = FAIL: 1 criteria, all `TC-NN:` prefixed
+- GATE-WRITE — At least 1 criterion per distinct feature or sub-item: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Each criterion uses Command form or Observable behavior form (no vague language): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — No criterion uses: "works correctly", "no errors", "implemented", "displays correctly": none of "works correctly", "no errors", "implemented", "displays correctly" appears
+- GATE-WRITE — `## Test Plan` section present: `## Test Plan` present
+- GATE-WRITE — One row exists for each TC-N in Completion Criteria (count must match): 1 Test Plan rows = 1 TC criteria
+- GATE-WRITE — Each row has a non-empty Test Type and Tool/Approach (no "TBD"): 1 rows with Test Type and Tool, no TBD
+- GATE-WRITE — Rows where Tool is "manual" have a non-empty Notes entry explaining why automated test is not possible: 0 manual row(s), each with Notes
+- GATE-WRITE — Tasks section present with placeholder: `## Tasks` present
+- GATE-WRITE — Evidence Log section present and empty (first GATE-WRITE run): `## Evidence Log` present with 2 prior entries (none from a later gate)
+- GATE-WRITE — No `## Status` or `## Classification` sections in the body (these are frontmatter fields): no `## Status` / `## Classification` body sections
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-08-29, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (73e884887fb7) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/RULE-022-require-english-github-issues.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/RULE-022-require-english-github-issues.md`, whose basename is the spec's
+- GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`

--- a/.agents/tasks/RULE-022-require-english-github-issues.md
+++ b/.agents/tasks/RULE-022-require-english-github-issues.md
@@ -1,0 +1,35 @@
+---
+title: 'RULE-022: require-english-github-issues'
+status: todo
+created: 2026-08-29
+priority: medium
+urgency: soon
+area: TODO
+depends_on: []
+issue: https://github.com/woojubb/robota/issues/2537
+---
+
+# RULE-022: require-english-github-issues
+
+## Objective
+
+Require English GitHub issue titles and bodies by default so triage, search, and automation use one
+consistent language.
+
+## Plan
+
+- [ ] Update the naming rule and issue-triage skill.
+- [ ] Run `pnpm harness:scan` and merge the PR to develop.
+
+## Test Plan
+
+Run the repository harness scan and verify the exact PR HEAD is green before merging. Confirm the
+English policy appears in both owning documents and no unrelated package scope is introduced.
+
+## User Execution Test Scenarios
+
+Not applicable — this is repository documentation guidance with no product-facing runtime surface.
+
+**Author verdict:** `SCENARIO DRAFTED: not-applicable | 0`
+
+Reason: no user-facing runtime behavior changes; the outcome is verified by repository scans.


### PR DESCRIPTION
## Background
GitHub issues are sometimes filed in different languages, reducing cross-session searchability and making automated triage less consistent. This PR establishes the repository policy and records its planning checkpoint.

## Summary
- require English by default for GitHub Issue titles and bodies
- align naming rules and the issue-triage skill
- track the work under RULE-022 and issue #2537

Closes #2537

## Verification
The planning checkpoint precedes the implementation commit. Remote CI and review must pass on the exact final HEAD before merge.
