### PR TITLE
fix(harness): add truthful work-run receipt invalidation

### DIFF
--- a/.agents/evals/work-runs/01e40dd5-3760-4850-a318-75cce66b90a9/g0-r0.json
+++ b/.agents/evals/work-runs/01e40dd5-3760-4850-a318-75cce66b90a9/g0-r0.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "01e40dd5-3760-4850-a318-75cce66b90a9",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "codex/proc-028-invalid-receipt",
+    "baseCommit": "1fc4792d8194218b5b8dda19da0a8ac84ef152a3",
+    "headCommit": "7841b36ce2bbaeba2b2b9df14df96a987ae0e44d",
+    "headTree": "e08035ad41b1108739eb0eda4ce6915fc12bbb54",
+    "commitOids": [
+      "7841b36ce2bbaeba2b2b9df14df96a987ae0e44d"
+    ],
+    "trailerDigest": "3e349e2e5387c72ff03f6574c5b4d85f6b8e2be84e8502c76716ed949dde37ca",
+    "ownerFingerprint": "67c3371f71776dc0101e2b16c8dfc0d5b526ab031a2f98eaea8e47dc8eccfbd9"
+  },
+  "cohort": {
+    "key": "L0/workflow-governance",
+    "lane": "L0",
+    "workKind": "workflow-governance"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "01e40dd5-3760-4850-a318-75cce66b90a9",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-06T03:41:47.603Z",
+      "data": {
+        "branch": "codex/proc-028-invalid-receipt"
+      },
+      "hash": "bfec49ffed7324fcae79d1f1c3738d1dd6cc604f11411bdcbbd24f40d0836cd9"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "01e40dd5-3760-4850-a318-75cce66b90a9",
+      "sequence": 2,
+      "previousHash": "bfec49ffed7324fcae79d1f1c3738d1dd6cc604f11411bdcbbd24f40d0836cd9",
+      "type": "work.bound",
+      "at": "2026-09-06T03:45:18.661Z",
+      "data": {
+        "workId": "PROC-028",
+        "lane": "L0",
+        "workKind": "workflow-governance"
+      },
+      "hash": "35f20c2d6bc3e332351abaa80362545c203fa142b7cac1a2c93b5137c2627eae"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "01e40dd5-3760-4850-a318-75cce66b90a9",
+      "sequence": 3,
+      "previousHash": "35f20c2d6bc3e332351abaa80362545c203fa142b7cac1a2c93b5137c2627eae",
+      "type": "work.started",
+      "at": "2026-09-06T03:45:19.105Z",
+      "data": {},
+      "hash": "2e3e64a36ffd1664559f6bb455df9bab4249b7ce58793433a124b58674661372"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "01e40dd5-3760-4850-a318-75cce66b90a9",
+      "sequence": 4,
+      "previousHash": "2e3e64a36ffd1664559f6bb455df9bab4249b7ce58793433a124b58674661372",
+      "type": "work.ready",
+      "at": "2026-09-06T03:45:19.551Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "7e49f84971b476a36a18b63592c18bc143d545ec29cbbbb41722f85086cc3c99"
+    }
+  ],
+  "durations": {
+    "wallMs": 211948,
+    "activeMs": 211948,
+    "pausedMs": 0,
+    "phases": {}
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-06T03:41:47.603Z",
+    "readyAt": "2026-09-06T03:45:19.551Z"
+  }
+}

--- a/.agents/tasks/completed/PROC-028-allow-truthful-invalidation-of-immutable-work-run-receipts-with-bad-phase-attrib.md
+++ b/.agents/tasks/completed/PROC-028-allow-truthful-invalidation-of-immutable-work-run-receipts-with-bad-phase-attrib.md
@@ -1,7 +1,7 @@
 ---
 title: 'PROC-028: Allow truthful invalidation of immutable work-run receipts with bad phase attribution'
 issue: https://github.com/woojubb/robota/issues/2562
-status: todo
+status: done
 created: 2026-08-31
 priority: medium
 urgency: soon
@@ -19,12 +19,21 @@ auditable way to remove that run from the included measurement population.
 
 ## Plan
 
-- [ ] Define a terminal invalidation contract for a sealed pre-PR receipt whose event chain is structurally
+- [x] Define a terminal invalidation contract for a sealed pre-PR receipt whose event chain is structurally
       valid but whose phase attribution is semantically false.
-- [ ] Ensure generation-zero revisions cannot present inherited incorrect phase durations as corrected or
+- [x] Ensure generation-zero revisions cannot present inherited incorrect phase durations as corrected or
       included measurement.
-- [ ] Update the reducer, receipt validation, reporting population, CLI routing, scans, and fixtures without
+- [x] Update the reducer, receipt validation, reporting population, CLI routing, scans, and fixtures without
       permitting receipt rewriting or synthetic backdated events.
+
+## Completion evidence
+
+- Added the hash-chained `work.invalidated` terminal event and `work-run invalidate --reason` route.
+- Added immutable invalidation receipts at the next generation-zero revision while retaining the original
+  g0-r0 receipt and full event history.
+- Receipt validation now checks the invalidation terminal, projection, and original-receipt coordinates;
+  reporting removes the invalidated included receipt from measurement while retaining the invalid reason.
+- Focused work-run contract, store, validation, and report suites passed: 136 tests.
 
 ## Test Plan
 

--- a/scripts/harness/__tests__/work-run-contract.test.mjs
+++ b/scripts/harness/__tests__/work-run-contract.test.mjs
@@ -50,6 +50,7 @@ describe('work-run contract', () => {
       'work.reopened',
       'work.abandoned',
       'work.excluded',
+      'work.invalidated',
     ]);
     const run = legalRun();
     expect(run.events.map((event) => event.sequence)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -189,6 +190,27 @@ describe('work-run contract', () => {
         data: { workId: 'OBSERVABILITY-002', lane: 'L3', workKind: 'observability' },
       }),
     ).toThrow(/lane.*L0.*L1.*L2/i);
+  });
+
+  it('keeps the original generation-zero phase history when invalidating a ready run', () => {
+    const ready = legalRun();
+    const invalidated = appendWorkRunEvent(ready, {
+      type: 'work.invalidated',
+      at: at(13),
+      data: {
+        generation: 0,
+        revision: 1,
+        reason: 'bad-phase-attribution',
+        invalidatedReceipt: 'g0-r0',
+      },
+    });
+
+    expect(reduceWorkRun(invalidated.events)).toMatchObject({
+      status: 'invalid',
+      generation: 0,
+      revision: 1,
+    });
+    expect(projectWorkRunDurations(invalidated.events).phases).toEqual({ implementation: 7_000 });
   });
 
   it('projects generation rework from its revision-zero reopen', () => {

--- a/scripts/harness/__tests__/work-run-report.test.mjs
+++ b/scripts/harness/__tests__/work-run-report.test.mjs
@@ -549,6 +549,41 @@ describe('work-run report', () => {
     expect(report.metrics.wallMs).toEqual({ p50: 10, p90: 20 });
   });
 
+  it('removes an invalidated generation-zero receipt from included measurement', () => {
+    const original = includedReceipt({ runId: 'invalidated-run', wallMs: 20 });
+    let run = { schemaVersion: 1, runId: original.runId, events: original.events };
+    run = appendWorkRunEvent(run, {
+      type: 'work.invalidated',
+      at: '2026-08-30T00:00:00.030Z',
+      data: {
+        generation: 0,
+        revision: 1,
+        reason: 'bad-phase-attribution',
+        invalidatedReceipt: 'g0-r0',
+      },
+    });
+    const state = reduceWorkRun(run.events);
+    const invalidated = {
+      schemaVersion: 1,
+      disposition: 'invalid',
+      reason: 'bad-phase-attribution',
+      runId: run.runId,
+      generation: 0,
+      revision: 1,
+      identity: receiptIdentity,
+      invalidatedReceipt: 'g0-r0',
+      cohort: { key: cohortKey(state), lane: state.lane, workKind: state.workKind },
+      events: run.events,
+      durations: projectWorkRunDurations(run.events),
+      timestamps: { claimedAt: run.events[0].at, invalidatedAt: run.events.at(-1).at },
+    };
+
+    const report = reportWorkRuns([original, invalidated]);
+
+    expect(report.populations).toMatchObject({ included: 0, invalid: 1 });
+    expect(report.invalidReasons).toEqual({ 'bad-phase-attribution': 1 });
+  });
+
   it('joins first PR when the ready head starts the proven PR-head commit range', () => {
     const receipt = {
       runId: 'run-1',

--- a/scripts/harness/__tests__/work-run-store.test.mjs
+++ b/scripts/harness/__tests__/work-run-store.test.mjs
@@ -13,7 +13,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 
@@ -457,6 +457,48 @@ describe('work-run store', () => {
     });
     expect(JSON.parse(readFileSync(revised.receiptPath, 'utf8')).revision).toBe(1);
     expect(JSON.parse(readFileSync(revised.receiptPath, 'utf8')).generation).toBe(0);
+  });
+
+  it('invalidates a ready generation-zero receipt without rewriting the original', () => {
+    const root = makeTemp('work-run-invalidation-');
+    mkdirSync(join(root, '.git'), { recursive: true });
+    const store = new WorkRunStore({ root, gitCommonDir: join(root, '.git') });
+    const run = store.claim({ branch: identity.branch, at: '2026-08-30T00:00:00.000Z' });
+    store.append(run.runId, {
+      type: 'work.bound',
+      at: '2026-08-30T00:00:01.000Z',
+      data: { workId: 'OBSERVABILITY-002', lane: 'L2', workKind: 'observability' },
+    });
+    store.append(run.runId, {
+      type: 'work.started',
+      at: '2026-08-30T00:00:02.000Z',
+      data: {},
+    });
+    const ready = store.ready({ runId: run.runId, identity, at: '2026-08-30T00:00:03.000Z' });
+    const original = readFileSync(ready.receiptPath, 'utf8');
+
+    const invalidated = store.invalidate({
+      runId: run.runId,
+      identity,
+      reason: 'bad-phase-attribution',
+      at: '2026-08-30T00:00:04.000Z',
+    });
+
+    expect(readFileSync(ready.receiptPath, 'utf8')).toBe(original);
+    expect(invalidated.receiptPath).toContain('/g0-r1.json');
+    expect(invalidated.receipt).toMatchObject({
+      disposition: 'invalid',
+      reason: 'bad-phase-attribution',
+      invalidatedReceipt: 'g0-r0',
+    });
+    expect(validateWorkRunReceipt(invalidated.receipt, {
+      receiptPath: relative(root, invalidated.receiptPath),
+    }).ok).toBe(true);
+    expect(store.invalidate({
+      runId: run.runId,
+      identity,
+      reason: 'bad-phase-attribution',
+    }).receipt).toEqual(invalidated.receipt);
   });
 
   it('recovers state from an immutable receipt after persistence fails between receipt and state', () => {

--- a/scripts/harness/work-run-cli.mjs
+++ b/scripts/harness/work-run-cli.mjs
@@ -117,7 +117,8 @@ function preservedTrailerCorrelation(argv) {
 
 function handleTerminal(command, argv, context, store, run, subject, at) {
   const exclude = command === 'exclude';
-  const identity = exclude
+  const invalidate = command === 'invalidate';
+  const identity = exclude || invalidate
     ? currentIdentity(
         context.root,
         subject.branch,
@@ -128,7 +129,7 @@ function handleTerminal(command, argv, context, store, run, subject, at) {
   const state = reduceWorkRun(run.events);
   const receiptPath = store.receiptPath(run.runId, state.generation, state.revision);
   const allowedReceiptPath = exclude ? pendingReceiptPath(context.root, receiptPath) : null;
-  const workingTreeStatus = exclude ? boundedGitStatus(context.root) : '';
+  const workingTreeStatus = exclude || invalidate ? boundedGitStatus(context.root) : '';
   return terminalizeWorkRun({
     command,
     store,
@@ -137,7 +138,7 @@ function handleTerminal(command, argv, context, store, run, subject, at) {
     reason: exclude ? option(argv, '--reason') : option(argv, '--reason', 'unspecified'),
     identity,
     workingTreeStatus,
-    allowedReceiptPath,
+    allowedReceiptPath: invalidate ? pendingReceiptPath(context.root, receiptPath) : allowedReceiptPath,
   });
 }
 
@@ -217,7 +218,7 @@ function handleBoundCommand(command, argv, runtime) {
   }
   const simple = appendSimple(command, argv, store, run.runId, at);
   if (simple !== null) return simple;
-  if (command === 'abandon' || command === 'exclude') {
+  if (command === 'abandon' || command === 'exclude' || command === 'invalidate') {
     return handleTerminal(command, argv, context, store, run, subject, at);
   }
   if (command === 'reopen')
@@ -234,7 +235,7 @@ function execute(input, now) {
   const command = argv[0];
   if (!command)
     throw new Error(
-      'usage: work-run <claim|bind|start|phase-start|phase-complete|pause|resume|ready|reopen|exclude|abandon|recover|trailers|cutover-plan|cutover-seal>',
+      'usage: work-run <claim|bind|start|phase-start|phase-complete|pause|resume|ready|reopen|exclude|invalidate|abandon|recover|trailers|cutover-plan|cutover-seal>',
     );
   const context = repoContext(option(argv, '--root', process.cwd()));
   const store = new WorkRunStore({

--- a/scripts/harness/work-run-contract.mjs
+++ b/scripts/harness/work-run-contract.mjs
@@ -16,6 +16,7 @@ export const WORK_RUN_EVENT_TYPES = Object.freeze([
   'work.reopened',
   'work.abandoned',
   'work.excluded',
+  'work.invalidated',
 ]);
 
 const EVENT_TYPE_SET = new Set(WORK_RUN_EVENT_TYPES);
@@ -97,7 +98,7 @@ export function projectWorkRunDurations(events) {
   const scopedEvents = events.slice(scopeStart);
   const first = instant(scopedEvents[0].at);
   const terminal = scopedEvents.findLast((event) =>
-    ['work.ready', 'work.abandoned', 'work.excluded'].includes(event.type),
+    ['work.ready', 'work.abandoned', 'work.excluded', 'work.invalidated'].includes(event.type),
   );
   const last = instant((terminal ?? scopedEvents.at(-1)).at);
   let pauseStart = null;

--- a/scripts/harness/work-run-domain.mjs
+++ b/scripts/harness/work-run-domain.mjs
@@ -221,5 +221,10 @@ export function terminalizeWorkRun({
     if (!reason) throw new Error('exclude requires --reason');
     return store.exclude({ runId, at, reason, identity });
   }
+  if (command === 'invalidate') {
+    assertReadyWorkingTreeClean(workingTreeStatus, allowedReceiptPath);
+    if (!reason) throw new Error('invalidate requires --reason');
+    return store.invalidate({ runId, at, reason, identity });
+  }
   throw new Error(`unsupported terminal work-run command: ${command}`);
 }

--- a/scripts/harness/work-run-receipt-validation.mjs
+++ b/scripts/harness/work-run-receipt-validation.mjs
@@ -38,6 +38,20 @@ const STATE_LOST_RECEIPT_KEYS = Object.freeze([
   'identity',
   'timestamps',
 ]);
+const INVALIDATION_RECEIPT_KEYS = Object.freeze([
+  'schemaVersion',
+  'disposition',
+  'reason',
+  'runId',
+  'generation',
+  'revision',
+  'identity',
+  'invalidatedReceipt',
+  'cohort',
+  'events',
+  'durations',
+  'timestamps',
+]);
 
 function decodeReceipt(receiptValue) {
   try {
@@ -54,16 +68,45 @@ function decodeReceipt(receiptValue) {
       receipt.timestamps.claimedAt === null &&
       receipt.timestamps.readyAt === null;
     if (
-      receipt.reason !== 'state-lost' ||
-      !exactKeys(receipt, STATE_LOST_RECEIPT_KEYS) ||
-      receipt.generation !== 0 ||
-      receipt.revision !== 0 ||
-      !validateWorkRunIdentity(receipt.identity) ||
-      !timestampsValid
+      receipt.reason === 'state-lost' &&
+      exactKeys(receipt, STATE_LOST_RECEIPT_KEYS) &&
+      receipt.generation === 0 &&
+      receipt.revision === 0 &&
+      validateWorkRunIdentity(receipt.identity) &&
+      timestampsValid
     ) {
-      throw new Error();
+      return { ok: true, receipt, state: null };
     }
-    return { ok: true, receipt, state: null };
+    if (
+      receipt.reason === 'bad-phase-attribution' &&
+      exactKeys(receipt, INVALIDATION_RECEIPT_KEYS) &&
+      Array.isArray(receipt.events) &&
+      receipt.events.length > 0 &&
+      validateWorkRunIdentity(receipt.identity) &&
+      receipt.generation === 0 &&
+      receipt.revision === 1 &&
+      receipt.invalidatedReceipt === 'g0-r0'
+    ) {
+      const state = reduceWorkRun(receipt.events);
+      const terminal = receipt.events.at(-1);
+      const timestamps =
+        exactKeys(receipt.timestamps, ['claimedAt', 'invalidatedAt']) &&
+        receipt.timestamps.claimedAt === receipt.events[0].at &&
+        receipt.timestamps.invalidatedAt === terminal.at;
+      if (
+        state.status === 'invalid' &&
+        terminal.type === 'work.invalidated' &&
+        terminal.data?.reason === receipt.reason &&
+        terminal.data?.invalidatedReceipt === receipt.invalidatedReceipt &&
+        state.generation === receipt.generation &&
+        state.revision === receipt.revision &&
+        timestamps &&
+        validateProjection(receipt, state)
+      ) {
+        return { ok: true, receipt, state };
+      }
+    }
+    throw new Error();
   } catch {
     return { ok: false, reason: 'malformed-receipt' };
   }

--- a/scripts/harness/work-run-receipts.mjs
+++ b/scripts/harness/work-run-receipts.mjs
@@ -110,6 +110,27 @@ export function stateLostReceipt(runId, identity) {
   };
 }
 
+export function invalidationReceipt(run, state, identity) {
+  const terminal = run.events.at(-1);
+  if (state.status !== 'invalid' || terminal?.type !== 'work.invalidated') {
+    throw new Error('invalidation receipt requires invalidated work');
+  }
+  return {
+    schemaVersion: 1,
+    disposition: 'invalid',
+    reason: terminal.data.reason,
+    runId: run.runId,
+    generation: state.generation,
+    revision: state.revision,
+    identity: structuredClone(identity),
+    invalidatedReceipt: terminal.data.invalidatedReceipt,
+    cohort: receiptCohort(state),
+    events: run.events,
+    durations: projectWorkRunDurations(run.events),
+    timestamps: { claimedAt: run.events[0].at, invalidatedAt: terminal.at },
+  };
+}
+
 export function reconcileExclusionReceipt({
   current,
   receiptPath,

--- a/scripts/harness/work-run-report-metrics.mjs
+++ b/scripts/harness/work-run-report-metrics.mjs
@@ -186,9 +186,18 @@ function projectFirstPullRequests(root, queryPullRequests, budget) {
 }
 
 function selectLatest(normalized) {
+  const invalidated = new Set(
+    normalized
+      .filter((receipt) => receipt.disposition === 'invalid' && receipt.invalidatedReceipt)
+      .map((receipt) => `${receipt.runId}/${receipt.invalidatedReceipt}`),
+  );
   const latest = new Map();
   for (const receipt of normalized) {
-    if (receipt.disposition !== 'included') continue;
+    if (
+      receipt.disposition !== 'included' ||
+      invalidated.has(`${receipt.runId}/g${receipt.generation ?? 0}-r${receipt.revision ?? 0}`)
+    )
+      continue;
     const key = `${receipt.runId}/${receipt.generation ?? 0}`;
     const previous = latest.get(key);
     if (!previous || (receipt.revision ?? 0) > (previous.revision ?? 0)) latest.set(key, receipt);

--- a/scripts/harness/work-run-state-transition.mjs
+++ b/scripts/harness/work-run-state-transition.mjs
@@ -185,6 +185,21 @@ function transitionTerminal(state, event, data) {
   state.status = 'excluded';
 }
 
+function transitionInvalidated(state, data) {
+  if (state.status !== 'ready') throw new Error('only ready work may be invalidated');
+  validateCoordinates(data, 'invalidated');
+  if (data.generation !== state.generation || data.revision !== state.revision + 1) {
+    throw new Error('invalidated generation and revision must advance the current state');
+  }
+  if (!data.reason) throw new Error('work.invalidated needs a reason');
+  if (typeof data.invalidatedReceipt !== 'string' || !/^g0-r0$/u.test(data.invalidatedReceipt)) {
+    throw new Error('work.invalidated needs the original generation-zero receipt');
+  }
+  state.status = 'invalid';
+  state.generation = data.generation;
+  state.revision = data.revision;
+}
+
 export function applyWorkRunTransition(state, event) {
   const data = event.data ?? {};
   if (['work.claimed', 'work.bound', 'work.started'].includes(event.type)) {
@@ -199,6 +214,8 @@ export function applyWorkRunTransition(state, event) {
     transitionReopened(state, data);
   } else if (['work.abandoned', 'work.excluded'].includes(event.type)) {
     transitionTerminal(state, event, data);
+  } else if (event.type === 'work.invalidated') {
+    transitionInvalidated(state, data);
   } else {
     throw new Error(`unknown event type: ${event.type}`);
   }

--- a/scripts/harness/work-run-store.mjs
+++ b/scripts/harness/work-run-store.mjs
@@ -15,6 +15,7 @@ import {
 } from './work-run-paths.mjs';
 import {
   exclusionReceipt,
+  invalidationReceipt,
   readyReceipt,
   reconcileExclusionReceipt,
   reconcileReceipt,
@@ -239,6 +240,46 @@ export class WorkRunStore {
       });
       state = reduceWorkRun(run.events);
       const receipt = exclusionReceipt(run, state, identity);
+      immutableJson(receiptPath, receipt, this.root);
+      this.persistenceHooks.afterReceiptPersist?.({ receiptPath, receipt });
+      atomicJson(this.statePath(runId), run, this.root);
+      return { receiptPath, receipt };
+    });
+  }
+
+  invalidate({ runId, identity, reason, at = this.now() }) {
+    return this.withLock(runId, () => {
+      let run = this.read(runId);
+      let state = reduceWorkRun(run.events);
+      if (!reason) throw new Error('invalidate requires a reason');
+      if (state.status === 'invalid') {
+        const receiptPath = this.receiptPath(runId, state.generation, state.revision);
+        const existing = readJson(receiptPath, this.root);
+        const expected = invalidationReceipt(run, state, identity);
+        if (!sameJson(existing, expected)) {
+          throw new Error(`immutable work-run receipt conflict: ${receiptPath}`);
+        }
+        return { receiptPath, receipt: existing };
+      }
+      if (state.generation !== 0 || state.revision !== 0 || state.status !== 'ready') {
+        throw new Error('only a ready generation-zero work run may be invalidated');
+      }
+      const originalPath = this.receiptPath(runId, 0, 0);
+      if (!existsSync(originalPath)) {
+        throw new Error('invalidation requires the original generation-zero receipt');
+      }
+      const original = readJson(originalPath, this.root);
+      if (original.disposition !== 'included') {
+        throw new Error('invalidation requires an included generation-zero receipt');
+      }
+      run = appendWorkRunEvent(run, {
+        type: 'work.invalidated',
+        at,
+        data: { generation: 0, revision: 1, reason, invalidatedReceipt: 'g0-r0' },
+      });
+      state = reduceWorkRun(run.events);
+      const receiptPath = this.receiptPath(runId, state.generation, state.revision);
+      const receipt = invalidationReceipt(run, state, identity);
       immutableJson(receiptPath, receipt, this.root);
       this.persistenceHooks.afterReceiptPersist?.({ receiptPath, receipt });
       atomicJson(this.statePath(runId), run, this.root);


### PR DESCRIPTION
Closes #2562

Adds a terminal work.invalidated event and CLI route that preserves the immutable g0-r0 receipt and event chain while publishing an invalid g0-r1 receipt. Reporting excludes the invalidated included receipt from measurement.

Focused work-run suites: 136 passed.