### PR TITLE
chore(infra-173): reconcile duplicate planning identifier

### DIFF
--- a/.agents/evals/work-runs/e109fe88-b81b-4695-a96c-2696389d9950/g0-r0.json
+++ b/.agents/evals/work-runs/e109fe88-b81b-4695-a96c-2696389d9950/g0-r0.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "codex/infra173-collision-cleanup-v2",
+    "baseCommit": "ffa7ca25332047b8a283290e2586458874c6fb57",
+    "headCommit": "3b210e4418cdefca18fd4a25232af1b441337a72",
+    "headTree": "e6733a0ee792f5d0a0bbb0911061beb78ad87d41",
+    "commitOids": [
+      "3b210e4418cdefca18fd4a25232af1b441337a72"
+    ],
+    "trailerDigest": "2d55e177066c3d846d87f43c7980a81b6bf8c085cf099b253b6a7e1905e9ddee",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T18:34:54.906Z",
+      "data": {
+        "branch": "codex/infra173-collision-cleanup-v2"
+      },
+      "hash": "a083f53ae8c9e5b1ab6238de1907030add41265f14656af8f501b182818fc631"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 2,
+      "previousHash": "a083f53ae8c9e5b1ab6238de1907030add41265f14656af8f501b182818fc631",
+      "type": "work.bound",
+      "at": "2026-09-05T18:35:08.079Z",
+      "data": {
+        "workId": "INFRA-173",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "c031b575829bdcc3bed1df533ee7ba39dc0cd258519ca39de9af45064c67b299"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 3,
+      "previousHash": "c031b575829bdcc3bed1df533ee7ba39dc0cd258519ca39de9af45064c67b299",
+      "type": "work.started",
+      "at": "2026-09-05T18:35:08.511Z",
+      "data": {},
+      "hash": "257dc4a96bb67beb676bce89d31b504ffb50a3c763ab32e9d1cdd69b4d6e981e"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 4,
+      "previousHash": "257dc4a96bb67beb676bce89d31b504ffb50a3c763ab32e9d1cdd69b4d6e981e",
+      "type": "phase.started",
+      "at": "2026-09-05T18:35:08.948Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "62490d3ecf0fc26601c4e80c8964b343189e801195ad73dc284d3a79945da94f"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 5,
+      "previousHash": "62490d3ecf0fc26601c4e80c8964b343189e801195ad73dc284d3a79945da94f",
+      "type": "phase.completed",
+      "at": "2026-09-05T18:35:21.053Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "5197c5918da63e89343166c296e098ae8928866a5405fe7f0799c4acd70b2cb5"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 6,
+      "previousHash": "5197c5918da63e89343166c296e098ae8928866a5405fe7f0799c4acd70b2cb5",
+      "type": "phase.started",
+      "at": "2026-09-05T18:35:21.482Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "b50cda7d1258ca2307cddeda2c569186926822a1daaef16b5bb67634fe296e94"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 7,
+      "previousHash": "b50cda7d1258ca2307cddeda2c569186926822a1daaef16b5bb67634fe296e94",
+      "type": "phase.completed",
+      "at": "2026-09-05T18:35:21.912Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "17b9c384fe266a4b2969c8945ad77bdf787e66cad59669d56e89fbb56bfb629d"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "e109fe88-b81b-4695-a96c-2696389d9950",
+      "sequence": 8,
+      "previousHash": "17b9c384fe266a4b2969c8945ad77bdf787e66cad59669d56e89fbb56bfb629d",
+      "type": "work.ready",
+      "at": "2026-09-05T18:35:35.377Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "f727bd4a123508913854a3a2a2d58ae020fcd65d84d07a537d1879d0ece71906"
+    }
+  ],
+  "durations": {
+    "wallMs": 40471,
+    "activeMs": 40471,
+    "pausedMs": 0,
+    "phases": {
+      "implementation": 12105,
+      "verification": 430
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T18:34:54.906Z",
+    "readyAt": "2026-09-05T18:35:35.377Z"
+  }
+}

--- a/.agents/spec-docs/todo/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/spec-docs/todo/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -5,7 +5,7 @@ tags: [cli, typescript]
 lane: L2
 ---
 
-# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop
+# INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop
 
 ## Problem
 
@@ -78,7 +78,7 @@ verification, and review requirements.
 
 ## Tasks
 
-- [ ] `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
+- [ ] `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
 
 ## Evidence Log
 
@@ -87,10 +87,10 @@ verification, and review requirements.
 **Status remains:** draft
 **Failed criteria:**
 
-- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
   **Required action:** pair the Task and the spec by basename
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
 
 ### [GATE-APPROVAL] — ✅ PASS | 2026-09-06
 
@@ -109,7 +109,7 @@ verification, and review requirements.
 - GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
 - GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
 
 ### [GATE-PLAN] — ✅ PASS | 2026-09-06
 
@@ -150,8 +150,8 @@ verification, and review requirements.
 - GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
 - GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
 - GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
-- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
-- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
 - GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)

--- a/.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
+title: 'INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
 status: in-progress
 created: 2026-09-06
 priority: medium
@@ -9,7 +9,7 @@ depends_on: []
 no-issue: repository policy alignment requested directly by the maintainer; no GitHub issue is the source record
 ---
 
-# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
+# INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
 
 ## Objective
 


### PR DESCRIPTION
## Summary

Reconcile the duplicate `INFRA-171` planning records introduced by concurrent work by assigning the direct-develop policy record the next free identifier, `INFRA-173`.

## Changes

- Rename the paired Task and spec from `INFRA-171` to `INFRA-173`.
- Update their internal identifiers and recorded paths consistently.

## Verification

- `work-item-id-collision` passes.
- `backlog-placement` passes.

Lane: L2

Work-Run: 62652eac-b097-4884-b745-4fb114bd3887
