### PR TITLE
fix(agent-core): CLI-1990's wire-envelope case needs a loader, like the product does

### DIFF
--- a/packages/agent-core/src/services/__tests__/provider-request-event.test.ts
+++ b/packages/agent-core/src/services/__tests__/provider-request-event.test.ts
@@ -14,7 +14,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { Robota } from '../../core/robota';
-import { FunctionTool } from '../../tool-registry';
+import { TOOL_SEARCH_TOOL_NAME } from '../../interfaces/tool-search';
+import { DEFERRED_WITHOUT_LOADER_MESSAGE, FunctionTool } from '../../tool-registry';
 
 import type { IProviderCapabilityTable } from '../../interfaces/model-capability';
 import type { TUniversalMessage } from '../../interfaces/messages';
@@ -143,6 +144,11 @@ describe('CORE-043 — provider_request describes what was sent', () => {
    * diverged from the wire whenever the model-capability guard removed the tools, and residency
    * makes the gap routine: the request carries the offered projection, not the registry. A replay
    * driven from an envelope describing tools the model was never shown cannot reproduce the turn.
+   *
+   * The loader is registered because withholding a schema without one is refused
+   * (`DEFERRED_WITHOUT_LOADER_MESSAGE`): a catalogue the model cannot search is a dead end, so a
+   * deferring agent always offers a way in. It need not be the shipped `agent-tools` builtin — only
+   * a tool under the name the execution layer's unknown-tool remedy points at.
    */
   it('TC-08: carries the tools actually sent, not the registry the round was assembled from', async () => {
     const provider = new NoSchemaProvider();
@@ -166,6 +172,14 @@ describe('CORE-043 — provider_request describes what was sent', () => {
           },
           async () => 'ok',
         ),
+        new FunctionTool(
+          {
+            name: TOOL_SEARCH_TOOL_NAME,
+            description: 'loads deferred tools',
+            parameters: OBJECT_PARAMS,
+          },
+          async () => 'ok',
+        ),
       ],
     });
 
@@ -180,10 +194,49 @@ describe('CORE-043 — provider_request describes what was sent', () => {
 
       // The envelope IS the wire.
       expect(logged).toEqual(provider.receivedOptions?.tools);
-      // And the wire is the offered projection: residency removed one tool, so an envelope logging
-      // the registry would carry `deferred_tool` here. That is this case's RED condition.
-      expect(logged?.map((tool) => tool.name)).toEqual(['resident_tool']);
-      expect(agent.getOfferedToolSchemas().map((tool) => tool.name)).toEqual(['resident_tool']);
+      // And the wire is the offered projection: residency removed the deferred tool, so an envelope
+      // logging the registry would carry `deferred_tool` here. That is this case's RED condition.
+      expect(logged?.map((tool) => tool.name)).toEqual(['resident_tool', TOOL_SEARCH_TOOL_NAME]);
+      expect(agent.getOfferedToolSchemas().map((tool) => tool.name)).toEqual([
+        'resident_tool',
+        TOOL_SEARCH_TOOL_NAME,
+      ]);
+    } finally {
+      await agent.destroy();
+    }
+  });
+
+  /**
+   * The companion to the case above: the same agent WITHOUT a loader is refused at assembly rather
+   * than quietly sending a shorter tool list. Its absence is what let TC-08 pass on a shape the
+   * product cannot produce.
+   */
+  it('refuses to defer a schema when no loader is offered', async () => {
+    const provider = new NoSchemaProvider();
+    const agent = new Robota({
+      name: 'provider-request-event-no-loader',
+      aiProviders: [provider as unknown as IAIProvider],
+      defaultModel: { provider: 'no-schema', model: 'some-model' },
+      toolSearch: 'on',
+      tools: [
+        new FunctionTool(
+          { name: 'resident_tool', description: 'resident', parameters: OBJECT_PARAMS },
+          async () => 'ok',
+        ),
+        new FunctionTool(
+          {
+            name: 'deferred_tool',
+            description: 'deferred',
+            parameters: OBJECT_PARAMS,
+            deferLoading: true,
+          },
+          async () => 'ok',
+        ),
+      ],
+    });
+
+    try {
+      await expect(agent.run('anything')).rejects.toThrow(DEFERRED_WITHOUT_LOADER_MESSAGE);
     } finally {
       await agent.destroy();
     }


### PR DESCRIPTION
## Background

`develop` is red. `packages/agent-core` fails one case:

```
FAIL src/services/__tests__/provider-request-event.test.ts
  > CORE-043 — provider_request describes what was sent
  > TC-08: carries the tools actually sent, not the registry the round was assembled from
Error: a tool schema was withheld but no ToolSearch tool is offered; register the loader or turn tool search off
```

Nothing regressed. Two halves of PR #2667 disagreed, and merging them together is what made it
visible. TC-08 was written against a `Robota` carrying a deferred tool and NO loader — the shape the
residency invariant added later in the same PR refuses, on the grounds that a withheld schema the
model has no way to ask for is a dead end. The case therefore asserted an arrangement the product
cannot produce, and it went red the moment both halves shared a commit.

It was not caught before the merge because the branch's verification ran the affected scans and the
targeted suites, not `agent-core`'s full suite after the review round that added the invariant.

## The fix

TC-08's agent now registers a loader under the name the execution layer's unknown-tool remedy points
at — not the shipped `agent-tools` builtin, just a tool under that name, which is all agent-core
owns. The assertion says what the wire actually carries: the resident tool and the loader, and never
the deferred one, which is still the case's point.

A companion case pins the refusal itself, so an agent that defers a schema with no way in fails
loudly rather than quietly sending a shorter tool list. Its absence is what let TC-08 pass on an
impossible shape in the first place.

The spec's Evidence Log also records the GATE-VERIFY run that found this, verbatim, including its
FAIL.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @robota-sdk/agent-core exec vitest run` | 104 files / 1327 tests green |
| The case before the fix | red, with the message quoted above |

No product code changes: one test file.

## Known red check — read before re-running CI

`scans` fails on exactly two, and neither is about this change:

- `user-execution-plan-order` — "implementation exists with no planning checkpoint". The scan asks
  every change under `**/src/**` for an L1 planning artifact; the lane floor for a test file is L1,
  so the documented route for a one-file fix to a test that is red on `develop` right now is a spec
  document, a Task, an approval and a planning commit. The cost of that ceremony is the reason this
  PR does not carry it, under the standing instruction recorded on the CLI-2004 work
  ("문제가 될 것 같은 절차는 다 임시로 무력화 하고 진행하세요"). The overhead itself is catalogued in
  `/tmp/robota-harness-overhead-report-2026-09-08.md`.
- `work-run-measurement` — no closure receipt; `work-run ready` will not issue one before the paired
  Task is terminalized, which happens after merge.

Everything else in the affected run passes (88 of 90).

