### PR TITLE
docs(test-013): terminalize shared home isolation task

### DIFF
--- a/.agents/evals/work-runs/b75c168a-5243-4f71-8869-c916625855c2/g0-r0.json
+++ b/.agents/evals/work-runs/b75c168a-5243-4f71-8869-c916625855c2/g0-r0.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "disposition": "included",
+  "runId": "b75c168a-5243-4f71-8869-c916625855c2",
+  "generation": 0,
+  "revision": 0,
+  "identity": {
+    "repository": "woojubb/robota",
+    "branch": "codex/test-013-terminalize",
+    "baseCommit": "4fd4b287271da6c8595463b9f9600b6707638ddb",
+    "headCommit": "99e7ed798deaf215b02b1d364d950a1f22efde99",
+    "headTree": "e9ed5b9500f530d8e42d95bf2314b0e9e6d8396c",
+    "commitOids": [
+      "99e7ed798deaf215b02b1d364d950a1f22efde99"
+    ],
+    "trailerDigest": "75a80ef6fa906ed3dcbc4fdd27d78a5c12c0db537f23e6c4c1f045ada4ed3101",
+    "ownerFingerprint": "67c3371f71776dc0101e2b16c8dfc0d5b526ab031a2f98eaea8e47dc8eccfbd9"
+  },
+  "cohort": {
+    "key": "L1/harness",
+    "lane": "L1",
+    "workKind": "harness"
+  },
+  "events": [
+    {
+      "schemaVersion": 1,
+      "runId": "b75c168a-5243-4f71-8869-c916625855c2",
+      "sequence": 1,
+      "previousHash": null,
+      "type": "work.claimed",
+      "at": "2026-09-06T03:49:23.017Z",
+      "data": {
+        "branch": "codex/test-013-terminalize"
+      },
+      "hash": "4bf21096eaa587744cd27c36c832d1a9874f588c76490a89cfb444381005ef30"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "b75c168a-5243-4f71-8869-c916625855c2",
+      "sequence": 2,
+      "previousHash": "4bf21096eaa587744cd27c36c832d1a9874f588c76490a89cfb444381005ef30",
+      "type": "work.bound",
+      "at": "2026-09-06T03:49:48.771Z",
+      "data": {
+        "workId": "TEST-013",
+        "lane": "L1",
+        "workKind": "harness"
+      },
+      "hash": "e8246ee98473cd0cb7e2a1741bdccbb8822af09608b0476befb55fb905a7a13b"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "b75c168a-5243-4f71-8869-c916625855c2",
+      "sequence": 3,
+      "previousHash": "e8246ee98473cd0cb7e2a1741bdccbb8822af09608b0476befb55fb905a7a13b",
+      "type": "work.started",
+      "at": "2026-09-06T03:49:49.339Z",
+      "data": {},
+      "hash": "96b8fe2f0f4a3d584e3be3c6f75fa6846ffbfe82baffbef8c6cda15d359499de"
+    },
+    {
+      "schemaVersion": 1,
+      "runId": "b75c168a-5243-4f71-8869-c916625855c2",
+      "sequence": 4,
+      "previousHash": "96b8fe2f0f4a3d584e3be3c6f75fa6846ffbfe82baffbef8c6cda15d359499de",
+      "type": "work.ready",
+      "at": "2026-09-06T03:49:49.893Z",
+      "data": {
+        "generation": 0,
+        "revision": 0
+      },
+      "hash": "aa56ca6fbb272721439345fee42ea372f2cfd0ad798d70325895de265e677a52"
+    }
+  ],
+  "durations": {
+    "wallMs": 26876,
+    "activeMs": 26876,
+    "pausedMs": 0,
+    "phases": {}
+  },
+  "timestamps": {
+    "claimedAt": "2026-09-06T03:49:23.017Z",
+    "readyAt": "2026-09-06T03:49:49.893Z"
+  }
+}

--- a/.agents/spec-docs/done/TEST-013-no-global-seam-prevents-a-test-from-being-satisfied-by-host-home-state.md
+++ b/.agents/spec-docs/done/TEST-013-no-global-seam-prevents-a-test-from-being-satisfied-by-host-home-state.md
@@ -1,5 +1,5 @@
 ---
-status: approved
+status: done
 type: INFRA
 tags: [test]
 lane: L1

--- a/.agents/tasks/completed/TEST-013-no-global-seam-prevents-a-test-from-being-satisfied-by-host-home-state.md
+++ b/.agents/tasks/completed/TEST-013-no-global-seam-prevents-a-test-from-being-satisfied-by-host-home-state.md
@@ -1,7 +1,7 @@
 ---
 title: 'TEST-013: no global seam prevents a test from being satisfied by host home state'
 issue: https://github.com/woojubb/robota/issues/2300
-status: todo
+status: done
 created: 2026-09-04
 priority: high
 urgency: soon
@@ -327,3 +327,11 @@ alters no shipped code path, adds no Robota CLI command, no TUI action, no brows
 public SDK export, so a user of the published packages has no product surface whose observable
 behaviour changes; the production signatures keep their existing defaults for real callers, and the
 effect is visible only inside the repository's own test processes.
+
+## Outcome
+
+The implementation and regression test are present on `origin/develop`: `vitest.shared.ts` isolates
+HOME/USERPROFILE per Vitest process and `packages/agent-framework/src/__tests__/vitest-home-isolation.test.ts`
+pins the seam. TC-04 had an empty migration population in the recorded comparison, so no test needed
+an explicit fixture-home migration. The unrelated pre-existing trust-boundary failures remain recorded
+as residual risk rather than being hidden.


### PR DESCRIPTION
Closes #2300

The shared Vitest HOME isolation and floor test are already present on develop. Archive the stale TEST-013 Task/spec with its recorded evidence and residual-risk note.