### PR TITLE
chore(infra-173): reconcile duplicate planning identifier

### DIFF
--- a/.agents/evals/work-runs/145e616c-0e37-4886-9755-a4c8f89a37b6/g0-r0.json
+++ b/.agents/evals/work-runs/145e616c-0e37-4886-9755-a4c8f89a37b6/g0-r0.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "codex/infra173-collision-cleanup-v3",
+    "baseCommit": "ffa7ca25332047b8a283290e2586458874c6fb57",
+    "headCommit": "ee1823e85f042a2f4b2087ab97b9029d145ff963",
+    "headTree": "e6733a0ee792f5d0a0bbb0911061beb78ad87d41",
+    "commitOids": ["ee1823e85f042a2f4b2087ab97b9029d145ff963"],
+    "trailerDigest": "c26cc8a586e56f1ee8260753e53146a0164884e245804d696d2d642c8caa27a5",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/INFRA",
+    "lane": "L2",
+    "workKind": "INFRA"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-05T18:41:49.405Z",
+      "data": {
+        "branch": "codex/infra173-collision-cleanup-v3"
+      },
+      "hash": "7f8d6d49adbc53a0ddef576cabc65c12b9529e730de47143bb88cd080e3fc471"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 2,
+      "previousHash": "7f8d6d49adbc53a0ddef576cabc65c12b9529e730de47143bb88cd080e3fc471",
+      "type": "work.bound",
+      "at": "2026-09-05T18:41:54.543Z",
+      "data": {
+        "workId": "INFRA-173",
+        "lane": "L2",
+        "workKind": "INFRA"
+      },
+      "hash": "a925a772394b7528a667065607ac2fc92c443b5f23d0c09501dcae796967e7ca"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 3,
+      "previousHash": "a925a772394b7528a667065607ac2fc92c443b5f23d0c09501dcae796967e7ca",
+      "type": "work.started",
+      "at": "2026-09-05T18:41:54.940Z",
+      "data": {},
+      "hash": "085efab49231b0c5d8163f110b3f6e44b92c94119199f07ca680c86a29083245"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 4,
+      "previousHash": "085efab49231b0c5d8163f110b3f6e44b92c94119199f07ca680c86a29083245",
+      "type": "phase.started",
+      "at": "2026-09-05T18:41:55.342Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "b648ec70793ad3c5fc3355e7ccad730c2e0817d58f5c9b448778b6a76ac1dabb"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 5,
+      "previousHash": "b648ec70793ad3c5fc3355e7ccad730c2e0817d58f5c9b448778b6a76ac1dabb",
+      "type": "phase.completed",
+      "at": "2026-09-05T18:42:12.520Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "055eb9c79d0feab4e375ca1b5096480eb2dd212b29f5ad8100510c5ec5028cfd"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 6,
+      "previousHash": "055eb9c79d0feab4e375ca1b5096480eb2dd212b29f5ad8100510c5ec5028cfd",
+      "type": "phase.started",
+      "at": "2026-09-05T18:42:12.970Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "8aa781238355011dece93f0e43ff336f71183bdd89a6ec30491b5a5552502db7"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 7,
+      "previousHash": "8aa781238355011dece93f0e43ff336f71183bdd89a6ec30491b5a5552502db7",
+      "type": "phase.completed",
+      "at": "2026-09-05T18:42:13.417Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "42c0f85f4247d396d3187b7b23a29a5d2cdfb47523c082aa70ef4afcf0072ed2"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "145e616c-0e37-4886-9755-a4c8f89a37b6",
+      "sequence": 8,
+      "previousHash": "42c0f85f4247d396d3187b7b23a29a5d2cdfb47523c082aa70ef4afcf0072ed2",
+      "type": "work.ready",
+      "at": "2026-09-05T18:42:19.910Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "ab02786743605526a903a69c99a66453987a145e917985d50db05b358c474584"
+    }
+  ],
+  "durations": {
+    "wallMs": 30505,
+    "activeMs": 30505,
+    "pausedMs": 0,
+    "phases": {
+      "implementation": 17178,
+      "verification": 447
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-05T18:41:49.405Z",
+    "readyAt": "2026-09-05T18:42:19.910Z"
+  }
+}

--- a/.agents/spec-docs/todo/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/spec-docs/todo/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -5,7 +5,7 @@ tags: [cli, typescript]
 lane: L2
 ---
 
-# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop
+# INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop
 
 ## Problem
 
@@ -78,7 +78,7 @@ verification, and review requirements.
 
 ## Tasks
 
-- [ ] `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
+- [ ] `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` — todo
 
 ## Evidence Log
 
@@ -87,10 +87,10 @@ verification, and review requirements.
 **Status remains:** draft
 **Failed criteria:**
 
-- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is not the spec's (INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md)
   **Required action:** pair the Task and the spec by basename
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop.md` blob `be959b47826d` (untracked)
 
 ### [GATE-APPROVAL] — ✅ PASS | 2026-09-06
 
@@ -109,7 +109,7 @@ verification, and review requirements.
 - GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
 - GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `66f46570736b` (untracked)
 
 ### [GATE-PLAN] — ✅ PASS | 2026-09-06
 
@@ -150,8 +150,8 @@ verification, and review requirements.
 - GATE-APPROVAL — The item is inside the class as the registry defines it — a boundary the guard evaluates, not one the entry ar: N/A — not required for lane L1 (spec-workflow.md § Lanes)
 - GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (0d38b9063aa5) equals the document's current fingerprint
 - GATE-APPROVAL — **Independent architecture validation (conditional):** IF the spec introduces a new package / app / surface or: N/A — not required for lane L1 (spec-workflow.md § Lanes)
-- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
-- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
+- GATE-IMPLEMENT — `.agents/tasks/<ID>.md` has been created: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, which exists
+- GATE-IMPLEMENT — Tasks file path is recorded in the `## Tasks` section of the spec document: `## Tasks` names `.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md`, whose basename is the spec's
 - GATE-IMPLEMENT — The exact Task records a subject-bound user-execution PLAN terminal outcome: `not-applicable` includes the aut: Task `## User Execution Test Scenarios` records `SCENARIO DRAFTED: not-applicable | 0`
 
-**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-171-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)
+**Judged at:** HEAD `d9b521a06c71` · base `origin/develop@d9b521a06c71` · document `.agents/spec-docs/draft/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md` blob `7f612a66efe1` (untracked)

--- a/.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
+++ b/.agents/tasks/INFRA-173-allow-explicitly-requested-direct-commits-pushes-and-merges-on-develop-while-ret.md
@@ -1,5 +1,5 @@
 ---
-title: 'INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
+title: 'INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections'
 status: in-progress
 created: 2026-09-06
 priority: medium
@@ -9,7 +9,7 @@ depends_on: []
 no-issue: repository policy alignment requested directly by the maintainer; no GitHub issue is the source record
 ---
 
-# INFRA-171: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
+# INFRA-173: Allow explicitly requested direct commits, pushes, and merges on develop while retaining main/master protections
 
 ## Objective
 


### PR DESCRIPTION
## Summary

Reconcile the duplicate `INFRA-171` planning records introduced by concurrent work by assigning the direct-develop policy record the next free identifier, `INFRA-173`.

## Changes

- Rename the paired Task and spec from `INFRA-171` to `INFRA-173`.
- Update their internal identifiers and recorded paths consistently.

## Verification

- `work-item-id-collision` passes.
- `backlog-placement` passes.

Lane: L2

Work-Run: 145e616c-0e37-4886-9755-a4c8f89a37b6
