### PR TITLE
chore(infra-173): reconcile duplicate planning identifier

### DIFF
--- a/.agents/evals/work-runs/62652eac-b097-4884-b745-4fb114bd3887/g0-r0.json
+++ b/.agents/evals/work-runs/62652eac-b097-4884-b745-4fb114bd3887/g0-r0.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "codex/infra173-collision-cleanup",
+    "baseCommit": "ffa7ca25332047b8a283290e2586458874c6fb57",
+    "headCommit": "1c2d49b67de71a029e9bfcef2da0588188f5d298",
+    "headTree": "e6733a0ee792f5d0a0bbb0911061beb78ad87d41",
+    "commitOids": [
+      "1c2d49b67de71a029e9bfcef2da0588188f5d298"
+    ],
+    "trailerDigest": "35dbf7ec9fab33369db817734054fcd7ffd52ca95901f4c1e7f26749392e762c",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T18:28:52.059Z",
+      "data": {
+        "branch": "codex/infra173-collision-cleanup"
+      },
+      "hash": "ff63d833af06d0db335a4d93bec580561afc0702bcad12e38690785d840a5d57"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 2,
+      "previousHash": "ff63d833af06d0db335a4d93bec580561afc0702bcad12e38690785d840a5d57",
+      "type": "work.bound",
+      "at": "2026-09-05T18:28:55.509Z",
+      "data": {
+        "workId": "INFRA-173",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "a182e29fc1a4ea069d6affaaef82773e06330632ec567113fb6d3d36b302aa97"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 3,
+      "previousHash": "a182e29fc1a4ea069d6affaaef82773e06330632ec567113fb6d3d36b302aa97",
+      "type": "work.started",
+      "at": "2026-09-05T18:28:55.918Z",
+      "data": {},
+      "hash": "1eef2a9e59226cee03236e07089df0ead20d7d07e8965353391f43a855fffeaf"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 4,
+      "previousHash": "1eef2a9e59226cee03236e07089df0ead20d7d07e8965353391f43a855fffeaf",
+      "type": "phase.started",
+      "at": "2026-09-05T18:28:56.331Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "12d63d11ebb201a8b3c653814573eb44e652eb298551af1243fcfb39277a0951"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 5,
+      "previousHash": "12d63d11ebb201a8b3c653814573eb44e652eb298551af1243fcfb39277a0951",
+      "type": "phase.completed",
+      "at": "2026-09-05T18:29:43.584Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "ab3e65c320ec49e0d5865836e0ef57826f44c39944dfe2cf08e89687fb23f534"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 6,
+      "previousHash": "ab3e65c320ec49e0d5865836e0ef57826f44c39944dfe2cf08e89687fb23f534",
+      "type": "phase.started",
+      "at": "2026-09-05T18:29:43.986Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "2334d481302ca4ad11a8cd261004a6a2ec5622242cb7901289bf2eaabe87a6be"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 7,
+      "previousHash": "2334d481302ca4ad11a8cd261004a6a2ec5622242cb7901289bf2eaabe87a6be",
+      "type": "phase.completed",
+      "at": "2026-09-05T18:29:44.405Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "115ccb10c864ec40dcc58e7df8e12177df6180ca4e5c0b0660fcd09f7cd572bd"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "62652eac-b097-4884-b745-4fb114bd3887",
+      "sequence": 8,
+      "previousHash": "115ccb10c864ec40dcc58e7df8e12177df6180ca4e5c0b0660fcd09f7cd572bd",
+      "type": "work.ready",
+      "at": "2026-09-05T18:29:49.518Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "001cc9d45cea11e27e781f8781de30c956363ef4ef1f046e36c29f7be8c48231"
+    }
+  ],
+  "durations": {
+    "wallMs": 57459,
+    "activeMs": 57459,
+    "pausedMs": 0,
+    "phases": {
+      "implementation": 47253,
+      "verification": 419
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T18:28:52.059Z",
+    "readyAt": "2026-09-05T18:29:49.518Z"
+  }
+}

--- a/.agents/spec-docs/todo/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/spec-docs/todo/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -5,7 +5,7 @@ tags: [cli, typescript]
 lane: L2
 ---
 
-# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop
+# INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop
 
 ## Problem
 
@@ -78,7 +78,7 @@ verification, and review requirements.
 
 ## Tasks
 
-- [ ] `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
+- [ ] `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
 
 ## Evidence Log
 
@@ -87,10 +87,10 @@ verification, and review requirements.
 **Status remains:** draft
 **Failed criteria:**
 
-- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
   **Required action:** pair the Task and the spec by basename
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
 
 ### [GATE-APPROVAL] — ✅ PASS | 2026-09-06
 
@@ -109,7 +109,7 @@ verification, and review requirements.
 - GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
 - GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
 
 ### [GATE-PLAN] — ✅ PASS | 2026-09-06
 
@@ -150,8 +150,8 @@ verification, and review requirements.
 - GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
 - GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
 - GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
-- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
-- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
 - GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)

--- a/.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
+title: 'INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
 status: in-progress
 created: 2026-09-06
 priority: medium
@@ -9,7 +9,7 @@ depends_on: []
 no-issue: repository policy alignment requested directly by the maintainer; no GitHub issue is the source record
 ---
 
-# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
+# INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
 
 ## Objective
 


### PR DESCRIPTION
## Summary

Reconcile the duplicate `INFRA-171` planning records introduced by concurrent work by assigning the direct-develop policy record the next free identifier, `INFRA-173`.

## Changes

- Rename the paired Task and spec from `INFRA-171` to `INFRA-173`.
- Update their internal identifiers and recorded paths consistently.

## Verification

- `work-item-id-collision` passes.
- `backlog-placement` passes.

Lane: L2

Work-Run: 62652eac-b097-4884-b745-4fb114bd3887
