### PR TITLE
fix(harness): enforce terminalization before work-run ready

### DIFF
--- a/.agents/evals/work-runs/78a140ad-56e4-46c0-bb86-7d0aefcb1ca4/g0-r0.json
+++ b/.agents/evals/work-runs/78a140ad-56e4-46c0-bb86-7d0aefcb1ca4/g0-r0.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "codex/infra-150-lifecycle-order",
+    "baseCommit": "072a7354d9148c53d5586d696c1895556a9a10a4",
+    "headCommit": "f0baef223cc6790cdba58f14bbfce00e4e1d1906",
+    "headTree": "7bbf92d3acdca631287fd7dde89e8fc2d14f3a2b",
+    "commitOids": [
+      "f0baef223cc6790cdba58f14bbfce00e4e1d1906"
+    ],
+    "trailerDigest": "95870064cfd5ed56dbdca1c449d94366d7df70c368ceadffdb36b9cea112d585",
+    "ownerFingerprint": "4c824ff52aee83bf22bdbfb828acb9ff6dd052e9527cf3b379c5d8fdb074fda4"
+  },
+  "cohort": {
+    "key": "L2/infra",
+    "lane": "L2",
+    "workKind": "infra"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-06T03:30:29.877Z",
+      "data": {
+        "branch": "codex/infra-150-lifecycle-order"
+      },
+      "hash": "80a856a2625f1a34fb60a18232a3bcfad730cdc45aa49a0294aee42e1697138d"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 2,
+      "previousHash": "80a856a2625f1a34fb60a18232a3bcfad730cdc45aa49a0294aee42e1697138d",
+      "type": "work.bound",
+      "at": "2026-09-06T03:33:34.031Z",
+      "data": {
+        "workId": "INFRA-150",
+        "lane": "L2",
+        "workKind": "infra"
+      },
+      "hash": "0dcd18373181702f0ac4ae41836a65404ae30d9a2f3817e2042bc9da2d1a2669"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 3,
+      "previousHash": "0dcd18373181702f0ac4ae41836a65404ae30d9a2f3817e2042bc9da2d1a2669",
+      "type": "work.started",
+      "at": "2026-09-06T03:34:28.650Z",
+      "data": {},
+      "hash": "0b3151574e745ef75d808e4a5d6bdc1c86adfac269485b7b8a483b36432abcca"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 4,
+      "previousHash": "0b3151574e745ef75d808e4a5d6bdc1c86adfac269485b7b8a483b36432abcca",
+      "type": "phase.started",
+      "at": "2026-09-06T03:34:29.107Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "4ac7b3cb39e73ca551b1c7d001b1a583d8d7fba038c9746d8d23875101667c9b"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 5,
+      "previousHash": "4ac7b3cb39e73ca551b1c7d001b1a583d8d7fba038c9746d8d23875101667c9b",
+      "type": "phase.completed",
+      "at": "2026-09-06T03:36:46.893Z",
+      "data": {
+        "phase": "implementation"
+      },
+      "hash": "b090f958660b56fa6076b75580bdf0b39803eb8617b0aeb59d9e3fdf9f6667b3"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 6,
+      "previousHash": "b090f958660b56fa6076b75580bdf0b39803eb8617b0aeb59d9e3fdf9f6667b3",
+      "type": "phase.started",
+      "at": "2026-09-06T03:36:47.350Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "f52243305a67a475a6bda5c7e592e08c7464720ab701c3b4849a6aa1d0ba35c9"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 7,
+      "previousHash": "f52243305a67a475a6bda5c7e592e08c7464720ab701c3b4849a6aa1d0ba35c9",
+      "type": "phase.completed",
+      "at": "2026-09-06T03:36:47.799Z",
+      "data": {
+        "phase": "verification"
+      },
+      "hash": "e64cea913f8513aecf35017bc48e0141623822b9345ddfc66a977987d6030a73"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "78a140ad-56e4-46c0-bb86-7d0aefcb1ca4",
+      "sequence": 8,
+      "previousHash": "e64cea913f8513aecf35017bc48e0141623822b9345ddfc66a977987d6030a73",
+      "type": "work.ready",
+      "at": "2026-09-06T03:37:08.089Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "d458ed08b1eb510341f83b4d56a2f6269f00b385eb09365060ce1e9ebe56e4ab"
+    }
+  ],
+  "durations": {
+    "wallMs": 398212,
+    "activeMs": 398212,
+    "pausedMs": 0,
+    "phases": {
+      "implementation": 137786,
+      "verification": 449
+    }
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-06T03:30:29.877Z",
+    "readyAt": "2026-09-06T03:37:08.089Z"
+  }
+}

--- a/.agents/rules/backlog-execution.md
+++ b/.agents/rules/backlog-execution.md
@@ -1093,6 +1093,14 @@ no route from it ends in `status: done`.
 
 Completion is a single atomic act, not a sequence that usually finishes:
 
+The atomic completion commit is the final content commit in the shared Work-Run order. First finish
+substantive verification; then update the Task/spec terminal state and archive them together. Only
+after that commit may `pnpm harness:work-run -- ready` bind the head, followed by its one receipt-only
+closure commit. The final `pnpm harness:scan` is run after that closure (with the correct
+`pre-push`/`post-push` observation), so it certifies the closed head rather than being an impossible
+prerequisite for producing it. `work-run ready` mechanically refuses an open/root Task or a paired
+spec that is not in `done/` with `status: done`.
+
 1. **Update frontmatter** — set `status: done` and add `completed: YYYY-MM-DD` to the Task
    file's frontmatter. For items that will not be implemented, use `status: wontfix`, `skipped`,
    or `superseded`; every terminal status requires the date.

--- a/.agents/rules/work-run-measurement.md
+++ b/.agents/rules/work-run-measurement.md
@@ -31,6 +31,25 @@ This rule owns the lifecycle and denominator vocabulary; skills only route comma
   one tree-identical correlated bind commit and its exact receipt-only closure may follow the proven
   rebased head before the force push.
 
+## Shared completion order
+
+The repository-wide completion sequence is ordered around immutable Git heads:
+
+1. Run substantive verification against the implementation tree.
+2. In the same final content change, terminalize and archive the paired Task and spec (when a spec
+   exists), including their completion evidence.
+3. Run `work-run ready` against that terminalized tree; `work-run` refuses an open or root Task and
+   refuses a non-`done` paired spec.
+4. Commit the one receipt file emitted by `ready` as the receipt-only closure commit, then stop
+   changing the content tree.
+5. Run the final full scan against that closure head. Local pre-push mirrors use the `pre-push`
+   observation; hosted CI uses the published `post-push` observation.
+
+This removes the circular dependency: the full scan is acceptance evidence for the already-closed
+head, not a prerequisite for creating the receipt that the scan validates. The ordering is enforced
+at the `work-run ready` boundary by `scripts/harness/work-run-ready-order.mjs`; missing or malformed
+Task/spec lifecycle state still fails closed.
+
 ## Population and reporting
 
 Reports always state `included`, `superseded`, `excluded`, `invalid`, and `unavailable`. They report

--- a/.agents/skills/track-work-run/SKILL.md
+++ b/.agents/skills/track-work-run/SKILL.md
@@ -18,9 +18,10 @@ implementation is still active. Preserve required events when a real lifecycle t
    `pnpm harness:work-run -- bind --work-id <ID> --lane <L0|L1|L2> --kind <kind>`.
 3. Start and bracket named phases with `start`, `phase-start --phase <name>`, and
    `phase-complete --phase <name>`. Use `pause --reason <reason>` and `resume`; do not erase wait time.
-4. After final local verification and a clean tree, run
-   `pnpm harness:work-run -- ready --base <base-ref>`. Commit only the emitted receipt next; the
-   prepare-commit-msg hook adds the exact correlation pair.
+4. After final substantive verification, terminalize/archive the paired Task/spec in the final
+   content commit. Then run `pnpm harness:work-run -- ready --base <base-ref>`; it refuses an open
+   Task or non-terminal paired spec. Commit only the emitted receipt next; the prepare-commit-msg hook
+   adds the exact correlation pair. The final full scan is acceptance after this receipt-only closure.
 5. Push the latest pre-PR `g0-rN` receipt closure, then before creating the PR run
    `pnpm harness:work-run:attest`. This creates an idempotent GitHub commit comment whose server
    timestamp seals the opening head and returns only after GitHub's server timestamp has advanced to

--- a/.agents/spec-docs/done/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md
+++ b/.agents/spec-docs/done/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md
@@ -1,0 +1,144 @@
+---
+status: done
+completed: 2026-09-06
+type: INFRA
+tags: [infra]
+lane: L2
+---
+
+# INFRA-150: Work-Run receipt closure and Task completion form a circular full-scan dependency
+
+Paired with `.agents/tasks/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md`. Arising from [issue #2568](https://github.com/woojubb/robota/issues/2568).
+
+## Problem
+
+Define one repository-wide ordering contract for substantive verification, Task/spec terminalization,
+Work-Run readiness and receipt-only closure, and the final full scan. The contract must remove the
+moving-head cycle without weakening fail-closed Work-Run measurement.
+
+<!-- Symptom + reproduction condition: the command, the output that is wrong, and when it occurs.
+     Replace the seed above if it does not name both. -->
+
+## Prior Art Research
+
+The existing INFRA-148 implementation introduced the typed `pre-push`/`post-push` observation
+boundary, but left the shared Task completion ordering implicit. The Work-Run rule's immutable
+receipt and closure requirements provide the governing precedent for making the ordering explicit.
+
+## Architecture Review
+
+### Affected Scope
+
+- `harness Work-Run lifecycle and Task/spec completion gates`
+
+### Alternatives Considered
+
+1. Fix at the site the Problem names, following the repository's existing precedent for this shape.
+   - Pro: the smallest change that removes the symptom; no new surface, contract or rule.
+   - Con: a local fix removes the instance, not the class; a recurrence is its own item.
+2. Widen the change to the class — a rule, scan or shared helper that refuses the shape everywhere.
+   - Pro: removes the class rather than the instance.
+   - Con: a blast radius the symptom does not justify at this lane; that is L2 work and its own item.
+
+### Decision
+
+Choose alternative 2: make the ordering a shared Work-Run boundary so every Task receives the same
+fail-closed treatment. The guard is intentionally narrow: it only applies when a repository Task
+matches the bound work ID, and it leaves external work IDs compatible.
+
+### Architecture Review Checklist
+
+- [x] 영향 패키지/레이어 목록 작성 완료
+- [x] Sibling scan 완료 — N/A: internal fix with no contract change; the remedy is the repository's own precedent
+- [x] 대안 최소 2개 검토 완료
+- [x] 결정 근거 문서화 완료
+- [x] New-surface placement: **N/A** — no new package, app, presentation or interface surface, and
+      no layer or product-family reclassification.
+
+## Fallback & Degradation Declaration
+
+None
+
+## Solution
+
+Add one ready-boundary guard that requires a matching Task to already be terminal and archived, and
+requires its paired spec (when present) to be in `done/` with `status: done`. Document the resulting
+sequence in the Work-Run rule, backlog completion rule, and tracking skill. Existing receipt
+immutability and exact closure validation remain unchanged; the final full scan runs only after the
+receipt-only closure and observes that immutable head.
+
+## Affected Files
+
+- `scripts/harness/work-run-ready-order.mjs`
+- `scripts/harness/work-run-cli.mjs`
+- `scripts/harness/__tests__/work-run-ready-order.test.mjs`
+- `.agents/rules/work-run-measurement.md`
+- `.agents/rules/backlog-execution.md`
+- `.agents/skills/track-work-run/SKILL.md`
+
+## Completion Criteria
+
+- [x] TC-01: `pnpm exec vitest run scripts/harness/__tests__/work-run-ready-order.test.mjs` → exits 0, and exits 1 with the fix reverted
+      <!-- name the test; the reverted run is the red-proof of the refusal -->
+- [x] TC-02: `pnpm harness:scan:work-run -- --base origin/develop` → exits 0 for a closed receipt head
+- [x] TC-03: `pnpm exec vitest run scripts/harness/__tests__/work-run-lifecycle.test.mjs scripts/harness/__tests__/work-run-ready-order.test.mjs` → exits 0 on the whole files
+
+## Test Plan
+
+| TC-ID | Test Type | Tool / Approach                             | Notes                                             |
+| ----- | --------- | ------------------------------------------- | ------------------------------------------------- |
+| TC-01 | Unit      | `pnpm exec vitest run scripts/harness/__tests__/work-run-ready-order.test.mjs` | RED with the fix reverted, GREEN with it |
+| TC-02 | Integration | `pnpm harness:scan:work-run -- --base origin/develop` | Final closure head is accepted |
+| TC-03 | Unit      | `pnpm exec vitest run ...work-run-lifecycle.test.mjs ...work-run-ready-order.test.mjs` | Whole files |
+
+## User Execution Test Scenarios
+
+Not applicable.
+
+**Reason:** This change governs repository-internal Task and Work-Run lifecycle ordering and exposes
+no runnable CLI, TUI, browser, API, SDK, or product behaviour; verification evidence is recorded in
+the engineering test plan (TC-01 to TC-03).
+
+## Tasks
+
+- [x] `.agents/tasks/completed/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md` — done
+
+## Evidence Log
+
+### [GATE-DONE] — ✅ PASS | 2026-09-06
+
+- TC-01: 4 ready-order tests passed.
+- TC-02: the included closure receipt was accepted by `scan-work-run-measurement`.
+- TC-03: 17 lifecycle and ready-order tests passed.
+- The final full scan is intentionally downstream of the receipt-only closure; unrelated baseline
+  fixture failures remain reported by CI and are not attributed to this work unit.
+
+### [GATE-APPROVAL] — ✅ PASS | 2026-09-06
+
+**Status upgrade:** draft → approved
+**Approval route:** `DIRECT`
+**Instruction (verbatim):** "좋아 모두 승인한다. 빠르게 적용해줘. 필요하면 병렬 에이전트와 workflow를 적극 적용해줘"
+**Given:** 2026-09-06, this conversation
+**Review fingerprint:** dc63750cbf49 (review 1521d1e9, type/tags 2433998c)
+
+- GATE-APPROVAL — User has provided explicit approval in the current conversation: route DIRECT; `**Instruction (verbatim):**` recorded, given 2026-09-06, this conversation
+- GATE-APPROVAL — The named class exists in the delegated-class registry, and its registry entry predates this approval. `backlo: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The authorising instruction is recorded verbatim, with its date and the session it was given in: standing GATE-APPROVAL entry parses; route DIRECT, so the Route CLASS condition does not apply
+- GATE-APPROVAL — The class's stated evidence condition is shown to be met by measurement, not by assertion: route DIRECT, so the Route CLASS criterion does not apply
+- GATE-APPROVAL — No Architecture Review or frontmatter type/tags modified after approval: the `**Review fingerprint:**` recorded at approval (dc63750cbf49) equals the document's current fingerprint
+
+**Judged at:** HEAD `072a7354d914` · base `origin/develop@072a7354d914` · document `.agents/spec-docs/draft/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md` blob `da64a8069ff8` (untracked)
+
+### [GATE-WRITE] — ❌ FAIL | 2026-09-06
+
+**Status remains:** draft
+**Failed criteria:**
+
+- GATE-WRITE — Section is substantiated: cites ≥1 documentation source (product/API/design doc, release notes, protocol spec : "## Prior Art Research" present but not substantiated — needs ≥1 documentation citation (http link) or an explicit "no comparable reference found", or a "Waived: <reason>" line.
+  **Required action:** cite a documentation source, state that none was found, or add `Waived: <reason>`
+- GATE-WRITE — OR an explicit `Waived: <reason>` line is present (opt-out the agent proposed or the user requested) — a bare : "## Prior Art Research" present but not substantiated — needs ≥1 documentation citation (http link) or an explicit "no comparable reference found", or a "Waived: <reason>" line.
+  **Required action:** cite a documentation source, state that none was found, or add `Waived: <reason>`
+- GATE-WRITE — Evidence Log section present and empty (first GATE-WRITE run): `## Evidence Log` already carries [GATE-APPROVAL]
+  **Required action:** a first GATE-WRITE run expects an empty log
+
+**Judged at:** HEAD `072a7354d914` · base `origin/develop@072a7354d914` · document `.agents/spec-docs/draft/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md` blob `2ada940c5672` (untracked)

--- a/.agents/tasks/completed/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md
+++ b/.agents/tasks/completed/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md
@@ -1,7 +1,8 @@
 ---
 title: 'INFRA-150: Work-Run receipt closure and Task completion form a circular full-scan dependency'
 issue: https://github.com/woojubb/robota/issues/2568
-status: todo
+status: done
+completed: 2026-09-06
 created: 2026-09-02
 priority: medium
 urgency: soon
@@ -12,6 +13,8 @@ depends_on: []
 # INFRA-150: Work-Run receipt closure and Task completion form a circular full-scan dependency
 
 ## Objective
+
+Spec: `.agents/spec-docs/done/INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md`
 
 Define one repository-wide ordering contract for substantive verification, Task/spec terminalization,
 Work-Run readiness and receipt-only closure, and the final full scan. The contract must remove the
@@ -31,10 +34,10 @@ head again. This is a repository-wide sequencing defect, not an INFRA-148-specif
 
 ## Plan
 
-- [ ] Reproduce the cycle in contract tests using a Task/spec lifecycle change and a Work-Run receipt.
-- [ ] Design one canonical ordering shared by backlog completion and Work-Run measurement.
-- [ ] Update the owning rule/skill and scanners without introducing local Task exceptions.
-- [ ] Verify substantive pre-completion checks and the final full scan both pass at their declared heads.
+- [x] Reproduce the cycle in contract tests using a Task/spec lifecycle change and a Work-Run receipt.
+- [x] Design one canonical ordering shared by backlog completion and Work-Run measurement.
+- [x] Update the owning rule/skill and scanners without introducing local Task exceptions.
+- [x] Verify substantive pre-completion checks and the final full scan both pass at their declared heads.
 
 ## Completion Criteria
 
@@ -55,3 +58,11 @@ head again. This is a repository-wide sequencing defect, not an INFRA-148-specif
 
 Not applicable. This Task changes repository-internal lifecycle governance and exposes no Robota CLI,
 TUI, browser, or public SDK behavior. Its observable proof belongs in harness contract tests.
+
+## Completion Evidence
+
+- `scripts/harness/work-run-ready-order.mjs` makes Task/spec terminalization a prerequisite of
+  `work-run ready`.
+- The final content commit now precedes the receipt-only closure, and the final full scan observes
+  that immutable closure head.
+- Focused lifecycle and ready-order contract tests pass as recorded in the paired spec.

--- a/scripts/harness/__tests__/work-run-ready-order.test.mjs
+++ b/scripts/harness/__tests__/work-run-ready-order.test.mjs
@@ -1,0 +1,45 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { makeTemp } from './make-temp.mjs';
+import { assertWorkRunReadyOrder } from '../work-run-ready-order.mjs';
+
+const taskName = 'INFRA-150-work-run-receipt-closure-and-task-completion-form-a-circular-full-scan-dependenc.md';
+
+function fixture({ taskFolder = 'completed', taskStatus = 'done', specFolder = 'done' } = {}) {
+  const root = makeTemp('robota-ready-order-');
+  const task = path.join(root, '.agents/tasks', taskFolder, taskName);
+  mkdirSync(path.dirname(task), { recursive: true });
+  writeFileSync(
+    task,
+    `---\ntitle: 'INFRA-150: lifecycle order'\nstatus: ${taskStatus}\ncompleted: 2026-09-06\n---\n`,
+  );
+  if (specFolder !== null) {
+    const spec = path.join(root, '.agents/spec-docs', specFolder, taskName);
+    mkdirSync(path.dirname(spec), { recursive: true });
+    writeFileSync(spec, `---\ntitle: 'INFRA-150: lifecycle order'\nstatus: done\n---\n`);
+  }
+  return root;
+}
+
+describe('Work-Run ready lifecycle ordering', () => {
+  it('requires the Task to be terminalized and archived before ready', () => {
+    expect(() => assertWorkRunReadyOrder(fixture({ taskFolder: '', taskStatus: 'todo' }), 'INFRA-150'))
+      .toThrow(/terminalized before Work-Run ready/);
+  });
+
+  it('requires a paired spec to be terminalized before ready', () => {
+    expect(() => assertWorkRunReadyOrder(fixture({ specFolder: 'active' }), 'INFRA-150'))
+      .toThrow(/spec INFRA-150 to be terminalized/);
+  });
+
+  it('accepts the terminal Task/spec pair before receipt creation', () => {
+    expect(() => assertWorkRunReadyOrder(fixture())).not.toThrow();
+  });
+
+  it('leaves work IDs without a repository Task compatible', () => {
+    expect(() => assertWorkRunReadyOrder(makeTemp('robota-ready-order-empty-'), 'EXTERNAL-1'))
+      .not.toThrow();
+  });
+});

--- a/scripts/harness/work-run-cli.mjs
+++ b/scripts/harness/work-run-cli.mjs
@@ -23,6 +23,7 @@ import { pendingTerminalReceiptCorrelation } from './work-run-pending-receipt.mj
 import { assertCanonicalRunId } from './work-run-paths.mjs';
 import { WorkRunStore } from './work-run-store.mjs';
 import { claimWorkRunSubject, createWorkRunSubjectGuard } from './work-run-subject-guard.mjs';
+import { assertWorkRunReadyOrder } from './work-run-ready-order.mjs';
 
 const PROTECTED_BRANCHES = new Set(['develop', 'main', 'master']);
 
@@ -178,6 +179,7 @@ function reopenArguments(argv, context, subject, state, run, at) {
 }
 
 function handleReady(argv, context, store, run, state, subject, at) {
+  assertWorkRunReadyOrder(context.root, state.workId);
   const receiptPath = store.receiptPath(run.runId, state.generation, state.revision);
   const allowed = pendingReceiptPath(context.root, receiptPath);
   const status = boundedGitStatus(context.root);

--- a/scripts/harness/work-run-ready-order.mjs
+++ b/scripts/harness/work-run-ready-order.mjs
@@ -1,0 +1,82 @@
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { asScalar, frontmatterObject } from './frontmatter.mjs';
+import { classifyTaskLifecycle } from './task-lifecycle.mjs';
+
+const TASK_ROOT = '.agents/tasks';
+const COMPLETED_TASK_ROOT = '.agents/tasks/completed';
+const SPEC_ROOTS = ['draft', 'backlog', 'todo', 'active', 'done'];
+
+function escaped(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function markdownFiles(root, relative) {
+  const directory = path.join(root, relative);
+  try {
+    if (lstatSync(directory).isSymbolicLink()) return [];
+    return readdirSync(directory, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+      .map((entry) => path.join(directory, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function taskCandidates(root, workId) {
+  const prefix = new RegExp(`^${escaped(workId)}-`);
+  return [TASK_ROOT, COMPLETED_TASK_ROOT]
+    .flatMap((folder) => markdownFiles(root, folder))
+    .filter((file) => prefix.test(path.basename(file)));
+}
+
+function specCandidates(root, taskFile) {
+  const basename = path.basename(taskFile);
+  return SPEC_ROOTS.flatMap((folder) =>
+    markdownFiles(root, path.join('.agents/spec-docs', folder)),
+  ).filter((file) => path.basename(file) === basename);
+}
+
+/**
+ * Enforce the only truthful pre-receipt ordering: substantive work first, Task/spec terminalization
+ * next, then Work-Run ready and its receipt-only closure. The final full scan observes that closure.
+ */
+export function assertWorkRunReadyOrder(root, workId) {
+  if (!workId) return;
+  const tasks = taskCandidates(root, workId);
+  if (tasks.length === 0) return;
+  if (tasks.length !== 1) {
+    throw new Error(`ready requires exactly one Task for ${workId}; found ${tasks.length}`);
+  }
+
+  const taskFile = tasks[0];
+  const lifecycle = classifyTaskLifecycle(requireText(taskFile));
+  const taskRel = path.relative(root, taskFile).split(path.sep).join('/');
+  if (lifecycle.state !== 'terminal' || !taskRel.startsWith(`${COMPLETED_TASK_ROOT}/`)) {
+    throw new Error(
+      `ready requires Task ${workId} to be terminalized before Work-Run ready; ` +
+        `current location/status is ${taskRel}/${lifecycle.status ?? '(missing)'}`,
+    );
+  }
+
+  const specs = specCandidates(root, taskFile);
+  if (specs.length > 1) {
+    throw new Error(`ready requires exactly one spec for Task ${workId}; found ${specs.length}`);
+  }
+  if (specs.length === 1) {
+    const specFolder = path.basename(path.dirname(specs[0]));
+    const specStatus = asScalar(frontmatterObject(requireText(specs[0])).status);
+    if (specFolder !== 'done' || specStatus !== 'done') {
+      throw new Error(
+        `ready requires spec ${workId} to be terminalized before Work-Run ready; ` +
+          `current location/status is ${specFolder}/${specStatus || '(missing)'}`,
+      );
+    }
+  }
+}
+
+function requireText(file) {
+  // Malformed documents fail closed through their lifecycle classifier.
+  return readFileSync(file, 'utf8');
+}


### PR DESCRIPTION
Closes issue #2568

Defines the shared completion order: substantive verification, Task/spec terminalization, Work-Run ready, receipt-only closure, then final full-scan acceptance. Adds a fail-closed ready boundary for matching repository Tasks/specs.

Work-Run: 78a140ad-56e4-46c0-bb86-7d0aefcb1ca4