### PR TITLE
fix(harness): recognize an honestly staged multi-PR Task via its Plan checklist (INFRA-171)

### DIFF
--- a/.agents/evals/work-runs/e6f5e4cb-1aa0-483d-9676-8373a8a7864e/g0-r0.json
+++ b/.agents/evals/work-runs/e6f5e4cb-1aa0-483d-9676-8373a8a7864e/g0-r0.json
@@ -1,0 +1,86 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "e6f5e4cb-1aa0-483d-9676-8373a8a7864e",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "fix/task-merged-citation-plan-scope-2",
+    "baseCommit": "cac1040da69030cd04dffd122563a7c9da46ceb3",
+    "headCommit": "a5b6d80c6c8d93fef0fc11bb5cffe047bc758a3c",
+    "headTree": "81a50232982d0ccb1c1444da58a4e9286b74d152",
+    "commitOids": [
+      "cb772462fb5e35fcc95e83c8d63b6d1bab7d2926",
+      "a5b6d80c6c8d93fef0fc11bb5cffe047bc758a3c"
+    ],
+    "trailerDigest": "8c735f32274f4f6e53a56ad2e3937341697edb56b9fe96e20ebc1f238e083d4b",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L1/fix",
+    "lane": "L1",
+    "workKind": "fix"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "e6f5e4cb-1aa0-483d-9676-8373a8a7864e",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T17:09:09.175Z",
+      "data": {
+        "branch": "fix/task-merged-citation-plan-scope-2"
+      },
+      "hash": "80d6b2b76dbd4cd9046eb33e46707f4c70b7a4a0579eb890bba4c09f28112369"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e6f5e4cb-1aa0-483d-9676-8373a8a7864e",
+      "sequence": 2,
+      "previousHash": "80d6b2b76dbd4cd9046eb33e46707f4c70b7a4a0579eb890bba4c09f28112369",
+      "type": "work.bound",
+      "at": "2026-09-05T17:09:15.096Z",
+      "data": {
+        "workId": "INFRA-171",
+        "lane": "L1",
+        "workKind": "fix"
+      },
+      "hash": "7d6c21ec63885ecaab14477295c02b06b03c467b5f3a7f98582059cbc525e34d"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e6f5e4cb-1aa0-483d-9676-8373a8a7864e",
+      "sequence": 3,
+      "previousHash": "7d6c21ec63885ecaab14477295c02b06b03c467b5f3a7f98582059cbc525e34d",
+      "type": "work.started",
+      "at": "2026-09-05T17:09:15.506Z",
+      "data": {},
+      "hash": "1544e590c7294981865cd63f8120e55665995e21832e22f3f9ca3befd7a2fa14"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e6f5e4cb-1aa0-483d-9676-8373a8a7864e",
+      "sequence": 4,
+      "previousHash": "1544e590c7294981865cd63f8120e55665995e21832e22f3f9ca3befd7a2fa14",
+      "type": "work.ready",
+      "at": "2026-09-05T17:10:04.892Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "fc6dded39ceb0f4ebb0c0f3d583174ce0b79673bd557145dfa743866c7dd19ff"
+    }
+  ],
+  "durations": {
+    "wallMs": 55717,
+    "activeMs": 55717,
+    "pausedMs": 0,
+    "phases": {}
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T17:09:09.175Z",
+    "readyAt": "2026-09-05T17:10:04.892Z"
+  }
+}

--- a/.agents/spec-docs/todo/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md
+++ b/.agents/spec-docs/todo/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md
@@ -1,0 +1,166 @@
+---
+status: approved
+type: INFRA
+tags: [infra]
+lane: L1
+---
+
+# INFRA-171: task-merged-citation recognizes an honestly staged multi-PR Task via its Plan checklist
+
+Paired with `.agents/tasks/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md`. Arising from [issue #2586](https://github.com/woojubb/robota/issues/2586).
+
+## Problem
+
+`scan-task-merged-citation.mjs` fails on `develop` under `--context integration`: STRUCT-012
+(`.agents/tasks/STRUCT-012-refactor-the-transport-family-onto-its-name-hierarchy.md`) is a large,
+owner-directed, five-unit (S1–S5) refactor. S1 and S2 are complete and merged; S3–S5 are not started,
+and the owner explicitly directed stopping after the S2 delivery until they resume. The `in-progress`
+status is accurate. The scan's own header comment anticipates a Task spanning several pull requests,
+but its only mechanism for one — `LEGACY_BASELINE` — is explicitly closed to new entries ("Records
+already in this state when the scan was adopted... No additions."), so an honestly staged task has no
+way to stay green short of lying about its status or landing every unit in one shot.
+
+<!-- Symptom + reproduction condition: the command, the output that is wrong, and when it occurs.
+     Replace the seed above if it does not name both. -->
+
+## Prior Art Research
+
+Waived: internal harness script fix with no contract change; the remedy is the repository's own precedent (this fix's rationale is Task INFRA-171)
+
+## Architecture Review
+
+### Affected Scope
+
+- `scripts/harness/scan-task-merged-citation.mjs`
+
+### Alternatives Considered
+
+1. Fix at the site the Problem names, following the repository's existing precedent for this shape.
+   - Pro: the smallest change that removes the symptom; no new surface, contract or rule.
+   - Con: a local fix removes the instance, not the class; a recurrence is its own item.
+2. Widen the change to the class — a rule, scan or shared helper that refuses the shape everywhere.
+   - Pro: removes the class rather than the instance.
+   - Con: a blast radius the symptom does not justify at this lane; that is L2 work and its own item.
+
+### Decision
+
+**Alternative 1.** The repository already tags which unit a commit delivers (`(STRUCT-012 S1)`) and
+already tracks completed units in the Task's own Plan checklist (`- [x] S1`); reading both at the one
+site that currently over-flags is the smallest change, and needs no new declaration or baseline
+grammar.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — N/A: internal harness script fix with no contract change; the remedy is the repository's own precedent (this fix's rationale is Task INFRA-171)
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+- [x] New-surface placement: **N/A** — no new package, app, presentation or interface surface, and
+      no layer or product-family reclassification.
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+Apply the fix at the site the Problem names, following the repository's existing precedent for
+this shape, and add the test TC-01 names so the symptom is refused mechanically from then on.
+
+## Affected Files
+
+- `scripts/harness/scan-task-merged-citation.mjs`
+
+## Completion Criteria
+
+- [x] TC-01: `pnpm exec vitest run scripts/harness/__tests__/scan-task-merged-citation.test.mjs` →
+      exits 0; the three new reconciliation cases fail with the fix reverted (red-proof).
+- [x] TC-02: `node scripts/harness/run-all-scans.mjs --affected --context pr --skip dist --skip build-contracts` → exits 0
+- [x] TC-03: `node scripts/harness/scan-task-merged-citation.mjs` on this clone → exits 0, STRUCT-012
+      does not appear in findings, and the 16-record frozen-baseline notice is unchanged.
+
+## Test Plan
+
+| TC-ID | Test Type   | Tool / Approach                                                           | Notes                                             |
+| ----- | ----------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
+| TC-01 | Unit        | `vitest run scripts/harness/__tests__/scan-task-merged-citation.test.mjs` | RED with the fix reverted, GREEN with it          |
+| TC-02 | Suite       | `run-all-scans.mjs --affected --context pr`                               | Regression — the affected set, not the full suite |
+| TC-03 | Integration | `node scripts/harness/scan-task-merged-citation.mjs`                      | Real-history regression proof on develop          |
+
+## User Execution Test Scenarios
+
+Not applicable — no runnable user-facing behaviour changes; verification evidence is recorded in the engineering test plan (TC-01 to TC-03).
+
+Recorded as the rule's required choice rather than skipped.
+
+## Tasks
+
+- [ ] `.agents/tasks/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md` — todo
+
+## Evidence Log
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-09-05
+
+**Status upgrade:** draft → approved
+**Approval route:** `CLASS`
+**Class:** `LANE-L0-L1`
+**Instruction (verbatim):** "좋아 모두 승인한다. 빠르게 적용해줘. 필요하면 병렬 에이전트와 workflow를 적극 적용해줘"
+**Given:** 2026-09-05, this conversation
+**Evidence condition met:** `node scripts/harness/scan-lane-declaration.mjs --changed <12 path(s)> --diff-file <diff vs origin/develop> --trailers-file <Lane: L1>` over 12 changed path(s) — committed and working-tree changes vs origin/develop (merge base aa2271fab6c7) → exit 0, `lane-declaration summary: violations=0 result=PASS` (Lane L1 (spec-doc frontmatter .agents/spec-docs/draft/INFRA-169-loop-run-close-refuses-without-ref-for-the-subject-bound-user-execution-scenario.md) is at or above the floor L1)
+**Review fingerprint:** 60a50ea8f311 (review ab8de71f, type/tags 2433998c)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route CLASS, so the Route DIRECT criterion does not apply
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route CLASS, class registered before the approval date
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route CLASS, class registered before the approval date
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route CLASS; evidence condition recorded as a measurement (`node scripts/harness/scan-lane-declaration.mjs --changed <1)
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (60a50ea8f311) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+
+**Judged at:** HEAD `aa2271fab6c7` · base `origin/develop@aa2271fab6c7` · document `.agents/spec-docs/draft/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md` blob `ccb64222fad7` (untracked)
+
+### [GATE-PLAN] — ✅ PASS | 2026-09-05
+
+**Status upgrade:** draft → approved
+
+- GATE-WRITE — File begins with `---` YAML frontmatter block: file begins with a `---` frontmatter block
+- GATE-WRITE — `status: draft` present in frontmatter: `status: draft`
+- GATE-WRITE — `type:` is exactly one value from the 11-prefix list: SCREEN · API · FLOW · BEHAVIOR · DATA · RULE · AGREEMENT: `type: INFRA` is one of 11 allowed values
+- GATE-WRITE — `tags:` field present in frontmatter (may be empty array `[]`): `tags:` present (1 value(s))
+- GATE-WRITE — Contains a concrete symptom (specific command, output, or behavior that is wrong): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Contains a reproduction condition (when/where it occurs): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Does not contain "TBD", "TODO", or vague single-sentence descriptions: `## Problem` has no TBD/TODO; 781 chars, 5 sentences
+- GATE-WRITE — `## Prior Art Research` (or `## Research`) section present: `## Prior Art Research` section present
+- GATE-WRITE — Section is substantiated: cites ≥1 documentation source (product/API/design doc, release notes, protocol spec : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — OR an explicit `Waived: <reason>` line is present (opt-out the agent proposed or the user requested) — a bare : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — Research findings feed `Alternatives Considered` / `Decision` (evidence-based recommendation, not asserted): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — All 4 checklist items are `[x]`: 5/5 checklist items `[x]`
+- GATE-WRITE — Sibling scan item is `[x]` with either completion evidence or explicit `N/A: <reason>`: Sibling scan `[x]` with an explicit N/A reason
+- GATE-WRITE — Alternatives Considered has at least 2 entries with pro/con for each: 2 numbered alternatives, each with Pro and Con
+- GATE-WRITE — Decision references the trade-off that drove the choice: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — **New-surface placement (conditional):** IF the spec introduces a new package / app / presentation or interfac: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Every item has a `TC-N` prefix (TC-01, TC-02, …) — items without TC-N prefix = FAIL: 3 criteria, all `TC-NN:` prefixed
+- GATE-WRITE — At least 1 criterion per distinct feature or sub-item: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Each criterion uses Command form or Observable behavior form (no vague language): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — No criterion uses: "works correctly", "no errors", "implemented", "displays correctly": none of "works correctly", "no errors", "implemented", "displays correctly" appears
+- GATE-WRITE — `## Test Plan` section present: `## Test Plan` present
+- GATE-WRITE — One row exists for each TC-N in Completion Criteria (count must match): 3 Test Plan rows = 3 TC criteria
+- GATE-WRITE — Each row has a non-empty Test Type and Tool/Approach (no "TBD"): 3 rows with Test Type and Tool, no TBD
+- GATE-WRITE — Rows where Tool is "manual" have a non-empty Notes entry explaining why automated test is not possible: 0 manual row(s), each with Notes
+- GATE-WRITE — Tasks section present with placeholder: `## Tasks` present
+- GATE-WRITE — Evidence Log section present and empty (first GATE-WRITE run): `## Evidence Log` present with 1 prior entry (none from a later gate)
+- GATE-WRITE — No `## Status` or `## Classification` sections in the body (these are frontmatter fields): no `## Status` / `## Classification` body sections
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route CLASS, so the Route DIRECT criterion does not apply
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route CLASS, class registered before the approval date
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route CLASS, class registered before the approval date
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route CLASS; evidence condition recorded as a measurement (`node scripts/harness/scan-lane-declaration.mjs --changed <1)
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (60a50ea8f311) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md`, whose basename is the spec's
+- GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`
+
+**Judged at:** HEAD `aa2271fab6c7` · base `origin/develop@aa2271fab6c7` · document `.agents/spec-docs/draft/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md` blob `61c45a823616` (untracked)

--- a/.agents/tasks/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md
+++ b/.agents/tasks/INFRA-171-task-merged-citation-recognizes-an-honestly-staged-multi-pr-task-via-its-plan-ch.md
@@ -1,0 +1,73 @@
+---
+title: 'INFRA-171: task-merged-citation recognizes an honestly staged multi-PR Task via its Plan checklist'
+issue: https://github.com/woojubb/robota/issues/2586
+status: todo
+created: 2026-09-05
+priority: medium
+urgency: soon
+area:
+  - scripts/harness/scan-task-merged-citation.mjs
+depends_on: []
+---
+
+# INFRA-171: task-merged-citation recognizes an honestly staged multi-PR Task via its Plan checklist
+
+## Objective
+
+`scan-task-merged-citation.mjs` fails on `develop` under `--context integration`: STRUCT-012
+(`.agents/tasks/STRUCT-012-refactor-the-transport-family-onto-its-name-hierarchy.md`) is a large,
+owner-directed, five-unit (S1–S5) refactor. S1 and S2 are complete and merged; S3–S5 are not started,
+and the owner explicitly directed stopping after the S2 delivery until they resume. The `in-progress`
+status is accurate. The scan's own header comment anticipates a Task spanning several pull requests,
+but its only mechanism for one — `LEGACY_BASELINE` — is explicitly closed to new entries ("Records
+already in this state when the scan was adopted... No additions."), so an honestly staged task has no
+way to stay green short of lying about its status or landing every unit in one shot.
+
+The repository's own convention already tags which unit a commit delivers — the merged commit reads
+`feat(harness): arm the name-derived FAMILY-SIBLINGS dependency gate (STRUCT-012 S1)` — and the Task's
+own Plan checklist already marks that unit `- [x] S1 — ...`. The fix teaches the scanner to read both:
+a delivering commit citing a Plan unit the record itself already marks complete is staged, honest
+progress, not a premature-completion claim, and does not reconcile as a finding. A commit citing the
+bare ID with no unit suffix, or a unit still unchecked, is unaffected and still reconciles (issue
+#2586).
+
+## Plan
+
+- [x] Add `citedUnitOf(subject, id)` — the unit token cited alongside a work-item ID inside its own
+      parenthetical (`S1` in `(STRUCT-012 S1)`), null for a bare-ID or outside-parens citation.
+- [x] Add `completedPlanUnits(content)` — the set of unit tokens a Task's own body marks `- [x]`.
+- [x] In `findTaskMergedCitationFindings`, filter `delivering` commits down to `unreconciled` ones
+      whose cited unit (if any) is not already in the record's `completedPlanUnits`, and report only
+      those.
+- [x] Add fixture tests: a completed-unit citation does not reconcile; a still-unchecked-unit citation
+      still reconciles; a bare-ID citation (no unit suffix) still reconciles; direct unit tests for
+      `citedUnitOf` and `completedPlanUnits`.
+- [x] Run the real scan against this clone and confirm STRUCT-012 no longer appears in findings while
+      the 16 pre-existing frozen-baseline notices are unaffected.
+
+## Completion Criteria
+
+- TC-01: Command — `pnpm exec vitest run scripts/harness/__tests__/scan-task-merged-citation.test.mjs`
+  — all tests (existing 6 plus the 4 new ones) pass.
+- TC-02: Command — `node scripts/harness/scan-task-merged-citation.mjs` on this clone — exits 0,
+  reports `task-merged-citation scan passed.`, and the 16 frozen-baseline notice is unchanged.
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach                                                           | Notes                                    |
+| ----- | --------- | ------------------------------------------------------------------------- | ---------------------------------------- |
+| TC-01 | automated | `vitest run scripts/harness/__tests__/scan-task-merged-citation.test.mjs` | red-first: completed/uncompleted/bare-ID |
+| TC-02 | automated | `node scripts/harness/scan-task-merged-citation.mjs`                      | real-history regression proof on develop |
+
+## User Execution Test Scenarios
+
+<!-- backlog-execution.md § User Execution Test Scenario Rule. Outcome is one of
+     not-applicable | automatable | manual; the count is the number of scenarios drafted. Keep the
+     not-applicable form ONLY with a product-surface reason (≥ 50 characters, not build/typecheck
+     evidence); otherwise write the scenario a user can run and raise the count. -->
+
+**Author verdict:** `SCENARIO DRAFTED: not-applicable | 0`
+
+**Reason:** This is a repository integration scan judging commit history against Task records, not a
+product surface. No end user runs it; only the harness's own CI mirror and `pnpm harness:scan` do, and
+the corrected behavior is exercised by the fixture tests and the real-history run above.

--- a/scripts/harness/__tests__/scan-task-merged-citation.test.mjs
+++ b/scripts/harness/__tests__/scan-task-merged-citation.test.mjs
@@ -7,7 +7,9 @@ import { makeTemp } from './make-temp.mjs';
 
 import { SCAN_COMMANDS, advisoryScanNames } from '../run-all-scans.mjs';
 import {
+  citedUnitOf,
   citesWorkItem,
+  completedPlanUnits,
   deliversOutsideRecords,
   examinedCommitCount,
   examinedRecordCount,
@@ -19,10 +21,11 @@ import {
 function workspace(records) {
   const root = makeTemp('task-merged-citation-');
   mkdirSync(path.join(root, '.agents/tasks/completed'), { recursive: true });
-  for (const [name, status] of Object.entries(records)) {
+  for (const [name, spec] of Object.entries(records)) {
+    const { status, body = '# record\n' } = typeof spec === 'string' ? { status: spec } : spec;
     writeFileSync(
       path.join(root, '.agents/tasks', name),
-      `---\nid: ${workItemIdOf(path.basename(name)) ?? 'X-0'}\nstatus: ${status}\n---\n# record\n`,
+      `---\nid: ${workItemIdOf(path.basename(name)) ?? 'X-0'}\nstatus: ${status}\n---\n${body}`,
       'utf8',
     );
   }
@@ -107,6 +110,66 @@ describe('task-merged-citation (issue #2186)', () => {
     expect(findings).toEqual([]);
     expect(notices.some((n) => /GONE-1 no longer fires/.test(n))).toBe(true);
     expect(notices.some((n) => /1 frozen record\(s\) still cited.*ARCH-100/.test(n))).toBe(true);
+  });
+
+  it('reads the unit token cited alongside an ID, and the units a record marks complete', () => {
+    expect(citedUnitOf('feat(harness): arm the gate (STRUCT-012 S1)', 'STRUCT-012')).toBe('S1');
+    expect(citedUnitOf('feat: STRUCT-012 done', 'STRUCT-012')).toBe(null);
+    expect(completedPlanUnits('## Plan\n\n- [x] S1 — a\n- [ ] S2 — b\n')).toEqual(new Set(['S1']));
+    expect(completedPlanUnits('# record\n')).toEqual(new Set());
+  });
+
+  it('does not mistake a `- [x]` line outside the Plan section for a completed unit', () => {
+    const body =
+      '## Plan\n\n- [ ] S1 — not done\n\n## Completion Criteria\n\n- [x] S1 — CI green\n';
+    expect(completedPlanUnits(body)).toEqual(new Set());
+  });
+
+  it('a delivering commit citing an already-completed Plan unit does not reconcile as a finding', () => {
+    const root = workspace({
+      'STRUCT-012-x.md': {
+        status: 'in-progress',
+        body: '# record\n\n## Plan\n\n- [x] S1 — done\n- [ ] S2 — not done\n',
+      },
+    });
+    const findings = findTaskMergedCitationFindings(root, {
+      ref: 'develop',
+      commits: [{ sha: 'aaaaaaaaa1', subject: 'feat(harness): arm the gate (STRUCT-012 S1)' }],
+      changedPaths: () => ['packages/x/src/a.ts'],
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it('a delivering commit citing a Plan unit still unchecked still reconciles as a finding', () => {
+    const root = workspace({
+      'STRUCT-012-x.md': {
+        status: 'in-progress',
+        body: '# record\n\n## Plan\n\n- [x] S1 — done\n- [ ] S2 — not done\n',
+      },
+    });
+    const findings = findTaskMergedCitationFindings(root, {
+      ref: 'develop',
+      commits: [
+        { sha: 'aaaaaaaaa1', subject: 'feat(harness): wire the next stage (STRUCT-012 S2)' },
+      ],
+      changedPaths: () => ['packages/x/src/a.ts'],
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('a delivering commit citing the bare ID with no unit suffix still reconciles as a finding', () => {
+    const root = workspace({
+      'STRUCT-012-x.md': {
+        status: 'in-progress',
+        body: '# record\n\n## Plan\n\n- [x] S1 — done\n',
+      },
+    });
+    const findings = findTaskMergedCitationFindings(root, {
+      ref: 'develop',
+      commits: [{ sha: 'aaaaaaaaa1', subject: 'feat(harness): STRUCT-012 done' }],
+      changedPaths: () => ['packages/x/src/a.ts'],
+    });
+    expect(findings).toHaveLength(1);
   });
 
   it('does not read archived records', () => {

--- a/scripts/harness/scan-task-merged-citation.mjs
+++ b/scripts/harness/scan-task-merged-citation.mjs
@@ -81,6 +81,41 @@ export function deliversOutsideRecords(changedPaths) {
   return changedPaths.some((file) => !file.startsWith(RECORD_PREFIX));
 }
 
+/**
+ * The unit token cited alongside a work-item ID inside its own parenthetical — `S1` in a subject
+ * citing `(STRUCT-012 S1)` — or null when the citation names only the bare ID, or names it outside
+ * parens (prose like "STRUCT-012 done" is not a unit citation). Lets a staged, multi-PR Task tag
+ * which of its own Plan units a commit delivers, instead of every delivering commit reading as the
+ * whole item.
+ */
+export function citedUnitOf(subject, id) {
+  const match = new RegExp(`\\(${escapeRegExp(id)}\\s+([A-Za-z][A-Za-z0-9]*)\\)`).exec(subject);
+  return match ? match[1] : null;
+}
+
+/** The `## Plan` section body of a Task record, or '' when the record has none. */
+function planSectionOf(content) {
+  const heading = /^## Plan\s*$/m.exec(content);
+  if (heading === null) return '';
+  const start = heading.index + heading[0].length;
+  const next = content.indexOf('\n## ', start);
+  return content.slice(start, next === -1 ? content.length : next);
+}
+
+/**
+ * Unit tokens a Task record's own `## Plan` section marks complete — `S1` from a `- [x] S1 — ...`
+ * line. Scoped to that section so a `- [x]` line elsewhere in the record (Completion Criteria, Test
+ * Plan) is never mistaken for a staged unit. A record with no such lines (the common case — most
+ * Tasks are not staged into named units) yields an empty set, so `citedUnitOf` returning non-null
+ * against it still reconciles nothing.
+ */
+export function completedPlanUnits(content) {
+  const units = new Set();
+  const lineRe = /^- \[x\] ([A-Za-z][A-Za-z0-9]*)\b/gm;
+  for (const match of planSectionOf(content).matchAll(lineRe)) units.add(match[1]);
+  return units;
+}
+
 function git(root, args) {
   const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
   if (result.status !== 0) {
@@ -158,6 +193,7 @@ export function findTaskMergedCitationFindings(root = WORKSPACE_ROOT, io = {}) {
   const changedPaths = io.changedPaths ?? ((sha) => changedPathsOf(root, sha));
   const legacy = io.legacy ?? legacyReconcilePending(root);
   const notices = io.notices ?? [];
+  const taskContent = io.taskContent ?? ((file) => readFileSync(path.join(root, file), 'utf8'));
   const records = openTaskRecords(root);
   examinedRecords = records.length;
   examinedCommits = commits.length;
@@ -172,7 +208,15 @@ export function findTaskMergedCitationFindings(root = WORKSPACE_ROOT, io = {}) {
       stillPending.add(record.id);
       continue;
     }
-    const named = delivering
+    // A commit citing a Plan unit the record itself already marks `[x]` complete is a staged,
+    // honestly multi-PR delivery — not a premature-completion claim — and does not reconcile.
+    const completedUnits = completedPlanUnits(taskContent(record.file));
+    const unreconciled = delivering.filter((commit) => {
+      const unit = citedUnitOf(commit.subject, record.id);
+      return unit === null || !completedUnits.has(unit);
+    });
+    if (unreconciled.length === 0) continue;
+    const named = unreconciled
       .slice(0, 3)
       .map((commit) => `${commit.sha.slice(0, 9)} ${commit.subject}`)
       .join('; ');
@@ -180,9 +224,9 @@ export function findTaskMergedCitationFindings(root = WORKSPACE_ROOT, io = {}) {
       file: record.file,
       type: 'task-merged-citation',
       detail:
-        `${record.id} is \`${record.status ?? '(no status)'}\` but ${delivering.length} commit(s) ` +
+        `${record.id} is \`${record.status ?? '(no status)'}\` but ${unreconciled.length} commit(s) ` +
         `merged to ${ref} cite it and deliver outside ${RECORD_PREFIX}: ${named}` +
-        `${delivering.length > 3 ? '; …' : ''} — reconcile the record (a citation is not proof ` +
+        `${unreconciled.length > 3 ? '; …' : ''} — reconcile the record (a citation is not proof ` +
         'of completion: the item may span more pull requests).',
     });
   }


### PR DESCRIPTION
## Background

`scan-task-merged-citation.mjs` had no way to represent an honestly staged, multi-PR Task short of
lying about status or landing every unit in one shot. STRUCT-012 is a large, owner-directed,
five-unit refactor: S1 and S2 are complete and merged, S3-S5 are not started, and the owner directed
stopping after S2 until they resume. The `in-progress` status is accurate, but the scan's only prior
mechanism for this, `LEGACY_BASELINE`, is explicitly closed to new entries — so the scan is red on
`develop` for STRUCT-012 (issue #2586).

## Fix

The repository's own convention already tags which unit a commit delivers (`(STRUCT-012 S1)`), and
the Task's own Plan checklist already marks that unit `- [x]`. Teach the scanner to read both: a
delivering commit citing a Plan unit the record's own `## Plan` section already marks complete is
staged, honest progress — not a premature-completion claim — and does not reconcile as a finding. A
commit citing the bare ID with no unit suffix, a unit still unchecked, or a `- [x]` line outside the
`## Plan` section (Completion Criteria, Test Plan) is unaffected and still reconciles.

## Test plan

- [x] `pnpm exec vitest run scripts/harness/__tests__/scan-task-merged-citation.test.mjs` — 11/11 pass
- [x] `node scripts/harness/scan-task-merged-citation.mjs` — passes, 16 frozen-baseline notice unchanged
- [x] `node scripts/harness/scan-file-size.mjs` — passes
- [x] `pnpm harness:pre-push` — 57 scans passed, 2 advisory (non-blocking in PR context)

Work-Run: e6f5e4cb-1aa0-483d-9676-8373a8a7864e
