### PR TITLE
fix(harness): discover self-declared scan entrypoints (#2399)

### DIFF
--- a/scripts/harness/__tests__/scan-discovery.test.mjs
+++ b/scripts/harness/__tests__/scan-discovery.test.mjs
@@ -1,0 +1,46 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { discoverAdditionalScans } from '../discovery-loader.mjs';
+import { makeTemp } from './make-temp.mjs';
+
+const temporaryRoots = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixtureRoot() {
+  const root = makeTemp('robota-scan-discovery-');
+  mkdirSync(path.join(root, 'scripts', 'harness'), { recursive: true });
+  temporaryRoots.push(root);
+  return root;
+}
+
+describe('scan discovery', () => {
+  it('loads a self-declared scan without a runner edit', async () => {
+    const root = fixtureRoot();
+    writeFileSync(
+      path.join(root, 'scripts', 'harness', 'scan-fixture.mjs'),
+      "export const scanDefinition = { name: 'fixture', examines: ['fixtures/**'], advisory: true };\n",
+    );
+
+    await expect(discoverAdditionalScans({ root })).resolves.toEqual([
+      {
+        name: 'fixture',
+        examines: ['fixtures/**'],
+        advisory: true,
+        command: ['node', 'scripts/harness/scan-fixture.mjs'],
+      },
+    ]);
+  });
+
+  it('refuses a candidate that has no declaration', async () => {
+    const root = fixtureRoot();
+    writeFileSync(path.join(root, 'scripts', 'harness', 'scan-undecided.mjs'), 'export {};\n');
+
+    await expect(discoverAdditionalScans({ root })).rejects.toThrow(
+      'without scanDefinition; declare what it reads',
+    );
+  });
+});

--- a/scripts/harness/discovery-loader.mjs
+++ b/scripts/harness/discovery-loader.mjs
@@ -1,0 +1,104 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ENTRYPOINT_PATTERN = /^(?:scan|check)-.+\.mjs$/;
+
+// These files are reusable libraries or one-off workflow helpers. Their names predate the
+// discovery convention, so they are excluded explicitly rather than being silently ignored.
+export const NON_SCAN_ENTRYPOINTS = new Set([
+  'check-patch-coverage.mjs',
+  'check-plan.mjs',
+  'check-pr-body.mjs',
+  'check-regression-red-proof.mjs',
+  'check-review-gate.mjs',
+  'scan-promotion-closes.mjs',
+  'scan-receipt.mjs',
+]);
+
+function candidateFiles(harnessDir) {
+  return readdirSync(harnessDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && ENTRYPOINT_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function validateDefinition(definition, file) {
+  if (!definition || typeof definition !== 'object') {
+    throw new Error(
+      `scan discovery: ${file} must export a scanDefinition object; ` +
+        'a scan without an explicit declaration is refused',
+    );
+  }
+  if (typeof definition.name !== 'string' || definition.name.trim() === '') {
+    throw new Error(`scan discovery: ${file} has no non-empty scanDefinition.name`);
+  }
+  if (definition.always !== true && !Array.isArray(definition.examines)) {
+    throw new Error(
+      `scan discovery: ${file} (${definition.name}) declares neither examines nor always; ` +
+        '--affected would otherwise skip it without knowing what it reads',
+    );
+  }
+  if (definition.advisory !== undefined && typeof definition.advisory !== 'boolean') {
+    throw new Error(`scan discovery: ${file} (${definition.name}) has a non-boolean advisory flag`);
+  }
+  return definition;
+}
+
+/**
+ * Discover additional scan entrypoints that are not in the compatibility registry.
+ *
+ * Existing entries remain the compatibility baseline while scans migrate incrementally. A new
+ * candidate must export its own declaration; otherwise this function fails closed before any scan
+ * is run. The returned command shape intentionally matches SCAN_COMMANDS.
+ */
+export async function discoverAdditionalScans({ root = process.cwd(), legacyScans = [] } = {}) {
+  const harnessDir = path.join(root, 'scripts', 'harness');
+  const legacyFiles = new Set(
+    legacyScans
+      .map((scan) => scan.command?.[1])
+      .filter((file) => typeof file === 'string')
+      .map((file) => path.basename(file)),
+  );
+  const legacyNames = new Set(legacyScans.map((scan) => scan.name));
+  const discovered = [];
+
+  for (const file of candidateFiles(harnessDir)) {
+    if (legacyFiles.has(file) || NON_SCAN_ENTRYPOINTS.has(file)) continue;
+
+    const filePath = path.join(harnessDir, file);
+    const source = readFileSync(filePath, 'utf8');
+    if (!/export\s+const\s+scanDefinition\s*=/.test(source)) {
+      throw new Error(
+        `scan discovery: ${file} is a new scan candidate without scanDefinition; ` +
+          'declare what it reads (examines/always) and whether it is advisory',
+      );
+    }
+    const module = await import(`${pathToFileURL(filePath).href}?scan-discovery`);
+    const definition = validateDefinition(module.scanDefinition, file);
+    if (legacyNames.has(definition.name)) {
+      throw new Error(`scan discovery: ${file} duplicates registered scan name ${definition.name}`);
+    }
+    discovered.push({
+      ...definition,
+      command: definition.command ?? ['node', `scripts/harness/${file}`],
+    });
+  }
+
+  return discovered.sort((left, right) => {
+    const leftOrder = Number.isInteger(left.order) ? left.order : Number.MAX_SAFE_INTEGER;
+    const rightOrder = Number.isInteger(right.order) ? right.order : Number.MAX_SAFE_INTEGER;
+    return leftOrder - rightOrder || left.name.localeCompare(right.name);
+  });
+}
+
+export async function loadScanCommands(legacyScans, options = {}) {
+  const additional = await discoverAdditionalScans({ ...options, legacyScans });
+  const all = [...legacyScans, ...additional];
+  const names = new Set();
+  for (const scan of all) {
+    if (names.has(scan.name)) throw new Error(`scan discovery: duplicate scan name ${scan.name}`);
+    names.add(scan.name);
+  }
+  return all;
+}

--- a/scripts/harness/run-all-scans.mjs
+++ b/scripts/harness/run-all-scans.mjs
@@ -15,6 +15,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { classifyRange } from './classify-changed-paths.mjs';
+import { loadScanCommands } from './discovery-loader.mjs';
 import { planScanReuse, scansThatAlwaysRun, writeScanReceipt } from './scan-receipt.mjs';
 import { resolveBaseRef, resolveWorkspaceRoot } from './shared.mjs';
 import { createWorkRunMeasurementScan } from './work-run-scan-registration.mjs';
@@ -351,7 +352,7 @@ const CONTENT = under('content');
 const MARKDOWN = ['**', '*.md'].join('/');
 const REGISTRY = 'scripts/harness/run-all-scans.mjs';
 
-export const SCAN_COMMANDS = [
+const LEGACY_SCAN_COMMANDS = [
   {
     name: 'lane-declaration',
     command: ['node', 'scripts/harness/scan-lane-declaration.mjs'],
@@ -1338,6 +1339,13 @@ export const SCAN_COMMANDS = [
     examines: [under('scripts/docs'), PACKAGES],
   },
 ];
+
+// The legacy table remains the compatibility baseline while individual entrypoints migrate to
+// self-declared discovery. New scan/check modules are appended automatically by their own
+// scanDefinition export; they do not need a second edit in this runner.
+export const SCAN_COMMANDS = await loadScanCommands(LEGACY_SCAN_COMMANDS, {
+  root: WORKSPACE_ROOT,
+});
 
 /** The lanes a run can declare with `--context`; the default is the stricter one. */
 export const SCAN_CONTEXTS = ['pr', 'integration'];

--- a/scripts/harness/scan-guard-scope-fail-closed.mjs
+++ b/scripts/harness/scan-guard-scope-fail-closed.mjs
@@ -71,7 +71,7 @@
  * Exit code 0 = every classified guard behaves as declared, 1 = violation found.
  */
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -892,7 +892,7 @@ export const PENDING_CLASSIFICATION = [
 export const measuredVacuous = () =>
   PENDING_CLASSIFICATION.filter((entry) => entry.measured === 'vacuous');
 
-/** Scan scripts registered in `run-all-scans.mjs`, as bare filenames. Parsed, never hand-listed. */
+/** Scan scripts registered in the runner or declared for discovery, as bare filenames. */
 export function registeredScanFiles(root = WORKSPACE_ROOT) {
   // Comments are stripped first (HARNESS-052): the raw text of the registration file names scans in
   // its own docstrings and in `// …` notes beside table entries, so a scan that had been COMMENTED
@@ -901,6 +901,12 @@ export function registeredScanFiles(root = WORKSPACE_ROOT) {
   // derivation. Structure lives in the array; comments are prose.
   const source = stripJsComments(readFileSync(path.join(root, REGISTRATION_FILE), 'utf8'));
   const files = [...source.matchAll(/scripts\/harness\/([a-z0-9-]+\.mjs)/g)].map((m) => m[1]);
+  const harnessDir = path.join(root, HARNESS_DIR);
+  for (const entry of readdirSync(harnessDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !/^(?:scan|check)-.+\.mjs$/.test(entry.name)) continue;
+    const candidate = readFileSync(path.join(harnessDir, entry.name), 'utf8');
+    if (/export\s+const\s+scanDefinition\s*=/.test(candidate)) files.push(entry.name);
+  }
   if (files.length === 0)
     throw new Error(
       `${REGISTRATION_FILE} parsed to zero registered scans. An empty registration list would ` +


### PR DESCRIPTION
## Background
New harness scans had to be added to the central SCAN_COMMANDS table, creating a second registration edit and allowing new candidates to be overlooked.

## Change
- discover new scan/check entrypoints that export scanDefinition
- fail closed when a new candidate omits its declaration
- keep the existing registry compatible during incremental migration
- teach guard-scope derivation about self-declared scans
- add focused discovery tests

## Verification
- pnpm exec vitest run scripts/harness/__tests__/scan-discovery.test.mjs scripts/harness/__tests__/run-all-scans.test.mjs --reporter=dot
- pnpm exec vitest run scripts/harness/__tests__/scan-guard-scope-fail-closed.test.mjs scripts/harness/__tests__/scan-workspace-import-integrity.test.mjs scripts/harness/__tests__/scan-test-plan.test.mjs --reporter=dot

Lane: L2

Closes #2399