### PR TITLE
fix(harness): report review verdict corroboration (issue #2247)

### DIFF
--- a/.claude/hooks/merge-gate.sh
+++ b/.claude/hooks/merge-gate.sh
@@ -256,9 +256,18 @@ REVIEWER_RE='^github-actions(\\[bot\\])?$'
 #
 # So the selection asks for the marker ITSELF, across BOTH channels the reviewer writes to (issue
 # comments, where the summary lands, and pull-request reviews). Recency is then judged on the
-# verdict — the only entry whose age means anything.
-LAST_REVIEW=$(bounded_gh pr view "$PR" --json comments,reviews \
-  --jq "([.comments[] | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[] | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"$REVIEWER_RE\"))) | map(select(.body | test(\"ACTIONABLE FINDINGS:[[:space:]]*[0-9]+\"; \"i\"))) | sort_by(.at) | last // {}" || echo '{}')
+# verdict — the only entry whose age means anything. Keep the complete verdict list as evidence too:
+# a single zero is not the same fact as corroborating zeroes from every verdict that ran. The former
+# remains mergeable for now, but the output must say that corroboration is absent (#2247).
+REVIEW_VERDICTS=$(bounded_gh pr view "$PR" --json comments,reviews \
+  --jq "([.comments[] | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.createdAt // \"\")}] + [.reviews[] | {login: (.author.login // \"\"), body: (.body // \"\"), at: (.submittedAt // \"\")}]) | map(select(.login | test(\"$REVIEWER_RE\"))) | map(select(.body | test(\"ACTIONABLE FINDINGS:[[:space:]]*[0-9]+\"; \"i\"))) | sort_by(.at)" || echo '[]')
+VERDICT_COUNT=$(printf '%s' "$REVIEW_VERDICTS" | jq -r 'length' 2>/dev/null || echo "")
+if [[ ! "$VERDICT_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "[merge-gate] Blocked: could not count reviewer verdicts on #$PR." >&2
+  echo "[merge-gate] The difference between one zero and corroborated zeroes is unknown." >&2
+  exit 2
+fi
+LAST_REVIEW=$(printf '%s' "$REVIEW_VERDICTS" | jq -c 'last // {}' 2>/dev/null || echo '{}')
 LAST_REVIEW_AT=$(printf '%s' "$LAST_REVIEW" | jq -r '.at // ""' 2>/dev/null || echo "")
 
 if [[ -z "$LAST_REVIEW_AT" ]]; then
@@ -555,11 +564,17 @@ if [[ "$COUNT" != "0" ]]; then
   exit 2
 fi
 
+if [[ "$VERDICT_COUNT" == "1" ]]; then
+  REVIEW_EVIDENCE="1 verdict, 0 findings — no corroborating review"
+else
+  REVIEW_EVIDENCE="$VERDICT_COUNT verdicts, 0 findings"
+fi
+
 # The gate stops here on purpose. Whether a finding written in prose was addressed is the reviewer's
 # judgement, and a hook guessing at it would be a check measuring the wrong thing. What it has
 # established: CI is green, every inline finding is answered, the latest verdict names the exact
 # current head with zero findings, and its base is either the current base or an ancestor of it
 # whose local `git diff` to the current base — the whole diff, both names of every rename, no API
 # page cap — names no file this PR touches, with GitHub reporting the merge clean now.
-echo "[merge-gate] PR #$PR: CI CLEAN, exact head review, $BASE_VERDICT, ACTIONABLE FINDINGS: 0. READ IT." >&2
+echo "[merge-gate] PR #$PR: CI CLEAN, exact head review, $BASE_VERDICT, ACTIONABLE FINDINGS: 0, $REVIEW_EVIDENCE. READ IT." >&2
 exit 0

--- a/scripts/harness/__tests__/merge-gate-decision.test.mjs
+++ b/scripts/harness/__tests__/merge-gate-decision.test.mjs
@@ -249,7 +249,10 @@ function stubbedPath({
       '    mine = mine.filter((c) => /actionable findings:\\s*[0-9]+/i.test(c.body));',
       '  }',
       '  mine.sort((a, b) => (a.at < b.at ? -1 : a.at > b.at ? 1 : 0));',
-      '  console.log(JSON.stringify(mine.at(-1) ?? {}));',
+      '  // The hook reads the full verdict set, then selects the newest entry locally. Returning',
+      '  // only the newest object would turn jq `length` into an object-key count and confuse',
+      '  // "one verdict" with "three fields".',
+      '  console.log(JSON.stringify(mine));',
       '  process.exit(0);',
       '}',
       '// The gate asks whether every inline finding was ANSWERED where it was raised. These cases',
@@ -553,6 +556,32 @@ describe('the merge gate decides on CI and on a current review', () => {
     expect(verdict.output, 'a counted zero must not read like an absent count').toMatch(
       /ACTIONABLE FINDINGS: 0/,
     );
+  });
+
+  it('reports that one zero-finding verdict has no corroborating review', () => {
+    const verdict = judge({
+      state: 'CLEAN',
+      headAt: '2026-07-28T10:00:00Z',
+      comments: [REVIEW('2026-07-28T10:05:00Z', 'ACTIONABLE FINDINGS: 0')],
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(verdict.output).toMatch(/1 verdict, 0 findings.*no corroborating review/i);
+  });
+
+  it('reports corroborated zero findings when multiple verdicts exist', () => {
+    const verdict = judge({
+      state: 'CLEAN',
+      headAt: '2026-07-28T10:00:00Z',
+      comments: [
+        REVIEW('2026-07-28T10:05:00Z', 'first review\nACTIONABLE FINDINGS: 0'),
+        REVIEW('2026-07-28T10:06:00Z', 'second review\nACTIONABLE FINDINGS: 0'),
+      ],
+    });
+
+    expect(verdict.status, verdict.output).toBe(0);
+    expect(verdict.output).toMatch(/2 verdicts, 0 findings/);
+    expect(verdict.output).not.toMatch(/no corroborating review/i);
   });
 
   it('does not depend on the head commit date when the exact OIDs are readable', () => {
@@ -1141,8 +1170,9 @@ describe('the verdict-selection jq program the hook actually sends', () => {
       ],
     });
 
-    expect(out.at).toBe('2026-08-01T11:00:00Z');
-    expect(out.body).toMatch(/ACTIONABLE FINDINGS: 2/);
+    const latest = out.at(-1);
+    expect(latest.at).toBe('2026-08-01T11:00:00Z');
+    expect(latest.body).toMatch(/ACTIONABLE FINDINGS: 2/);
   });
 
   it('matches the [bot] login spelling through the spliced pattern', () => {
@@ -1157,10 +1187,10 @@ describe('the verdict-selection jq program the hook actually sends', () => {
       reviews: [],
     });
 
-    expect(out.at).toBe('2026-08-01T10:00:00Z');
+    expect(out.at(-1).at).toBe('2026-08-01T10:00:00Z');
   });
 
-  it('returns an empty object when nothing carries the marker', () => {
+  it('returns an empty list when nothing carries the marker', () => {
     const out = pick({
       comments: [
         { author: { login: 'github-actions' }, createdAt: '2026-08-01T10:00:00Z', body: 'silence' },
@@ -1168,6 +1198,6 @@ describe('the verdict-selection jq program the hook actually sends', () => {
       reviews: [],
     });
 
-    expect(out).toEqual({});
+    expect(out).toEqual([]);
   });
 });


### PR DESCRIPTION
## Background

Merge-gate previously exposed only the newest zero-finding reviewer verdict, making one reviewer result indistinguishable from corroborated review evidence.

## Change

- retain the complete marked verdict set and count it
- report a single zero verdict as having no corroborating review while preserving current mergeability
- report the verdict count in the successful gate message
- cover single and multiple verdict cases in the decision fixture

## Verification

- `pnpm exec vitest run scripts/harness/__tests__/merge-gate-decision.test.mjs --reporter=dot` (65 passed)
- `bash -n .claude/hooks/merge-gate.sh`
- `git diff --check`

Closes #2247

Lane: L2