### PR TITLE
docs(infra-171): plan develop direct integration policy

### DIFF
--- a/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g0-r0.json
+++ b/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g0-r0.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "chore/plan-infra-171",
+    "baseCommit": "cac1040da69030cd04dffd122563a7c9da46ceb3",
+    "headCommit": "f0a485a8296bc77c55af808c4c059bedd2ab437a",
+    "headTree": "8204dbf1061177ec00b299898d5a6686ed317483",
+    "commitOids": ["f0a485a8296bc77c55af808c4c059bedd2ab437a"],
+    "trailerDigest": "9e67720393916c97783f490f82b8fa8a29eaf488ce5072c37b35a03f92fb661a",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T17:21:40.903Z",
+      "data": {
+        "branch": "chore/plan-infra-171"
+      },
+      "hash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 2,
+      "previousHash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a",
+      "type": "work.bound",
+      "at": "2026-09-05T17:21:41.663Z",
+      "data": {
+        "workId": "INFRA-171",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 3,
+      "previousHash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad",
+      "type": "work.started",
+      "at": "2026-09-05T17:21:42.133Z",
+      "data": {},
+      "hash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 4,
+      "previousHash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e",
+      "type": "phase.started",
+      "at": "2026-09-05T17:21:42.601Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 5,
+      "previousHash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1",
+      "type": "phase.completed",
+      "at": "2026-09-05T17:21:43.050Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 6,
+      "previousHash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c",
+      "type": "work.ready",
+      "at": "2026-09-05T17:21:59.085Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6"
+    }
+  ],
+  "durations": {
+    "wallMs": 18182,
+    "activeMs": 18182,
+    "pausedMs": 0,
+    "phases": {
+      "planning": 449
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T17:21:40.903Z",
+    "readyAt": "2026-09-05T17:21:59.085Z"
+  }
+}

--- a/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g0-r1.json
+++ b/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g0-r1.json
@@ -1,0 +1,140 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+  "generation": 0,
+  "revision": 1,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "chore/plan-infra-171",
+    "baseCommit": "cac1040da69030cd04dffd122563a7c9da46ceb3",
+    "headCommit": "67cc9964b26eac9b89ddd651865ceb5df0bf772b",
+    "headTree": "910f99fb25b32333c7d0572f7966b596b9425f62",
+    "commitOids": [
+      "f0a485a8296bc77c55af808c4c059bedd2ab437a",
+      "d820faf82df03ce299ed60fcf4d017b3439e975b",
+      "67cc9964b26eac9b89ddd651865ceb5df0bf772b"
+    ],
+    "trailerDigest": "88b40fd2ad6071ed8e48e6522c09c5bd35dfd3cc4c31bd09143729cc32500a98",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T17:21:40.903Z",
+      "data": {
+        "branch": "chore/plan-infra-171"
+      },
+      "hash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 2,
+      "previousHash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a",
+      "type": "work.bound",
+      "at": "2026-09-05T17:21:41.663Z",
+      "data": {
+        "workId": "INFRA-171",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 3,
+      "previousHash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad",
+      "type": "work.started",
+      "at": "2026-09-05T17:21:42.133Z",
+      "data": {},
+      "hash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 4,
+      "previousHash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e",
+      "type": "phase.started",
+      "at": "2026-09-05T17:21:42.601Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 5,
+      "previousHash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1",
+      "type": "phase.completed",
+      "at": "2026-09-05T17:21:43.050Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 6,
+      "previousHash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c",
+      "type": "work.ready",
+      "at": "2026-09-05T17:21:59.085Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 7,
+      "previousHash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6",
+      "type": "work.reopened",
+      "at": "2026-09-05T17:24:38.603Z",
+      "data": {
+        "ground": "local-fix",
+        "generation": 0,
+        "revision": 1
+      },
+      "hash": "2ba4e7ed7ea85dd6349246c28c93dd0cda17dc77e6e6fad46cdbe0a010e54af2"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 8,
+      "previousHash": "2ba4e7ed7ea85dd6349246c28c93dd0cda17dc77e6e6fad46cdbe0a010e54af2",
+      "type": "work.ready",
+      "at": "2026-09-05T17:24:44.694Z",
+      "data": {
+        "generation": 0,
+        "revision": 1
+      },
+      "hash": "35ed90e062b5bedc23b4479b464f4e0db7b5e430a516dd955103686006a01539"
+    }
+  ],
+  "durations": {
+    "wallMs": 183791,
+    "activeMs": 183791,
+    "pausedMs": 0,
+    "phases": {
+      "planning": 449
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T17:21:40.903Z",
+    "readyAt": "2026-09-05T17:24:44.694Z"
+  }
+}

--- a/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g0-r2.json
+++ b/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g0-r2.json
@@ -1,0 +1,169 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+  "generation": 0,
+  "revision": 2,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "chore/plan-infra-171",
+    "baseCommit": "cac1040da69030cd04dffd122563a7c9da46ceb3",
+    "headCommit": "d14d3574299d7e282ff5760b2c919111310160ed",
+    "headTree": "a01048ebe1c97bdf1a86fab6860cfae6a2d2ff45",
+    "commitOids": [
+      "f0a485a8296bc77c55af808c4c059bedd2ab437a",
+      "d820faf82df03ce299ed60fcf4d017b3439e975b",
+      "67cc9964b26eac9b89ddd651865ceb5df0bf772b",
+      "2a1a40e220864c728b34c7a067531fe06c2518c7",
+      "d14d3574299d7e282ff5760b2c919111310160ed"
+    ],
+    "trailerDigest": "b063751975b2e08079a177371cf76a989f835ea1d273c922e598a4dcb6c489d5",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T17:21:40.903Z",
+      "data": {
+        "branch": "chore/plan-infra-171"
+      },
+      "hash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 2,
+      "previousHash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a",
+      "type": "work.bound",
+      "at": "2026-09-05T17:21:41.663Z",
+      "data": {
+        "workId": "INFRA-171",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 3,
+      "previousHash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad",
+      "type": "work.started",
+      "at": "2026-09-05T17:21:42.133Z",
+      "data": {},
+      "hash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 4,
+      "previousHash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e",
+      "type": "phase.started",
+      "at": "2026-09-05T17:21:42.601Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 5,
+      "previousHash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1",
+      "type": "phase.completed",
+      "at": "2026-09-05T17:21:43.050Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 6,
+      "previousHash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c",
+      "type": "work.ready",
+      "at": "2026-09-05T17:21:59.085Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 7,
+      "previousHash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6",
+      "type": "work.reopened",
+      "at": "2026-09-05T17:24:38.603Z",
+      "data": {
+        "ground": "local-fix",
+        "generation": 0,
+        "revision": 1
+      },
+      "hash": "2ba4e7ed7ea85dd6349246c28c93dd0cda17dc77e6e6fad46cdbe0a010e54af2"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 8,
+      "previousHash": "2ba4e7ed7ea85dd6349246c28c93dd0cda17dc77e6e6fad46cdbe0a010e54af2",
+      "type": "work.ready",
+      "at": "2026-09-05T17:24:44.694Z",
+      "data": {
+        "generation": 0,
+        "revision": 1
+      },
+      "hash": "35ed90e062b5bedc23b4479b464f4e0db7b5e430a516dd955103686006a01539"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 9,
+      "previousHash": "35ed90e062b5bedc23b4479b464f4e0db7b5e430a516dd955103686006a01539",
+      "type": "work.reopened",
+      "at": "2026-09-05T17:26:45.509Z",
+      "data": {
+        "ground": "local-fix",
+        "generation": 0,
+        "revision": 2
+      },
+      "hash": "b8eb6727ea1880d2acdd0958daa6fafdb5a397ee3aac2282bc83e831d28954b9"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 10,
+      "previousHash": "b8eb6727ea1880d2acdd0958daa6fafdb5a397ee3aac2282bc83e831d28954b9",
+      "type": "work.ready",
+      "at": "2026-09-05T17:27:00.278Z",
+      "data": {
+        "generation": 0,
+        "revision": 2
+      },
+      "hash": "6adce6856dfc72177408aac80bfcc9615e8619da2f387d118ea80246e4e42a4f"
+    }
+  ],
+  "durations": {
+    "wallMs": 319375,
+    "activeMs": 319375,
+    "pausedMs": 0,
+    "phases": {
+      "planning": 449
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T17:21:40.903Z",
+    "readyAt": "2026-09-05T17:27:00.278Z"
+  }
+}

--- a/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g1-r0.json
+++ b/.agents/evals/work-runs/7dae5672-b9e6-4936-a1c3-d3a5eb046e0a/g1-r0.json
@@ -1,0 +1,225 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+  "generation": 1,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "chore/plan-infra-171",
+    "baseCommit": "cac1040da69030cd04dffd122563a7c9da46ceb3",
+    "headCommit": "098c49a25c0b7d43a32487beca0c340363abdb56",
+    "headTree": "51c0cd7307e5d1335d0e0449c6b775b4ae2839d1",
+    "commitOids": [
+      "f0a485a8296bc77c55af808c4c059bedd2ab437a",
+      "d820faf82df03ce299ed60fcf4d017b3439e975b",
+      "67cc9964b26eac9b89ddd651865ceb5df0bf772b",
+      "2a1a40e220864c728b34c7a067531fe06c2518c7",
+      "d14d3574299d7e282ff5760b2c919111310160ed",
+      "c5421ebd3dda75086c427429fc5e985343ab24ae",
+      "098c49a25c0b7d43a32487beca0c340363abdb56"
+    ],
+    "trailerDigest": "3a5b3714442b64c3f1f563498cb43d81b9175987758152b4af850cb4b3e2235e",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T17:21:40.903Z",
+      "data": {
+        "branch": "chore/plan-infra-171"
+      },
+      "hash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 2,
+      "previousHash": "4441a1b1ba4d9c6b658f0fedd9ba89698c0520a308649c0893a69061aebb391a",
+      "type": "work.bound",
+      "at": "2026-09-05T17:21:41.663Z",
+      "data": {
+        "workId": "INFRA-171",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 3,
+      "previousHash": "d4d6b11553482a2d4b80c5235ba2fbeff6b4043f216a22f836319e650d4b40ad",
+      "type": "work.started",
+      "at": "2026-09-05T17:21:42.133Z",
+      "data": {},
+      "hash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 4,
+      "previousHash": "196eef13d69cc174c54a140f19cdabc223af61bc821dc519489582df6127fd3e",
+      "type": "phase.started",
+      "at": "2026-09-05T17:21:42.601Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 5,
+      "previousHash": "e5ec76fb90898bd72d8f30b600cf982da277c70d44cd15ceab0de3e9c7cf92c1",
+      "type": "phase.completed",
+      "at": "2026-09-05T17:21:43.050Z",
+      "data": {
+        "phase": "planning"
+      },
+      "hash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 6,
+      "previousHash": "4aac812b860597286a3d5287c591d1edca26cf59c39d7fffdba59d005bafdb4c",
+      "type": "work.ready",
+      "at": "2026-09-05T17:21:59.085Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 7,
+      "previousHash": "dc0983d2f2a0db566ef88490de722c4bd21f6fd6f195f7c2c63265b9634b02c6",
+      "type": "work.reopened",
+      "at": "2026-09-05T17:24:38.603Z",
+      "data": {
+        "ground": "local-fix",
+        "generation": 0,
+        "revision": 1
+      },
+      "hash": "2ba4e7ed7ea85dd6349246c28c93dd0cda17dc77e6e6fad46cdbe0a010e54af2"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 8,
+      "previousHash": "2ba4e7ed7ea85dd6349246c28c93dd0cda17dc77e6e6fad46cdbe0a010e54af2",
+      "type": "work.ready",
+      "at": "2026-09-05T17:24:44.694Z",
+      "data": {
+        "generation": 0,
+        "revision": 1
+      },
+      "hash": "35ed90e062b5bedc23b4479b464f4e0db7b5e430a516dd955103686006a01539"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 9,
+      "previousHash": "35ed90e062b5bedc23b4479b464f4e0db7b5e430a516dd955103686006a01539",
+      "type": "work.reopened",
+      "at": "2026-09-05T17:26:45.509Z",
+      "data": {
+        "ground": "local-fix",
+        "generation": 0,
+        "revision": 2
+      },
+      "hash": "b8eb6727ea1880d2acdd0958daa6fafdb5a397ee3aac2282bc83e831d28954b9"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 10,
+      "previousHash": "b8eb6727ea1880d2acdd0958daa6fafdb5a397ee3aac2282bc83e831d28954b9",
+      "type": "work.ready",
+      "at": "2026-09-05T17:27:00.278Z",
+      "data": {
+        "generation": 0,
+        "revision": 2
+      },
+      "hash": "6adce6856dfc72177408aac80bfcc9615e8619da2f387d118ea80246e4e42a4f"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 11,
+      "previousHash": "6adce6856dfc72177408aac80bfcc9615e8619da2f387d118ea80246e4e42a4f",
+      "type": "work.reopened",
+      "at": "2026-09-05T17:40:22.379Z",
+      "data": {
+        "ground": "finding",
+        "generation": 1,
+        "revision": 0,
+        "authorization": {
+          "prNumber": 2595,
+          "head": "c5421ebd3dda75086c427429fc5e985343ab24ae",
+          "verdict": 1,
+          "action": "push",
+          "ground": "finding",
+          "evidence": "https://github.com/woojubb/robota/pull/2595#issuecomment-5553548300",
+          "scope": "update the planning task record only; implementation remains for the dependent source PR",
+          "approvedBy": "@woojubb",
+          "commentId": 5553604857,
+          "commentUrl": "https://github.com/woojubb/robota/pull/2595#issuecomment-5553604857",
+          "commentAuthor": "woojubb",
+          "commentAuthorAssociation": "OWNER"
+        }
+      },
+      "hash": "8d2ed0c3d59dfb75131a4ee45a976ee309eefe07822ea36e30c2a5d3760c9e96"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "7dae5672-b9e6-4936-a1c3-d3a5eb046e0a",
+      "sequence": 12,
+      "previousHash": "8d2ed0c3d59dfb75131a4ee45a976ee309eefe07822ea36e30c2a5d3760c9e96",
+      "type": "work.ready",
+      "at": "2026-09-05T17:40:27.604Z",
+      "data": {
+        "generation": 1,
+        "revision": 0
+      },
+      "hash": "ecaf226bcea7de537430e41fab9abbf02d256fbdeb124b0fa1a9ddce656efff5"
+    }
+  ],
+  "durations": {
+    "wallMs": 5225,
+    "activeMs": 5225,
+    "pausedMs": 0,
+    "phases": {}
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T17:21:40.903Z",
+    "readyAt": "2026-09-05T17:40:27.604Z"
+  },
+  "ground": "finding",
+  "authorization": {
+    "prNumber": 2595,
+    "head": "c5421ebd3dda75086c427429fc5e985343ab24ae",
+    "verdict": 1,
+    "action": "push",
+    "ground": "finding",
+    "evidence": "https://github.com/woojubb/robota/pull/2595#issuecomment-5553548300",
+    "scope": "update the planning task record only; implementation remains for the dependent source PR",
+    "approvedBy": "@woojubb",
+    "commentId": 5553604857,
+    "commentUrl": "https://github.com/woojubb/robota/pull/2595#issuecomment-5553604857",
+    "commentAuthor": "woojubb",
+    "commentAuthorAssociation": "OWNER"
+  }
+}

--- a/.agents/spec-docs/todo/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/spec-docs/todo/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -2,7 +2,7 @@
 status: approved
 type: INFRA
 tags: [cli, typescript]
-lane: L1
+lane: L2
 ---
 
 # INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop

--- a/.agents/spec-docs/todo/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/spec-docs/todo/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -1,0 +1,157 @@
+---
+status: approved
+type: INFRA
+tags: [cli, typescript]
+lane: L1
+---
+
+# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop
+
+## Problem
+
+The branch policy and local commit guards still describe and enforce `develop` as a protected
+commit target even though the maintainer has explicitly authorized direct integration-branch
+updates. This causes a direct `develop` commit to be rejected while `main`/`master` protections
+remain necessary.
+
+## Prior Art Research
+
+Waived: this is a repository-local policy alignment with no external product or protocol behavior.
+
+## Architecture Review
+
+### Affected Scope
+
+- `.agents/rules/git-branch.md`
+- `.claude/hooks/branch-guard.sh`
+- `.husky/pre-commit`
+
+### Alternatives Considered
+
+1. Remove only the prose prohibition. Pro: smallest textual change. Con: local hooks would still
+   reject the authorized workflow.
+2. Align the prose and both local commit guards while retaining release-branch protections. Pro:
+   one coherent policy across all local enforcement points. Con: direct integration commits become
+   available when explicitly requested.
+
+### Decision
+
+Choose alternative 2 because the requested workflow must be represented consistently by the rule,
+the Claude command guard, and the Git-native pre-commit guard. Push and merge behavior already
+allows `develop`; `main` and `master` remain blocked.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — N/A: repository workflow policy, not a command family
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+Remove `develop` from the protected-commit sets in the policy text, `branch-guard.sh`, and
+`.husky/pre-commit`; retain the existing release-branch protections and all branch-creation,
+verification, and review requirements.
+
+## Affected Files
+
+- `.agents/rules/git-branch.md`
+- `.claude/hooks/branch-guard.sh`
+- `.husky/pre-commit`
+
+## Completion Criteria
+
+- [ ] TC-01: static policy and hook assertions show `develop` is not rejected for commits while
+      `main` and `master` remain rejected.
+- [ ] TC-02: `pnpm harness:scan` exits 0 on the final tree.
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach         | Notes                                         |
+| ----- | --------- | ----------------------- | --------------------------------------------- |
+| TC-01 | Unit      | shell/static assertions | Verify both allow and deny branches.          |
+| TC-02 | CI smoke  | `pnpm harness:scan`     | Repository-wide policy and consistency scans. |
+
+## Tasks
+
+- [ ] `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
+
+## Evidence Log
+
+### [GATE-PLAN] — ❌ FAIL | 2026-09-06
+
+**Status remains:** draft
+**Failed criteria:**
+
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
+  **Required action:** pair the Task and the spec by basename
+
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-09-06
+
+**Status upgrade:** draft → approved
+**Approval route:** `DIRECT`
+**Instruction (verbatim):** "변경은 매우 쉬운 작업이니 빨리 작업해서 develop 을 베이스브랜치로 pr올려서 바로 pr을 머지하세요"
+**Given:** 2026-09-06, this conversation
+**Review fingerprint:** 0d38b9063aa5 (review c397f578, type/tags aba2e7e1)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-09-06, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
+
+### [GATE-PLAN] — ✅ PASS | 2026-09-06
+
+**Status upgrade:** draft → approved
+
+- GATE-WRITE — File begins with `---` YAML frontmatter block: file begins with a `---` frontmatter block
+- GATE-WRITE — `status: draft` present in frontmatter: `status: draft`
+- GATE-WRITE — `type:` is exactly one value from the 11-prefix list: SCREEN · API · FLOW · BEHAVIOR · DATA · RULE · AGREEMENT: `type: INFRA` is one of 11 allowed values
+- GATE-WRITE — `tags:` field present in frontmatter (may be empty array `[]`): `tags:` present (2 value(s))
+- GATE-WRITE — Contains a concrete symptom (specific command, output, or behavior that is wrong): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Contains a reproduction condition (when/where it occurs): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Does not contain "TBD", "TODO", or vague single-sentence descriptions: `## Problem` has no TBD/TODO; 300 chars, 2 sentences
+- GATE-WRITE — `## Prior Art Research` (or `## Research`) section present: `## Prior Art Research` section present
+- GATE-WRITE — Section is substantiated: cites ≥1 documentation source (product/API/design doc, release notes, protocol spec : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — OR an explicit `Waived: <reason>` line is present (opt-out the agent proposed or the user requested) — a bare : `scan-spec-research` reports the section substantiated or explicitly waived
+- GATE-WRITE — Research findings feed `Alternatives Considered` / `Decision` (evidence-based recommendation, not asserted): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — All 4 checklist items are `[x]`: 4/4 checklist items `[x]`
+- GATE-WRITE — Sibling scan item is `[x]` with either completion evidence or explicit `N/A: <reason>`: Sibling scan `[x]` with an explicit N/A reason
+- GATE-WRITE — Alternatives Considered has at least 2 entries with pro/con for each: 2 numbered alternatives, each with Pro and Con
+- GATE-WRITE — Decision references the trade-off that drove the choice: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — **New-surface placement (conditional):** IF the spec introduces a new package / app / presentation or interfac: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Every item has a `TC-N` prefix (TC-01, TC-02, …) — items without TC-N prefix = FAIL: 2 criteria, all `TC-NN:` prefixed
+- GATE-WRITE — At least 1 criterion per distinct feature or sub-item: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — Each criterion uses Command form or Observable behavior form (no vague language): N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-WRITE — No criterion uses: "works correctly", "no errors", "implemented", "displays correctly": none of "works correctly", "no errors", "implemented", "displays correctly" appears
+- GATE-WRITE — `## Test Plan` section present: `## Test Plan` present
+- GATE-WRITE — One row exists for each TC-N in Completion Criteria (count must match): 2 Test Plan rows = 2 TC criteria
+- GATE-WRITE — Each row has a non-empty Test Type and Tool/Approach (no "TBD"): 2 rows with Test Type and Tool, no TBD
+- GATE-WRITE — Rows where Tool is "manual" have a non-empty Notes entry explaining why automated test is not possible: 0 manual row(s), each with Notes
+- GATE-WRITE — Tasks section present with placeholder: `## Tasks` present
+- GATE-WRITE — Evidence Log section present and empty (first GATE-WRITE run): `## Evidence Log` present with 2 prior entries (none from a later gate)
+- GATE-WRITE — No `## Status` or `## Classification` sections in the body (these are frontmatter fields): no `## Status` / `## Classification` body sections
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-09-06, this conversation
+- GATE-APPROVAL — Approval is a direct, unambiguous statement directed at this spec document: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
+- GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
+- GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`
+
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)

--- a/.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -1,0 +1,41 @@
+---
+title: 'INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
+status: in-progress
+created: 2026-09-06
+priority: medium
+urgency: soon
+area: .agents/rules, .claude/hooks, .husky
+depends_on: []
+---
+
+# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
+
+## Objective
+
+Align the branch-policy document and local commit guard with the maintainer-authorized workflow:
+`develop` may receive explicitly requested direct commits, pushes, and merges, while `main` and
+`master` remain protected.
+
+## Plan
+
+- [x] Update the branch-policy wording.
+- [x] Permit `develop` in the command-string and git-native commit guards.
+- [ ] Run focused shell checks and the repository scan.
+
+## User Execution Test Scenarios
+
+<!-- backlog-execution.md § User Execution Test Scenario Rule. Outcome is one of
+     not-applicable | automatable | manual; the count is the number of scenarios drafted. Keep the
+     not-applicable form ONLY with a product-surface reason (≥ 50 characters, not build/typecheck
+     evidence); otherwise write the scenario a user can run and raise the count. -->
+
+**Author verdict:** `SCENARIO DRAFTED: not-applicable | 0`
+
+**Reason:** This changes repository-maintainer workflow enforcement and local Git hooks; it has no
+end-user runtime surface, CLI behavior, SDK contract, or product-facing interaction to execute.
+
+## Verification
+
+- Focused static assertions must show `main`/`master` remain blocked and `develop` is not blocked by
+  either commit guard.
+- `pnpm harness:scan` must pass for the final tree.

--- a/.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -19,8 +19,8 @@ Align the branch-policy document and local commit guard with the maintainer-auth
 
 ## Plan
 
-- [x] Update the branch-policy wording.
-- [x] Permit `develop` in the command-string and git-native commit guards.
+- [ ] Update the branch-policy wording.
+- [ ] Permit `develop` in the command-string and git-native commit guards.
 - [ ] Run focused shell checks and the repository scan.
 
 ## User Execution Test Scenarios

--- a/.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -6,6 +6,7 @@ priority: medium
 urgency: soon
 area: .agents/rules, .claude/hooks, .husky
 depends_on: []
+no-issue: repository policy alignment requested directly by the maintainer; no GitHub issue is the source record
 ---
 
 # INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections


### PR DESCRIPTION
## Background

The develop branch policy needs an explicit maintainer-requested integration path recorded in the repository governance documents.

## Change

This planning checkpoint records INFRA-171 and its L2 execution lane. The dependent implementation PR will update the branch rule and its mechanical hook consumers.

## Verification

The local pre-push contract and affected-scan gates passed for this planning-only change.

Work-Run: 7dae5672-b9e6-4936-a1c3-d3a5eb046e0a